### PR TITLE
chore(configs): target esnext on tsconfig

### DIFF
--- a/packages/configs/ts/tsconfig.json
+++ b/packages/configs/ts/tsconfig.json
@@ -15,7 +15,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es5"
+    "target": "esnext"
   },
   "plugins": [
     {


### PR DESCRIPTION
Let babel handle transpiring to es5 and not TS + babel.