### PR TITLE
feat(component): add `positionFixed` prop to Select

### DIFF
--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -10,6 +10,7 @@ interface Props {
   isOpen: boolean;
   maxHeight?: number;
   placement?: Placement;
+  positionFixed?: boolean;
 }
 
 type ListProps = Props & React.HTMLAttributes<HTMLUListElement>;
@@ -21,10 +22,23 @@ export class List extends React.PureComponent<ListProps> {
   };
 
   render() {
-    const { children, handleListRef, isOpen, maxHeight, placement: selectedPlacement, ...rest } = this.props;
+    const {
+      children,
+      handleListRef,
+      isOpen,
+      maxHeight,
+      placement: selectedPlacement,
+      positionFixed,
+      ...rest
+    } = this.props;
 
     return (
-      <Popper innerRef={handleListRef} placement={selectedPlacement} modifiers={{ offset: { offset: '0, 10' } }}>
+      <Popper
+        innerRef={handleListRef}
+        placement={selectedPlacement}
+        positionFixed={positionFixed}
+        modifiers={{ offset: { offset: '0, 10' } }}
+      >
         {({ placement, ref, scheduleUpdate, style }) => (
           <StyledList
             data-placement={placement}

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -27,6 +27,7 @@ interface Props {
   label?: React.ReactChild;
   maxHeight?: number;
   placement?: Placement;
+  positionFixed?: boolean;
   required?: boolean;
   value?: AllHTMLAttributes<HTMLElement>['value'];
   onActionClick?(inputText: string): void;

--- a/packages/docs/PropTables/SelectPropTable.tsx
+++ b/packages/docs/PropTables/SelectPropTable.tsx
@@ -36,6 +36,9 @@ export const SelectPropTable: React.FC = () => (
     >
       Determines the location in which the dropdown will be placed.
     </PropTable.Prop>
+    <PropTable.Prop name="positionFixed" defaults="false" types="boolean">
+      If set, uses <Code>position: fixed</Code> instead of <Code>position: absolute</Code> to position the items.
+    </PropTable.Prop>
     <PropTable.Prop name="required" types="boolean">
       Sets the field as required.
     </PropTable.Prop>


### PR DESCRIPTION
By default we use `absolute` to position a Select list, this prop allows changing the positioning strategy to use `fixed`