### PR TITLE
chore: lerna ignore changes in .md and specs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,6 @@
       "conventionalCommits": true,
       "message": "chore(release): publish"
     }
-  }
+  },
+  "ignoreChanges": ["**/*spec.ts", "**/*spec.tsx", "**/*.snap", "**/*.md"]
 }


### PR DESCRIPTION
Ignore some files on `lerna diff/changed`. This will avoid some unnecessary version bumps, for eg: [big-design-theme 0.1.1](https://github.com/bigcommerce/big-design/blob/master/packages/big-design-theme/CHANGELOG.md) which was released because we made a change to its `README.md`.