### PR TITLE
feat(plab): add Link component

### DIFF
--- a/packages/plab/src/components/Link/Link.tsx
+++ b/packages/plab/src/components/Link/Link.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import { StyledLink } from './styled';
+
+export const Link: React.FunctionComponent<React.AnchorHTMLAttributes<{}>> = props => <StyledLink {...props} />;

--- a/packages/plab/src/components/Link/index.ts
+++ b/packages/plab/src/components/Link/index.ts
@@ -1,0 +1,1 @@
+export * from './Link';

--- a/packages/plab/src/components/Link/styled.tsx
+++ b/packages/plab/src/components/Link/styled.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+import { defaultTheme } from '../../theme';
+
+export const StyledLink = styled.a`
+  color: ${({ theme }) => theme.colors.primary};
+  text-decoration: none;
+`;
+
+StyledLink.defaultProps = { theme: defaultTheme };

--- a/packages/plab/src/components/index.ts
+++ b/packages/plab/src/components/index.ts
@@ -7,6 +7,7 @@ export * from './GlobalStyle';
 export * from './Grid';
 export * from './Icons';
 export * from './Input';
+export * from './Link';
 export * from './Lozenge';
 export * from './Modal';
 export * from './Panel';

--- a/packages/storybook/src/Link.story.tsx
+++ b/packages/storybook/src/Link.story.tsx
@@ -1,0 +1,15 @@
+import { H3, Link, Panel } from '@bigcommerce/plab';
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+
+storiesOf('Link', module).add('Overview', () => (
+  <div style={{ padding: '2rem' }}>
+    <Panel>
+      <H3>Links that point to other places</H3>
+      Links are not underlined and have the correct color.&nbsp;
+      <Link href="https://www.bigcommerce.com" target="_blank">
+        Learn more.
+      </Link>
+    </Panel>
+  </div>
+));


### PR DESCRIPTION
## What?
- Adds a Link component that is basically an anchor tag with the right color of blue and without underline

## Why
- For places where we do things like `New to Bigcommerce? <a href="...">Learn more</a>`

<img width="1067" alt="link" src="https://user-images.githubusercontent.com/6025510/54638464-136d8480-4a59-11e9-82b3-b179219e9a1b.png">

## Notes
Feedback welcome on naming, eg `Link` vs `A`