### PR TITLE
feat(story): update PropTables and StoryWrapper for responsiveness

### DIFF
--- a/packages/storybook/components/PropTable/PropTable.tsx
+++ b/packages/storybook/components/PropTable/PropTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { StyledTable, StyledTableBody, StyledTableFooter, StyledTableHead } from './styled';
+import { StyledTable, StyledTableBody, StyledTableFigure, StyledTableFooter, StyledTableHead } from './styled';
 import { Footer } from './Footer';
 import { Header } from './Header';
 import { Prop } from './Prop';
@@ -12,15 +12,17 @@ export class PropTable extends React.PureComponent {
 
   render() {
     return (
-      <StyledTable>
-        <StyledTableHead>
-          <PropTable.Header />
-        </StyledTableHead>
-        <StyledTableBody>{this.renderChildren()}</StyledTableBody>
-        <StyledTableFooter>
-          <PropTable.Footer />
-        </StyledTableFooter>
-      </StyledTable>
+      <StyledTableFigure>
+        <StyledTable>
+          <StyledTableHead>
+            <PropTable.Header />
+          </StyledTableHead>
+          <StyledTableBody>{this.renderChildren()}</StyledTableBody>
+          <StyledTableFooter>
+            <PropTable.Footer />
+          </StyledTableFooter>
+        </StyledTable>
+      </StyledTableFigure>
     );
   }
 

--- a/packages/storybook/components/PropTable/styled.tsx
+++ b/packages/storybook/components/PropTable/styled.tsx
@@ -2,6 +2,17 @@ import { defaultTheme } from '@bigcommerce/big-design';
 import styled, { css } from 'styled-components';
 
 // TODO: Convert to BigDesign table when built
+export const StyledTableFigure = styled.figure`
+  margin: ${({ theme }) => theme.spacing.none};
+  max-width: 100%;
+  overflow-x: auto;
+  white-space: nowrap;
+
+  ${({ theme }) => theme.breakpoints.tablet} {
+    white-space: normal;
+  }
+`;
+
 export const StyledTable = styled.table`
   border-collapse: collapse;
   margin-bottom: ${({ theme }) => theme.spacing.xLarge}
@@ -42,6 +53,7 @@ export const StyledCode = styled.code<StyledCodeProps>`
   color: ${({ altColor, theme }) => (altColor ? theme.colors.primary50 : theme.colors.danger50)}};
 `;
 
+StyledTableFigure.defaultProps = { theme: defaultTheme };
 StyledTable.defaultProps = { theme: defaultTheme };
 StyledTableHead.defaultProps = { theme: defaultTheme };
 StyledTableBody.defaultProps = { theme: defaultTheme };

--- a/packages/storybook/components/StoryWrapper/StoryWrapper.tsx
+++ b/packages/storybook/components/StoryWrapper/StoryWrapper.tsx
@@ -27,7 +27,7 @@ export const StoryWrapper: React.FC<Props> = props => {
     <CodeEditorThemeContext.Provider value={{ editorTheme, toggleEditorTheme }}>
       <>
         <GlobalStyle />
-        <Box margin="xxLarge">{props.storyFn()}</Box>
+        <Box margin={{ mobile: 'medium', tablet: 'xxLarge' }}>{props.storyFn()}</Box>
       </>
     </CodeEditorThemeContext.Provider>
   );


### PR DESCRIPTION
# What

Updated `PropTables` to overflow and `white-space: nowrap;` on mobile. Decreased margin on the StoryWrapper for mobile.

> To preserve readability, make good use of non-breaking spaces and white-space:nowrap to limit the amount the data wraps in the cells. It’s better to have a readable table that requires scrolling than an unreadable one which doesn’t.
\- [Web Typography: Designing Tables to be Read, Not Looked At](https://alistapart.com/article/web-typography-tables/)

# Screenshot
<img width="373" alt="Screen Shot 2019-07-22 at 10 04 50 PM" src="https://user-images.githubusercontent.com/10539418/61679802-0d203b00-accd-11e9-9897-93211c3b5a47.png">
