### PR TITLE
fix(story): fix favicon on gh-pages

### DIFF
--- a/packages/storybook/.storybook/manager-head.html
+++ b/packages/storybook/.storybook/manager-head.html
@@ -1,4 +1,4 @@
-<link rel="icon" type="image/png" href="/favicon.png">
+<link rel="icon" type="image/png" href="favicon.png">
 
 <script>
   setTitle();
@@ -9,7 +9,7 @@
   // https://github.com/storybookjs/storybook/issues/6339
   // This is a temp workaround
   function setTitle() {
-    const title = 'Big Design';
+    const title = 'BigDesign';
 
     document.title = title;
 


### PR DESCRIPTION
Since the url to our docs is `https://bigcommerce.github.io/big-design` using a `/` was trying to load the icon from `https://bigcommerce.github.io/favicon.png` instead of `https://bigcommerce.github.io/big-design/favicon.png`