### PR TITLE
Revert "feat(component): add spacing between buttons (#105)"

### DIFF
--- a/packages/big-design/src/components/Button/Button.tsx
+++ b/packages/big-design/src/components/Button/Button.tsx
@@ -25,14 +25,7 @@ class RawButton extends React.PureComponent<ButtonProps & PrivateProps> {
     const { forwardedRef, ...props } = this.props;
 
     return (
-      <StyledButton
-        role="button"
-        tabIndex={0}
-        className="bd-button"
-        {...props}
-        onClick={this.handleClick}
-        ref={forwardedRef}
-      >
+      <StyledButton role="button" tabIndex={0} {...props} onClick={this.handleClick} ref={forwardedRef}>
         {props.isLoading ? this.renderLoadingSpinner() : null}
         <ContentWrapper isLoading={props.isLoading} theme={props.theme}>
           {!props.iconOnly && props.iconLeft}

--- a/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
@@ -39,7 +39,6 @@ exports[`render default button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: #3C64F4;
@@ -54,10 +53,6 @@ exports[`render default button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -97,7 +92,7 @@ exports[`render default button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -148,7 +143,6 @@ exports[`render destructive button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: #DB3643;
@@ -163,10 +157,6 @@ exports[`render destructive button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -206,7 +196,7 @@ exports[`render destructive button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -257,7 +247,6 @@ exports[`render destructive disabled button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: #DB3643;
@@ -272,10 +261,6 @@ exports[`render destructive disabled button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -315,7 +300,7 @@ exports[`render destructive disabled button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   disabled=""
   role="button"
   tabindex="0"
@@ -367,7 +352,6 @@ exports[`render disabled button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: #3C64F4;
@@ -382,10 +366,6 @@ exports[`render disabled button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -425,7 +405,7 @@ exports[`render disabled button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   disabled=""
   role="button"
   tabindex="0"
@@ -483,7 +463,6 @@ exports[`render icon left and right button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   padding-left: 0.5rem;
@@ -500,10 +479,6 @@ exports[`render icon left and right button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -543,7 +518,7 @@ exports[`render icon left and right button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -636,7 +611,6 @@ exports[`render icon left button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   padding-left: 0.5rem;
@@ -652,10 +626,6 @@ exports[`render icon left button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -695,7 +665,7 @@ exports[`render icon left button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -770,7 +740,6 @@ exports[`render icon only button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   padding: 0 0.5rem;
@@ -786,10 +755,6 @@ exports[`render icon only button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -829,7 +794,7 @@ exports[`render icon only button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -903,7 +868,6 @@ exports[`render icon right button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   padding-right: 0.5rem;
@@ -919,10 +883,6 @@ exports[`render icon right button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -962,7 +922,7 @@ exports[`render icon right button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -1089,7 +1049,6 @@ exports[`render loading button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: #3C64F4;
@@ -1104,10 +1063,6 @@ exports[`render loading button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -1159,7 +1114,7 @@ exports[`render loading button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -1233,7 +1188,6 @@ exports[`render secondary button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: transparent;
@@ -1248,10 +1202,6 @@ exports[`render secondary button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -1291,7 +1241,7 @@ exports[`render secondary button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -1342,7 +1292,6 @@ exports[`render secondary destructive button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: transparent;
@@ -1357,10 +1306,6 @@ exports[`render secondary destructive button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -1400,7 +1345,7 @@ exports[`render secondary destructive button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -1451,7 +1396,6 @@ exports[`render secondary destructive disabled button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: transparent;
@@ -1466,10 +1410,6 @@ exports[`render secondary destructive disabled button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -1509,7 +1449,7 @@ exports[`render secondary destructive disabled button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   disabled=""
   role="button"
   tabindex="0"
@@ -1561,7 +1501,6 @@ exports[`render secondary disabled button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: transparent;
@@ -1576,10 +1515,6 @@ exports[`render secondary disabled button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -1619,7 +1554,7 @@ exports[`render secondary disabled button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   disabled=""
   role="button"
   tabindex="0"
@@ -1671,7 +1606,6 @@ exports[`render subtle button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: transparent;
@@ -1686,10 +1620,6 @@ exports[`render subtle button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -1730,7 +1660,7 @@ exports[`render subtle button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -1781,7 +1711,6 @@ exports[`render subtle destructive button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: transparent;
@@ -1796,10 +1725,6 @@ exports[`render subtle destructive button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -1840,7 +1765,7 @@ exports[`render subtle destructive button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   role="button"
   tabindex="0"
 >
@@ -1891,7 +1816,6 @@ exports[`render subtle destructive disabled button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: transparent;
@@ -1906,10 +1830,6 @@ exports[`render subtle destructive disabled button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -1950,7 +1870,7 @@ exports[`render subtle destructive disabled button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   disabled=""
   role="button"
   tabindex="0"
@@ -2002,7 +1922,6 @@ exports[`render subtle disabled button 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   background-color: transparent;
@@ -2017,10 +1936,6 @@ exports[`render subtle disabled button 1`] = `
 .c0[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c0 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c0:active {
@@ -2061,7 +1976,7 @@ exports[`render subtle disabled button 1`] = `
 }
 
 <button
-  class="bd-button c0"
+  class="c0"
   disabled=""
   role="button"
   tabindex="0"

--- a/packages/big-design/src/components/Button/styled.tsx
+++ b/packages/big-design/src/components/Button/styled.tsx
@@ -29,7 +29,6 @@ export const StyledButton = styled.button<ButtonProps & MarginProps>`
   text-align: center;
   text-decoration: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
 
@@ -40,10 +39,6 @@ export const StyledButton = styled.button<ButtonProps & MarginProps>`
   &[disabled] {
     border-color: ${({ theme }) => theme.colors.secondary30};
     pointer-events: none;
-  }
-
-  + .bd-button {
-    margin-left: ${({ theme }) => theme.spacing.xSmall};
   }
 
   ${({ theme }) => theme.breakpoints.tablet} {

--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -80,7 +80,6 @@ exports[`render open modal 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   padding: 0 0.5rem;
@@ -96,10 +95,6 @@ exports[`render open modal 1`] = `
 .c5[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c5 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c5:active {
@@ -222,7 +217,7 @@ exports[`render open modal 1`] = `
           class="c4"
         >
           <button
-            class="bd-button c5"
+            class="c5"
             role="button"
             tabindex="0"
           >
@@ -334,7 +329,6 @@ exports[`render open modal without backdrop 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
   white-space: nowrap;
   width: 100%;
   padding: 0 0.5rem;
@@ -350,10 +344,6 @@ exports[`render open modal without backdrop 1`] = `
 .c5[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
-}
-
-.c5 + .bd-button {
-  margin-left: 0.5rem;
 }
 
 .c5:active {
@@ -473,7 +463,7 @@ exports[`render open modal without backdrop 1`] = `
           class="c4"
         >
           <button
-            class="bd-button c5"
+            class="c5"
             role="button"
             tabindex="0"
           >

--- a/packages/storybook/stories/Button/Button.story.tsx
+++ b/packages/storybook/stories/Button/Button.story.tsx
@@ -1,4 +1,4 @@
-import { Button, H0, H1, H2, Link, Text } from '@bigcommerce/big-design';
+import { Button, Grid, H0, H1, H2, Link, Text } from '@bigcommerce/big-design';
 import { AddIcon, ArrowDropDownIcon } from '@bigcommerce/big-design-icons';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
@@ -48,11 +48,11 @@ storiesOf('Button', module).add('Overview', () => (
 
     <CodePreview>
       {/* jsx-to-string:start */}
-      <>
+      <Grid columns="repeat(3, min-content)">
         <Button variant="primary">Primary</Button>
         <Button variant="secondary">Secondary</Button>
         <Button variant="subtle">Subtle</Button>
-      </>
+      </Grid>
       {/* jsx-to-string:end */}
     </CodePreview>
 
@@ -65,10 +65,10 @@ storiesOf('Button', module).add('Overview', () => (
 
     <CodePreview>
       {/* jsx-to-string:start */}
-      <>
+      <Grid columns="repeat(2, min-content)">
         <Button actionType="normal">Normal</Button>
         <Button actionType="destructive">Destructive</Button>
-      </>
+      </Grid>
       {/* jsx-to-string:end */}
     </CodePreview>
 
@@ -115,7 +115,7 @@ storiesOf('Button', module).add('Overview', () => (
 
     <CodePreview>
       {/* jsx-to-string:start */}
-      <>
+      <Grid columns="repeat(3, min-content)">
         <Button disabled>Disabled</Button>
         <Button disabled variant="secondary">
           Disabled
@@ -123,7 +123,7 @@ storiesOf('Button', module).add('Overview', () => (
         <Button disabled variant="subtle">
           Disabled
         </Button>
-      </>
+      </Grid>
       {/* jsx-to-string:end */}
     </CodePreview>
 
@@ -136,14 +136,14 @@ storiesOf('Button', module).add('Overview', () => (
 
     <CodePreview>
       {/* jsx-to-string:start */}
-      <>
+      <Grid columns="repeat(4, min-content)">
         <Button iconOnly={<AddIcon title="add" />} />
         <Button iconLeft={<AddIcon />}>Label</Button>
         <Button iconLeft={<AddIcon />} iconRight={<ArrowDropDownIcon />}>
           Label
         </Button>
         <Button iconRight={<ArrowDropDownIcon />}>Label</Button>
-      </>
+      </Grid>
       {/* jsx-to-string:end */}
     </CodePreview>
   </>

--- a/packages/storybook/stories/Modal.story.tsx
+++ b/packages/storybook/stories/Modal.story.tsx
@@ -48,7 +48,7 @@ class Story extends React.PureComponent<{}, State> {
           </Modal.Body>
 
           <Modal.Actions>
-            <Button variant="subtle" onClick={this.closeModal}>
+            <Button variant="subtle" onClick={this.closeModal} marginRight="xSmall">
               Cancel
             </Button>
             <Button onClick={this.closeModal}>Apply</Button>
@@ -71,7 +71,7 @@ class Story extends React.PureComponent<{}, State> {
           </Modal.Body>
 
           <Modal.Actions>
-            <Button variant="subtle" onClick={this.closeDialog}>
+            <Button variant="subtle" onClick={this.closeDialog} marginRight="xSmall">
               Cancel
             </Button>
             <Button onClick={this.closeDialog}>Apply</Button>


### PR DESCRIPTION
Reverts #105.

After discussion, we'll need to find a way to override the `.button + .button` styles using the Button props. Otherwise developers can use the margin props to add margin between buttons.