### PR TITLE
feat(story): add CodeSnippet component

### DIFF
--- a/packages/storybook/components/CodePreview/CodePreview.tsx
+++ b/packages/storybook/components/CodePreview/CodePreview.tsx
@@ -1,15 +1,13 @@
 import * as BigDesign from '@bigcommerce/big-design';
 import clipboardCopy from 'clipboard-copy';
-import { default as lightTheme } from 'prism-react-renderer/themes/github';
-import { default as darkTheme } from 'prism-react-renderer/themes/oceanicNext';
 import React, { useContext, useState } from 'react';
 import reactElementToJSXString, { JsxToStringOptions } from 'react-element-to-jsx-string';
 import { LiveEditor, LivePreview, LiveProvider } from 'react-live';
 
+import { SnippetControls } from '../SnippetControls';
 import { CodeEditorThemeContext } from '../StoryWrapper/StoryWrapper';
 
 import { StyledLiveError } from './styled';
-import { PreviewControls } from './PreviewControls';
 
 function getInitialCode(children: React.ReactNode, options: Partial<JsxToStringOptions> = {}): string {
   return typeof children === 'string'
@@ -24,26 +22,18 @@ function getInitialCode(children: React.ReactNode, options: Partial<JsxToStringO
       });
 }
 
-function getTheme(darkEditorTheme: boolean) {
-  return darkEditorTheme ? darkTheme : lightTheme;
-}
-
 export const CodePreview: React.FC<{ options?: Partial<JsxToStringOptions> }> = props => {
   const initialCode = getInitialCode(props.children, props.options);
   const [code, setCode] = useState(initialCode);
-  const { darkEditorTheme, toggleCodeEditorTheme } = useContext(CodeEditorThemeContext);
+  const { editorTheme } = useContext(CodeEditorThemeContext);
 
   return (
     <>
-      <LiveProvider code={code} scope={BigDesign} theme={getTheme(darkEditorTheme)}>
+      <LiveProvider code={code} scope={BigDesign} theme={editorTheme}>
         <BigDesign.Box padding="medium" backgroundColor="white" border="box" borderBottom="none">
           <LivePreview />
         </BigDesign.Box>
-        <PreviewControls
-          copyToClipboard={() => clipboardCopy(code)}
-          resetCode={() => setCode(initialCode)}
-          toggleTheme={toggleCodeEditorTheme}
-        />
+        <SnippetControls copyToClipboard={() => clipboardCopy(code)} resetCode={() => setCode(initialCode)} />
         <BigDesign.Box border="box" borderTop="none">
           <LiveEditor onChange={setCode} />
         </BigDesign.Box>

--- a/packages/storybook/components/CodePreview/index.tsx
+++ b/packages/storybook/components/CodePreview/index.tsx
@@ -1,2 +1,1 @@
 export * from './CodePreview';
-export * from './PreviewControls';

--- a/packages/storybook/components/CodePreview/styled.tsx
+++ b/packages/storybook/components/CodePreview/styled.tsx
@@ -1,4 +1,4 @@
-import { defaultTheme, Flex } from '@bigcommerce/big-design';
+import { defaultTheme } from '@bigcommerce/big-design';
 import { LiveError } from 'react-live';
 import styled from 'styled-components';
 
@@ -9,9 +9,4 @@ export const StyledLiveError = styled(LiveError)`
   padding: ${({ theme }) => theme.spacing.small};
 `;
 
-export const StyledFlex = styled(Flex)`
-  flex-direction: row;
-`;
-
 StyledLiveError.defaultProps = { theme: defaultTheme };
-StyledFlex.defaultProps = { theme: defaultTheme };

--- a/packages/storybook/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/storybook/components/CodeSnippet/CodeSnippet.tsx
@@ -1,0 +1,59 @@
+import { Box } from '@bigcommerce/big-design';
+import clipboardCopy from 'clipboard-copy';
+import React, { useContext } from 'react';
+import { Editor } from 'react-live';
+
+import { SnippetControls } from '../SnippetControls';
+import { CodeEditorThemeContext } from '../StoryWrapper/StoryWrapper';
+
+interface EditorProps {
+  language?: string;
+}
+
+function formatCode(code: string) {
+  const lines = code.split('\n');
+
+  // Remove first line if empty (multiline)
+  if (lines[0].trim() === '') {
+    lines.splice(0, 1);
+  }
+
+  // Remove last line if empty (multiline)
+  if (lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+
+  // Number of whitespaces to remove from each line
+  const padding = lines[0].search(/\S|$/);
+
+  return lines.map(line => line.substr(padding)).join('\n');
+}
+
+function getCode(children: React.ReactNode) {
+  if (typeof children !== 'string') {
+    throw new Error('<CodeSnippet> children must be of type string');
+  }
+
+  return formatCode(children);
+}
+
+export const CodeSnippet: React.FC<EditorProps> = props => {
+  const { children, language } = props;
+  const { editorTheme } = useContext(CodeEditorThemeContext);
+  const code = getCode(children);
+
+  return (
+    <Box border="box">
+      <SnippetControls copyToClipboard={() => clipboardCopy(code)} helperText="Code example" />
+
+      {/* react-live Editor types are wrong, PR submitted */}
+      {/* 
+  // @ts-ignore */}
+      <Editor code={code} theme={editorTheme} language={language} disabled />
+    </Box>
+  );
+};
+
+CodeSnippet.defaultProps = {
+  language: 'jsx',
+};

--- a/packages/storybook/components/CodeSnippet/index.tsx
+++ b/packages/storybook/components/CodeSnippet/index.tsx
@@ -1,0 +1,1 @@
+export * from './CodeSnippet';

--- a/packages/storybook/components/SnippetControls/SnippetControls.tsx
+++ b/packages/storybook/components/SnippetControls/SnippetControls.tsx
@@ -9,14 +9,16 @@ import {
   RestoreIcon,
   Small,
 } from '@bigcommerce/big-design';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
+
+import { CodeEditorThemeContext } from '../StoryWrapper/StoryWrapper';
 
 import { StyledFlex } from './styled';
 
-interface PreviewControlsProps {
+interface SnippetControls {
+  helperText?: string;
   copyToClipboard(): void;
-  resetCode(): void;
-  toggleTheme(): void;
+  resetCode?(): void;
 }
 
 const { colors } = defaultTheme;
@@ -40,14 +42,21 @@ function onCopy(setIsCopying: (copying: boolean) => void, copyToClipboard: () =>
   }, 1000);
 }
 
-export const PreviewControls: React.FC<PreviewControlsProps> = props => {
-  const { copyToClipboard, resetCode, toggleTheme } = props;
+export const SnippetControls: React.FC<SnippetControls> = props => {
+  const { copyToClipboard, helperText, resetCode } = props;
   const [isCopying, setIsCopying] = useState(false);
+  const { toggleEditorTheme } = useContext(CodeEditorThemeContext);
 
   return (
-    <StyledFlex border="box" backgroundColor="secondary20" justifyContent="flex-end" alignItems="center">
+    <StyledFlex
+      borderBottom="box"
+      backgroundColor="secondary20"
+      justifyContent="flex-end"
+      alignItems="center"
+      style={{ zIndex: 999 }}
+    >
       <Flex.Item grow={1}>
-        <Small marginHorizontal="small">Play with the code!</Small>
+        <Small marginHorizontal="small">{helperText}</Small>
       </Flex.Item>
       <Flex.Item borderLeft="box">
         <Button
@@ -57,20 +66,26 @@ export const PreviewControls: React.FC<PreviewControlsProps> = props => {
           disabled={isCopying}
         />
       </Flex.Item>
-      <Flex.Item borderLeft="box">
-        <Button
-          iconOnly={<RestoreIcon title="Reset" color={colors.secondary60} />}
-          variant="subtle"
-          onClick={resetCode}
-        />
-      </Flex.Item>
+      {resetCode && (
+        <Flex.Item borderLeft="box">
+          <Button
+            iconOnly={<RestoreIcon title="Reset" color={colors.secondary60} />}
+            variant="subtle"
+            onClick={resetCode}
+          />
+        </Flex.Item>
+      )}
       <Flex.Item borderLeft="box">
         <Button
           iconOnly={<InvertColorsIcon title="Toggle Theme" color={colors.secondary60} />}
           variant="subtle"
-          onClick={toggleTheme}
+          onClick={toggleEditorTheme}
         />
       </Flex.Item>
     </StyledFlex>
   );
+};
+
+SnippetControls.defaultProps = {
+  helperText: 'Play with the code!',
 };

--- a/packages/storybook/components/SnippetControls/index.tsx
+++ b/packages/storybook/components/SnippetControls/index.tsx
@@ -1,0 +1,1 @@
+export * from './SnippetControls';

--- a/packages/storybook/components/SnippetControls/styled.tsx
+++ b/packages/storybook/components/SnippetControls/styled.tsx
@@ -1,0 +1,8 @@
+import { defaultTheme, Flex } from '@bigcommerce/big-design';
+import styled from 'styled-components';
+
+export const StyledFlex = styled(Flex)`
+  flex-direction: row;
+`;
+
+StyledFlex.defaultProps = { theme: defaultTheme };

--- a/packages/storybook/components/StoryWrapper/StoryWrapper.tsx
+++ b/packages/storybook/components/StoryWrapper/StoryWrapper.tsx
@@ -1,4 +1,7 @@
 import { Box, GlobalStyle } from '@bigcommerce/big-design';
+import { PrismTheme } from 'prism-react-renderer';
+import { default as lightTheme } from 'prism-react-renderer/themes/github';
+import { default as darkTheme } from 'prism-react-renderer/themes/oceanicNext';
 import React, { createContext, useState } from 'react';
 
 interface Props {
@@ -6,22 +9,22 @@ interface Props {
 }
 
 interface Context {
-  darkEditorTheme: boolean;
-  toggleCodeEditorTheme(): void;
+  editorTheme: PrismTheme;
+  toggleEditorTheme(): void;
 }
 
 export const CodeEditorThemeContext = createContext<Context>({
-  darkEditorTheme: true,
+  editorTheme: darkTheme,
   // tslint:disable-next-line: no-empty
-  toggleCodeEditorTheme: () => {},
+  toggleEditorTheme: () => {},
 });
 
 export const StoryWrapper: React.FC<Props> = props => {
-  const [darkEditorTheme, setDarkEditorTheme] = useState(true);
-  const toggleCodeEditorTheme = () => setDarkEditorTheme(!darkEditorTheme);
+  const [editorTheme, setEditorTheme] = useState(darkTheme);
+  const toggleEditorTheme = () => setEditorTheme(editorTheme === darkTheme ? lightTheme : darkTheme);
 
   return (
-    <CodeEditorThemeContext.Provider value={{ darkEditorTheme, toggleCodeEditorTheme }}>
+    <CodeEditorThemeContext.Provider value={{ editorTheme, toggleEditorTheme }}>
       <>
         <GlobalStyle />
         <Box margin="xxLarge">{props.storyFn()}</Box>


### PR DESCRIPTION
Add `<CodeSnippet>` component for docs.

Looks similar to `<CodePreviewer>` but the code doesn't render and the user can't edit the code.