### PR TITLE
feat: add required attr to Select component

### DIFF
--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -25,6 +25,7 @@ interface Props {
   label?: React.ReactChild;
   maxHeight?: number;
   placement?: Placement;
+  required?: boolean;
   value: AllHTMLAttributes<HTMLElement>['value'];
   onActionClick?(inputText: string): void;
   onItemChange(value: AllHTMLAttributes<HTMLElement>['value']): void;
@@ -162,7 +163,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
   }
 
   private renderInput() {
-    const { label, placeholder, error } = this.props;
+    const { label, placeholder, error, required } = this.props;
 
     const highlightedItem = this.getItemById(this.state.highlightedId);
     const ariaActiveDescendant = highlightedItem ? { 'aria-activedescendant': highlightedItem.id } : {};
@@ -182,6 +183,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
             onFocus={this.handleOnInputFocus}
             placeholder={placeholder}
             ref={ref}
+            required={required}
             value={this.state.inputText}
             {...ariaActiveDescendant}
             {...ariaControls}

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -453,3 +453,33 @@ test('select should render an error if one is provided', () => {
 
   expect(getByText('You must choose')).toBeInTheDocument();
 });
+
+test('select should have a required attr if set as required', () => {
+  const { getByLabelText } = render(
+    <Select label="Countries" placeholder="Choose country" error="Required" required>
+      <Select.Option value="us">United States</Select.Option>
+      <Select.Option value="mx">Mexico</Select.Option>
+      <Select.Option value="ca">Canada</Select.Option>
+      <Select.Option value="en">England</Select.Option>
+    </Select>,
+  );
+
+  const input = getByLabelText('Countries');
+
+  expect(input.getAttribute('required')).toEqual('');
+});
+
+test('select should not have a required attr if not set as required', () => {
+  const { getByLabelText } = render(
+    <Select label="Countries" placeholder="Choose country">
+      <Select.Option value="us">United States</Select.Option>
+      <Select.Option value="mx">Mexico</Select.Option>
+      <Select.Option value="ca">Canada</Select.Option>
+      <Select.Option value="en">England</Select.Option>
+    </Select>,
+  );
+
+  const input = getByLabelText('Countries');
+
+  expect(input.getAttribute('required')).toEqual(null);
+});

--- a/packages/storybook/stories/Select.story.tsx
+++ b/packages/storybook/stories/Select.story.tsx
@@ -43,6 +43,7 @@ class Story extends React.Component<{}, State> {
           placement={select('placement', placement, 'bottom-start')}
           value={this.state.value}
           error={this.state.value ? undefined : 'You must choose a country'}
+          required
         >
           <Select.Option value="us">United States</Select.Option>
           <Select.Option value="mx">Mexico</Select.Option>


### PR DESCRIPTION
## What?
Adds an optional `required` prop to select component to allow for required inputs inside forms

## Testing done
- Verified `required` attr shows up in the DOM when prop is there
- Unit tested