### PR TITLE
feat(component): add ellipsis prop to Typography components

### DIFF
--- a/packages/big-design/src/components/Typography/Typography.tsx
+++ b/packages/big-design/src/components/Typography/Typography.tsx
@@ -4,9 +4,13 @@ import { MarginProps } from '../../mixins';
 
 import { StyledH0, StyledH1, StyledH2, StyledH3, StyledH4, StyledSmall, StyledText } from './styled';
 
-export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & MarginProps;
-export type SmallProps = React.HTMLAttributes<HTMLParagraphElement> & MarginProps;
-export type HeadingProps = React.HTMLAttributes<HTMLHeadingElement> & MarginProps;
+export interface TypographyProps {
+  ellipsis?: boolean;
+}
+
+export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & MarginProps & TypographyProps;
+export type SmallProps = React.HTMLAttributes<HTMLParagraphElement> & MarginProps & TypographyProps;
+export type HeadingProps = React.HTMLAttributes<HTMLHeadingElement> & MarginProps & TypographyProps;
 
 // Private
 export const StyleableText = StyledText;

--- a/packages/big-design/src/components/Typography/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Typography/__snapshots__/spec.tsx.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render H0 1`] = `
+.c0 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 3rem;
+  font-weight: 200;
+  line-height: 3rem;
+  margin: 0 0 1.5rem;
+}
+
+<h1
+  class="c0"
+>
+  Test
+</h1>
+`;
+
+exports[`render H1 1`] = `
+.c0 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 2rem;
+  font-weight: 300;
+  line-height: 2.5rem;
+  margin: 0 0 1.5rem;
+}
+
+<h1
+  class="c0"
+>
+  Test
+</h1>
+`;
+
+exports[`render H2 1`] = `
+.c0 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 2rem;
+}
+
+<h2
+  class="c0"
+>
+  Test
+</h2>
+`;
+
+exports[`render H3 1`] = `
+.c0 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.75rem;
+  margin: 0 0 0.75rem;
+}
+
+<h3
+  class="c0"
+>
+  Test
+</h3>
+`;
+
+exports[`render H4 1`] = `
+.c0 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+<h4
+  class="c0"
+>
+  Test
+</h4>
+`;
+
+exports[`render Small 1`] = `
+.c0 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c0:last-child {
+  margin-bottom: 0;
+}
+
+<p
+  class="c0"
+>
+  Test
+</p>
+`;
+
+exports[`render Text 1`] = `
+.c0 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c0:last-child {
+  margin-bottom: 0;
+}
+
+<p
+  class="c0"
+>
+  Test
+</p>
+`;
+
+exports[`render Text with ellipsis 1`] = `
+.c0 {
+  color: #313440;
+  margin: 0 0 1rem;
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c0:last-child {
+  margin-bottom: 0;
+}
+
+<p
+  class="c0"
+>
+  Test with ellipsis
+</p>
+`;

--- a/packages/big-design/src/components/Typography/spec.tsx
+++ b/packages/big-design/src/components/Typography/spec.tsx
@@ -1,0 +1,130 @@
+import 'jest-styled-components';
+import React from 'react';
+import { render } from 'react-testing-library';
+
+import { H0, H1, H2, H3, H4, Small, Text } from './Typography';
+
+test('render H0', () => {
+  const { container } = render(<H0>Test</H0>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render H1', () => {
+  const { container } = render(<H1>Test</H1>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render H2', () => {
+  const { container } = render(<H2>Test</H2>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render H3', () => {
+  const { container } = render(<H3>Test</H3>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render H4', () => {
+  const { container } = render(<H4>Test</H4>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render Small', () => {
+  const { container } = render(<Small>Test</Small>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render Text', () => {
+  const { container } = render(<Text>Test</Text>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render Text with ellipsis', () => {
+  const { container } = render(<Text ellipsis={true}>Test with ellipsis</Text>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('H0 - does not forward styles', () => {
+  const { container } = render(
+    <H0 className="test" style={{ background: 'red' }}>
+      Test
+    </H0>,
+  );
+
+  expect(container.getElementsByClassName('test').length).toBe(0);
+  expect(container.firstChild).not.toHaveStyle('background: red');
+});
+
+test('H1 - does not forward styles', () => {
+  const { container } = render(
+    <H1 className="test" style={{ background: 'red' }}>
+      Test
+    </H1>,
+  );
+
+  expect(container.getElementsByClassName('test').length).toBe(0);
+  expect(container.firstChild).not.toHaveStyle('background: red');
+});
+
+test('H2 - does not forward styles', () => {
+  const { container } = render(
+    <H2 className="test" style={{ background: 'red' }}>
+      Test
+    </H2>,
+  );
+
+  expect(container.getElementsByClassName('test').length).toBe(0);
+  expect(container.firstChild).not.toHaveStyle('background: red');
+});
+
+test('H3 - does not forward styles', () => {
+  const { container } = render(
+    <H3 className="test" style={{ background: 'red' }}>
+      Test
+    </H3>,
+  );
+
+  expect(container.getElementsByClassName('test').length).toBe(0);
+  expect(container.firstChild).not.toHaveStyle('background: red');
+});
+
+test('H4 - does not forward styles', () => {
+  const { container } = render(
+    <H4 className="test" style={{ background: 'red' }}>
+      Test
+    </H4>,
+  );
+
+  expect(container.getElementsByClassName('test').length).toBe(0);
+  expect(container.firstChild).not.toHaveStyle('background: red');
+});
+
+test('Small - does not forward styles', () => {
+  const { container } = render(
+    <Small className="test" style={{ background: 'red' }}>
+      Test
+    </Small>,
+  );
+
+  expect(container.getElementsByClassName('test').length).toBe(0);
+  expect(container.firstChild).not.toHaveStyle('background: red');
+});
+
+test('Text - does not forward styles', () => {
+  const { container } = render(
+    <Text className="test" style={{ background: 'red' }}>
+      Test
+    </Text>,
+  );
+
+  expect(container.getElementsByClassName('test').length).toBe(0);
+  expect(container.firstChild).not.toHaveStyle('background: red');
+});

--- a/packages/big-design/src/components/Typography/styled.tsx
+++ b/packages/big-design/src/components/Typography/styled.tsx
@@ -1,17 +1,20 @@
+import { ellipsis } from 'polished';
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../mixins';
 import { defaultTheme } from '../../theme';
 
-import { HeadingProps, SmallProps, TextProps } from './Typography';
+import { HeadingProps, SmallProps, TextProps, TypographyProps } from './Typography';
 
-const CommonTextStyles = css`
+const commonTextStyles = (props: TypographyProps) => css`
   color: ${({ theme }) => theme.colors.secondary70};
   margin: 0 0 ${({ theme }) => theme.spacing.medium};
+
+  ${props.ellipsis && ellipsis()};
 `;
 
 export const StyledH0 = styled.h1<HeadingProps>`
-  ${CommonTextStyles};
+  ${props => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.xxxLarge};
   font-weight: ${({ theme }) => theme.typography.fontWeight.extraLight};
   line-height: ${({ theme }) => theme.lineHeight.xxxLarge};
@@ -20,7 +23,7 @@ export const StyledH0 = styled.h1<HeadingProps>`
 `;
 
 export const StyledH1 = styled.h1<HeadingProps>`
-  ${CommonTextStyles};
+  ${props => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.xxLarge};
   font-weight: ${({ theme }) => theme.typography.fontWeight.light};
   line-height: ${({ theme }) => theme.lineHeight.xxLarge};
@@ -29,7 +32,7 @@ export const StyledH1 = styled.h1<HeadingProps>`
 `;
 
 export const StyledH2 = styled.h2<HeadingProps>`
-  ${CommonTextStyles};
+  ${props => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.xLarge};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
   line-height: ${({ theme }) => theme.lineHeight.xLarge};
@@ -37,7 +40,7 @@ export const StyledH2 = styled.h2<HeadingProps>`
 `;
 
 export const StyledH3 = styled.h3<HeadingProps>`
-  ${CommonTextStyles};
+  ${props => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.large};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   line-height: ${({ theme }) => theme.lineHeight.large};
@@ -46,7 +49,7 @@ export const StyledH3 = styled.h3<HeadingProps>`
 `;
 
 export const StyledH4 = styled.h4<HeadingProps>`
-  ${CommonTextStyles};
+  ${props => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   line-height: ${({ theme }) => theme.lineHeight.medium};
@@ -55,7 +58,7 @@ export const StyledH4 = styled.h4<HeadingProps>`
 `;
 
 export const StyledText = styled.p<TextProps>`
-  ${CommonTextStyles};
+  ${props => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
   line-height: ${({ theme }) => theme.lineHeight.medium};
@@ -68,7 +71,7 @@ export const StyledText = styled.p<TextProps>`
 `;
 
 export const StyledSmall = styled.p<SmallProps>`
-  ${CommonTextStyles};
+  ${props => commonTextStyles(props)};
   color: ${({ theme }) => theme.colors.secondary60};
   font-size: ${({ theme }) => theme.typography.fontSize.small};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};


### PR DESCRIPTION
Adds ellipsis prop to all Typography Components, eg:
![image](https://user-images.githubusercontent.com/2752665/58566679-a879c000-81f6-11e9-8764-bf2daa60ed54.png)

@bigcommerce/frontend 