### PR TITLE
fix: use flex to center icon inside Select

### DIFF
--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -4,6 +4,7 @@ import { Manager, Reference } from 'react-popper';
 import scrollIntoView from 'scroll-into-view-if-needed';
 
 import { uniqueId } from '../../utils';
+import { Flex } from '../Flex/Flex';
 import { Input } from '../Input';
 import { ListAction } from '../List/Action/Action';
 import { ListItem } from '../List/Item/Item';
@@ -121,6 +122,21 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
     );
   }
 
+  private renderDropdownIcon() {
+    return (
+      <Flex>
+        <StyledDropdownIcon
+          aria-haspopup={true}
+          aria-label="toggle menu" // Will need to translate this label in the future
+          onClick={this.toggleList}
+          role="button"
+          tabIndex={-1}
+          style={{ outline: 'none' }}
+        />
+      </Flex>
+    );
+  }
+
   private renderLabel() {
     const { label } = this.props;
 
@@ -158,16 +174,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
         {({ ref }) => (
           <Input
             error={error}
-            iconRight={
-              <StyledDropdownIcon
-                aria-haspopup={true}
-                aria-label="toggle menu" // Will need to translate this label in the future
-                onClick={this.toggleList}
-                role="button"
-                tabIndex={-1}
-                style={{ outline: 'none' }}
-              />
-            }
+            iconRight={this.renderDropdownIcon()}
             aria-autocomplete="list"
             id={this.getInputId()}
             onChange={this.handleOnInputChange}


### PR DESCRIPTION
## What?
The icon inside the dropdown was not being centered in a way that plays well with different font-sizes (eg inside a microapp)

## Before
<img width="416" alt="dropdown" src="https://user-images.githubusercontent.com/6025510/60912092-3dd29000-a24a-11e9-813e-86615edf6282.png">

## After
<img width="636" alt="Screen Shot 2019-07-09 at 1 04 28 PM" src="https://user-images.githubusercontent.com/6025510/60912110-44610780-a24a-11e9-91c1-4ec42e60cf8e.png">

## Verified it also looks good in storybook
<img width="252" alt="Screen Shot 2019-07-09 at 1 06 15 PM" src="https://user-images.githubusercontent.com/6025510/60912154-5c388b80-a24a-11e9-81d9-d6599cbe0afa.png">
