### PR TITLE
docs(story): add margin and padding collapsible PropTables

### DIFF
--- a/packages/storybook/components/index.tsx
+++ b/packages/storybook/components/index.tsx
@@ -1,6 +1,7 @@
 export * from './Code';
 export * from './CodePreview';
 export * from './CodeSnippet';
+export * from './Collapsible';
 export * from './List';
 export * from './PropTable';
 export * from './StoryWrapper';

--- a/packages/storybook/stories/Box/Box.story.tsx
+++ b/packages/storybook/stories/Box/Box.story.tsx
@@ -1,9 +1,10 @@
-import { Box, Flex, H0, H1, Text } from '@bigcommerce/big-design';
+import { Box, Flex, H0, H1, H2, Text } from '@bigcommerce/big-design';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import styled from 'styled-components';
 
-import { CodePreview } from '../../components';
+import { CodePreview, Collapsible } from '../../components';
+import { MarginPropTable, PaddingPropTable } from '../Utilities/index';
 
 import { BoxPropTable } from './BoxPropTable';
 
@@ -23,7 +24,19 @@ storiesOf('Box', module).add('Overview', () => (
 
     <H1>API</H1>
 
+    <H2>Box</H2>
+
     <BoxPropTable />
+
+    <H2>Inherited Props</H2>
+
+    <Collapsible title="Margin Props">
+      <MarginPropTable />
+    </Collapsible>
+
+    <Collapsible title="Padding Props">
+      <PaddingPropTable />
+    </Collapsible>
 
     <H1>Examples</H1>
     <Box>

--- a/packages/storybook/stories/Button/Button.story.tsx
+++ b/packages/storybook/stories/Button/Button.story.tsx
@@ -2,7 +2,8 @@ import { Button, DropdownIcon, Grid, H0, H1, H2, Link, PlusIcon, Text } from '@b
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 
-import { Code, CodePreview } from '../../components';
+import { Code, CodePreview, Collapsible } from '../../components';
+import { MarginPropTable } from '../Utilities/index';
 
 import { ButtonPropTable } from './';
 
@@ -27,7 +28,15 @@ storiesOf('Button', module).add('Overview', () => (
 
     <H1>API</H1>
 
+    <H2>Button</H2>
+
     <ButtonPropTable />
+
+    <H2>Inherited Props</H2>
+
+    <Collapsible title="Margin Props">
+      <MarginPropTable />
+    </Collapsible>
 
     <H1>Variants</H1>
 

--- a/packages/storybook/stories/Flex/Flex.story.tsx
+++ b/packages/storybook/stories/Flex/Flex.story.tsx
@@ -2,7 +2,8 @@ import { Box, Flex, H0, H1, H2, Text } from '@bigcommerce/big-design';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 
-import { Code, CodePreview } from '../../components';
+import { Code, CodePreview, Collapsible } from '../../components';
+import { MarginPropTable, PaddingPropTable } from '../Utilities/index';
 
 import { FlexItemPropTable, FlexPropTable } from './';
 
@@ -52,6 +53,16 @@ storiesOf('Flex', module).add('Overview', () => (
     <H2>Flex.Item</H2>
 
     <FlexItemPropTable />
+
+    <H2>Inherited Props</H2>
+
+    <Collapsible title="Margin Props">
+      <MarginPropTable />
+    </Collapsible>
+
+    <Collapsible title="Padding Props">
+      <PaddingPropTable />
+    </Collapsible>
 
     <H1>Examples</H1>
 

--- a/packages/storybook/stories/Link/Link.story.tsx
+++ b/packages/storybook/stories/Link/Link.story.tsx
@@ -2,8 +2,7 @@ import { H0, H2, Link, Text } from '@bigcommerce/big-design';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 
-import { CodePreview } from '../../components';
-import { Collapsible } from '../../components/Collapsible';
+import { CodePreview, Collapsible } from '../../components';
 import { MarginPropTable } from '../Utilities/Margin';
 
 storiesOf('Link', module).add('Overview', () => (


### PR DESCRIPTION
# What
Add `Margin` and `Padding` prop tables to multiple components and update `Collapsible` export path.