### PR TITLE
chore(story): add webpack loader to help with docs

### DIFF
--- a/packages/storybook/.storybook/webpack.config.js
+++ b/packages/storybook/.storybook/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = ({ config }) => {
       {
         loader: require.resolve('ts-loader'),
       },
+      require.resolve('jsx-to-string-loader'),
     ],
   });
 

--- a/packages/storybook/components/CodePreview/CodePreview.tsx
+++ b/packages/storybook/components/CodePreview/CodePreview.tsx
@@ -1,7 +1,7 @@
 import * as BigDesign from '@bigcommerce/big-design';
 import clipboardCopy from 'clipboard-copy';
+import { Language } from 'prism-react-renderer';
 import React, { useContext, useState } from 'react';
-import reactElementToJSXString, { JsxToStringOptions } from 'react-element-to-jsx-string';
 import { LiveEditor, LivePreview, LiveProvider } from 'react-live';
 
 import { SnippetControls } from '../SnippetControls';
@@ -9,27 +9,33 @@ import { CodeEditorThemeContext } from '../StoryWrapper/StoryWrapper';
 
 import { StyledLiveError } from './styled';
 
-function getInitialCode(children: React.ReactNode, options: Partial<JsxToStringOptions> = {}): string {
-  return typeof children === 'string'
-    ? children
-    : reactElementToJSXString(children, {
-        maxInlineAttributesLineLength: 100,
-        showDefaultProps: false,
-        showFunctions: false,
-        sortProps: true,
-        tabStop: 2,
-        ...options,
-      });
+const defaultScope = {
+  ...BigDesign,
+  React,
+};
+
+function getInitialCode(children: React.ReactNode): string {
+  if (typeof children !== 'string') {
+    throw new Error('<CodePreview> children must be of type string');
+  }
+
+  return children;
 }
 
-export const CodePreview: React.FC<{ options?: Partial<JsxToStringOptions> }> = props => {
-  const initialCode = getInitialCode(props.children, props.options);
+export interface CodePreviewProps {
+  scope?: { [key: string]: any };
+  language?: Language;
+}
+
+export const CodePreview: React.FC<CodePreviewProps> = props => {
+  const { children, language, scope } = props;
+  const initialCode = getInitialCode(children);
   const [code, setCode] = useState(initialCode);
   const { editorTheme } = useContext(CodeEditorThemeContext);
 
   return (
     <>
-      <LiveProvider code={code} scope={BigDesign} theme={editorTheme}>
+      <LiveProvider code={code} scope={scope} theme={editorTheme} language={language}>
         <BigDesign.Box padding="medium" backgroundColor="white" border="box" borderBottom="none">
           <LivePreview />
         </BigDesign.Box>
@@ -41,4 +47,9 @@ export const CodePreview: React.FC<{ options?: Partial<JsxToStringOptions> }> = 
       </LiveProvider>
     </>
   );
+};
+
+CodePreview.defaultProps = {
+  language: 'jsx',
+  scope: defaultScope,
 };

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -28,7 +28,6 @@
     "prism-react-renderer": "^0.1.7",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "react-element-to-jsx-string": "^14.0.2",
     "react-live": "^2.1.2",
     "styled-components": "^4.1.3"
   },
@@ -55,6 +54,7 @@
     "@types/storybook__react": "^4.0.1",
     "@types/styled-components": "^4.1.12",
     "babel-loader": "^8.0.5",
+    "jsx-to-string-loader": "^1.1.1",
     "rimraf": "^2.6.3",
     "ts-loader": "^6.0.4"
   }

--- a/packages/storybook/stories/Tabs.story.tsx
+++ b/packages/storybook/stories/Tabs.story.tsx
@@ -2,37 +2,33 @@ import { Box, Tabs, Text } from '@bigcommerce/big-design';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 
-interface State {
-  activeTab: string;
-}
+import { CodePreview } from '../components';
 
-class TabsStory extends React.PureComponent<{}, State> {
-  state = {
-    activeTab: 'tab1',
-  };
+storiesOf('Tabs', module).add('Overview', () => (
+  <CodePreview>
+    {/* jsx-to-string:start */}
+    {function Example() {
+      const [activeTab, setActiveTab] = React.useState('tab1');
 
-  render() {
-    const { activeTab } = this.state;
-
-    return (
-      <>
-        <Tabs activeTab={activeTab} onTabClick={clickedTab => this.setState({ activeTab: clickedTab })}>
-          <Tabs.Tab id="tab1">Example 1</Tabs.Tab>
-          <Tabs.Tab id="tab2">Example 2</Tabs.Tab>
-          <Tabs.Tab id="tab3">Example 3</Tabs.Tab>
-          <Tabs.Tab id="tab4" disabled>
-            Example 4
-          </Tabs.Tab>
-        </Tabs>
-        <Box marginTop="large">
-          {activeTab === 'tab1' && <Text>Content 1</Text>}
-          {activeTab === 'tab2' && <Text>Content 2</Text>}
-          {activeTab === 'tab3' && <Text>Content 3</Text>}
-          {activeTab === 'tab4' && <Text>Content 4</Text>}
-        </Box>
-      </>
-    );
-  }
-}
-
-storiesOf('Tabs', module).add('Overview', () => <TabsStory />);
+      return (
+        <>
+          <Tabs activeTab={activeTab} onTabClick={setActiveTab}>
+            <Tabs.Tab id="tab1">Example 1</Tabs.Tab>
+            <Tabs.Tab id="tab2">Example 2</Tabs.Tab>
+            <Tabs.Tab id="tab3">Example 3</Tabs.Tab>
+            <Tabs.Tab id="tab4" disabled>
+              Example 4
+            </Tabs.Tab>
+          </Tabs>
+          <Box marginTop="large">
+            {activeTab === 'tab1' && <Text>Content 1</Text>}
+            {activeTab === 'tab2' && <Text>Content 2</Text>}
+            {activeTab === 'tab3' && <Text>Content 3</Text>}
+            {activeTab === 'tab4' && <Text>Content 4</Text>}
+          </Box>
+        </>
+      );
+    }}
+    {/* jsx-to-string:end */}
+  </CodePreview>
+));

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "target": "es5",
     "rootDirs": ["stories"],
-    "baseUrl": "src"
+    "baseUrl": "src",
+    "noUnusedLocals": false
   },
   "include": ["stories/**/*", "typings.d.ts", "styled.d.ts", ".storybook/*", "components/**/*"],
   "exclude": ["node_modules", "build", "scripts"]

--- a/packages/storybook/typings.d.ts
+++ b/packages/storybook/typings.d.ts
@@ -1,23 +1,2 @@
-declare module 'react-element-to-jsx-string' {
-  export interface JsxToStringOptions {
-    filterProps: string[];
-    showDefaultProps: boolean;
-    showFunctions: boolean;
-    tabStop: number;
-    useBooleanShorthandSyntax: boolean;
-    useFragmentShortSyntax: boolean;
-    sortProps: boolean;
-
-    maxInlineAttributesLineLength?: number;
-    functionValue(): void;
-    displayName?(element: React.Element<any>): string;
-  }
-
-  export default function reactElementToJSXString(
-    element: ReactElement<any>,
-    options: Partial<JsxToStringOptions>,
-  ): string;
-}
-
 declare module '*.md';
 declare module '*.svg';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8623,6 +8623,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jsx-to-string-loader@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/jsx-to-string-loader/-/jsx-to-string-loader-1.1.1.tgz#9b610356c31d4b7a6a674f85dab0944fb6771080"
+  integrity sha512-8p8etmB9daCHoWhfIm+X/QlrAenFEzIN9ZvPUzHrbGT8EF/89N0KIxVazQWYAuKa3vEpnor91TcPcP//uUxyOA==
+
 kind-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
@@ -8941,12 +8946,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.14, lodash@^4.0.1, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
-  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
-
-lodash@^4.17.11:
+lodash@4.17.14, lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==


### PR DESCRIPTION
Remove `react-element-to-jsx-string` in favor of a Webpack loader (`jsx-to-string-loader`) to help us with documentation code snippets/preview.

See `Tabs.story.tsx ` for usage.
