### PR TITLE
fix(component): textarea rendering two errors

### DIFF
--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -46,7 +46,6 @@ class StyleableTextarea extends React.PureComponent<TextareaProps & PrivateProps
         <StyledTextareaWrapper>
           <StyledTextarea {...props} id={id} rows={this.getRows(rows)} resize={resize} ref={forwardedRef} />
         </StyledTextareaWrapper>
-        {this.renderError()}
       </div>
     );
   }
@@ -83,20 +82,6 @@ class StyleableTextarea extends React.PureComponent<TextareaProps & PrivateProps
       return React.cloneElement(label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>, {
         htmlFor: id,
       });
-    }
-
-    return null;
-  }
-
-  private renderError() {
-    const { error } = this.props;
-
-    if (typeof error === 'string') {
-      return <Textarea.Error>{error}</Textarea.Error>;
-    }
-
-    if (React.isValidElement(error) && error.type === Textarea.Error) {
-      return error;
     }
 
     return null;

--- a/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`renders all together 1`] = `
   margin-bottom: 0;
 }
 
-.c2 {
+.c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -27,7 +27,7 @@ exports[`renders all together 1`] = `
   position: relative;
 }
 
-.c3 {
+.c4 {
   background-color: #FFFFFF;
   border-radius: 0.25rem;
   box-sizing: border-box;
@@ -40,38 +40,38 @@ exports[`renders all together 1`] = `
   border: 1px solid #D9DCE9;
 }
 
-.c3:hover:not([disabled]) {
+.c4:hover:not([disabled]) {
   border: 1px solid #B4BAD1;
 }
 
-.c3:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 0 4px #DBE3FE;
 }
 
-.c3[disabled] {
+.c4[disabled] {
   background-color: #ECEEF5;
 }
 
-.c3::-webkit-input-placeholder {
+.c4::-webkit-input-placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
 }
 
-.c3::-moz-placeholder {
+.c4::-moz-placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
 }
 
-.c3:-ms-input-placeholder {
+.c4:-ms-input-placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
 }
 
-.c3::placeholder {
+.c4::placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
@@ -88,6 +88,13 @@ exports[`renders all together 1`] = `
   margin-bottom: 0.25rem;
 }
 
+@media (min-width:720px) {
+  .eLjSIS .styled__StyledInputWrapper-g32raa-0,
+  .eLjSIS .c2 {
+    max-width: 26rem;
+  }
+}
+
 <div>
   <label
     class="c0"
@@ -101,10 +108,10 @@ exports[`renders all together 1`] = `
     This is a description
   </p>
   <span
-    class="c2"
+    class="c2 c3"
   >
     <textarea
-      class="c3"
+      class="c4"
       id="textarea_0"
       rows="3"
     />

--- a/packages/big-design/src/components/Textarea/spec.tsx
+++ b/packages/big-design/src/components/Textarea/spec.tsx
@@ -2,6 +2,8 @@ import { render } from '@testing-library/react';
 import 'jest-styled-components';
 import React from 'react';
 
+import { Form } from '../Form';
+
 import { Textarea, TextareaProps } from './index';
 
 test('forwards ref', () => {
@@ -28,8 +30,12 @@ test('renders an textarea with matched label', () => {
 test('create unique ids if not provided', () => {
   const { queryByTestId } = render(
     <>
-      <Textarea label="Test Label" data-testid="item1" />
-      <Textarea label="Test Label" data-testid="item2" />
+      <Form.Group>
+        <Textarea label="Test Label" data-testid="item1" />
+      </Form.Group>
+      <Form.Group>
+        <Textarea label="Test Label" data-testid="item2" />
+      </Form.Group>
     </>,
   );
 
@@ -64,7 +70,11 @@ test('renders a description', () => {
 
 test('renders an error', () => {
   const errorText = 'This is an error';
-  const { queryByText } = render(<Textarea error={errorText} />);
+  const { queryByText } = render(
+    <Form.Group>
+      <Textarea error={errorText} />
+    </Form.Group>,
+  );
 
   expect(queryByText(errorText)).toBeInTheDocument();
 });
@@ -139,7 +149,11 @@ test('accepts an Error Component', () => {
     </Textarea.Error>
   );
 
-  const { queryByTestId } = render(<Textarea error={CustomError} />);
+  const { queryByTestId } = render(
+    <Form.Group>
+      <Textarea error={CustomError} />
+    </Form.Group>,
+  );
 
   expect(queryByTestId('test')).toBeInTheDocument();
 });
@@ -154,7 +168,11 @@ test('does not accept non-Error Components', () => {
     </div>
   );
 
-  const { queryByTestId } = render(<Textarea error={NotAnError} />);
+  const { queryByTestId } = render(
+    <Form.Group>
+      <Textarea error={NotAnError} />
+    </Form.Group>,
+  );
 
   expect(queryByTestId('test')).not.toBeInTheDocument();
 });

--- a/packages/big-design/src/components/Textarea/styled.tsx
+++ b/packages/big-design/src/components/Textarea/styled.tsx
@@ -1,4 +1,4 @@
-import { addValues, theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { TextareaProps } from './Textarea';
@@ -58,12 +58,6 @@ export const StyledTextarea = styled.textarea<TextareaProps>`
     line-height: ${({ theme }) => theme.lineHeight.medium};
     font-size: ${({ theme }) => theme.typography.fontSize.medium};
   }
-
-  ${props =>
-    props.error &&
-    css`
-      padding-right: ${addValues(props.theme.spacing.xxLarge, props.theme.spacing.xxSmall)};
-    `};
 `;
 
 StyledTextarea.defaultProps = { theme: defaultTheme };


### PR DESCRIPTION
Fixes this:
<img width="435" alt="Screen Shot 2019-08-29 at 3 47 55 PM" src="https://user-images.githubusercontent.com/10539418/63976230-818d8d00-ca76-11e9-8bd8-7b78800213c2.png">
