### PR TITLE
fix(component): prevent document scrolling when using arrow keys

### DIFF
--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -290,6 +290,8 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
 
     return scrollIntoView(element, {
       behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
       scrollMode: 'if-needed',
     });
   };

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -235,7 +235,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
       const item = value && this.findItemByValue(value);
 
       if (item) {
-        this.updateHighlightedId(item.id);
+        this.updateHighlightedId(item.id, true);
       }
 
       return this.inputRef && this.inputRef.focus({ preventScroll: true });
@@ -546,7 +546,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
     return null;
   }
 
-  private updateHighlightedId(id: string | null) {
+  private updateHighlightedId(id: string | null, instantScroll = false) {
     if (!id) {
       return;
     }
@@ -556,12 +556,12 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
         highlightedId: id,
       },
       () => {
-        this.scrollIntoView();
+        this.scrollIntoView(instantScroll);
       },
     );
   }
 
-  private scrollIntoView() {
+  private scrollIntoView(instantScroll: boolean) {
     const element = this.getItemById(this.state.highlightedId);
 
     if (!element) {
@@ -569,7 +569,9 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
     }
 
     return scrollIntoView(element, {
-      behavior: 'smooth',
+      behavior: instantScroll ? 'instant' : 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
       scrollMode: 'if-needed',
     });
   }


### PR DESCRIPTION
Added `block: 'nearest', inline: 'nearest'` to keep element in view but without scrolling the document unless element is really out of sight.

Select will now scroll `instantly` to selected element when opened. Made no sense to make it smooth.