### PR TITLE
chore(all): setup releases

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'scope-enum': [2, 'always', ['all', 'configs', 'story', 'component']]
+    'scope-enum': [2, 'always', ['all', 'configs', 'story', 'component', 'release']]
   }
 };

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,13 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "independent",
   "npmClient": "yarn",
-  "useWorkspaces": true
+  "useWorkspaces": true,
+  "command": {
+    "version": {
+      "allowBranch": "master",
+      "conventionalCommits": true,
+      "message": "chore(release): publish"
+    }
+  }
 }

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@bigcommerce/big-design",
   "version": "0.1.0",
+  "private": true,
   "sideEffects": false,
   "main": "dist/big-design.cjs.js",
   "module": "dist/big-design.es.js",


### PR DESCRIPTION
Setup releases + automated Changelogs.

Using `"private": true` in `@bigcommerce/big-design` to avoid publishing it by mistake. We should add a `publishConfig` with a private registry when we get one.