### PR TITLE
feat(docs): add typography documentation

### DIFF
--- a/packages/docs/PropTables/TypographyPropTable.tsx
+++ b/packages/docs/PropTables/TypographyPropTable.tsx
@@ -1,0 +1,15 @@
+import { Link } from '@bigcommerce/big-design';
+import React from 'react';
+
+import { PropTable } from '../components';
+
+export const TypographyPropTable: React.FC = () => (
+  <PropTable>
+    <PropTable.Prop name="color" types={<Link href="/colors">Color</Link>} defaults="secondary70">
+      Sets the text color given a color name from our <Link href="/colors">palette</Link>.
+    </PropTable.Prop>
+    <PropTable.Prop name="ellipse" types="boolean">
+      Controls whether the text will concat and display ellipse... on overflow.
+    </PropTable.Prop>
+  </PropTable>
+);

--- a/packages/docs/PropTables/index.ts
+++ b/packages/docs/PropTables/index.ts
@@ -16,3 +16,4 @@ export * from './RadioPropTable';
 export * from './SelectPropTable';
 export * from './TabsPropTable';
 export * from './TextareaPropTable';
+export * from './TypographyPropTable';

--- a/packages/docs/pages/Typography/TypographyPage.tsx
+++ b/packages/docs/pages/Typography/TypographyPage.tsx
@@ -1,14 +1,76 @@
-import { H0, H1, H2, H3, H4, Small, Text } from '@bigcommerce/big-design';
+import { Box, Flex, H0, H1, H2, H3, H4, Link, Small, Text } from '@bigcommerce/big-design';
 import React from 'react';
+
+import { Code, CodePreview, Collapsible } from '../../components';
+import { MarginPropTable, TypographyPropTable } from '../../PropTables';
 
 export default () => (
   <>
-    <H0>Hero header - h0</H0>
-    <H1>Page header - h1</H1>
-    <H2>Panel header - h2</H2>
-    <H3>Section header - h3</H3>
-    <H4>Group header - h4</H4>
-    <Text>Text - p</Text>
-    <Small>Small text - small</Small>
+    <H0>Typography</H0>
+
+    <Text>
+      BigDesign comes with a collection of predefined typography components.{' '}
+      <Link href="https://design.bigcommerce.com/components/typography">Typography Design Guidelines</Link>.
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      <>
+        <H0>Hero header - h0</H0>
+        <H1>Page header - h1</H1>
+        <H2>Panel header - h2</H2>
+        <H3>Section header - h3</H3>
+        <H4>Group header - h4</H4>
+        <Text>Text - p</Text>
+        <Small>Small text - small</Small>
+      </>
+      {/* jsx-to-string:end */}
+    </CodePreview>
+
+    <Text></Text>
+
+    <H1>API</H1>
+
+    <H2>Typography</H2>
+
+    <TypographyPropTable />
+
+    <H2>Inherited Props</H2>
+
+    <Collapsible title="Margin Props">
+      <MarginPropTable />
+    </Collapsible>
+
+    <H1>Examples</H1>
+
+    <H2>Color</H2>
+
+    <Text>
+      Choose any color from our <Link href="/colors">color pallete</Link> to style your text color.
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      <Flex flexDirection="column">
+        <Text color="primary40">This color is primary40</Text>
+        <Text color="danger70">This color is danger70</Text>
+        <Text color="success50">This color is success50</Text>
+      </Flex>
+      {/* jsx-to-string:end */}
+    </CodePreview>
+
+    <H2>Ellipse</H2>
+
+    <Text>
+      Setting the <Code>ellipsis</Code> prop, will allow text to overflow nicely.
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      <Box style={{ maxWidth: '400px' }}>
+        <H0 ellipsis>Indexes start at 0 and so do our headers.</H0>
+      </Box>
+      {/* jsx-to-string:end */}
+    </CodePreview>
   </>
 );


### PR DESCRIPTION
## What

Add typography documentation.

## Screenshot
![screencapture-localhost-3000-typography-2019-08-08-15_31_51](https://user-images.githubusercontent.com/10539418/62735819-ac457200-b9f1-11e9-8af3-be9338df5ca8.jpg)


I had a hard time coming up with stuff to write about, so make any suggestions @amckemie.