### PR TITLE
feat(plab): margin mixin

### DIFF
--- a/packages/plab/src/components/Button/styled.tsx
+++ b/packages/plab/src/components/Button/styled.tsx
@@ -42,7 +42,7 @@ export const StyledButton = styled.button<ButtonProps>`
     margin-left: ${({ theme }) => theme.spacing.medium};
   }
 
-  ${({ theme }) => theme.breakpoints.medium} {
+  ${({ theme }) => theme.breakpoints.tablet} {
     width: auto;
   }
 

--- a/packages/plab/src/components/Flex/styled.tsx
+++ b/packages/plab/src/components/Flex/styled.tsx
@@ -10,7 +10,7 @@ export const StyledFlex = styled.div<FlexProps>`
   align-items: ${({ alignItems }) => alignItems};
   justify-content: ${({ justifyContent }) => justifyContent};
 
-  ${({ theme }) => theme.breakpoints.medium} {
+  ${({ theme }) => theme.breakpoints.tablet} {
     flex-direction: ${({ flexDirection }) => flexDirection};
   }
 `;

--- a/packages/plab/src/components/Form/Row/styled.tsx
+++ b/packages/plab/src/components/Form/Row/styled.tsx
@@ -11,7 +11,7 @@ interface StyledRowProps {
 export const StyledRow = styled.div<StyledRowProps>`
   margin-bottom: ${({ theme }) => theme.spacing.medium};
 
-  ${({ theme }) => theme.breakpoints.medium} {
+  ${({ theme }) => theme.breakpoints.tablet} {
     display: grid;
     grid-gap: ${({ theme }) => theme.spacing.medium};
 

--- a/packages/plab/src/mixins/margins/__snapshots__/spec.tsx.snap
+++ b/packages/plab/src/mixins/margins/__snapshots__/spec.tsx.snap
@@ -1,0 +1,204 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`responsive and non responsive combination 1`] = `
+.c0 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+@media (max-width:719px) {
+  .c0 {
+    margin-left: 0;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    margin-left: 0.75rem;
+  }
+}
+
+@media (min-width:1025px) {
+  .c0 {
+    margin-left: 1rem;
+  }
+}
+
+<div
+  class="c0"
+/>
+`;
+
+exports[`responsive margin 1`] = `
+@media (max-width:719px) {
+  .c0 {
+    margin: 0;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    margin: 0.75rem;
+  }
+}
+
+@media (min-width:1025px) {
+  .c0 {
+    margin: 1rem;
+  }
+}
+
+<div
+  class="c0"
+/>
+`;
+
+exports[`responsive marginBottom 1`] = `
+@media (max-width:719px) {
+  .c0 {
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    margin-bottom: 0.75rem;
+  }
+}
+
+@media (min-width:1025px) {
+  .c0 {
+    margin-bottom: 1rem;
+  }
+}
+
+<div
+  class="c0"
+/>
+`;
+
+exports[`responsive marginHorizontal 1`] = `
+@media (max-width:719px) {
+  .c0 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    margin-left: 0.75rem;
+    margin-right: 0.75rem;
+  }
+}
+
+@media (min-width:1025px) {
+  .c0 {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+}
+
+<div
+  class="c0"
+/>
+`;
+
+exports[`responsive marginLeft 1`] = `
+@media (max-width:719px) {
+  .c0 {
+    margin-left: 0;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    margin-left: 0.75rem;
+  }
+}
+
+@media (min-width:1025px) {
+  .c0 {
+    margin-left: 1rem;
+  }
+}
+
+<div
+  class="c0"
+/>
+`;
+
+exports[`responsive marginRight 1`] = `
+@media (max-width:719px) {
+  .c0 {
+    margin-right: 0;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    margin-right: 0.75rem;
+  }
+}
+
+@media (min-width:1025px) {
+  .c0 {
+    margin-right: 1rem;
+  }
+}
+
+<div
+  class="c0"
+/>
+`;
+
+exports[`responsive marginTop 1`] = `
+@media (max-width:719px) {
+  .c0 {
+    margin-top: 0;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    margin-top: 0.75rem;
+  }
+}
+
+@media (min-width:1025px) {
+  .c0 {
+    margin-top: 1rem;
+  }
+}
+
+<div
+  class="c0"
+/>
+`;
+
+exports[`responsive marginVertical 1`] = `
+@media (max-width:719px) {
+  .c0 {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    margin-top: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+}
+
+@media (min-width:1025px) {
+  .c0 {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+}
+
+<div
+  class="c0"
+/>
+`;

--- a/packages/plab/src/mixins/margins/index.ts
+++ b/packages/plab/src/mixins/margins/index.ts
@@ -1,0 +1,1 @@
+export { withMargins, MarginProps } from './margins';

--- a/packages/plab/src/mixins/margins/margins.tsx
+++ b/packages/plab/src/mixins/margins/margins.tsx
@@ -1,0 +1,66 @@
+import { css } from 'styled-components';
+
+import { ThemeInterface } from '../../theme';
+import { Breakpoints } from '../../theme/system/breakpoints';
+import { Spacing } from '../../theme/system/spacing';
+
+type SingleMarginProp = keyof Spacing;
+type ResponsiveMarginProp = { [key in keyof Breakpoints]?: keyof Spacing };
+type MarginProp = SingleMarginProp | ResponsiveMarginProp;
+type MarginKey = 'margin' | 'margin-top' | 'margin-right' | 'margin-bottom' | 'margin-left';
+type MarginObject = { [key in MarginKey]: string | 0 };
+
+export interface MarginProps {
+  margin?: MarginProp;
+  marginTop?: MarginProp;
+  marginRight?: MarginProp;
+  marginBottom?: MarginProp;
+  marginLeft?: MarginProp;
+  marginVertical?: MarginProp;
+  marginHorizontal?: MarginProp;
+}
+
+export const withMargins = () => css<MarginProps>`
+  ${({ margin, theme }) => margin && getMargins(margin, theme, 'margin')};
+  ${({ marginTop, theme }) => marginTop && getMargins(marginTop, theme, 'margin-top')};
+  ${({ marginRight, theme }) => marginRight && getMargins(marginRight, theme, 'margin-right')};
+  ${({ marginBottom, theme }) => marginBottom && getMargins(marginBottom, theme, 'margin-bottom')};
+  ${({ marginLeft, theme }) => marginLeft && getMargins(marginLeft, theme, 'margin-left')};
+  ${({ marginVertical, theme }) => marginVertical && getMargins(marginVertical, theme, 'margin-top', 'margin-bottom')};
+  ${({ marginHorizontal, theme }) =>
+    marginHorizontal && getMargins(marginHorizontal, theme, 'margin-left', 'margin-right')};
+`;
+
+function getMargins(margin: MarginProp, theme: ThemeInterface, ...marginKeys: MarginKey[]) {
+  if (typeof margin === 'object') {
+    return getResponsiveMargins(margin, theme, marginKeys);
+  }
+
+  if (typeof margin === 'string') {
+    return getSimpleMargins(margin, theme, marginKeys);
+  }
+
+  return css``;
+}
+
+function getSimpleMargins(margin: SingleMarginProp, theme: ThemeInterface, marginKeys: MarginKey[]) {
+  return marginKeys.reduce<MarginObject>(
+    (acc, marginKey) => {
+      acc[marginKey] = theme.spacing[margin];
+
+      return acc;
+    },
+    {} as MarginObject,
+  );
+}
+
+function getResponsiveMargins(responsiveMargin: ResponsiveMarginProp, theme: ThemeInterface, marginKeys: MarginKey[]) {
+  return (Object.keys(responsiveMargin) as Array<keyof Breakpoints>).map(
+    breakpointKey =>
+      css`
+        ${theme.breakpoints[breakpointKey]} {
+          ${getSimpleMargins(responsiveMargin[breakpointKey] as keyof Spacing, theme, marginKeys)}
+        }
+      `,
+  );
+}

--- a/packages/plab/src/mixins/margins/spec.tsx
+++ b/packages/plab/src/mixins/margins/spec.tsx
@@ -1,0 +1,152 @@
+import 'jest-styled-components';
+import React from 'react';
+import { render } from 'react-testing-library';
+import styled from 'styled-components';
+
+import { defaultTheme } from '../../theme';
+
+import { withMargins, MarginProps } from './margins';
+
+const TestComponent = styled.div<MarginProps>`
+  ${withMargins()};
+`;
+
+TestComponent.defaultProps = { theme: defaultTheme };
+
+test('margin', () => {
+  const { container } = render(<TestComponent margin="medium" />);
+
+  expect(container.firstChild).toHaveStyle('margin: 1rem');
+});
+
+test('marginTop', () => {
+  const { container } = render(<TestComponent marginTop="medium" />);
+
+  expect(container.firstChild).toHaveStyle('margin-top: 1rem');
+
+  expect(container.firstChild).not.toHaveStyle('margin: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-right: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-left: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-bottom: 1rem');
+});
+
+test('marginRight', () => {
+  const { container } = render(<TestComponent marginRight="medium" />);
+
+  expect(container.firstChild).toHaveStyle('margin-right: 1rem');
+
+  expect(container.firstChild).not.toHaveStyle('margin: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-top: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-left: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-bottom: 1rem');
+});
+
+test('marginBottom', () => {
+  const { container } = render(<TestComponent marginBottom="medium" />);
+
+  expect(container.firstChild).toHaveStyle('margin-bottom: 1rem');
+
+  expect(container.firstChild).not.toHaveStyle('margin: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-top: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-right: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-left: 1rem');
+});
+
+test('marginLeft', () => {
+  const { container } = render(<TestComponent marginLeft="medium" />);
+
+  expect(container.firstChild).toHaveStyle('margin-left: 1rem');
+
+  expect(container.firstChild).not.toHaveStyle('margin: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-top: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-right: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-bottom: 1rem');
+});
+
+test('marginVertical', () => {
+  const { container } = render(<TestComponent marginVertical="medium" />);
+
+  expect(container.firstChild).toHaveStyle('margin-top: 1rem');
+  expect(container.firstChild).toHaveStyle('margin-bottom: 1rem');
+
+  expect(container.firstChild).not.toHaveStyle('margin: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-right: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-left: 1rem');
+});
+
+test('marginHorizontal', () => {
+  const { container } = render(<TestComponent marginHorizontal="medium" />);
+
+  expect(container.firstChild).toHaveStyle('margin-left: 1rem');
+  expect(container.firstChild).toHaveStyle('margin-right: 1rem');
+
+  expect(container.firstChild).not.toHaveStyle('margin: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-top: 1rem');
+  expect(container.firstChild).not.toHaveStyle('margin-bottom: 1rem');
+});
+
+test('simple margins combination', () => {
+  const { container } = render(<TestComponent marginTop="medium" marginBottom="none" marginRight="small" />);
+
+  expect(container.firstChild).toHaveStyle('margin-top: 1rem');
+  expect(container.firstChild).toHaveStyle('margin-bottom: 0px');
+  expect(container.firstChild).toHaveStyle('margin-right: 0.75rem');
+});
+
+test('responsive margin', () => {
+  const { container } = render(<TestComponent margin={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('responsive marginTop', () => {
+  const { container } = render(<TestComponent marginTop={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('responsive marginRight', () => {
+  const { container } = render(<TestComponent marginRight={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('responsive marginBottom', () => {
+  const { container } = render(<TestComponent marginBottom={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('responsive marginLeft', () => {
+  const { container } = render(<TestComponent marginLeft={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('responsive marginVertical', () => {
+  const { container } = render(
+    <TestComponent marginVertical={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('responsive marginHorizontal', () => {
+  const { container } = render(
+    <TestComponent marginHorizontal={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('responsive and non responsive combination', () => {
+  const { container } = render(
+    <TestComponent
+      marginTop="none"
+      marginLeft={{ mobile: 'none', tablet: 'small', desktop: 'medium' }}
+      marginBottom="medium"
+    />,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/packages/plab/src/theme/system/breakpoints.ts
+++ b/packages/plab/src/theme/system/breakpoints.ts
@@ -1,9 +1,11 @@
 export interface Breakpoints {
-  medium: string;
-  large: string;
+  mobile: string;
+  tablet: string;
+  desktop: string;
 }
 
 export const breakpoints: Breakpoints = {
-  medium: `@media (min-width: 720px)`,
-  large: `@media (min-width: 1025px)`,
+  mobile: `@media (max-width: 719px)`,
+  tablet: `@media (min-width: 720px)`,
+  desktop: `@media (min-width: 1025px)`,
 };

--- a/packages/plab/src/theme/system/spacing.ts
+++ b/packages/plab/src/theme/system/spacing.ts
@@ -3,6 +3,7 @@ import { rem } from 'polished';
 import { ThemeOptions } from '../index';
 
 export interface Spacing {
+  none: 0;
   xxSmall: string;
   xSmall: string;
   small: string;
@@ -14,6 +15,7 @@ export interface Spacing {
 }
 
 export const createSpacing = (options: ThemeOptions): Spacing => ({
+  none: 0,
   xxSmall: rem(4, options.htmlFontSize),
   xSmall: rem(8, options.htmlFontSize),
   small: rem(12, options.htmlFontSize),


### PR DESCRIPTION
Introducing a helper for margins since now we are locking all styles we need a way to tweak margins here and there.

Check tests for usage 👀 supports responsive and non-responsive margins.

The idea is to add `withMargins()` to most of the components.