### PR TITLE
fix(docs): add missing docs for Flex/Grid

### DIFF
--- a/packages/docs/pages/Flex/FlexPage.tsx
+++ b/packages/docs/pages/Flex/FlexPage.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, H0, H1, H2, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { Code, CodePreview, Collapsible } from '../../components';
-import { FlexItemPropTable, FlexPropTable, MarginPropTable, PaddingPropTable } from '../../PropTables';
+import { BoxPropTable, FlexItemPropTable, FlexPropTable, MarginPropTable, PaddingPropTable } from '../../PropTables';
 
 const ExampleBox: React.FC<{ vertical?: boolean }> = ({ children, vertical }) => (
   <Box
@@ -58,6 +58,10 @@ export default () => (
     <FlexItemPropTable />
 
     <H2>Inherited Props</H2>
+
+    <Collapsible title="Box Props">
+      <BoxPropTable />
+    </Collapsible>
 
     <Collapsible title="Margin Props">
       <MarginPropTable />

--- a/packages/docs/pages/Grid/GridPage.tsx
+++ b/packages/docs/pages/Grid/GridPage.tsx
@@ -1,8 +1,8 @@
 import { Box, Grid, H0, H1, H2, Link, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
-import { Code, CodePreview } from '../../components';
-import { GridItemPropTable, GridPropTable } from '../../PropTables';
+import { Code, CodePreview, Collapsible } from '../../components';
+import { BoxPropTable, GridItemPropTable, GridPropTable, MarginPropTable, PaddingPropTable } from '../../PropTables';
 
 const ExampleBox: React.FC = ({ children }) => (
   <Box backgroundColor="secondary20" border="box" padding="small" style={{ height: '100%' }}>
@@ -50,6 +50,20 @@ export default () => (
     <H2>Grid.Item</H2>
 
     <GridItemPropTable />
+
+    <H2>Inherited Props</H2>
+
+    <Collapsible title="Box Props">
+      <BoxPropTable />
+    </Collapsible>
+
+    <Collapsible title="Margin Props">
+      <MarginPropTable />
+    </Collapsible>
+
+    <Collapsible title="Padding Props">
+      <PaddingPropTable />
+    </Collapsible>
 
     <H1>Examples</H1>
 

--- a/packages/docs/pages/Panel/PanelPage.tsx
+++ b/packages/docs/pages/Panel/PanelPage.tsx
@@ -53,10 +53,6 @@ export default () => (
 
     <H2>Inherited Props</H2>
 
-    <Collapsible title="Box Props">
-      <BoxPropTable />
-    </Collapsible>
-
     <Collapsible title="Margin Props">
       <MarginPropTable />
     </Collapsible>


### PR DESCRIPTION
`Flex/Grid` should show `Box` props, but not `Panel`