### PR TITLE
fix(component): ignore dist files on lint-staged

### DIFF
--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -26,11 +26,14 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": [
-      "tslint --fix",
-      "prettier --write",
-      "git add"
-    ]
+    "linters": {
+      "*.{js,ts,tsx}": [
+        "tslint --fix",
+        "prettier --write",
+        "git add"
+      ]
+    },
+    "ignore": ["dist/**"]
   },
   "dependencies": {
     "@types/hoist-non-react-statics": "^3.3.0",


### PR DESCRIPTION
Ignore `dist` files on commit hooks.

If we had our private registry, we wouldn't need to do this 🤕 