### PR TITLE
feat(component): add remCalc helper

### DIFF
--- a/packages/big-design/src/components/Form/Row/styled.tsx
+++ b/packages/big-design/src/components/Form/Row/styled.tsx
@@ -1,7 +1,6 @@
-import { rem } from 'polished';
 import styled, { css } from 'styled-components';
 
-import { defaultTheme } from '../../../theme';
+import { defaultTheme, remCalc } from '../../../theme';
 import { StyledInputWrapper } from '../../Input/styled';
 import { StyledTextareaWrapper } from '../../Textarea/styled';
 
@@ -19,18 +18,18 @@ export const StyledRow = styled.div<StyledRowProps>`
     ${({ childrenCount }) =>
       childrenCount === 2 &&
       css`
-        grid-template-columns: repeat(2, ${rem(200)});
+        grid-template-columns: repeat(2, ${remCalc(200)});
       `}
 
     ${({ childrenCount }) =>
       childrenCount === 3 &&
       css`
-        grid-template-columns: repeat(3, ${rem(128)});
+        grid-template-columns: repeat(3, ${remCalc(128)});
       `}
 
     ${StyledInputWrapper},
     ${StyledTextareaWrapper} {
-      max-width: ${rem(416)};
+      max-width: ${remCalc(416)};
     }
   }
 

--- a/packages/big-design/src/components/List/Action/styled.tsx
+++ b/packages/big-design/src/components/List/Action/styled.tsx
@@ -1,7 +1,6 @@
-import { rem } from 'polished';
 import styled from 'styled-components';
 
-import { defaultTheme } from '../../../theme';
+import { defaultTheme, remCalc } from '../../../theme';
 
 import { ListActionProps } from './Action';
 
@@ -9,7 +8,7 @@ export const StyledListAction = styled.li<ListActionProps>`
   border-top: 1px solid ${({ theme }) => theme.colors.secondary30};
   color: ${({ actionType, theme }) => (actionType === 'normal' ? theme.colors.primary : theme.colors.danger)};
   margin-top: ${({ theme }) => theme.spacing.xSmall};
-  min-width: ${rem(256)};
+  min-width: ${remCalc(256)};
   outline: none;
   overflow: hidden;
   padding: ${({ theme }) => theme.spacing.xSmall} 0 0;
@@ -26,7 +25,7 @@ export const StyledListAction = styled.li<ListActionProps>`
 export const Wrapper = styled.div`
   cursor: pointer;
   display: flex;
-  height: ${rem(36)};
+  height: ${remCalc(36)};
   padding: 0 ${({ theme }) => theme.spacing.medium};
   width: 100%;
 `;

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -1,7 +1,6 @@
-import { rem } from 'polished';
 import styled, { css } from 'styled-components';
 
-import { defaultTheme } from '../../../theme';
+import { defaultTheme, remCalc } from '../../../theme';
 
 import { ListItemProps } from './Item';
 
@@ -10,9 +9,9 @@ export const StyledListItem = styled.li<ListItemProps>`
   box-sizing: border-box;
   cursor: default;
   display: flex;
-  height: ${rem(36)};
+  height: ${remCalc(36)};
   justify-content: space-between;
-  min-width: ${rem(256)};
+  min-width: ${remCalc(256)};
   outline: none;
   padding: 0 ${({ theme }) => theme.spacing.medium};
 

--- a/packages/big-design/src/components/List/styled.tsx
+++ b/packages/big-design/src/components/List/styled.tsx
@@ -1,7 +1,7 @@
-import { hideVisually, rem } from 'polished';
+import { hideVisually } from 'polished';
 import styled, { css } from 'styled-components';
 
-import { defaultTheme } from './../../theme';
+import { defaultTheme, remCalc } from './../../theme';
 
 interface StyledList {
   isOpen?: boolean;
@@ -20,7 +20,7 @@ export const StyledList = styled.ul<StyledList>`
       color: ${({ theme }) => theme.colors.secondary70};
       display: inline-block;
       margin: 0;
-      max-height: ${props.maxHeight ? rem(props.maxHeight) : ''};
+      max-height: ${props.maxHeight ? remCalc(props.maxHeight) : ''};
       outline: none;
       overflow-y: scroll;
       padding: ${({ theme }) => theme.spacing.xSmall} 0;

--- a/packages/big-design/src/components/Modal/styled.tsx
+++ b/packages/big-design/src/components/Modal/styled.tsx
@@ -1,7 +1,7 @@
-import { rem, rgba } from 'polished';
+import { rgba } from 'polished';
 import styled, { css } from 'styled-components';
 
-import { defaultTheme } from '../../theme';
+import { defaultTheme, remCalc } from '../../theme';
 import { Flex } from '../Flex';
 
 import { ModalProps } from './Modal';
@@ -53,7 +53,7 @@ export const StyledModalContent = styled(Flex)<{ variant: ModalProps['variant'] 
 
         height: auto;
         left: 50%;
-        max-height: ${rem(664)};
+        max-height: ${remCalc(664)};
         max-width: ${({ theme }) => theme.breakpointValues.tablet};
         top: 50%;
         transform: translate(-50%, -50%);

--- a/packages/big-design/src/components/Textarea/styled.tsx
+++ b/packages/big-design/src/components/Textarea/styled.tsx
@@ -1,8 +1,7 @@
-import { rem } from 'polished';
 import styled, { css } from 'styled-components';
 
 import { defaultTheme } from '../../theme';
-import { addValues } from '../../theme/helpers/helpers';
+import { addValues, remCalc } from '../../theme/helpers/helpers';
 
 import { TextareaProps } from './Textarea';
 
@@ -18,7 +17,7 @@ export const StyledTextarea = styled.textarea<TextareaProps>`
   box-sizing: border-box;
   color: ${({ theme }) => theme.colors.secondary70};
   line-height: ${({ theme }) => theme.lineHeight.medium};
-  max-height: ${rem(224)};
+  max-height: ${remCalc(224)};
   padding: ${({ theme }) => `${theme.spacing.xxSmall} ${theme.spacing.small}`};
   width: 100%;
 

--- a/packages/big-design/src/components/Tooltip/styled.tsx
+++ b/packages/big-design/src/components/Tooltip/styled.tsx
@@ -1,7 +1,6 @@
-import { rem } from 'polished';
 import styled from 'styled-components';
 
-import { defaultTheme } from '../../theme';
+import { defaultTheme, remCalc } from '../../theme';
 
 export const StyledTooltipTrigger = styled.div`
   display: inline-block;
@@ -13,7 +12,7 @@ export const StyledTooltip = styled.div`
   color: ${({ theme }) => theme.colors.white};
   background-color: ${({ theme }) => theme.colors.secondary70};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
-  max-width: ${rem(300)};
+  max-width: ${remCalc(300)};
   padding: ${({ theme }) => `${theme.spacing.small} ${theme.spacing.medium}`};
 `;
 

--- a/packages/big-design/src/theme/helpers/helpers.ts
+++ b/packages/big-design/src/theme/helpers/helpers.ts
@@ -1,4 +1,6 @@
-import { stripUnit, transparentize } from 'polished';
+import { rem, stripUnit, transparentize } from 'polished';
+
+import { themeOptions } from '../options';
 
 export const addValues = (first: string, second: string) => {
   const [firstValue, firstUnit] = stripUnit(first, true);
@@ -20,4 +22,10 @@ export const createRGBA = (color: string, alpha: number) => {
   const calculatedAmount = 1 - alpha;
 
   return transparentize(calculatedAmount, color);
+};
+
+export const remCalc = (value: string | number) => {
+  const { htmlFontSize } = themeOptions.getOptions();
+
+  return rem(value, htmlFontSize);
 };

--- a/packages/big-design/src/theme/index.ts
+++ b/packages/big-design/src/theme/index.ts
@@ -1,3 +1,4 @@
+import { themeOptions, ThemeOptions } from './options';
 import { createBorder, createBorderRadius, Border, BorderRadius } from './system/border';
 import { breakpoints, breakpointValues, Breakpoints, BreakpointValues } from './system/breakpoints';
 import { colors, Colors } from './system/colors';
@@ -9,14 +10,6 @@ import { createTypography, Typography } from './system/typography';
 import { zIndex, ZIndex } from './system/z-index';
 
 export * from './helpers';
-
-export interface ThemeOptions {
-  htmlFontSize: number;
-}
-
-const defaultOptions: ThemeOptions = {
-  htmlFontSize: 16,
-};
 
 export interface ThemeInterface {
   border: Border;
@@ -32,23 +25,20 @@ export interface ThemeInterface {
   zIndex: ZIndex;
 }
 
-export const createTheme = (themeOptions?: Partial<ThemeOptions>): ThemeInterface => {
-  const options: ThemeOptions = {
-    ...defaultOptions,
-    ...themeOptions,
-  };
+export const createTheme = (customOptions: Partial<ThemeOptions> = {}): ThemeInterface => {
+  themeOptions.setOptions(customOptions);
 
   return {
-    border: createBorder(options),
-    borderRadius: createBorderRadius(options),
+    border: createBorder(),
+    borderRadius: createBorderRadius(),
     breakpointValues,
     breakpoints,
     colors,
     elevation,
     keyframes,
-    lineHeight: createLineHeight(options),
-    spacing: createSpacing(options),
-    typography: createTypography(options),
+    lineHeight: createLineHeight(),
+    spacing: createSpacing(),
+    typography: createTypography(),
     zIndex,
   };
 };

--- a/packages/big-design/src/theme/options/index.ts
+++ b/packages/big-design/src/theme/options/index.ts
@@ -1,0 +1,1 @@
+export * from './options';

--- a/packages/big-design/src/theme/options/options.ts
+++ b/packages/big-design/src/theme/options/options.ts
@@ -1,0 +1,24 @@
+export interface ThemeOptions {
+  htmlFontSize: number;
+}
+
+class Options {
+  private options: ThemeOptions = {
+    htmlFontSize: 16,
+  };
+
+  getOptions() {
+    return { ...this.options };
+  }
+
+  setOptions(newOptions: Partial<ThemeOptions>) {
+    this.options = {
+      ...this.options,
+      ...newOptions,
+    };
+
+    return this.getOptions();
+  }
+}
+
+export const themeOptions = new Options();

--- a/packages/big-design/src/theme/system/border.ts
+++ b/packages/big-design/src/theme/system/border.ts
@@ -1,7 +1,6 @@
-import { rem } from 'polished';
 import { css } from 'styled-components';
 
-import { ThemeOptions } from '../index';
+import { remCalc } from '../helpers';
 import { AllStyleInterpolations } from '../styled/types';
 
 export interface Border {
@@ -16,7 +15,7 @@ export interface BorderRadius {
   normal: AllStyleInterpolations;
 }
 
-export const createBorder = (_options: ThemeOptions): Border => ({
+export const createBorder = (): Border => ({
   box: css`
     ${({ theme }) => `1px solid ${theme.colors.secondary30}`};
   `,
@@ -28,8 +27,8 @@ export const createBorder = (_options: ThemeOptions): Border => ({
   none: 'none',
 });
 
-export const createBorderRadius = (options: ThemeOptions): BorderRadius => ({
+export const createBorderRadius = (): BorderRadius => ({
   circle: '50%',
   none: 0,
-  normal: rem(4, options.htmlFontSize),
+  normal: remCalc(4),
 });

--- a/packages/big-design/src/theme/system/line-height.ts
+++ b/packages/big-design/src/theme/system/line-height.ts
@@ -1,6 +1,4 @@
-import { rem } from 'polished';
-
-import { ThemeOptions } from '../index';
+import { remCalc } from '../helpers';
 
 export interface LineHeight {
   small: string;
@@ -11,11 +9,11 @@ export interface LineHeight {
   xxxLarge: string;
 }
 
-export const createLineHeight = (options: ThemeOptions): LineHeight => ({
-  small: rem(20, options.htmlFontSize),
-  medium: rem(24, options.htmlFontSize),
-  large: rem(28, options.htmlFontSize),
-  xLarge: rem(32, options.htmlFontSize),
-  xxLarge: rem(40, options.htmlFontSize),
-  xxxLarge: rem(48, options.htmlFontSize),
+export const createLineHeight = (): LineHeight => ({
+  small: remCalc(20),
+  medium: remCalc(24),
+  large: remCalc(28),
+  xLarge: remCalc(32),
+  xxLarge: remCalc(40),
+  xxxLarge: remCalc(48),
 });

--- a/packages/big-design/src/theme/system/spacing.ts
+++ b/packages/big-design/src/theme/system/spacing.ts
@@ -1,6 +1,4 @@
-import { rem } from 'polished';
-
-import { ThemeOptions } from '../index';
+import { remCalc } from '../helpers';
 
 export interface Spacing {
   none: 0;
@@ -14,14 +12,14 @@ export interface Spacing {
   xxxLarge: string;
 }
 
-export const createSpacing = (options: ThemeOptions): Spacing => ({
+export const createSpacing = (): Spacing => ({
   none: 0,
-  xxSmall: rem(4, options.htmlFontSize),
-  xSmall: rem(8, options.htmlFontSize),
-  small: rem(12, options.htmlFontSize),
-  medium: rem(16, options.htmlFontSize),
-  large: rem(20, options.htmlFontSize),
-  xLarge: rem(24, options.htmlFontSize),
-  xxLarge: rem(32, options.htmlFontSize),
-  xxxLarge: rem(48, options.htmlFontSize),
+  xxSmall: remCalc(4),
+  xSmall: remCalc(8),
+  small: remCalc(12),
+  medium: remCalc(16),
+  large: remCalc(20),
+  xLarge: remCalc(24),
+  xxLarge: remCalc(32),
+  xxxLarge: remCalc(48),
 });

--- a/packages/big-design/src/theme/system/typography.ts
+++ b/packages/big-design/src/theme/system/typography.ts
@@ -1,6 +1,4 @@
-import { rem } from 'polished';
-
-import { ThemeOptions } from '../index';
+import { remCalc } from '../helpers';
 
 export type FontFamily = string;
 
@@ -26,15 +24,15 @@ export interface Typography {
   fontWeight: FontWeight;
 }
 
-export const createTypography = (options: ThemeOptions): Typography => ({
+export const createTypography = (): Typography => ({
   fontFamily: '"Source Sans Pro", "Helvetica Neue", Arial, sans-serif',
   fontSize: {
-    small: rem(14, options.htmlFontSize),
-    medium: rem(16, options.htmlFontSize),
-    large: rem(20, options.htmlFontSize),
-    xLarge: rem(24, options.htmlFontSize),
-    xxLarge: rem(32, options.htmlFontSize),
-    xxxLarge: rem(48, options.htmlFontSize),
+    small: remCalc(14),
+    medium: remCalc(16),
+    large: remCalc(20),
+    xLarge: remCalc(24),
+    xxLarge: remCalc(32),
+    xxxLarge: remCalc(48),
   },
   fontWeight: {
     extraLight: 200,


### PR DESCRIPTION
Adds `remCalc` helper which takes into consideration `htmlFontSize` theme option.

Updated all `rem` calls to `remCalc`