### PR TITLE
feat(component): update grid component with responsive props

### DIFF
--- a/packages/big-design/src/components/Grid/Grid.tsx
+++ b/packages/big-design/src/components/Grid/Grid.tsx
@@ -7,14 +7,14 @@ import { GridItem } from './Item/Item';
 
 export type GridProps = BoxProps &
   Partial<{
-    areas: string;
-    autoColumns: string;
-    autoFlow: 'row' | 'column' | 'dense' | 'row dense' | 'column dense' | 'inherit' | 'initial' | 'unset';
-    autoRows: string;
-    columns: string;
-    gap: string;
-    rows: string;
-    template: string;
+    gridAreas: string;
+    gridAutoColumns: string;
+    gridAutoFlow: 'row' | 'column' | 'dense' | 'row dense' | 'column dense' | 'inherit' | 'initial' | 'unset';
+    gridAutoRows: string;
+    gridColumns: string;
+    gridGap: string;
+    gridRows: string;
+    gridTemplate: string;
   }>;
 
 export class Grid extends React.PureComponent<GridProps> {

--- a/packages/big-design/src/components/Grid/Item/Item.tsx
+++ b/packages/big-design/src/components/Grid/Item/Item.tsx
@@ -6,13 +6,13 @@ import { StyledGridItem } from './styled';
 
 export type GridItemProps = BoxProps &
   Partial<{
-    area: string;
-    column: string;
-    columnEnd: string;
-    columnStart: string;
-    row: string;
-    rowEnd: string;
-    rowStart: string;
+    gridArea: string;
+    gridColumn: string;
+    gridColumnEnd: string;
+    gridColumnStart: string;
+    gridRow: string;
+    gridRowEnd: string;
+    gridRowStart: string;
   }>;
 
 export const GridItem: React.FC<GridItemProps> = props => <StyledGridItem {...props} />;

--- a/packages/big-design/src/components/Grid/Item/styled.tsx
+++ b/packages/big-design/src/components/Grid/Item/styled.tsx
@@ -1,15 +1,10 @@
 import styled from 'styled-components';
 
 import { Box } from '../../Box';
+import { withGridedItems } from '../withGrid';
 
 import { GridItemProps } from './Item';
 
 export const StyledGridItem = styled(Box)<GridItemProps>`
-  grid-area: ${props => props.area};
-  grid-column-end: ${props => props.columnEnd};
-  grid-column-start: ${props => props.columnStart};
-  grid-column: ${props => props.column};
-  grid-row-end: ${props => props.rowEnd};
-  grid-row-start: ${props => props.rowStart};
-  grid-row: ${props => props.row};
+  ${withGridedItems()}
 `;

--- a/packages/big-design/src/components/Grid/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Grid/__snapshots__/spec.tsx.snap
@@ -6,9 +6,9 @@ exports[`render Grid 1`] = `
 }
 
 .c0 {
-  display: grid;
   grid-gap: 1rem;
   grid-template: "head head" 80px "nav  main" 1fr "nav  foot" 10% / 120px 1fr;
+  display: grid;
 }
 
 .c2 {

--- a/packages/big-design/src/components/Grid/spec.tsx
+++ b/packages/big-design/src/components/Grid/spec.tsx
@@ -13,11 +13,11 @@ test('render Grid', () => {
 `;
 
   const { container } = render(
-    <Grid template={template}>
-      <Grid.Item area="head">Header</Grid.Item>
-      <Grid.Item area="nav">Sidebar</Grid.Item>
-      <Grid.Item area="main">Content</Grid.Item>
-      <Grid.Item area="foot">Footer</Grid.Item>
+    <Grid gridTemplate={template}>
+      <Grid.Item gridArea="head">Header</Grid.Item>
+      <Grid.Item gridArea="nav">Sidebar</Grid.Item>
+      <Grid.Item gridArea="main">Content</Grid.Item>
+      <Grid.Item gridArea="foot">Footer</Grid.Item>
     </Grid>,
   );
 

--- a/packages/big-design/src/components/Grid/styled.tsx
+++ b/packages/big-design/src/components/Grid/styled.tsx
@@ -3,19 +3,13 @@ import styled from 'styled-components';
 
 import { Box } from '../Box';
 
+import { withGridedContainer } from './withGrid';
 import { GridProps } from './Grid';
 
 export const StyledGrid = styled(Box)<GridProps>`
-  display: grid;
+  ${withGridedContainer()}
 
-  grid-auto-flow: ${props => props.autoFlow};
-  grid-gap: ${props => (props.gap === undefined ? props.theme.spacing.medium : props.gap)};
-  grid-template: ${props => props.template};
-  grid-template-areas: ${props => props.areas};
-  grid-template-columns: ${props => props.columns};
-  grid-template-rows: ${props => props.rows};
-  grid-auto-columns: ${props => props.autoColumns};
-  grid-auto-rows: ${props => props.autoRows};
+  display: grid;
 `;
 
-StyledGrid.defaultProps = { theme: defaultTheme };
+StyledGrid.defaultProps = { theme: defaultTheme, gridGap: defaultTheme.spacing.medium };

--- a/packages/big-design/src/components/Grid/types.ts
+++ b/packages/big-design/src/components/Grid/types.ts
@@ -1,0 +1,103 @@
+import { ThemeInterface } from '@bigcommerce/big-design-theme';
+import { FlattenSimpleInterpolation } from 'styled-components';
+
+import { Responsive } from '../../types';
+
+type SingleGridAreas = string;
+type ResponsiveGridAreas = Responsive<SingleGridAreas>;
+type GridAreas = SingleGridAreas | ResponsiveGridAreas;
+
+type SingleGridAutoColumns = string;
+type ResponsiveGridAutoColumns = Responsive<SingleGridAutoColumns>;
+type GridAutoColumns = SingleGridAutoColumns | ResponsiveGridAutoColumns;
+
+type SingleGridAutoFlow = 'row' | 'column' | 'dense' | 'row dense' | 'column dense' | 'inherit' | 'initial' | 'unset';
+type ResponsiveGridAutoFlow = Responsive<SingleGridAutoFlow>;
+type GridAutoFlow = SingleGridAutoFlow | ResponsiveGridAutoFlow;
+
+type SingleGridAutoRows = string;
+type ResponsiveGridAutoRows = Responsive<SingleGridAutoRows>;
+type GridAutoRows = SingleGridAutoRows | ResponsiveGridAutoRows;
+
+type SingleGridColumns = string;
+type ResponsiveGridColumns = Responsive<SingleGridColumns>;
+type GridColumns = SingleGridColumns | ResponsiveGridColumns;
+
+type SingleGridGap = string;
+type ResponsiveGridGap = Responsive<SingleGridGap>;
+type GridGap = SingleGridGap | ResponsiveGridGap;
+
+type SingleGridRows = string;
+type ResponsiveGridRows = Responsive<SingleGridRows>;
+type GridRows = SingleGridRows | ResponsiveGridRows;
+
+type SingleGridTemplate = string;
+type ResponsiveGridTemplate = Responsive<SingleGridTemplate>;
+type GridTemplate = SingleGridTemplate | ResponsiveGridTemplate;
+
+type SingleGridArea = string;
+type ResponsiveGridArea = Responsive<SingleGridArea>;
+type GridArea = SingleGridArea | ResponsiveGridArea;
+
+type SingleGridColumn = string;
+type ResponsiveGridColumn = Responsive<SingleGridColumn>;
+type GridColumn = SingleGridColumn | ResponsiveGridColumn;
+
+type SingleGridColumnEnd = string;
+type ResponsiveGridColumnEnd = Responsive<SingleGridColumnEnd>;
+type GridColumnEnd = SingleGridColumnEnd | ResponsiveGridColumnEnd;
+
+type SingleGridColumnStart = string;
+type ResponsiveGridColumnStart = Responsive<SingleGridColumnStart>;
+type GridColumnStart = SingleGridColumnStart | ResponsiveGridColumnStart;
+
+type SingleGridRow = string;
+type ResponsiveGridRow = Responsive<SingleGridRow>;
+type GridRow = SingleGridRow | ResponsiveGridRow;
+
+type SingleGridRowEnd = string;
+type ResponsiveGridRowEnd = Responsive<SingleGridRowEnd>;
+type GridRowEnd = SingleGridRowEnd | ResponsiveGridRowEnd;
+
+type SingleGridRowStart = string;
+type ResponsiveGridRowStart = Responsive<SingleGridRowStart>;
+type GridRowStart = SingleGridRowStart | ResponsiveGridRowStart;
+
+export type GridedProps = Partial<{
+  gridAreas: GridAreas;
+  gridAutoColumns: GridAutoColumns;
+  gridAutoFlow: GridAutoFlow;
+  gridAutoRows: GridAutoRows;
+  gridColumns: GridColumns;
+  gridGap: GridGap;
+  gridRows: GridRows;
+  gridTemplate: GridTemplate;
+}>;
+
+export type GridedItemProps = Partial<{
+  gridArea: GridArea;
+  gridColumn: GridColumn;
+  gridColumnEnd: GridColumnEnd;
+  gridColumnStart: GridColumnStart;
+  gridRow: GridRow;
+  gridRowEnd: GridRowEnd;
+  gridRowStart: GridRowStart;
+}>;
+
+export interface GridedOverload {
+  (gridedProp: GridAreas, theme: ThemeInterface, cssKey: 'grid-template-areas'): FlattenSimpleInterpolation;
+  (gridedProp: GridAutoColumns, theme: ThemeInterface, cssKey: 'grid-auto-columns'): FlattenSimpleInterpolation;
+  (gridedProp: GridAutoFlow, theme: ThemeInterface, cssKey: 'grid-auto-flow'): FlattenSimpleInterpolation;
+  (gridedProp: GridAutoRows, theme: ThemeInterface, cssKey: 'grid-auto-rows'): FlattenSimpleInterpolation;
+  (gridedProp: GridColumns, theme: ThemeInterface, cssKey: 'grid-template-columns'): FlattenSimpleInterpolation;
+  (gridedProp: GridGap, theme: ThemeInterface, cssKey: 'grid-gap'): FlattenSimpleInterpolation;
+  (gridedProp: GridRows, theme: ThemeInterface, cssKey: 'grid-template-rows'): FlattenSimpleInterpolation;
+  (gridedProp: GridTemplate, theme: ThemeInterface, cssKey: 'grid-template'): FlattenSimpleInterpolation;
+  (gridedProp: GridArea, theme: ThemeInterface, cssKey: 'grid-area'): FlattenSimpleInterpolation;
+  (gridedProp: GridColumn, theme: ThemeInterface, cssKey: 'grid-column'): FlattenSimpleInterpolation;
+  (gridedProp: GridColumnEnd, theme: ThemeInterface, cssKey: 'grid-column-end'): FlattenSimpleInterpolation;
+  (gridedProp: GridColumnStart, theme: ThemeInterface, cssKey: 'grid-column-start'): FlattenSimpleInterpolation;
+  (gridedProp: GridRow, theme: ThemeInterface, cssKey: 'grid-row'): FlattenSimpleInterpolation;
+  (gridedProp: GridRowEnd, theme: ThemeInterface, cssKey: 'grid-row-end'): FlattenSimpleInterpolation;
+  (gridedProp: GridRowStart, theme: ThemeInterface, cssKey: 'grid-row-start'): FlattenSimpleInterpolation;
+}

--- a/packages/big-design/src/components/Grid/withGrid.ts
+++ b/packages/big-design/src/components/Grid/withGrid.ts
@@ -1,0 +1,66 @@
+import { breakpointsOrder, Breakpoints, ThemeInterface } from '@bigcommerce/big-design-theme';
+import { css, FlattenSimpleInterpolation } from 'styled-components';
+
+import { GridedItemProps, GridedOverload, GridedProps } from './types';
+
+export const withGridedContainer = () => css<GridedProps>`
+  ${({ gridAreas, theme }) => gridAreas && getGridedStyles(gridAreas, theme, 'grid-template-areas')};
+  ${({ gridAutoColumns, theme }) => gridAutoColumns && getGridedStyles(gridAutoColumns, theme, 'grid-auto-columns')};
+  ${({ gridAutoFlow, theme }) => gridAutoFlow && getGridedStyles(gridAutoFlow, theme, 'grid-auto-flow')};
+  ${({ gridAutoRows, theme }) => gridAutoRows && getGridedStyles(gridAutoRows, theme, 'grid-auto-rows')};
+  ${({ gridColumns, theme }) => gridColumns && getGridedStyles(gridColumns, theme, 'grid-template-columns')};
+  ${({ gridGap, theme }) => gridGap && getGridedStyles(gridGap, theme, 'grid-gap')};
+  ${({ gridRows, theme }) => gridRows && getGridedStyles(gridRows, theme, 'grid-template-rows')};
+  ${({ gridTemplate, theme }) => gridTemplate && getGridedStyles(gridTemplate, theme, 'grid-template')};
+`;
+
+export const withGridedItems = () => css<GridedItemProps>`
+  ${({ gridArea, theme }) => gridArea && getGridedStyles(gridArea, theme, 'grid-area')};
+  ${({ gridColumn, theme }) => gridColumn && getGridedStyles(gridColumn, theme, 'grid-column')};
+  ${({ gridColumnEnd, theme }) => gridColumnEnd && getGridedStyles(gridColumnEnd, theme, 'grid-column-end')};
+  ${({ gridColumnStart, theme }) => gridColumnStart && getGridedStyles(gridColumnStart, theme, 'grid-column-start')};
+  ${({ gridRow, theme }) => gridRow && getGridedStyles(gridRow, theme, 'grid-row')};
+  ${({ gridRowEnd, theme }) => gridRowEnd && getGridedStyles(gridRowEnd, theme, 'grid-row-end')};
+  ${({ gridRowStart, theme }) => gridRowStart && getGridedStyles(gridRowStart, theme, 'grid-row-start')};
+`;
+
+const getGridedStyles: GridedOverload = (
+  gridedProp: any,
+  theme: ThemeInterface,
+  cssKey: any,
+): FlattenSimpleInterpolation => {
+  if (typeof gridedProp === 'object') {
+    return getResponsiveGrid(gridedProp, theme, cssKey);
+  }
+
+  if (typeof gridedProp === 'string' || typeof gridedProp === 'number') {
+    return getSimpleGrid(gridedProp, cssKey);
+  }
+
+  return [];
+};
+
+const getSimpleGrid = (gridedProp: string | number, cssKey: string): FlattenSimpleInterpolation => css`
+  ${cssKey}: ${gridedProp}
+`;
+
+const getResponsiveGrid: GridedOverload = (
+  gridedProp: any,
+  theme: ThemeInterface,
+  cssKey: string,
+): FlattenSimpleInterpolation[] => {
+  const breakpointKeys = Object.keys(gridedProp).sort(
+    (firstBreakpoint, secondBreakpoint) =>
+      breakpointsOrder.indexOf(firstBreakpoint as keyof Breakpoints) -
+      breakpointsOrder.indexOf(secondBreakpoint as keyof Breakpoints),
+  );
+
+  return (breakpointKeys as Array<keyof Breakpoints>).map(
+    breakpointKey =>
+      css`
+        ${theme.breakpoints[breakpointKey]} {
+          ${getSimpleGrid(gridedProp[breakpointKey], cssKey)}
+        }
+      `,
+  );
+};

--- a/packages/docs/PropTables/GridPropTable.tsx
+++ b/packages/docs/PropTables/GridPropTable.tsx
@@ -4,37 +4,37 @@ import { Code, PropTable } from '../components';
 
 export const GridPropTable: React.FC = () => (
   <PropTable>
-    <PropTable.Prop name="areas" types="string">
+    <PropTable.Prop name="gridAreas" types="string">
       Defines a grid template by referencing the names of the grid areas which are specified with the grid-area property
       of a grid item. Same as the <Code highlight={false}>grid-template-areas</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="autoColumns" types="string">
+    <PropTable.Prop name="gridAutoColumns" types="string">
       Specifies the size of any auto-generated column grid tracks. Same as the{' '}
       <Code highlight={false}>grid-auto-columns</Code> CSS property.
     </PropTable.Prop>
     <PropTable.Prop
-      name="autoFlow"
+      name="gridAutoFlow"
       types={['row', 'column', 'dense', 'row dense', 'column dense', 'inherit', 'initial', 'unset']}
     >
       Controls how auto placement of grid items work. Same as the <Code highlight={false}>grid-auto-flow</Code> CSS
       property.
     </PropTable.Prop>
-    <PropTable.Prop name="autoRows" types="string">
+    <PropTable.Prop name="gridAutoRows" types="string">
       Specifies the size of any auto-generated row grid tracks. Same as the{' '}
       <Code highlight={false}>grid-auto-rows</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="columns" types="string">
+    <PropTable.Prop name="gridColumns" types="string">
       Defines the columns of the grid with a space-separated list of values. Same as the{' '}
       <Code highlight={false}>grid-template-columns</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="gap" types="string">
+    <PropTable.Prop name="gridGap" types="string">
       Controls the spacing between grid items. Same as the <Code highlight={false}>grid-gap</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="rows" types="string">
+    <PropTable.Prop name="gridRows" types="string">
       Defines the rows of the grid with a space-separated list of values. Same as the{' '}
       <Code highlight={false}>grid-template-rows</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="template" types="string">
+    <PropTable.Prop name="gridTemplate" types="string">
       Shorthand for <Code highlight={false}>grid-template-columns</Code>,{' '}
       <Code highlight={false}>grid-template-rows</Code>, and <Code highlight={false}>grid-template-areas</Code>. Same as
       the <Code highlight={false}>grid-template</Code> CSS property.
@@ -44,31 +44,31 @@ export const GridPropTable: React.FC = () => (
 
 export const GridItemPropTable: React.FC = () => (
   <PropTable>
-    <PropTable.Prop name="area" types="string">
+    <PropTable.Prop name="gridArea" types="string">
       Gives a grid item and area defined via <Code highlight={false}>grid-template-areas</Code>. Same as the{' '}
       <Code highlight={false}>grid-area</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="column" types="string">
+    <PropTable.Prop name="gridColumn" types="string">
       Shorthand for <Code highlight={false}>grid-column-start</Code> and <Code highlight={false}>grid-column-end</Code>.
       Same as the <Code highlight={false}>grid-column</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="columnEnd" types="string">
+    <PropTable.Prop name="gridColumnEnd" types="string">
       Determines a grid item's location within the grid by referring to specific grid lines. Same as the{' '}
       <Code highlight={false}>grid-column-end</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="columnStart" types="string">
+    <PropTable.Prop name="gridColumnStart" types="string">
       Determines a grid item's location within the grid by referring to specific grid lines. Same as the{' '}
       <Code highlight={false}>grid-column-start</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="row" types="string">
+    <PropTable.Prop name="gridRow" types="string">
       Shorthand for <Code highlight={false}>grid-row-start</Code> and <Code highlight={false}>grid-row-end</Code>. Same
       as the <Code highlight={false}>grid-row</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="rowEnd" types="string">
+    <PropTable.Prop name="gridRowEnd" types="string">
       Determines a grid item's location within the grid by referring to specific grid lines. Same as the{' '}
       <Code highlight={false}>grid-row-end</Code> CSS property.
     </PropTable.Prop>
-    <PropTable.Prop name="rowStart" types="string">
+    <PropTable.Prop name="gridRowStart" types="string">
       Determines a grid item's location within the grid by referring to specific grid lines. Same as the{' '}
       <Code highlight={false}>grid-row-start</Code> CSS property.
     </PropTable.Prop>

--- a/packages/docs/pages/Badge/BadgePage.tsx
+++ b/packages/docs/pages/Badge/BadgePage.tsx
@@ -42,7 +42,7 @@ export default () => (
 
     <CodePreview>
       {/* jsx-to-string:start */}
-      <Grid columns="repeat(4, min-content)">
+      <Grid gridColumns="repeat(4, min-content)">
         <Badge variant="secondary">secondary</Badge>
         <Badge variant="success">success</Badge>
         <Badge variant="warning">warning</Badge>

--- a/packages/docs/pages/Dropdown/DropdownPage.tsx
+++ b/packages/docs/pages/Dropdown/DropdownPage.tsx
@@ -48,7 +48,7 @@ export default () => (
     </Text>
     <CodePreview>
       {/* jsx-to-string:start */}
-      <Grid columns="repeat(4, min-content)">
+      <Grid gridColumns="repeat(4, min-content)">
         <Dropdown trigger={<Button>Button</Button>}>
           <Dropdown.Item value={1}>Option</Dropdown.Item>
           <Dropdown.Item value={2}>Option</Dropdown.Item>
@@ -76,7 +76,7 @@ export default () => (
     </Text>
     <CodePreview>
       {/* jsx-to-string:start */}
-      <Grid columns="repeat(4, min-content)">
+      <Grid gridColumns="repeat(4, min-content)">
         <Dropdown placement="right" trigger={<Button>Right</Button>}>
           <Dropdown.Item value={1}>Option</Dropdown.Item>
           <Dropdown.Item value={2}>Option</Dropdown.Item>
@@ -104,7 +104,7 @@ export default () => (
     </Text>
     <CodePreview>
       {/* jsx-to-string:start */}
-      <Grid columns="repeat(3, min-content)">
+      <Grid gridColumns="repeat(3, min-content)">
         <Dropdown trigger={<Button>Default</Button>}>
           <Dropdown.Item value={1}>Option</Dropdown.Item>
           <Dropdown.Item value={2}>Option</Dropdown.Item>
@@ -145,7 +145,7 @@ export default () => (
     </Text>
     <CodePreview>
       {/* jsx-to-string:start */}
-      <Grid columns="repeat(2, min-content)">
+      <Grid gridColumns="repeat(2, min-content)">
         <Dropdown trigger={<Button>With Values</Button>}>
           <Dropdown.Item value={1}>Option</Dropdown.Item>
           <Dropdown.Item value={2}>Option</Dropdown.Item>

--- a/packages/docs/pages/Form/SelectPage.tsx
+++ b/packages/docs/pages/Form/SelectPage.tsx
@@ -78,7 +78,7 @@ export default () => (
 
     <CodePreview>
       {/* jsx-to-string:start */}
-      <Grid columns="repeat(4, 1fr)">
+      <Grid gridColumns="repeat(4, 1fr)">
         <Select label="Select" placeholder="Choose from above" onItemChange={() => null} placement="top">
           <Select.Option value={1}>Option</Select.Option>
           <Select.Option value={2}>Option</Select.Option>
@@ -116,7 +116,7 @@ export default () => (
 
     <CodePreview>
       {/* jsx-to-string:start */}
-      <Grid columns="repeat(3, 1fr)">
+      <Grid gridColumns="repeat(3, 1fr)">
         <Select label="Select" placeholder="Default" onItemChange={() => null}>
           <Select.Option value={1}>Option</Select.Option>
           <Select.Option value={2}>Option</Select.Option>

--- a/packages/docs/pages/Grid/GridPage.tsx
+++ b/packages/docs/pages/Grid/GridPage.tsx
@@ -53,7 +53,8 @@ export default () => (
     <H1>Examples</H1>
 
     <Text>
-      Grid allows you to create custom layouts using combinations of <Code>template</Code> and <Code>area</Code> props.
+      Grid allows you to create custom layouts using combinations of <Code>gridTemplate</Code> and <Code>gridArea</Code>{' '}
+      props.
     </Text>
 
     <CodePreview scope={{ ExampleBox }}>
@@ -67,17 +68,17 @@ export default () => (
         `;
 
         return (
-          <Grid template={template}>
-            <Grid.Item area="head">
+          <Grid gridTemplate={template}>
+            <Grid.Item gridArea="head">
               <ExampleBox>Header</ExampleBox>
             </Grid.Item>
-            <Grid.Item area="nav">
+            <Grid.Item gridArea="nav">
               <ExampleBox>Sidebar</ExampleBox>
             </Grid.Item>
-            <Grid.Item area="main">
+            <Grid.Item gridArea="main">
               <ExampleBox>Content</ExampleBox>
             </Grid.Item>
-            <Grid.Item area="foot">
+            <Grid.Item gridArea="foot">
               <ExampleBox>Footer</ExampleBox>
             </Grid.Item>
           </Grid>
@@ -87,12 +88,12 @@ export default () => (
     </CodePreview>
 
     <Text>
-      You can use the <Code>columns</Code> prop to create columned layouts.
+      You can use the <Code>gridColumns</Code> prop to create columned layouts.
     </Text>
 
     <CodePreview scope={{ ExampleBox }}>
       {/* jsx-to-string:start */}
-      <Grid columns="repeat(3, 1fr)">
+      <Grid gridColumns="repeat(3, 1fr)">
         <Grid.Item>
           <ExampleBox>
             Reprehenderit ullamco et elit eu duis non reprehenderit eiusmod pariatur ea deserunt irure. Reprehenderit et

--- a/packages/docs/pages/_app.tsx
+++ b/packages/docs/pages/_app.tsx
@@ -39,12 +39,12 @@ export default class MyApp extends App {
         <ThemeProvider theme={theme}>
           <>
             <GlobalStyles />
-            <Grid template={gridTemplate} backgroundColor="secondary10" gap="0" style={{ minHeight: '100%' }}>
-              <Grid.Item area="nav" shadow="raised">
+            <Grid gridTemplate={gridTemplate} backgroundColor="secondary10" gridGap="0" style={{ minHeight: '100%' }}>
+              <Grid.Item gridArea="nav" shadow="raised">
                 <SideNav />
               </Grid.Item>
               <Grid.Item
-                area="main"
+                gridArea="main"
                 marginVertical="medium"
                 marginHorizontal="xxLarge"
                 style={{ maxWidth: '100%', overflow: 'hidden' }}


### PR DESCRIPTION
## What
Add responsive breakpoints for `Grid` components.

Fixes issue #74

## Usage
**Single prop:**
```jsx
<Grid gridGap="1rem">...</Grid>
```
Responsive props:
```jsx
<Grid gridGap={{ mobile: '2rem', tablet: '1rem' }}>...</Grid>
```
Same method is used for other Grid props.

CHP-5986

## BREAKING CHANGE:
Changed Grid and Grid.Item props to be more verbose (e.g. areas -> gridAreas)