### PR TITLE
feat(docs): add figma UI kit and sample app to resources section

### DIFF
--- a/packages/docs/pages/GettingStarted/GettingStartedPage.tsx
+++ b/packages/docs/pages/GettingStarted/GettingStartedPage.tsx
@@ -54,10 +54,7 @@ export default () => {
             </Link>
           </List.Item>
           <List.Item>
-            <Link
-              href="https://www.figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate"
-              target="_blank"
-            >
+            <Link href="https://www.figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit" target="_blank">
               Figma UI Kit
             </Link>
           </List.Item>

--- a/packages/docs/pages/GettingStarted/GettingStartedPage.tsx
+++ b/packages/docs/pages/GettingStarted/GettingStartedPage.tsx
@@ -54,6 +54,19 @@ export default () => {
             </Link>
           </List.Item>
           <List.Item>
+            <Link
+              href="https://www.figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate"
+              target="_blank"
+            >
+              Figma UI Kit
+            </Link>
+          </List.Item>
+          <List.Item>
+            <Link href="https://github.com/bigcommerce/channels-app" target="_blank">
+              Sample App
+            </Link>
+          </List.Item>
+          <List.Item>
             <Link href="https://developer.bigcommerce.com" target="_blank">
               Dev Center
             </Link>


### PR DESCRIPTION
**What**
Added links in Helpful Resources section for Figma UI Kit and sample app. 

**Why**
https://jira.bigcommerce.com/browse/CHP-6053

To provide developers and designers with more resources to help them in building apps with BigDesign
