### PR TITLE
feat(plab): allow any component to work as a trigger

### DIFF
--- a/packages/plab/src/components/Dropdown/Downshift/Downshift.tsx
+++ b/packages/plab/src/components/Dropdown/Downshift/Downshift.tsx
@@ -14,8 +14,9 @@ import React, { ComponentType, ReactNode } from 'react';
 import { FunctionComponent } from 'react';
 
 import { Omit } from '../../../types/shared';
-import { DropdownProps, DropdownToggleProps } from '../Dropdown';
 import { DropdownItem, DropdownItemProps } from '../Item/Item';
+import { DropdownMenuProps } from '../Menu/Menu';
+import { DropdownTriggerProps } from '../Trigger/Trigger';
 
 const DownshiftContext = React.createContext({});
 
@@ -24,18 +25,18 @@ interface Downshift<Item> {
 }
 
 interface DownshiftComponentsProps<Item> extends Omit<DownshiftProps<Item>, 'children'> {
-  children: React.ReactNode[];
+  children: React.ReactNode;
 }
 
 interface ItemProps<Item> extends DropdownItemProps, GetItemPropsOptions<Item> {
   children: ReactNode;
 }
 
-interface MenuProps extends Omit<DropdownProps<DropdownItem>, 'onChange'>, GetMenuPropsOptions, GetPropsCommonOptions {
+interface MenuProps extends DropdownMenuProps, GetMenuPropsOptions, GetPropsCommonOptions {
   children: ReactNode;
 }
 
-type ToggleProps = DropdownToggleProps & GetToggleButtonPropsOptions;
+type TriggerProps = DropdownTriggerProps & GetToggleButtonPropsOptions;
 
 function DownshiftComponents({ children, ...rest }: DownshiftComponentsProps<DropdownItem>) {
   return (
@@ -50,9 +51,9 @@ function DownshiftComponents({ children, ...rest }: DownshiftComponentsProps<Dro
 }
 
 function withDownshift(
-  type: 'toggle',
-  Component: FunctionComponent<ToggleProps & Downshift<DropdownItem>>,
-): ComponentType<ToggleProps>;
+  type: 'trigger',
+  Component: FunctionComponent<TriggerProps & Downshift<DropdownItem>>,
+): ComponentType<TriggerProps>;
 function withDownshift(
   type: 'item',
   Component: FunctionComponent<ItemProps<DropdownItem> & Downshift<DropdownItem>>,

--- a/packages/plab/src/components/Dropdown/Dropdown.tsx
+++ b/packages/plab/src/components/Dropdown/Dropdown.tsx
@@ -1,66 +1,23 @@
 import { ControllerStateAndHelpers } from 'downshift';
-import { Placement } from 'popper.js';
 import React from 'react';
-import { Manager, Popper, Reference } from 'react-popper';
+import { Manager } from 'react-popper';
 
-import { Button } from '../Button';
-
-import { StyledDropdown } from './styled';
-import { withDownshift, Downshift } from './Downshift/Downshift';
+import { Downshift } from './Downshift/Downshift';
 import { DropdownItem } from './Item/Item';
+import { DropdownMenu } from './Menu/Menu';
+import { DropdownTrigger } from './Trigger/Trigger';
 
 export interface DropdownProps<Item> {
-  maxHeight?: number;
-  placement?: Placement;
   onChange?(item: Item | null, value: string | string[] | number, extras: ControllerStateAndHelpers<Item>): void;
 }
 
-export interface DropdownToggleProps {
-  component: typeof Button;
-}
-
-const Toggle = withDownshift(
-  'toggle',
-  ({ downshift: { getToggleButtonProps }, component: ToggleComponent, ...rest }) => (
-    <Reference>
-      {({ ref }) => (
-        <ToggleComponent {...getToggleButtonProps(rest)} ref={ref}>
-          Open
-        </ToggleComponent>
-      )}
-    </Reference>
-  ),
-);
-
-const Menu = withDownshift(
-  'menu',
-  ({
-    downshift: { isOpen, getMenuProps },
-    children,
-    maxHeight,
-    placement: selectedPlacement,
-    suppressRefError,
-    ...rest
-  }) => (
-    <Popper placement={selectedPlacement} modifiers={{ offset: { offset: '0, 10' } }}>
-      {({ placement, ref, style }) =>
-        isOpen && (
-          <div ref={ref} style={style} data-placement={placement}>
-            <StyledDropdown maxHeight={maxHeight} {...getMenuProps(rest, { suppressRefError })}>
-              {children}
-            </StyledDropdown>
-          </div>
-        )
-      }
-    </Popper>
-  ),
-);
-
 export class Dropdown extends React.PureComponent<DropdownProps<DropdownItem>> {
   static Item = DropdownItem;
+  static Menu = DropdownMenu;
+  static Trigger = DropdownTrigger;
 
   render() {
-    const { children, maxHeight, onChange, placement, ...props } = this.props;
+    const { children, onChange, ...props } = this.props;
 
     return (
       <Manager>
@@ -71,11 +28,9 @@ export class Dropdown extends React.PureComponent<DropdownProps<DropdownItem>> {
               selectedItem && onChange && onChange(selectedItem, itemToString(selectedItem), { itemToString, ...rest })
             );
           }}
+          {...props}
         >
-          <Toggle component={Button} />
-          <Menu maxHeight={maxHeight} placement={placement} {...props}>
-            {children}
-          </Menu>
+          {children}
         </Downshift>
       </Manager>
     );

--- a/packages/plab/src/components/Dropdown/Menu/Menu.tsx
+++ b/packages/plab/src/components/Dropdown/Menu/Menu.tsx
@@ -1,0 +1,47 @@
+import { Placement } from 'popper.js';
+import React from 'react';
+import { Popper } from 'react-popper';
+
+import { withDownshift } from '../Downshift/Downshift';
+
+import { StyledDropdownMenu } from './styled';
+
+export interface DropdownMenuProps {
+  children: React.ReactNode;
+  maxHeight?: number;
+  placement?: Placement;
+}
+
+const Menu = withDownshift(
+  'menu',
+  ({
+    downshift: { isOpen, getMenuProps },
+    children,
+    maxHeight,
+    placement: selectedPlacement,
+    suppressRefError,
+    ...rest
+  }) => (
+    <Popper placement={selectedPlacement} modifiers={{ offset: { offset: '0, 10' } }}>
+      {({ placement, ref, style }) =>
+        isOpen && (
+          <div ref={ref} style={style} data-placement={placement}>
+            <StyledDropdownMenu maxHeight={maxHeight} {...getMenuProps(rest, { suppressRefError })}>
+              {children}
+            </StyledDropdownMenu>
+          </div>
+        )
+      }
+    </Popper>
+  ),
+);
+
+export const DropdownMenu = (props: DropdownMenuProps) => {
+  const { children, maxHeight, placement, ...rest } = props;
+
+  return (
+    <Menu maxHeight={maxHeight} placement={placement} {...rest}>
+      {children}
+    </Menu>
+  );
+};

--- a/packages/plab/src/components/Dropdown/Menu/styled.tsx
+++ b/packages/plab/src/components/Dropdown/Menu/styled.tsx
@@ -1,12 +1,11 @@
 import { rem } from 'polished';
 import styled from 'styled-components';
 
-import { defaultTheme } from '../../theme';
+import { defaultTheme } from '../../../theme';
 
-import { DropdownProps } from './Dropdown';
-import { DropdownItem } from './Item/Item';
+import { DropdownMenuProps } from './Menu';
 
-export const StyledDropdown = styled.ul<DropdownProps<DropdownItem>>`
+export const StyledDropdownMenu = styled.ul<DropdownMenuProps>`
   ${({ theme }) => theme.elevation.raised};
 
   background-color: ${({ theme }) => theme.colors.white};
@@ -18,4 +17,4 @@ export const StyledDropdown = styled.ul<DropdownProps<DropdownItem>>`
   padding: ${({ theme }) => theme.spacing.xSmall} 0;
 `;
 
-StyledDropdown.defaultProps = { theme: defaultTheme };
+StyledDropdownMenu.defaultProps = { theme: defaultTheme };

--- a/packages/plab/src/components/Dropdown/Trigger/Trigger.tsx
+++ b/packages/plab/src/components/Dropdown/Trigger/Trigger.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Reference, RefHandler } from 'react-popper';
+
+import { withDownshift } from '../Downshift/Downshift';
+
+export interface DropdownTriggerProps {
+  children: React.ReactNode;
+}
+
+const Trigger = withDownshift('trigger', ({ downshift: { getToggleButtonProps }, children, ...rest }) => {
+  const toggleWithProps = (ref: RefHandler) =>
+    React.Children.map(children, dropdownToggle => {
+      if (!React.isValidElement(dropdownToggle)) {
+        return null;
+      }
+
+      return React.cloneElement(dropdownToggle as React.ReactElement<any>, { ...getToggleButtonProps(rest), ref });
+    });
+
+  return <Reference>{({ ref }) => toggleWithProps(ref)}</Reference>;
+});
+
+export const DropdownTrigger = ({ children, ...props }: DropdownTriggerProps) => (
+  <Trigger {...props}>{children}</Trigger>
+);

--- a/packages/storybook/src/Dropdown.story.tsx
+++ b/packages/storybook/src/Dropdown.story.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, Flex } from '@bigcommerce/plab';
+import { Button, Dropdown, Flex } from '@bigcommerce/plab';
 import { action } from '@storybook/addon-actions';
 import { number, select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
@@ -25,42 +25,48 @@ const placement: Placement[] = [
 
 storiesOf('Dropdown', module).add('Overview', () => (
   <Flex justifyContent="space-around">
-    <Dropdown
-      maxHeight={number('maxHeight', 300)}
-      onChange={action('onChange')}
-      placement={select('placement', placement, 'bottom')}
-    >
-      <Dropdown.Item value={1}>Option</Dropdown.Item>
-      <Dropdown.Item value={2}>Option</Dropdown.Item>
-      <Dropdown.Item value={3}>Option</Dropdown.Item>
-      <Dropdown.Item value={4}>Option</Dropdown.Item>
-      <Dropdown.Item value={5}>Option</Dropdown.Item>
-      <Dropdown.Item value={6}>Option</Dropdown.Item>
-      <Dropdown.Item value={7}>Option</Dropdown.Item>
-      <Dropdown.Item value={8}>Option</Dropdown.Item>
-      <Dropdown.Item value={9}>Option</Dropdown.Item>
-      <Dropdown.Item value={10}>Option</Dropdown.Item>
-      <Dropdown.Item value={11}>Option</Dropdown.Item>
-      <Dropdown.Item value={12}>Option</Dropdown.Item>
-      <Dropdown.Item value={13}>Option</Dropdown.Item>
-      <Dropdown.Item value={14}>Option</Dropdown.Item>
-      <Dropdown.Item value={15}>Option</Dropdown.Item>
-      <Dropdown.Item value={16}>Option</Dropdown.Item>
+    <Dropdown onChange={action('onChange')}>
+      <Dropdown.Trigger>
+        <Button>Open</Button>
+      </Dropdown.Trigger>
+      <Dropdown.Menu maxHeight={number('maxHeight', 300)} placement={select('placement', placement, 'bottom')}>
+        <Dropdown.Item value={1}>Option</Dropdown.Item>
+        <Dropdown.Item value={2}>Option</Dropdown.Item>
+        <Dropdown.Item value={3}>Option</Dropdown.Item>
+        <Dropdown.Item value={4}>Option</Dropdown.Item>
+        <Dropdown.Item value={5}>Option</Dropdown.Item>
+        <Dropdown.Item value={6}>Option</Dropdown.Item>
+        <Dropdown.Item value={7}>Option</Dropdown.Item>
+        <Dropdown.Item value={8}>Option</Dropdown.Item>
+        <Dropdown.Item value={9}>Option</Dropdown.Item>
+        <Dropdown.Item value={10}>Option</Dropdown.Item>
+        <Dropdown.Item value={11}>Option</Dropdown.Item>
+        <Dropdown.Item value={12}>Option</Dropdown.Item>
+        <Dropdown.Item value={13}>Option</Dropdown.Item>
+        <Dropdown.Item value={14}>Option</Dropdown.Item>
+        <Dropdown.Item value={15}>Option</Dropdown.Item>
+        <Dropdown.Item value={16}>Option</Dropdown.Item>
+      </Dropdown.Menu>
     </Dropdown>
 
-    <Dropdown maxHeight={number('maxHeight', 300)} placement={select('placement', placement, 'bottom')}>
-      <Dropdown.Item>
-        <a href="#">Option</a>
-      </Dropdown.Item>
-      <Dropdown.Item>
-        <a href="#">Option</a>
-      </Dropdown.Item>
-      <Dropdown.Item>
-        <a href="#">Option</a>
-      </Dropdown.Item>
-      <Dropdown.Item>
-        <a href="#">Option</a>
-      </Dropdown.Item>
+    <Dropdown>
+      <Dropdown.Trigger>
+        <Button>Open</Button>
+      </Dropdown.Trigger>
+      <Dropdown.Menu maxHeight={number('maxHeight', 300)} placement={select('placement', placement, 'bottom')}>
+        <Dropdown.Item>
+          <a href="#">Option</a>
+        </Dropdown.Item>
+        <Dropdown.Item>
+          <a href="#">Option</a>
+        </Dropdown.Item>
+        <Dropdown.Item>
+          <a href="#">Option</a>
+        </Dropdown.Item>
+        <Dropdown.Item>
+          <a href="#">Option</a>
+        </Dropdown.Item>
+      </Dropdown.Menu>
     </Dropdown>
   </Flex>
 ));


### PR DESCRIPTION
Dropdown will now accept a `DropdownTrigger` child that contains the component/element that will be the trigger for the Dropdown.

As such, there's now also a `DropdownMenu` component that contains all `DropdownItems`.

New markdown will be like so:

```typescript
    <Dropdown onChange={action('onChange')}>
      <Dropdown.Trigger>
        <Button>Open</Button>
      </Dropdown.Trigger>
      <Dropdown.Menu maxHeight={number('maxHeight', 300)} placement={select('placement', placement, 'bottom')}>
        <Dropdown.Item value={1}>Option</Dropdown.Item>
        <Dropdown.Item value={2}>Option</Dropdown.Item>
        <Dropdown.Item value={3}>Option</Dropdown.Item>
        <Dropdown.Item value={4}>Option</Dropdown.Item>
        <Dropdown.Item value={5}>Option</Dropdown.Item>
        <Dropdown.Item value={6}>Option</Dropdown.Item>
        <Dropdown.Item value={7}>Option</Dropdown.Item>
        <Dropdown.Item value={8}>Option</Dropdown.Item>
        <Dropdown.Item value={9}>Option</Dropdown.Item>
        <Dropdown.Item value={10}>Option</Dropdown.Item>
        <Dropdown.Item value={11}>Option</Dropdown.Item>
        <Dropdown.Item value={12}>Option</Dropdown.Item>
        <Dropdown.Item value={13}>Option</Dropdown.Item>
        <Dropdown.Item value={14}>Option</Dropdown.Item>
        <Dropdown.Item value={15}>Option</Dropdown.Item>
        <Dropdown.Item value={16}>Option</Dropdown.Item>
      </Dropdown.Menu>
    </Dropdown>
```