### PR TITLE
docs: Fix markdown in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,10 @@ Currently, BigDesign is not open for external pull requests and contributions.
 
 If you have a question, issue, or bug, you can open a Github issue. First, make sure to follow these instructions:
 
-  1. Ensure the bug was not already reported by searching on GitHub under Issues within the BigDesign repo.
-  2. If you're unable to find an open issue addressing the problem, open a new one. (Instructions [here](https://help.github.com/en/articles/creating-an-issue)). Be sure to include a title and clear description, and as much relevant information as possible. If possible, use the relevant template to create the issue. If none of the templates match your issue, open a regular issue. Currently supported templates are:
-  	* **Bug report**: For situations in which you are experiencing an error with the library or a component itself. Expected functionality is specified per components [here](developer.bigcommerce.com/big-design/) and via design guidelines [here](http://bigcommerce.design/bigdesign).
-  		* Please include details to replicate the issue, including environment, OS, and any exceptions/backtraces
-  		* Include a code sample or an executable test case demonstrating the expected behavior that is not occurring when possible
-	* **Feature / Improvement Request**: For situations in which the library or a component are working as expected, but you desire additional functionality. This is the appropriate template for requesting new components.
-	* **Question**: For situations in which you need help from the BigCommerce engineering team, regarding guidance on using the BigDesign library, specific components, or other issues.
+1. Ensure the bug was not already reported by searching on GitHub under Issues within the BigDesign repo.
+2. If you're unable to find an open issue addressing the problem, open a new one. (Instructions [here](https://help.github.com/en/articles/creating-an-issue)). Be sure to include a title and clear description, and as much relevant information as possible. If possible, use the relevant template to create the issue. If none of the templates match your issue, open a regular issue. Currently supported templates are:
+* **Bug report**: For situations in which you are experiencing an error with the library or a component itself. Expected functionality is specified per components [here](developer.bigcommerce.com/big-design/) and via design guidelines [here](http://bigcommerce.design/bigdesign).
+	* Please include details to replicate the issue, including environment, OS, and any exceptions/backtraces
+	* Include a code sample or an executable test case demonstrating the expected behavior that is not occurring when possible
+* **Feature / Improvement Request**: For situations in which the library or a component are working as expected, but you desire additional functionality. This is the appropriate template for requesting new components.
+* **Question**: For situations in which you need help from the BigCommerce engineering team, regarding guidance on using the BigDesign library, specific components, or other issues.


### PR DESCRIPTION
## What?
Fix markdown

## Why?
It looks a bit broken at the moment

## Testing / Proof
<img width="956" alt="Screen Shot 2019-07-18 at 4 47 15 pm" src="https://user-images.githubusercontent.com/1606901/61435412-bb4d7d00-a97b-11e9-8b5b-5cad38298e2d.png">

@bigcommerce/frontend @amckemie 
