### PR TITLE
fix(component): select will reset text if value returns empty string

### DIFF
--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -73,6 +73,15 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
     });
   }
 
+  componentDidUpdate(prevProps: Props) {
+    const { value } = this.props;
+
+    // Reset input if value was reset to empty string
+    if (prevProps.value && !value) {
+      this.setState({ inputText: '' });
+    }
+  }
+
   render() {
     const {
       children,


### PR DESCRIPTION
`Select` will now reset the value of the `input` if users changes value to a `falsy`.

Thanks @rtalvarez for catching this.