### PR TITLE
feat: add disabled prop to select

### DIFF
--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -21,6 +21,7 @@ interface SelectState {
 }
 
 interface Props {
+  disabled?: boolean;
   error?: React.ReactChild;
   label?: React.ReactChild;
   maxHeight?: number;
@@ -163,7 +164,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
   }
 
   private renderInput() {
-    const { label, placeholder, error, required } = this.props;
+    const { label, placeholder, error, required, disabled } = this.props;
 
     const highlightedItem = this.getItemById(this.state.highlightedId);
     const ariaActiveDescendant = highlightedItem ? { 'aria-activedescendant': highlightedItem.id } : {};
@@ -184,6 +185,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
             placeholder={placeholder}
             ref={ref}
             required={required}
+            disabled={disabled}
             value={this.state.inputText}
             {...ariaActiveDescendant}
             {...ariaControls}

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -483,3 +483,33 @@ test('select should not have a required attr if not set as required', () => {
 
   expect(input.getAttribute('required')).toEqual(null);
 });
+
+test('select should have a disabled attr if set as disabled', () => {
+  const { getByLabelText } = render(
+    <Select label="Countries" value="us" disabled>
+      <Select.Option value="us">United States</Select.Option>
+      <Select.Option value="mx">Mexico</Select.Option>
+      <Select.Option value="ca">Canada</Select.Option>
+      <Select.Option value="en">England</Select.Option>
+    </Select>,
+  );
+
+  const input = getByLabelText('Countries');
+
+  expect(input.getAttribute('disabled')).toEqual('');
+});
+
+test('select should not have a disabled attr if not set as disabled', () => {
+  const { getByLabelText } = render(
+    <Select label="Countries" placeholder="Choose country">
+      <Select.Option value="us">United States</Select.Option>
+      <Select.Option value="mx">Mexico</Select.Option>
+      <Select.Option value="ca">Canada</Select.Option>
+      <Select.Option value="en">England</Select.Option>
+    </Select>,
+  );
+
+  const input = getByLabelText('Countries');
+
+  expect(input.getAttribute('disabled')).toEqual(null);
+});


### PR DESCRIPTION
## What?
Adds a `disabled` prop to the top level `Select` component so that we can have completely disabled select inputs (not just disabled _options_), mimicking native behavior when needed

## SS
<img width="353" alt="Screen Shot 2019-07-24 at 3 31 13 PM" src="https://user-images.githubusercontent.com/6025510/61826773-bc255980-ae28-11e9-86ff-5f7755353a99.png">

## Testing done
- Verified select cannot be clicked when specified as `disabled`
- Verified only selects with `disabled` are `disabled`