### PR TITLE
feat(docs): support template strings on CodePreview

### DIFF
--- a/packages/docs/components/CodePreview/CodePreview.tsx
+++ b/packages/docs/components/CodePreview/CodePreview.tsx
@@ -26,13 +26,18 @@ function getInitialCode(children: React.ReactNode): string {
   return children;
 }
 
+function transformCode(code: string, noInline = false) {
+  return noInline ? '(' + code.replace('return', 'render') + ')()' : code;
+}
+
 export interface CodePreviewProps {
   scope?: { [key: string]: any };
   language?: Language;
+  noInline?: boolean;
 }
 
 export const CodePreview: React.FC<CodePreviewProps> = props => {
-  const { children, language } = props;
+  const { children, language, noInline } = props;
   const initialCode = getInitialCode(children);
   const [code, setCode] = useState(initialCode);
   const { editorTheme } = useContext(CodeEditorThemeContext);
@@ -40,7 +45,14 @@ export const CodePreview: React.FC<CodePreviewProps> = props => {
 
   return (
     <BigDesign.Box border="box" marginBottom="xxLarge">
-      <LiveProvider code={code} scope={scope} theme={editorTheme} language={language}>
+      <LiveProvider
+        code={code}
+        scope={scope}
+        theme={editorTheme}
+        language={language}
+        transformCode={codeToTransform => transformCode(codeToTransform, noInline)}
+        noInline={noInline}
+      >
         <BigDesign.Box padding="medium" backgroundColor="white" borderBottom="box">
           <LivePreview />
         </BigDesign.Box>

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -44,7 +44,7 @@
     "@bigcommerce/configs": "^0.5.0",
     "@types/styled-components": "^4.1.12",
     "babel-plugin-styled-components": "^1.10.6",
-    "jsx-to-string-loader": "^1.1.2",
+    "jsx-to-string-loader": "^1.2.0",
     "prettier": "^1.16.4",
     "push-dir": "^0.4.1",
     "tslint": "^5.14.0",

--- a/packages/docs/pages/Box/BoxPage.tsx
+++ b/packages/docs/pages/Box/BoxPage.tsx
@@ -58,14 +58,14 @@ export default () => (
         Box is extendable, here is an example on how to create an Avatar component extending from Box with a couple of
         extra styles:
       </Text>
-      <CodePreview>
+      <CodePreview noInline>
         {/* jsx-to-string:start */}
         {function Avatar() {
-          const StyledBox = styled(Box)(({ theme }) => ({
-            boxSizing: 'content-box',
-            height: theme.spacing.large,
-            width: theme.spacing.large,
-          }));
+          const StyledBox = styled(Box)`
+            box-sizing: content-box;
+            height: ${({ theme }) => theme.spacing.large};
+            width: ${({ theme }) => theme.spacing.large};
+          `;
 
           return (
             <StyledBox backgroundColor="primary20" border="box" borderRadius="circle" padding="medium">

--- a/yarn.lock
+++ b/yarn.lock
@@ -6940,10 +6940,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-to-string-loader@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/jsx-to-string-loader/-/jsx-to-string-loader-1.1.2.tgz#b8a7e55f3aa585dc9844b3c231be661e66a5ae57"
-  integrity sha512-5Y9Yi5VwDMtCmzYiTrtyhgQVd9yADxNqPP7HJUEkzIyrwWZ778LvF2kx8LRHKO75+U/0qs5m7jg0uaZDPPbWaw==
+jsx-to-string-loader@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/jsx-to-string-loader/-/jsx-to-string-loader-1.2.0.tgz#eba7a913c0a7815987643b4f95eb328cb999144f"
+  integrity sha512-wrb16ubPTw6gjpYRBvzqMuMicRmIz3oWPRfaGUSy0Xvu1VImGqsY4hcMUKAkOpWQCGRJTKu3LRNLWFwavsgZeA==
 
 kind-of@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Had to do a couple of things to get this working:
- Had to update [jsx-to-string-loader](https://github.com/deini/jsx-to-string-loader/commit/d5ce84ac51bfad44f9c66b324a991d3187f860ce) to escape `$` characters.
- React live accepts a `noInline` prop, when set, it lets you "write imperative code, and render by calling render." so when using `noInline` I'm transforming the code replace `return` for `render` and wrapping it in an IIFE so that render runs.

#### Usage (the only thing that changes is adding `noInline`)
```jsx
<CodePreview noInline>
  {/* jsx-to-string:start */}
  {function Avatar() {
    const StyledBox = styled(Box)`
      box-sizing: content-box;
      height: ${({ theme }) => theme.spacing.large};
      width: ${({ theme }) => theme.spacing.large};
    `;

    return (
      <StyledBox backgroundColor="primary20" border="box" borderRadius="circle" padding="medium">
        BC
      </StyledBox>
    );
  }}
  {/* jsx-to-string:end */}
</CodePreview>
```



![image](https://user-images.githubusercontent.com/2752665/62947486-3a31ac00-bda8-11e9-9aef-de2ded8dc6f4.png)
