### PR TITLE
chore(docs): stop using defaultTheme directly

### DIFF
--- a/packages/docs/components/Code/styled.tsx
+++ b/packages/docs/components/Code/styled.tsx
@@ -1,4 +1,3 @@
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { CodeProps } from './';
@@ -20,5 +19,3 @@ export const StyledCode = styled.code<CodeProps>`
       color: ${theme.colors.primary70};
     `};
 `;
-
-StyledCode.defaultProps = { theme: defaultTheme };

--- a/packages/docs/components/CodePreview/CodePreview.tsx
+++ b/packages/docs/components/CodePreview/CodePreview.tsx
@@ -1,11 +1,10 @@
 import * as BigDesign from '@bigcommerce/big-design';
 import * as BigDesignIcons from '@bigcommerce/big-design-icons';
-import { theme } from '@bigcommerce/big-design-theme';
 import clipboardCopy from 'clipboard-copy';
 import { Language } from 'prism-react-renderer';
 import React, { useContext, useState } from 'react';
 import { LiveEditor, LivePreview, LiveProvider } from 'react-live';
-import styled, { ThemeProvider } from 'styled-components';
+import styled from 'styled-components';
 
 import { SnippetControls } from '../SnippetControls';
 import { CodeEditorThemeContext } from '../StoryWrapper/StoryWrapper';
@@ -43,9 +42,7 @@ export const CodePreview: React.FC<CodePreviewProps> = props => {
     <BigDesign.Box border="box" marginBottom="xxLarge">
       <LiveProvider code={code} scope={scope} theme={editorTheme} language={language}>
         <BigDesign.Box padding="medium" backgroundColor="white" borderBottom="box">
-          <ThemeProvider theme={theme}>
-            <LivePreview />
-          </ThemeProvider>
+          <LivePreview />
         </BigDesign.Box>
         <SnippetControls copyToClipboard={() => clipboardCopy(code)} resetCode={() => setCode(initialCode)} />
         <LiveEditor onChange={setCode} />

--- a/packages/docs/components/CodePreview/styled.tsx
+++ b/packages/docs/components/CodePreview/styled.tsx
@@ -1,4 +1,3 @@
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { LiveError } from 'react-live';
 import styled from 'styled-components';
 
@@ -10,5 +9,3 @@ export const StyledLiveError = styled(LiveError)`
   margin-top: ${({ theme }) => theme.spacing.xxLarge};
   padding: ${({ theme }) => theme.spacing.small};
 `;
-
-StyledLiveError.defaultProps = { theme: defaultTheme };

--- a/packages/docs/components/Collapsible/styled.tsx
+++ b/packages/docs/components/Collapsible/styled.tsx
@@ -1,9 +1,6 @@
 import { Flex } from '@bigcommerce/big-design';
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 export const StyledFlex = styled(Flex)`
   cursor: pointer;
 `;
-
-StyledFlex.defaultProps = { theme: defaultTheme };

--- a/packages/docs/components/List/styled.tsx
+++ b/packages/docs/components/List/styled.tsx
@@ -1,4 +1,3 @@
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { ListProps } from './List';
@@ -20,6 +19,3 @@ export const StyledUnorderedList = styled.ul<ListProps>`
   ${SharedListStyles}
   list-style-type: ${({ bulleted }) => `${bulleted ? 'disc' : 'none'}`}
 `;
-
-StyledOrderedList.defaultProps = { theme: defaultTheme };
-StyledUnorderedList.defaultProps = { theme: defaultTheme };

--- a/packages/docs/components/PropTable/styled.tsx
+++ b/packages/docs/components/PropTable/styled.tsx
@@ -1,4 +1,3 @@
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 // TODO: Convert to BigDesign table when built
@@ -43,12 +42,3 @@ export const StyledTableHeader = styled.th`
 export const StyledTableData = styled.td`
   ${SharedCellStyles}
 `;
-
-StyledTableFigure.defaultProps = { theme: defaultTheme };
-StyledTable.defaultProps = { theme: defaultTheme };
-StyledTableHead.defaultProps = { theme: defaultTheme };
-StyledTableBody.defaultProps = { theme: defaultTheme };
-StyledTableFooter.defaultProps = { theme: defaultTheme };
-StyledTableRow.defaultProps = { theme: defaultTheme };
-StyledTableHeader.defaultProps = { theme: defaultTheme };
-StyledTableData.defaultProps = { theme: defaultTheme };

--- a/packages/docs/components/SnippetControls/styled.tsx
+++ b/packages/docs/components/SnippetControls/styled.tsx
@@ -1,9 +1,6 @@
 import { Flex } from '@bigcommerce/big-design';
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 export const StyledFlex = styled(Flex)`
   flex-direction: row;
 `;
-
-StyledFlex.defaultProps = { theme: defaultTheme };

--- a/packages/docs/pages/Colors/ColorsPage.tsx
+++ b/packages/docs/pages/Colors/ColorsPage.tsx
@@ -1,59 +1,63 @@
 import { Box, Flex, H0, H2, Text } from '@bigcommerce/big-design';
-import { remCalc, theme as defaultTheme, ThemeInterface } from '@bigcommerce/big-design-theme';
-import React from 'react';
-import styled from 'styled-components';
+import { remCalc, ThemeInterface } from '@bigcommerce/big-design-theme';
+import React, { useContext } from 'react';
+import styled, { ThemeContext } from 'styled-components';
 
 import { CodePreview } from '../../components';
 
-const { colors } = defaultTheme;
 const COLORS_TO_OMIT = ['primary', 'secondary', 'danger', 'warning', 'success'];
-type Color = keyof ThemeInterface['colors'];
+type Colors = ThemeInterface['colors'];
+type Color = keyof Colors;
 
 const StyledColor = styled(Box)`
   height: ${remCalc(30)};
   width: ${remCalc(300)};
 `;
 
-export default () => (
-  <>
-    <H0>Colors</H0>
+export default () => {
+  const { colors } = useContext(ThemeContext);
 
-    <Text>Colors can be used directly on some of our components that expect a color as a prop:</Text>
+  return (
+    <>
+      <H0>Colors</H0>
 
-    <CodePreview>
-      {/* jsx-to-string:start */}
-      <Box backgroundColor="primary20">Box example</Box>
-      {/* jsx-to-string:end */}
-    </CodePreview>
+      <Text>Colors can be used directly on some of our components that expect a color as a prop:</Text>
 
-    <Text>You can also use the colors directly from the theme to style other components, for example:</Text>
+      <CodePreview>
+        {/* jsx-to-string:start */}
+        <Box backgroundColor="primary20">Box example</Box>
+        {/* jsx-to-string:end */}
+      </CodePreview>
 
-    <CodePreview>
-      {/* jsx-to-string:start */}
-      {function Example() {
-        const StyledBox = styled(Box)(({ theme }) => ({
-          backgroundColor: theme.colors.primary20,
-        }));
+      <Text>You can also use the colors directly from the theme to style other components, for example:</Text>
 
-        return <StyledBox>StyledBox Example</StyledBox>;
-      }}
-      {/* jsx-to-string:end */}
-    </CodePreview>
+      <CodePreview>
+        {/* jsx-to-string:start */}
+        {function Example() {
+          const StyledBox = styled(Box)(({ theme }) => ({
+            backgroundColor: theme.colors.primary20,
+          }));
 
-    <H2>Available Colors</H2>
+          return <StyledBox>StyledBox Example</StyledBox>;
+        }}
+        {/* jsx-to-string:end */}
+      </CodePreview>
 
-    <Flex flexDirection="column">
-      {getColors().map(color => (
-        <Flex alignItems="center" key={color}>
-          <StyledColor backgroundColor={color as Color} />
-          <Text marginLeft="medium">{getColorLabel(color)}</Text>
-        </Flex>
-      ))}
-    </Flex>
-  </>
-);
+      <H2>Available Colors</H2>
 
-function getColors() {
+      <Flex flexDirection="column">
+        {getFilteredColors(colors).map(color => (
+          <Flex alignItems="center" key={color}>
+            <StyledColor backgroundColor={color as Color} />
+            <Text marginLeft="medium">{getColorLabel(color)}</Text>
+          </Flex>
+        ))}
+      </Flex>
+    </>
+  );
+};
+
+function getFilteredColors(colors: Colors) {
   return Object.keys(colors).filter(color => !COLORS_TO_OMIT.includes(color));
 }
 


### PR DESCRIPTION
Since we are [already wrapping ](https://github.com/bigcommerce/big-design/blob/e665479725b67bfc84efe16cf95bc5f75ac39e43/packages/docs/pages/_app.tsx#L39)the whole docs in a `<ThemeProvider />` we don't really need to pass the theme as defaultProps to our internal components (we only do that on big-design so that the user can use the components without a ThemeProvider).

Also removed the `<ThemeProvider />` in `<CodePreview>` since we don't need it anymore (because of the root ThemeProvider).

Removed all direct references to the default theme. For components needed the values directly such as `ColorsPage` to iterate through the colors I'm now getting the theme from context 🔥 