### PR TITLE
fix: updates the input label if a matching children appears

### DIFF
--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -62,8 +62,8 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
     this.updatedSelectedItem();
   }
 
-  componentDidUpdate(prevProps: Props) {
-    const { value } = this.props;
+  componentDidUpdate(prevProps: SelectProps) {
+    const { children, value } = this.props;
 
     // Reset input if value was reset to empty string
     if (prevProps.value && !value) {
@@ -74,20 +74,14 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
     if (prevProps.value !== value) {
       this.updatedSelectedItem();
     }
+
+    if (prevProps.children !== children) {
+      this.updatedSelectedItem();
+    }
   }
 
   render() {
-    const {
-      children,
-      label,
-      maxHeight,
-      onActionClick,
-      onItemChange,
-      placeholder,
-      placement,
-      value,
-      ...rest
-    } = this.props;
+    const { label, maxHeight, onActionClick, onItemChange, placeholder, placement, value, ...rest } = this.props;
 
     const { isOpen } = this.state;
 

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -81,7 +81,17 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
   }
 
   render() {
-    const { label, maxHeight, onActionClick, onItemChange, placeholder, placement, value, ...rest } = this.props;
+    const {
+      children,
+      label,
+      maxHeight,
+      onActionClick,
+      onItemChange,
+      placeholder,
+      placement,
+      value,
+      ...rest
+    } = this.props;
 
     const { isOpen } = this.state;
 

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -68,15 +68,21 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
     // Reset input if value was reset to empty string
     if (prevProps.value && !value) {
       this.updatedSelectedItem();
+
+      return;
     }
 
     // Match input text to select value
     if (prevProps.value !== value) {
       this.updatedSelectedItem();
+
+      return;
     }
 
     if (prevProps.children !== children) {
       this.updatedSelectedItem();
+
+      return;
     }
   }
 

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -590,3 +590,28 @@ test('should be invalid when it has an error', () => {
 
   expect(input.checkValidity()).toEqual(false);
 });
+
+test('select input text should update if a matching child appears', () => {
+  const { getAllByLabelText, rerender } = render(
+    <Select onItemChange={onItemChange} label="Countries" placeholder="Choose country" value="mx">
+      <Select.Option value="us">United States</Select.Option>
+      <Select.Option value="ca">Canada</Select.Option>
+      <Select.Option value="en">England</Select.Option>
+    </Select>,
+  );
+
+  const input = getAllByLabelText('Countries')[0];
+
+  expect(input.getAttribute('value')).toEqual('');
+
+  rerender(
+    <Select onItemChange={onItemChange} label="Countries" placeholder="Choose country" value="mx">
+      <Select.Option value="us">United States</Select.Option>
+      <Select.Option value="mx">Mexico</Select.Option>
+      <Select.Option value="ca">Canada</Select.Option>
+      <Select.Option value="en">England</Select.Option>
+    </Select>,
+  );
+
+  expect(input.getAttribute('value')).toEqual('Mexico');
+});


### PR DESCRIPTION
## What?
Updates the input text of a Select component if a matching children suddenly appears within its children

## Testing done
- Verified bug cant be reproduced anymore
- Unit test