### PR TITLE
fix: setCustomValidity when Input updates/mounts

### DIFF
--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -54,15 +54,6 @@ class StyleableInput extends React.PureComponent<InputProps & PrivateProps, Inpu
   render() {
     const { chips, description, disabled, error, label, forwardedRef, onChipDelete, ...props } = this.props;
     const id = this.getId();
-    let downstreamRef: React.RefObject<HTMLInputElement> | Ref<HTMLInputElement>;
-
-    if (forwardedRef && typeof forwardedRef === 'object') {
-      downstreamRef = forwardedRef;
-    } else if (typeof forwardedRef === 'function') {
-      downstreamRef = this.setCallbackRef;
-    } else {
-      downstreamRef = this.defaultRef;
-    }
 
     return (
       <div>
@@ -81,7 +72,7 @@ class StyleableInput extends React.PureComponent<InputProps & PrivateProps, Inpu
               onBlur={this.onInputBlur}
               onChange={this.onInputChange}
               onFocus={this.onInputFocus}
-              ref={downstreamRef}
+              ref={this.getDownstreamRef(forwardedRef)}
             />
           </StyledInputContent>
 
@@ -91,13 +82,15 @@ class StyleableInput extends React.PureComponent<InputProps & PrivateProps, Inpu
     );
   }
 
-  private setCallbackRef = (ref: HTMLInputElement) => {
-    this.callbackRef = ref;
-
-    if (typeof this.props.forwardedRef === 'function') {
-      this.props.forwardedRef(ref);
+  private getDownstreamRef(forwardedRef: PrivateProps['forwardedRef']) {
+    if (forwardedRef && typeof forwardedRef === 'object') {
+      return forwardedRef;
+    } else if (typeof forwardedRef === 'function') {
+      return this.setCallbackRef;
     }
-  };
+
+    return this.defaultRef;
+  }
 
   private getId() {
     const { id } = this.props;
@@ -177,6 +170,14 @@ class StyleableInput extends React.PureComponent<InputProps & PrivateProps, Inpu
 
     return <StyledIconWrapper>{this.props.iconRight}</StyledIconWrapper>;
   }
+
+  private setCallbackRef = (ref: HTMLInputElement) => {
+    this.callbackRef = ref;
+
+    if (typeof this.props.forwardedRef === 'function') {
+      this.props.forwardedRef(ref);
+    }
+  };
 
   private setFocus(toggle: boolean) {
     this.setState({ focus: toggle });

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -260,19 +260,19 @@ test('it syncs setCustomValidity with the error prop on components with RefObjec
   const input = getByLabelText('Label') as HTMLInputElement;
 
   expect(input.checkValidity()).toEqual(false);
-  expect(ref.current.checkValidity()).toEqual(false);
+  expect((ref.current as HTMLInputElement).checkValidity()).toEqual(false);
   expect(ref.current === input).toEqual(true);
 
   rerender(<Input ref={ref} label="Label" value="9" error="" description="This is a description" required />);
 
   expect(input.checkValidity()).toEqual(true);
-  expect(ref.current.checkValidity()).toEqual(true);
+  expect((ref.current as HTMLInputElement).checkValidity()).toEqual(true);
   expect(ref.current === input).toEqual(true);
 });
 
 test('it syncs setCustomValidity with the error prop on components with Ref callback API', () => {
   let inputRef: HTMLInputElement | null = null;
-  const refSetter = ref => (inputRef = ref);
+  const refSetter = (ref: HTMLInputElement) => (inputRef = ref);
   const { getByLabelText, rerender } = render(
     <Input
       ref={refSetter}
@@ -286,13 +286,13 @@ test('it syncs setCustomValidity with the error prop on components with Ref call
   const input = getByLabelText('Label') as HTMLInputElement;
 
   expect(input.checkValidity()).toEqual(false);
-  expect(inputRef.checkValidity()).toEqual(false);
+  expect(((inputRef as unknown) as HTMLInputElement).checkValidity()).toEqual(false);
   expect(inputRef === input).toEqual(true);
 
   rerender(<Input ref={refSetter} label="Label" value="9" error="" description="This is a description" required />);
 
   expect(input.checkValidity()).toEqual(true);
-  expect(inputRef.checkValidity()).toEqual(true);
+  expect(((inputRef as unknown) as HTMLInputElement).checkValidity()).toEqual(true);
   expect(inputRef === input).toEqual(true);
 });
 

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -239,6 +239,63 @@ test('it is invalid when it was an error', () => {
   expect(input.checkValidity()).toEqual(false);
 });
 
+test('it syncs setCustomValidity with the error prop', () => {
+  const { getByLabelText, rerender } = render(
+    <Input label="Label" value="90" error="90 is too high" description="This is a description" required />,
+  );
+  const input = getByLabelText('Label') as HTMLInputElement;
+
+  expect(input.checkValidity()).toEqual(false);
+
+  rerender(<Input label="Label" value="9" error="" description="This is a description" required />);
+
+  expect(input.checkValidity()).toEqual(true);
+});
+
+test('it syncs setCustomValidity with the error prop on components with RefObject API', () => {
+  const ref = React.createRef<HTMLInputElement>();
+  const { getByLabelText, rerender } = render(
+    <Input ref={ref} label="Label" value="90" error="90 is too high" description="This is a description" required />,
+  );
+  const input = getByLabelText('Label') as HTMLInputElement;
+
+  expect(input.checkValidity()).toEqual(false);
+  expect(ref.current.checkValidity()).toEqual(false);
+  expect(ref.current === input).toEqual(true);
+
+  rerender(<Input ref={ref} label="Label" value="9" error="" description="This is a description" required />);
+
+  expect(input.checkValidity()).toEqual(true);
+  expect(ref.current.checkValidity()).toEqual(true);
+  expect(ref.current === input).toEqual(true);
+});
+
+test('it syncs setCustomValidity with the error prop on components with Ref callback API', () => {
+  let inputRef: HTMLInputElement | null = null;
+  const refSetter = ref => (inputRef = ref);
+  const { getByLabelText, rerender } = render(
+    <Input
+      ref={refSetter}
+      label="Label"
+      value="90"
+      error="90 is too high"
+      description="This is a description"
+      required
+    />,
+  );
+  const input = getByLabelText('Label') as HTMLInputElement;
+
+  expect(input.checkValidity()).toEqual(false);
+  expect(inputRef.checkValidity()).toEqual(false);
+  expect(inputRef === input).toEqual(true);
+
+  rerender(<Input ref={refSetter} label="Label" value="9" error="" description="This is a description" required />);
+
+  expect(input.checkValidity()).toEqual(true);
+  expect(inputRef.checkValidity()).toEqual(true);
+  expect(inputRef === input).toEqual(true);
+});
+
 test('error shows with valid string', () => {
   const error = 'Error';
   const { container, rerender } = render(


### PR DESCRIPTION
## What?
The current approach for `setCustomValidity` on Input components is broken, because it relies on user interaction via the `onChange` handler. Additionally, if no additional onChange handlers are run, the `setValidity` remains calculated based on the props from the previous render

## How?
I'm fixing this by making sure the custom validity is set when the component mounts or updates. This makes sure it is always kept up to date with the most recent props

## Testing done
- Verified component's validity on initial mount
- Verified component's validity on re-renders (on change events)
- Verified swapping the error prop syncs with the validity API
- Verified forms cannot be submitted when error prop exists

All of the above cases were verified by using no ref, `React.createRef` and ref callback functions.

I will continue to run tests, but everything I see works pretty well. LMK if i've missed anything