### PR TITLE
feat(story): use icons from new package

### DIFF
--- a/packages/storybook/components/CodePreview/CodePreview.tsx
+++ b/packages/storybook/components/CodePreview/CodePreview.tsx
@@ -1,4 +1,5 @@
 import * as BigDesign from '@bigcommerce/big-design';
+import * as BigDesignIcons from '@bigcommerce/big-design-icons';
 import { theme } from '@bigcommerce/big-design-theme';
 import clipboardCopy from 'clipboard-copy';
 import { Language } from 'prism-react-renderer';
@@ -13,6 +14,7 @@ import { StyledLiveError } from './styled';
 
 const defaultScope = {
   ...BigDesign,
+  ...BigDesignIcons,
   React,
   styled,
 };

--- a/packages/storybook/components/SnippetControls/SnippetControls.tsx
+++ b/packages/storybook/components/SnippetControls/SnippetControls.tsx
@@ -1,14 +1,5 @@
-import {
-  AssignmentIcon,
-  Box,
-  Button,
-  CheckIcon,
-  Flex,
-  InvertColorsIcon,
-  RestoreIcon,
-  Small,
-} from '@bigcommerce/big-design';
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { Button, Flex, Small } from '@bigcommerce/big-design';
+import { AssignmentIcon, CheckIcon, InvertColorsIcon, RestoreIcon } from '@bigcommerce/big-design-icons';
 import React, { useContext, useState } from 'react';
 
 import { CodeEditorThemeContext } from '../StoryWrapper/StoryWrapper';
@@ -21,15 +12,11 @@ interface SnippetControls {
   resetCode?(): void;
 }
 
-const { colors } = defaultTheme;
-
 function getCopyToClipboardIcon(isCopying: boolean) {
   return isCopying ? (
-    <Box paddingHorizontal="xxSmall">
-      <CheckIcon title="Copying" color={colors.success} size="small" />
-    </Box>
+    <CheckIcon title="Copying" color="success" />
   ) : (
-    <AssignmentIcon title="Copy" color={colors.secondary60} />
+    <AssignmentIcon title="Copy" color="secondary60" />
   );
 }
 
@@ -68,16 +55,12 @@ export const SnippetControls: React.FC<SnippetControls> = props => {
       </Flex.Item>
       {resetCode && (
         <Flex.Item borderLeft="box">
-          <Button
-            iconOnly={<RestoreIcon title="Reset" color={colors.secondary60} />}
-            variant="subtle"
-            onClick={resetCode}
-          />
+          <Button iconOnly={<RestoreIcon title="Reset" color="secondary60" />} variant="subtle" onClick={resetCode} />
         </Flex.Item>
       )}
       <Flex.Item borderLeft="box">
         <Button
-          iconOnly={<InvertColorsIcon title="Toggle Theme" color={colors.secondary60} />}
+          iconOnly={<InvertColorsIcon title="Toggle Theme" color="secondary60" />}
           variant="subtle"
           onClick={toggleEditorTheme}
         />

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@bigcommerce/big-design": "^0.5.0",
+    "@bigcommerce/big-design-icons": "^0.0.1",
     "@bigcommerce/big-design-theme": "^0.0.1",
     "clipboard-copy": "^3.0.0",
     "prism-react-renderer": "^0.1.7",

--- a/packages/storybook/stories/Button/Button.story.tsx
+++ b/packages/storybook/stories/Button/Button.story.tsx
@@ -1,4 +1,5 @@
-import { Button, DropdownIcon, Grid, H0, H1, H2, Link, PlusIcon, Text } from '@bigcommerce/big-design';
+import { Button, Grid, H0, H1, H2, Link, Text } from '@bigcommerce/big-design';
+import { AddIcon, ArrowDropDownIcon } from '@bigcommerce/big-design-icons';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 
@@ -127,12 +128,12 @@ storiesOf('Button', module).add('Overview', () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Grid columns="repeat(4, min-content)">
-        <Button iconOnly={<PlusIcon title="add" />} />
-        <Button iconLeft={<PlusIcon />}>Label</Button>
-        <Button iconLeft={<PlusIcon />} iconRight={<DropdownIcon />}>
+        <Button iconOnly={<AddIcon title="add" />} />
+        <Button iconLeft={<AddIcon />}>Label</Button>
+        <Button iconLeft={<AddIcon />} iconRight={<ArrowDropDownIcon />}>
           Label
         </Button>
-        <Button iconRight={<DropdownIcon />}>Label</Button>
+        <Button iconRight={<ArrowDropDownIcon />}>Label</Button>
       </Grid>
       {/* jsx-to-string:end */}
     </CodePreview>

--- a/packages/storybook/stories/Form.story.tsx
+++ b/packages/storybook/stories/Form.story.tsx
@@ -5,12 +5,13 @@ import {
   Form,
   H2,
   Input,
-  PlusIcon,
+  Panel,
   Radio,
   Text,
   Textarea,
   TextareaProps,
 } from '@bigcommerce/big-design';
+import { AddIcon } from '@bigcommerce/big-design-icons';
 import { boolean, number, NumberOptions } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
@@ -25,105 +26,107 @@ storiesOf('Forms', module)
         specifying one
       </Text>
 
-      <Form>
-        <Form.Fieldset
-          legend="Primary contact"
-          description="Minim velit quis aute adipisicing adipisicing do do exercitation cupidatat enim ex voluptate consequat labore."
-        >
-          <Form.Row>
-            <Input
-              label="First Name"
-              description="This is an example description for First Name"
-              placeholder="Placeholder text"
-            />
-          </Form.Row>
+      <Panel>
+        <Form>
+          <Form.Fieldset
+            legend="Primary contact"
+            description="Minim velit quis aute adipisicing adipisicing do do exercitation cupidatat enim ex voluptate consequat labore."
+          >
+            <Form.Row>
+              <Input
+                label="First Name"
+                description="This is an example description for First Name"
+                placeholder="Placeholder text"
+              />
+            </Form.Row>
 
-          <Form.Row>
-            <Input
-              label="Middle Name"
-              description="This is an example description for Last Name. Featuring a Left Icon."
-              iconLeft={<PlusIcon />}
-              placeholder="Placeholder text"
-            />
-          </Form.Row>
+            <Form.Row>
+              <Input
+                label="Middle Name"
+                description="This is an example description for Last Name. Featuring a Left Icon."
+                iconLeft={<AddIcon />}
+                placeholder="Placeholder text"
+              />
+            </Form.Row>
 
-          <Form.Row>
-            <Input
-              label="Last Name"
-              description="This is an example description for Last Name. Featuring a Right Icon."
-              placeholder="Placeholder text"
-              iconRight={<PlusIcon />}
-            />
-          </Form.Row>
+            <Form.Row>
+              <Input
+                label="Last Name"
+                description="This is an example description for Last Name. Featuring a Right Icon."
+                placeholder="Placeholder text"
+                iconRight={<AddIcon />}
+              />
+            </Form.Row>
 
-          <Form.Row>
-            <Input
-              label="Password"
-              description="The password must contain at least 8 characters. (Also features manually setting id, inspect it!)"
-              id="manualId"
-              placeholder="Placeholder text"
-              type="password"
-              error="Your password is not strong enough."
-            />
-          </Form.Row>
+            <Form.Row>
+              <Input
+                label="Password"
+                description="The password must contain at least 8 characters. (Also features manually setting id, inspect it!)"
+                id="manualId"
+                placeholder="Placeholder text"
+                type="password"
+                error="Your password is not strong enough."
+              />
+            </Form.Row>
 
-          <Form.Row>
-            <Input
-              label="Company"
-              description="This is an example description for Company. Featuring a Disabled field."
-              placeholder="Placeholder text disabled"
-              disabled
-            />
-          </Form.Row>
+            <Form.Row>
+              <Input
+                label="Company"
+                description="This is an example description for Company. Featuring a Disabled field."
+                placeholder="Placeholder text disabled"
+                disabled
+              />
+            </Form.Row>
 
-          <Form.Row>
-            <Textarea
-              label="Description"
-              description="This is an example description. Use Knobs to preview props."
-              placeholder="Placeholder text"
-              rows={
-                number('Textarea rows', 3, {
-                  range: true,
-                  min: 1,
-                  max: 7,
-                  step: 1,
-                } as NumberOptions) as TextareaProps['rows']
-              }
-              resize={boolean('Resizeable textarea', true)}
-              disabled={boolean('Disable textarea', false)}
-            />
-          </Form.Row>
+            <Form.Row>
+              <Textarea
+                label="Description"
+                description="This is an example description. Use Knobs to preview props."
+                placeholder="Placeholder text"
+                rows={
+                  number('Textarea rows', 3, {
+                    range: true,
+                    min: 1,
+                    max: 7,
+                    step: 1,
+                  } as NumberOptions) as TextareaProps['rows']
+                }
+                resize={boolean('Resizeable textarea', true)}
+                disabled={boolean('Disable textarea', false)}
+              />
+            </Form.Row>
 
-          <Form.Row>
-            <Input label="State" placeholder="Placeholder" />
-            <Input label="City" placeholder="Placeholder" />
-          </Form.Row>
+            <Form.Row>
+              <Input label="State" placeholder="Placeholder" />
+              <Input label="City" placeholder="Placeholder" />
+            </Form.Row>
 
-          <Form.Row>
-            <Input label="State" placeholder="Placeholder" />
-            <Input label="City" placeholder="Placeholder" />
-            <Input label="Country" placeholder="Placeholder" />
-          </Form.Row>
-        </Form.Fieldset>
+            <Form.Row>
+              <Input label="State" placeholder="Placeholder" />
+              <Input label="City" placeholder="Placeholder" />
+              <Input label="Country" placeholder="Placeholder" />
+            </Form.Row>
+          </Form.Fieldset>
 
-        <Form.Fieldset legend="Checkboxes" description="This is a description for checkboxes">
-          <Form.Row>
-            <Checkbox label="Unchecked" checked={false} onChange={() => null} />
-          </Form.Row>
-          <Form.Row>
-            <Checkbox label="Checked" checked={true} onChange={() => null} />
-          </Form.Row>
-        </Form.Fieldset>
+          <Form.Fieldset legend="Checkboxes" description="This is a description for checkboxes">
+            <Form.Row>
+              <Checkbox label="Unchecked" checked={false} onChange={() => null} />
+            </Form.Row>
+            <Form.Row>
+              <Checkbox label="Checked" checked={true} onChange={() => null} />
+            </Form.Row>
+          </Form.Fieldset>
 
-        <Form.Fieldset legend="Radio buttons" description="This is a description for radio buttons">
-          <Form.Row>
-            <Radio label="Unchecked" name="test-group" checked={false} onChange={() => null} />
-          </Form.Row>
-          <Form.Row>
-            <Radio label="Checked" name="test-group" checked={true} onChange={() => null} />
-          </Form.Row>
-        </Form.Fieldset>
-      </Form>
+          <Form.Fieldset legend="Radio buttons" description="This is a description for radio buttons">
+            <Form.Row>
+              <Radio label="Unchecked" name="test-group" checked={false} onChange={() => null} />
+            </Form.Row>
+            <Form.Row>
+              <Radio label="Checked" name="test-group" checked={true} onChange={() => null} />
+            </Form.Row>
+          </Form.Fieldset>
+        </Form>
+      </Panel>
     </>
   ))
   .add('Avalara Demo', () => (

--- a/packages/storybook/stories/Tooltip.story.tsx
+++ b/packages/storybook/stories/Tooltip.story.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, Flex, PlusIcon, Tooltip } from '@bigcommerce/big-design';
+import { Box, Button, Flex, Tooltip } from '@bigcommerce/big-design';
+import { AddIcon } from '@bigcommerce/big-design-icons';
 import { select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
@@ -34,7 +35,7 @@ storiesOf('Tooltip', module).add('Overview', () => (
     </Box>
     <Box marginTop="xxLarge">
       <Tooltip content="Tooltip Content" placement="bottom">
-        <PlusIcon />
+        <AddIcon />
       </Tooltip>
     </Box>
   </Flex>


### PR DESCRIPTION
Use new icons in storybook, additional changes:

- Expose icons to `<CodePreviewer>`
- Remove workarounds we had in place for our previous icons with different sizes