### PR TITLE
chore(all): install with --frozen-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ before_install:
 
 cache: yarn
 
+install:
+  - yarn install --frozen-lockfile
+
 script: yarn run ci


### PR DESCRIPTION
Fail travis build if `yarn.lock` is out of sync.