### PR TITLE
feat: add InlineFlex component

### DIFF
--- a/packages/big-design/src/components/InlineFlex/InlineFlex.tsx
+++ b/packages/big-design/src/components/InlineFlex/InlineFlex.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { Flex } from './../Flex/Flex';
+import { StyledInlineFlex } from './styled';
+
+export class InlineFlex extends Flex {
+  render() {
+    return <StyledInlineFlex {...this.props} />;
+  }
+}

--- a/packages/big-design/src/components/InlineFlex/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineFlex/__snapshots__/spec.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render inline flex 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+@media (min-width:720px) {
+  .c0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+<span
+  class="c0"
+  direction="row"
+  wrap="nowrap"
+>
+  Flex
+</span>
+`;

--- a/packages/big-design/src/components/InlineFlex/index.ts
+++ b/packages/big-design/src/components/InlineFlex/index.ts
@@ -1,0 +1,1 @@
+export { InlineFlex } from './InlineFlex';

--- a/packages/big-design/src/components/InlineFlex/spec.tsx
+++ b/packages/big-design/src/components/InlineFlex/spec.tsx
@@ -1,0 +1,39 @@
+import 'jest-styled-components';
+import React from 'react';
+import { render } from 'react-testing-library';
+
+import { InlineFlex } from './index';
+
+test('render inline flex', () => {
+  const { container } = render(<InlineFlex>Flex</InlineFlex>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('has display flex', () => {
+  const { container } = render(<InlineFlex>Flex</InlineFlex>);
+
+  expect(container.firstChild).toHaveStyle('display: inline-flex');
+});
+
+test('forwards styles', () => {
+  const { container } = render(
+    <InlineFlex className="test" style={{ background: 'red' }}>
+      Flex
+    </InlineFlex>,
+  );
+
+  expect(container.getElementsByClassName('test').length).toBe(1);
+  expect(container.firstChild).toHaveStyle('background: red');
+});
+
+test('Flex Item forwards styles', () => {
+  const { container } = render(
+    <InlineFlex.Item className="test" style={{ background: 'red' }}>
+      Flex
+    </InlineFlex.Item>,
+  );
+
+  expect(container.getElementsByClassName('test').length).toBe(1);
+  expect(container.firstChild).toHaveStyle('background: red');
+});

--- a/packages/big-design/src/components/InlineFlex/styled.tsx
+++ b/packages/big-design/src/components/InlineFlex/styled.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+import { defaultTheme } from '../../theme';
+import { FlexProps } from '../Flex';
+
+export const StyledInlineFlex = styled.span<FlexProps>`
+  display: inline-flex;
+  flex-direction: column;
+  flex-wrap: ${({ wrap }) => wrap};
+  align-content: ${({ alignContent }) => alignContent};
+  align-items: ${({ alignItems }) => alignItems};
+  justify-content: ${({ justifyContent }) => justifyContent};
+
+  ${({ theme }) => theme.breakpoints.tablet} {
+    flex-direction: ${({ direction }) => direction};
+  }
+`;
+
+StyledInlineFlex.defaultProps = {
+  alignContent: 'stretch',
+  alignItems: 'stretch',
+  direction: 'row',
+  wrap: 'nowrap',
+  justifyContent: 'flex-start',
+  theme: defaultTheme,
+};

--- a/packages/big-design/src/components/index.ts
+++ b/packages/big-design/src/components/index.ts
@@ -7,6 +7,7 @@ export * from './Form';
 export * from './GlobalStyle';
 export * from './Grid';
 export * from './Icons';
+export * from './InlineFlex';
 export * from './Input';
 export * from './Link';
 export * from './Lozenge';

--- a/packages/storybook/stories/InlineFlex.story.tsx
+++ b/packages/storybook/stories/InlineFlex.story.tsx
@@ -1,0 +1,18 @@
+import { H2, InlineFlex, Link, PlusIcon, Text } from '@bigcommerce/big-design';
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+
+storiesOf('InlineFlex', module).add('Overview', () => (
+  <>
+    <H2>Inline flex</H2>
+    <Text>
+      Some text that is inline-flex aligned with some other elements inside it.
+      <Link href="https://www.bigcommerce.com">
+        <InlineFlex alignItems="center">
+          &nbsp;Learn more
+          <PlusIcon size="medium" />
+        </InlineFlex>
+      </Link>
+    </Text>
+  </>
+));


### PR DESCRIPTION
## What?
Adds an `InlineFlex` component. This is needed when trying to flex align items inside an element that is either inline or inline-block.

## The problem
Consider the following design:
<img width="735" alt="Screen Shot 2019-07-10 at 10 26 12 AM" src="https://user-images.githubusercontent.com/6025510/60994652-8b1c3380-a316-11e9-999c-6a18b5d2457b.png">

Markup for this would be something like:
```javascript
<Text>
  If the business manager associated with your page ...
  <Flex alignItems="center">
     <Link href="">Learn more.</Link>
     <LearnMoreIcon />
  </Flex>
</Text>
```

However, the above is marked as invalid html by react because `Text` renders as a `p` and `Flex` renders as a `div`, and a `div` cannot appear as a descendant of `p`. This is just one example of such a scenario.

## Proposed fix
Expose access to an `InlineFlex` component that shares all `Flex` functionality, but is rendered as a `span` with `display: inline-flex`

Decided against using the `as={}` API in styled-components because this fails to forward Box props correctly and also because it screws up some types