### PR TITLE
fix(component): use font configs for link component

### DIFF
--- a/packages/big-design/src/components/Link/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Link/__snapshots__/spec.tsx.snap
@@ -4,6 +4,8 @@ exports[`render link 1`] = `
 .c0 {
   color: #3C64F4;
   cursor: pointer;
+  font-size: 1rem;
+  font-weight: 400;
   -webkit-text-decoration: none;
   text-decoration: none;
 }

--- a/packages/big-design/src/components/Link/styled.tsx
+++ b/packages/big-design/src/components/Link/styled.tsx
@@ -10,6 +10,8 @@ export const StyledLink = styled.a<LinkProps>`
 
   color: ${({ theme }) => theme.colors.primary};
   cursor: pointer;
+  font-size: ${({ theme }) => theme.typography.fontSize.medium};
+  font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
   text-decoration: none;
 `;
 


### PR DESCRIPTION
## What?
The Link component is not using font configs from the theme, hence if you have an html font size different than 16, the link component does not scale correctly, I believe this is a bug

<img width="1273" alt="link" src="https://user-images.githubusercontent.com/6025510/63969917-9105d980-ca68-11e9-9217-25b2ab065944.png">
