### PR TITLE
feat(component): add ButtonGroup component

### DIFF
--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,29 @@
+import { ThemeInterface } from '@bigcommerce/big-design-theme';
+import React from 'react';
+
+import { Button } from '../Button/Button';
+import { Dropdown } from '../Dropdown';
+import { FlexProps } from '../Flex';
+
+import { StyledButtonGroup } from './styled';
+
+export interface ButtonGroupProps extends FlexProps {
+  theme?: ThemeInterface;
+}
+
+export const ButtonGroup: React.FC<ButtonGroupProps> = ({ children, className, style, ...props }) => {
+  const renderChildren = () => {
+    return React.Children.map(children, child => {
+      if (React.isValidElement(child)) {
+        if (child.type === Button || child.type === Dropdown) {
+          return child;
+        }
+      }
+    });
+  };
+
+  return <StyledButtonGroup {...props}>{renderChildren()}</StyledButtonGroup>;
+};
+
+ButtonGroup.displayName = 'ButtonGroup';
+ButtonGroup.defaultProps = { flexDirection: 'row' };

--- a/packages/big-design/src/components/ButtonGroup/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/ButtonGroup/__snapshots__/spec.tsx.snap
@@ -1,0 +1,261 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders ButtonGroup 1`] = `
+.c2 {
+  box-sizing: border-box;
+}
+
+.c1 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.bd-button + .c0 {
+  margin-left: 0.5rem;
+}
+
+.c0 + .bd-button {
+  margin-left: 0.5rem;
+}
+
+.c0 .bd-button {
+  border-radius: 0;
+  margin: 0;
+  width: auto;
+}
+
+.c0 .bd-button:not(:first-of-type) {
+  border-left: none;
+}
+
+.c0 .bd-button:first-of-type {
+  border-bottom-left-radius: 0.25rem;
+  border-top-left-radius: 0.25rem;
+}
+
+.c0 .bd-button:last-of-type {
+  border-bottom-right-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+<div
+  class="c0 c1 c2"
+/>
+`;
+
+exports[`renders ButtonGroup with Buttons 1`] = `
+.c2 {
+  box-sizing: border-box;
+}
+
+.c1 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  background-color: #3C64F4;
+  border-color: #3C64F4;
+  font-weight: 600;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c3 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c3:active {
+  background-color: #0B38D9;
+}
+
+.c3:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c3:hover:not(:active) {
+  background-color: #2852EB;
+}
+
+.c3[disabled] {
+  background-color: #D9DCE9;
+}
+
+.c4 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+  visibility: visible;
+}
+
+.bd-button + .c0 {
+  margin-left: 0.5rem;
+}
+
+.c0 + .bd-button {
+  margin-left: 0.5rem;
+}
+
+.c0 .bd-button {
+  border-radius: 0;
+  margin: 0;
+  width: auto;
+}
+
+.c0 .bd-button:not(:first-of-type) {
+  border-left: none;
+}
+
+.c0 .bd-button:first-of-type {
+  border-bottom-left-radius: 0.25rem;
+  border-top-left-radius: 0.25rem;
+}
+
+.c0 .bd-button:last-of-type {
+  border-bottom-right-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+@media (min-width:720px) {
+  .c3 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c3 {
+    width: auto;
+  }
+}
+
+<div
+  class="c0 c1 c2"
+>
+  <button
+    class="bd-button c3"
+    role="button"
+    tabindex="0"
+  >
+    <span
+      class="c4"
+    >
+      Test
+    </span>
+  </button>
+  <button
+    class="bd-button c3"
+    role="button"
+    tabindex="0"
+  >
+    <span
+      class="c4"
+    >
+      Test
+    </span>
+  </button>
+  <button
+    class="bd-button c3"
+    role="button"
+    tabindex="0"
+  >
+    <span
+      class="c4"
+    >
+      Test
+    </span>
+  </button>
+</div>
+`;

--- a/packages/big-design/src/components/ButtonGroup/index.ts
+++ b/packages/big-design/src/components/ButtonGroup/index.ts
@@ -1,0 +1,1 @@
+export { ButtonGroup, ButtonGroupProps } from './ButtonGroup';

--- a/packages/big-design/src/components/ButtonGroup/spec.tsx
+++ b/packages/big-design/src/components/ButtonGroup/spec.tsx
@@ -1,0 +1,92 @@
+import { theme } from '@bigcommerce/big-design-theme';
+import { render } from '@testing-library/react';
+import 'jest-styled-components';
+import React from 'react';
+
+import { Button } from '../Button';
+import { Checkbox } from '../Checkbox';
+import { Dropdown } from '../Dropdown';
+
+import { ButtonGroup } from './index';
+
+test('renders ButtonGroup', () => {
+  const { container } = render(<ButtonGroup />);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('renders ButtonGroup with Buttons', () => {
+  const { container } = render(
+    <ButtonGroup>
+      <Button>Test</Button>
+      <Button>Test</Button>
+      <Button>Test</Button>
+    </ButtonGroup>,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('renders middle Button with no border-radius', () => {
+  const testId = 'middleButton';
+
+  const { queryByTestId } = render(
+    <ButtonGroup>
+      <Button>Test</Button>
+      <Button data-testid={testId}>Test</Button>
+      <Button>Test</Button>
+    </ButtonGroup>,
+  );
+
+  expect(queryByTestId(testId)).toHaveStyle('border-radius: 0');
+});
+
+test("renders Buttons with appropriate border-radius'", () => {
+  const firstTestId = 'firstButton';
+  const lastTestId = 'lastButton';
+
+  const { queryByTestId } = render(
+    <ButtonGroup>
+      <Button data-testid={firstTestId}>Test</Button>
+      <Button>Test</Button>
+      <Button data-testid={lastTestId}>Test</Button>
+    </ButtonGroup>,
+  );
+  expect(queryByTestId(firstTestId)).toHaveStyle(`border-bottom-left-radius: ${theme.borderRadius.normal}`);
+  expect(queryByTestId(firstTestId)).toHaveStyle(`border-top-left-radius: ${theme.borderRadius.normal}`);
+
+  expect(queryByTestId(lastTestId)).toHaveStyle(`border-bottom-right-radius: ${theme.borderRadius.normal}`);
+  expect(queryByTestId(lastTestId)).toHaveStyle(`border-top-right-radius: ${theme.borderRadius.normal}`);
+});
+
+test('renders with Dropdown', () => {
+  const { queryByTestId } = render(
+    <ButtonGroup>
+      <Button>Button</Button>
+      <Button>Button</Button>
+      <Dropdown data-testid="dropdown" trigger={<Button data-testid="dropdown-button">Button</Button>}>
+        <Dropdown.Item>Dropdown Item</Dropdown.Item>
+        <Dropdown.Item>Dropdown Item</Dropdown.Item>
+        <Dropdown.Item>Dropdown Item</Dropdown.Item>
+      </Dropdown>
+    </ButtonGroup>,
+  );
+
+  expect(queryByTestId('dropdown')).toBeInTheDocument();
+  expect(queryByTestId('dropdown-button')).toBeInTheDocument();
+});
+
+test("doesn't render with invalid Components", () => {
+  const checkbox = <Checkbox label="Test" />;
+
+  const { queryByLabelText } = render(<ButtonGroup>{checkbox}</ButtonGroup>);
+
+  expect(queryByLabelText('Test')).not.toBeInTheDocument();
+});
+
+test('does not forward styles', () => {
+  const { container } = render(<ButtonGroup className="test" style={{ background: 'red' }} />);
+
+  expect(container.getElementsByClassName('test').length).toBe(0);
+  expect(container.firstChild).not.toHaveStyle('background: red');
+});

--- a/packages/big-design/src/components/ButtonGroup/styled.tsx
+++ b/packages/big-design/src/components/ButtonGroup/styled.tsx
@@ -1,0 +1,38 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled from 'styled-components';
+
+import { Flex } from '../Flex';
+
+import { ButtonGroupProps } from './ButtonGroup';
+
+export const StyledButtonGroup = styled(Flex)<ButtonGroupProps>`
+  .bd-button + & {
+    margin-left: ${({ theme }) => theme.spacing.xSmall};
+  }
+
+  & + .bd-button {
+    margin-left: ${({ theme }) => theme.spacing.xSmall};
+  }
+
+  .bd-button {
+    border-radius: ${({ theme }) => theme.borderRadius.none};
+    margin: 0;
+    width: auto;
+  }
+
+  .bd-button:not(:first-of-type) {
+    border-left: ${({ theme }) => theme.border.none};
+  }
+
+  .bd-button:first-of-type {
+    border-bottom-left-radius: ${({ theme }) => theme.borderRadius.normal};
+    border-top-left-radius: ${({ theme }) => theme.borderRadius.normal};
+  }
+
+  .bd-button:last-of-type {
+    border-bottom-right-radius: ${({ theme }) => theme.borderRadius.normal};
+    border-top-right-radius: ${({ theme }) => theme.borderRadius.normal};
+  }
+`;
+
+StyledButtonGroup.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/index.ts
+++ b/packages/big-design/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from './Badge';
 export * from './Box';
 export * from './Button';
+export * from './ButtonGroup';
 export * from './Checkbox';
 export * from './Chip';
 export * from './Dropdown';

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -64,6 +64,9 @@ export const SideNav: React.FC = () => {
           <SideNavLink href="/Button/ButtonPage" as="/button">
             Button
           </SideNavLink>
+          <SideNavLink href="/ButtonGroup/ButtonGroupPage" as="/button-group">
+            Button Group
+          </SideNavLink>
           <SideNavLink href="/Checkbox/CheckboxPage" as="/checkbox">
             Checkbox
           </SideNavLink>

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -20,6 +20,7 @@ module.exports = {
     '/box': { page: '/Box/BoxPage' },
     '/breakpoints': { page: '/Breakpoints/BreakpointsPage' },
     '/button': { page: '/Button/ButtonPage' },
+    '/button-group': { page: '/ButtonGroup/ButtonGroupPage' },
     '/checkbox': { page: '/Checkbox/CheckboxPage' },
     '/colors': { page: '/Colors/ColorsPage' },
     '/dropdown': { page: '/Dropdown/DropdownPage' },

--- a/packages/docs/pages/ButtonGroup/ButtonGroupPage.tsx
+++ b/packages/docs/pages/ButtonGroup/ButtonGroupPage.tsx
@@ -1,0 +1,65 @@
+import { Button, ButtonGroup, Dropdown, H0, H1, H2, Text } from '@bigcommerce/big-design';
+import { ArrowDropDownIcon } from '@bigcommerce/big-design-icons';
+
+import { Code, CodePreview, CodeSnippet, Collapsible } from '../../components';
+import { FlexPropTable } from '../../PropTables';
+
+export default () => (
+  <>
+    <H0>Button Group</H0>
+
+    <Text>Group a series of Buttons.</Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      <ButtonGroup>
+        <Button>Button</Button>
+        <Button>Button</Button>
+        <Button iconRight={<ArrowDropDownIcon />}>Button</Button>
+      </ButtonGroup>
+      {/* jsx-to-string:end */}
+    </CodePreview>
+
+    <H2>Inherited Props</H2>
+
+    <Collapsible title="Flex Props">
+      <FlexPropTable />
+    </Collapsible>
+
+    <H1>Examples</H1>
+
+    <H2>Secondary Button Group</H2>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      <ButtonGroup>
+        <Button variant="secondary">Button</Button>
+        <Button variant="secondary">Button</Button>
+        <Button variant="secondary" iconRight={<ArrowDropDownIcon />}>
+          Button
+        </Button>
+      </ButtonGroup>
+      {/* jsx-to-string:end */}
+    </CodePreview>
+
+    <H2>Button Group with Dropdown</H2>
+
+    <Text>
+      Button Groups only allow <Code>Button</Code>'s and <Code>Dropdowns</Code> as children.
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      <ButtonGroup>
+        <Button>Button</Button>
+        <Button>Button</Button>
+        <Dropdown placement="bottom-end" trigger={<Button iconRight={<ArrowDropDownIcon />}>Button</Button>}>
+          <Dropdown.Item>Dropdown Item</Dropdown.Item>
+          <Dropdown.Item>Dropdown Item</Dropdown.Item>
+          <Dropdown.Item>Dropdown Item</Dropdown.Item>
+        </Dropdown>
+      </ButtonGroup>
+      {/* jsx-to-string:end */}
+    </CodePreview>
+  </>
+);


### PR DESCRIPTION
## What

Add `ButtonGroup` component to Library. Only accepts `Button` and `Dropdown` components as children.

## Screenshot
![screencapture-localhost-3000-button-group-2019-09-30-14_31_22](https://user-images.githubusercontent.com/10539418/65909981-5f49a080-e38f-11e9-91ae-25f602614ee1.jpg)
