### PR TITLE
feat(story): add bottomMargin to Collapsible when collapsed

### DIFF
--- a/packages/storybook/components/Collapsible/index.tsx
+++ b/packages/storybook/components/Collapsible/index.tsx
@@ -14,7 +14,7 @@ export const Collapsible: React.FC<CollapsibleProps> = ({ children, title }) => 
 
   return (
     <>
-      <StyledFlex alignItems="center" onClick={toggleIsCollapsed}>
+      <StyledFlex marginBottom="xLarge" alignItems="center" onClick={toggleIsCollapsed}>
         {isCollapsed ? <ChevronRightIcon title="Expand" /> : <ExpandMoreIcon title="Collapse" />}
         <Text>{title}</Text>
       </StyledFlex>

--- a/packages/storybook/components/Collapsible/styled.tsx
+++ b/packages/storybook/components/Collapsible/styled.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 export const StyledFlex = styled(Flex)`
   cursor: pointer;
-  margin-bottom: ${({ theme }) => theme.spacing.small};
 `;
 
 StyledFlex.defaultProps = { theme: defaultTheme };


### PR DESCRIPTION
Added some margin to `Collapsible`

### Before:
![image](https://user-images.githubusercontent.com/2752665/62320567-1eeca580-b466-11e9-957a-a6b331a390b6.png)

### After:
![image](https://user-images.githubusercontent.com/2752665/62320591-2d3ac180-b466-11e9-88ee-4fdc44828887.png)
