### PR TITLE
Radio component

### DIFF
--- a/default/src/components/Radio/Radio.story.tsx
+++ b/default/src/components/Radio/Radio.story.tsx
@@ -1,0 +1,15 @@
+import { action } from '@storybook/addon-actions';
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+
+import { Radio } from './Radio';
+
+storiesOf('Radio', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => (
+    <>
+      <Radio label="Radio 2" checked={boolean('checked', false)} />
+      <Radio label="Radio 3" defaultChecked />
+    </>
+  ));

--- a/default/src/components/Radio/Radio.tsx
+++ b/default/src/components/Radio/Radio.tsx
@@ -1,0 +1,38 @@
+import React, { ChangeEvent } from 'react';
+
+import { uniqueId } from '../../utils';
+
+import { HiddenRadio, StyledContainer, StyledLabel, StyledRadio } from './styled';
+
+export interface StyledRadioProps {
+  checked?: boolean;
+}
+
+export interface StyledLabelProps {
+  htmlFor: string;
+}
+
+interface Props {
+  label: string;
+}
+
+export type RadioProps = Props & React.InputHTMLAttributes<HTMLInputElement>;
+
+export class Radio extends React.PureComponent<RadioProps> {
+  static defaultProps = {
+    id: uniqueId('radio_'),
+  };
+
+  render() {
+    const { label, ...props } = this.props;
+    const { id, checked, defaultChecked } = props;
+
+    return (
+      <StyledContainer>
+        <HiddenRadio type="radio" {...props} />
+        <StyledRadio checked={checked || defaultChecked} />
+        <StyledLabel htmlFor={id}>{label}</StyledLabel>
+      </StyledContainer>
+    );
+  }
+}

--- a/default/src/components/Radio/index.ts
+++ b/default/src/components/Radio/index.ts
@@ -1,0 +1,1 @@
+export * from './Radio';

--- a/default/src/components/Radio/styled.tsx
+++ b/default/src/components/Radio/styled.tsx
@@ -1,0 +1,35 @@
+import { hideVisually } from 'polished';
+import styled, { css } from 'styled-components';
+
+import { defaultTheme } from '../../theme';
+import { TextStyles } from '../Text/styles';
+
+import { StyledLabelProps, StyledRadioProps } from './Radio';
+
+export const HiddenRadio = styled.input`
+  ${hideVisually()}
+`;
+
+export const StyledContainer = styled.div`
+  align-items: center;
+  display: flex;
+`;
+
+export const StyledRadio = styled.div<StyledRadioProps>`
+  background: ${props => (props.checked ? props.theme.colors.primary40 : props.theme.colors.white)};
+  border: ${({ theme }) => theme.border.box};
+  border-color: ${props => (props.checked ? props.theme.colors.primary40 : props.theme.colors.secondary30)};
+  border-radius: ${({ theme }) => theme.spacing.large};
+  box-shadow: inset 0px 0px 0px 3px ${({ theme }) => theme.colors.white};
+  height: ${({ theme }) => theme.spacing.large};
+  transition: all 150ms;
+  width: ${({ theme }) => theme.spacing.large};
+`;
+
+export const StyledLabel = styled.label<StyledLabelProps>`
+  ${TextStyles};
+  margin-left: ${({ theme }) => theme.spacing.small};
+`;
+
+StyledRadio.defaultProps = { theme: defaultTheme };
+StyledLabel.defaultProps = { theme: defaultTheme };


### PR DESCRIPTION
- I have tested the current setup and it is pretty nice. The theme injection inside the default props is a really smart idea.

- I have used a slightly different structure as a proposal which I'll try to explain. I have dissociated StyledComponent of React to keep the separation between the two technologies as opposed to the styles vs markup.

- Regarding the theme, I found the structure well though even if this pretty much what is given from the main open-source examples. I'll probably like mixins more than helpers but is not relevant. For the "system" directory it has pretty much what we need, but I often observe naming and data structure are really tied to design concept and sometimes they have their limitations when design mutates over time. That does not seem to be the case in BC, so as long as we sign off on the given design we should be fine. Maybe "border" just feels a bit different from the other and behave more like a mixin.

Note: I always feel a grid system should be part of those UI material libraries. Even if we have many options available today it is always nicer to frame the development around it.