### PR TITLE
refactor(docs): no longer need to transform react-live code

### DIFF
--- a/packages/docs/components/CodePreview/CodePreview.tsx
+++ b/packages/docs/components/CodePreview/CodePreview.tsx
@@ -26,31 +26,13 @@ function getInitialCode(children: React.ReactNode): string {
   return children;
 }
 
-function transformCode(code: string, noInline = false) {
-  if (!noInline) {
-    return code;
-  }
-
-  // Split code and make it an IIFE
-  const codeLines = ['(', ...code.split('\n'), ')()'];
-
-  return codeLines
-    .map(line =>
-      line.includes('return <')
-        ? line.replace('return', 'render(').replace('>;', '>);')
-        : line.replace('return', 'render'),
-    )
-    .join('\n');
-}
-
 export interface CodePreviewProps {
   scope?: { [key: string]: any };
   language?: Language;
-  noInline?: boolean;
 }
 
 export const CodePreview: React.FC<CodePreviewProps> = props => {
-  const { children, language, noInline } = props;
+  const { children, language } = props;
   const initialCode = getInitialCode(children);
   const [code, setCode] = useState(initialCode);
   const { editorTheme } = useContext(CodeEditorThemeContext);
@@ -58,14 +40,7 @@ export const CodePreview: React.FC<CodePreviewProps> = props => {
 
   return (
     <BigDesign.Box border="box" marginBottom="xxLarge">
-      <LiveProvider
-        code={code}
-        scope={scope}
-        theme={editorTheme}
-        language={language}
-        transformCode={codeToTransform => transformCode(codeToTransform, noInline)}
-        noInline={noInline}
-      >
+      <LiveProvider code={code} scope={scope} theme={editorTheme} language={language}>
         <BigDesign.Box padding="medium" backgroundColor="white" borderBottom="box">
           <LivePreview />
         </BigDesign.Box>

--- a/packages/docs/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/docs/components/CodeSnippet/CodeSnippet.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@bigcommerce/big-design';
 import clipboardCopy from 'clipboard-copy';
+import { Language } from 'prism-react-renderer';
 import React, { useContext } from 'react';
 import { Editor } from 'react-live';
 
@@ -7,7 +8,7 @@ import { SnippetControls } from '../SnippetControls';
 import { CodeEditorThemeContext } from '../StoryWrapper/StoryWrapper';
 
 interface EditorProps {
-  language?: string;
+  language?: Language;
   showControls?: boolean;
 }
 
@@ -47,9 +48,6 @@ export const CodeSnippet: React.FC<EditorProps> = props => {
     <Box border="box" marginBottom="xxLarge">
       {showControls && <SnippetControls copyToClipboard={() => clipboardCopy(code)} helperText="Code example" />}
 
-      {/* react-live Editor types are wrong, PR submitted */}
-      {/* 
-  // @ts-ignore */}
       <Editor code={code} theme={editorTheme} language={language} disabled />
     </Box>
   );

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -37,7 +37,7 @@
     "prism-react-renderer": "^0.1.7",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "react-live": "^2.1.2",
+    "react-live": "^2.2.0",
     "styled-components": "^4.1.3"
   },
   "devDependencies": {

--- a/packages/docs/pages/Box/BoxPage.tsx
+++ b/packages/docs/pages/Box/BoxPage.tsx
@@ -58,7 +58,7 @@ export default () => (
         Box is extendable, here is an example on how to create an Avatar component extending from Box with a couple of
         extra styles:
       </Text>
-      <CodePreview noInline>
+      <CodePreview>
         {/* jsx-to-string:start */}
         {function Avatar() {
           const StyledBox = styled(Box)`

--- a/packages/docs/pages/Breakpoints/BreakpointsPage.tsx
+++ b/packages/docs/pages/Breakpoints/BreakpointsPage.tsx
@@ -16,7 +16,7 @@ export default () => (
       <Code>{breakpointValues.desktop}</Code> respectively.
     </Text>
 
-    <CodePreview noInline>
+    <CodePreview>
       {/* jsx-to-string:start */}
       {function Example() {
         const StyledBox = styled(Box)`
@@ -41,7 +41,7 @@ export default () => (
       We also expose the <Code primary>breakpointValues</Code> for each breakpoint.
     </Text>
 
-    <CodePreview noInline>
+    <CodePreview>
       {/* jsx-to-string:start */}
       {function Example() {
         const StyledBox = styled(Box)`

--- a/yarn.lock
+++ b/yarn.lock
@@ -9015,10 +9015,10 @@ react-is@16.8.6, react-is@^16.5.2, react-is@^16.6.0, react-is@^16.7.0, react-is@
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-live@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/react-live/-/react-live-2.1.2.tgz#f81a2926d9531563b04a62afe4feee09d78c058c"
-  integrity sha512-RAyu0FaFPnSqC3mG3ira0qmAGfPmGKEmGcAkXHwUNTFgbhVa38gbUSz8K1kvLSZ4yi19EbtVEa7LWQwxO5mEsA==
+react-live@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-live/-/react-live-2.2.0.tgz#538dfb34c614dcdda98845716372129adf59fdef"
+  integrity sha512-Ebbqz2hJGdC0OisXk1XbJ5gb3M3xn7ZdaheisVVFCbivM901Pixy12k1tqBTLoMYjlY2wGAGwgDBTE63Lqaweg==
   dependencies:
     buble "0.19.6"
     core-js "^2.4.1"


### PR DESCRIPTION
Shoutouts to @sofiapoh for https://github.com/FormidableLabs/react-live/pull/159 we no longer need to do our hacky transform to support template strings.

