### PR TITLE
fix: tests unhandled warnings

### DIFF
--- a/packages/big-design/__mocks__/popper.js.ts
+++ b/packages/big-design/__mocks__/popper.js.ts
@@ -1,0 +1,14 @@
+import { default as PopperJs } from 'popper.js';
+
+export default class Popper {
+  static placements = PopperJs.placements;
+
+  constructor() {
+    return {
+      // tslint:disable-next-line: no-empty
+      destroy: () => {},
+      // tslint:disable-next-line: no-empty
+      scheduleUpdate: () => {},
+    };
+  }
+}

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -6,23 +6,6 @@ import { Button } from '../Button';
 
 import { Dropdown } from './Dropdown';
 
-jest.mock('popper.js', () => {
-  const PopperJS = jest.requireActual('popper.js');
-
-  return class {
-    static placements = PopperJS.placements;
-
-    constructor() {
-      return {
-        // tslint:disable-next-line: no-empty
-        destroy: () => {},
-        // tslint:disable-next-line: no-empty
-        scheduleUpdate: () => {},
-      };
-    }
-  };
-});
-
 const DropdownMock = (
   <Dropdown trigger={<Button>Button</Button>}>
     <Dropdown.Item value={0}>Option</Dropdown.Item>

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -7,23 +7,6 @@ import { Form } from '../Form';
 
 import { Select } from './Select';
 
-jest.mock('popper.js', () => {
-  const PopperJS = jest.requireActual('popper.js');
-
-  return class {
-    static placements = PopperJS.placements;
-
-    constructor() {
-      return {
-        // tslint:disable-next-line: no-empty
-        destroy: () => {},
-        // tslint:disable-next-line: no-empty
-        scheduleUpdate: () => {},
-      };
-    }
-  };
-});
-
 const onItemChange = jest.fn();
 
 const SelectMock = (

--- a/packages/docs/PropTables/PaginationPropTable.tsx
+++ b/packages/docs/PropTables/PaginationPropTable.tsx
@@ -6,22 +6,22 @@ export const PaginationPropTable: React.FC = () => {
   return (
     <PropTable>
       <PropTable.Prop name="itemsPerPage" types="number" defaults="" required>
-        Indicates how many items are displayed per page
+        Indicates how many items are displayed per page.
       </PropTable.Prop>
       <PropTable.Prop name="currentPage" types="number" defaults="" required>
-        Indicates the page currently/initially displayed
+        Indicates the page currently/initially displayed.
       </PropTable.Prop>
       <PropTable.Prop name="totalItems" types="number" defaults="" required>
-        Indicates how many items in total will be displayed
+        Indicates how many items in total will be displayed.
       </PropTable.Prop>
       <PropTable.Prop name="itemsPerPageOptions" types="number[]" defaults="" required>
-        Indicates options for per-page ranges
+        Indicates options for per-page ranges.
       </PropTable.Prop>
       <PropTable.Prop name="onPageChange" types="(page: number) => void" required>
-        Function that will be called when a navigation arrow is clicked
+        Function that will be called when a navigation arrow is clicked.
       </PropTable.Prop>
       <PropTable.Prop name="onItemsPerPageChange" types="(range: number) => void" required>
-        Function that will be called when a new per-page range is selected
+        Function that will be called when a new per-page range is selected.
       </PropTable.Prop>
     </PropTable>
   );


### PR DESCRIPTION
- Mocks popper.js globally in our tests, this fixes an unhandled warning.
- Add `.` to pagination prop table