### PR TITLE
docs: Fix typo in contributing guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to BigDesign
 
-Currently, BigDesign is a not open for external pull requests and contributions. 
+Currently, BigDesign is not open for external pull requests and contributions.
 
 ## Issues / Bugs
 


### PR DESCRIPTION
## What?
* Remove the extra "a".
* I noticed this typo because yesterday I copied and pasted this file for another BC repo, and @RobinOng spotted it when he reviewed my PR. 😄 

## Why?
* It's a typo.

## Testing / Proof
* None

@bigcommerce/frontend @amckemie 
