### PR TITLE
feat(component): add ability to pass arrays into input error

### DIFF
--- a/packages/big-design/src/components/Form/Group/Group.tsx
+++ b/packages/big-design/src/components/Form/Group/Group.tsx
@@ -9,7 +9,7 @@ import { Error as FormError } from '../Error';
 import { StyledError, StyledGroup, StyledInlineGroup } from './styled';
 
 export interface GroupProps extends React.HTMLAttributes<HTMLDivElement> {
-  errors?: string | React.ReactChild | Array<string | React.ReactChild>;
+  errors?: React.ReactChild | React.ReactChild[];
 }
 
 export const Group: React.FC<GroupProps> = props => {

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -10,7 +10,7 @@ import { StyledIconWrapper, StyledInput, StyledInputWrapper } from './styled';
 
 interface Props {
   description?: React.ReactChild;
-  error?: React.ReactChild;
+  error?: React.ReactChild | React.ReactChild[];
   iconLeft?: React.ReactChild;
   iconRight?: React.ReactChild;
   label?: React.ReactChild;

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -257,3 +257,26 @@ test('error shows with valid string', () => {
 
   expect(container.querySelector('[class*="StyledError"]')).toBeInTheDocument();
 });
+
+test('error shows when an array of strings', () => {
+  const errors = ['Error 0', 'Error 1'];
+  const { getByText } = render(
+    <Form.Group>
+      <Input error={errors} />
+    </Form.Group>,
+  );
+
+  errors.forEach(error => expect(getByText(error)).toBeInTheDocument());
+});
+
+test('error shows when an array of Errors', () => {
+  const testIds = ['error_0', 'error_1'];
+  const errors = testIds.map(id => <Input.Error data-testid={id}>Error</Input.Error>);
+  const { getByTestId } = render(
+    <Form.Group>
+      <Input error={errors} />
+    </Form.Group>,
+  );
+
+  testIds.forEach(id => expect(getByTestId(id)).toBeInTheDocument());
+});

--- a/packages/docs/PropTables/FormPropTable.tsx
+++ b/packages/docs/PropTables/FormPropTable.tsx
@@ -34,7 +34,7 @@ export const FormLabelPropTable: React.FC = () => (
 
 export const FormGroupPropTable: React.FC = () => (
   <PropTable>
-    <PropTable.Prop name="errors" types={['string', 'React.ReactChild', 'Array<string | React.ReactChild>']}>
+    <PropTable.Prop name="errors" types={['React.ReactChild', 'React.ReactChild[]']}>
       Pass error(s) into the form group to override child input errors.
     </PropTable.Prop>
   </PropTable>

--- a/packages/docs/PropTables/InputPropTable.tsx
+++ b/packages/docs/PropTables/InputPropTable.tsx
@@ -8,7 +8,7 @@ export const InputPropTable: React.FC = () => (
     <PropTable.Prop name="description" types="ReactChild">
       Append a description to the input field.
     </PropTable.Prop>
-    <PropTable.Prop name="error" types="ReactChild">
+    <PropTable.Prop name="error" types={['ReactChild', 'ReactChild[]']}>
       Displays an error message for the field. Error message will be passed to the <Code>Form.Group</Code> for display
       purposes.
     </PropTable.Prop>


### PR DESCRIPTION
## What

Add ability to pass in an array of strings into `Input`'s.

Also noticed that `React.ReactChild` includes strings, so removed erroneous `string` type declarations.