### PR TITLE
Restrict Dropdown

### DIFF
--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -119,13 +119,13 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
             {option.type === 'link' && !option.disabled ? (
               <Link href={option.url} target={option.target}>
                 <Flex alignItems="center">
-                  <FlexItem paddingRight="small">{this.renderIcon(icon, isHighlighted, option)}</FlexItem>
+                  {icon && <FlexItem paddingRight="small">{this.renderIcon(icon, isHighlighted, option)}</FlexItem>}
                   {content}
                 </Flex>
               </Link>
             ) : (
               <Flex alignItems="center">
-                <FlexItem paddingRight="small">{this.renderIcon(icon, isHighlighted, option)}</FlexItem>
+                {icon && <FlexItem paddingRight="small">{this.renderIcon(icon, isHighlighted, option)}</FlexItem>}
                 {content}
               </Flex>
             )}

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -31,7 +31,6 @@ export interface DropdownLinkItem extends BaseItem {
 }
 
 interface BaseItem extends Omit<ListItemProps, 'content' | 'onClick' | 'value'> {
-  actionType?: 'normal' | 'destructive';
   content: string;
   value?: any;
   onClick?(item: DropdownItem | DropdownLinkItem): void;
@@ -101,7 +100,7 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
         switch (option.type) {
           case 'string':
           default: {
-            const { content, onClick, value, ...rest } = option;
+            const { content, onClick, type, value, ...rest } = option;
 
             return (
               <ListItem
@@ -120,12 +119,14 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
             );
           }
           case 'link': {
-            const { content, onClick, url, target, value, ...rest } = option;
+            const { content, disabled, onClick, url, target, type, value, ...rest } = option;
+            const href = disabled ? {} : { href: url };
 
             return (
               <ListItem
                 {...rest}
                 data-highlighted={highlightedItem && id === highlightedItem.id}
+                disabled={disabled}
                 id={id}
                 key={index}
                 onClick={() => this.handleOnItemClick(option)}
@@ -134,7 +135,7 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
                 ref={ref}
                 role="option"
               >
-                <Link href={url} target={target}>
+                <Link {...href} target={target}>
                   {content}
                 </Link>
               </ListItem>

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -87,8 +87,8 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
             id={id}
             key={index}
             onClick={() => this.handleOnItemClick(option)}
-            onFocus={this.handleOnItemFocus}
-            onMouseOver={this.handleOnItemMouseOver}
+            onFocus={this.handleOnItemHighlighted}
+            onMouseOver={this.handleOnItemHighlighted}
             ref={ref}
             role="option"
           >
@@ -226,11 +226,10 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
     this.toggleList();
   };
 
-  private handleOnItemFocus = (event: React.FocusEvent<HTMLLIElement>) => {
-    return this.updateHighlightedItem(event.currentTarget);
-  };
-
-  private handleOnItemMouseOver = (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
+  // Need to handle focus event for cases when VO manipulate the list via the keyboard hotkeys
+  private handleOnItemHighlighted = (
+    event: React.FocusEvent<HTMLLIElement> | React.MouseEvent<HTMLLIElement, MouseEvent>,
+  ) => {
     return this.updateHighlightedItem(event.currentTarget);
   };
 

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -22,19 +22,18 @@ export interface DropdownProps extends React.HTMLAttributes<HTMLUListElement> {
 
 export interface DropdownItem extends BaseItem {
   type?: 'string';
-  onClick?(item: DropdownItem): void;
 }
 
 export interface DropdownLinkItem extends BaseItem {
   url: string;
   target?: HTMLAnchorElement['target'];
   type: 'link';
-  onClick?(item: DropdownLinkItem): void;
 }
 
 interface BaseItem extends Omit<ListItemProps, 'content' | 'onClick' | 'value'> {
   content: string;
   value?: any;
+  onClick?(item: DropdownItem | DropdownLinkItem): void;
 }
 
 export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> {

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -31,6 +31,7 @@ export interface DropdownLinkItem extends BaseItem {
 }
 
 interface BaseItem extends Omit<ListItemProps, 'content' | 'onClick' | 'value'> {
+  actionType?: 'normal' | 'destructive';
   content: string;
   value?: any;
   onClick?(item: DropdownItem | DropdownLinkItem): void;

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -94,13 +94,13 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
           >
             {option.type === 'link' && !option.disabled ? (
               <Link href={option.url} target={option.target}>
-                <Flex alignItems="center">
+                <Flex alignItems="center" flexDirection="row">
                   {icon && <FlexItem paddingRight="small">{this.renderIcon(option, isHighlighted)}</FlexItem>}
                   {content}
                 </Flex>
               </Link>
             ) : (
-              <Flex alignItems="center">
+              <Flex alignItems="center" flexDirection="row">
                 {icon && <FlexItem paddingRight="small">{this.renderIcon(option, isHighlighted)}</FlexItem>}
                 {content}
               </Flex>

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,3 @@
-import { Placement } from 'popper.js';
 import React, { RefObject } from 'react';
 import { Manager, Reference, RefHandler } from 'react-popper';
 import scrollIntoView from 'scroll-into-view-if-needed';
@@ -8,35 +7,13 @@ import { Flex } from '../Flex';
 import { FlexItem } from '../Flex/Item';
 import { Link } from '../Link';
 import { List } from '../List';
-import { ListItem, ListItemProps } from '../List/Item';
+import { ListItem } from '../List/Item';
+
+import { DropdownItem, DropdownLinkItem, DropdownProps } from './types';
 
 interface DropdownState {
   highlightedItem: HTMLLIElement | null;
   isOpen: boolean;
-}
-
-export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children'> {
-  maxHeight?: number;
-  options: Array<DropdownItem | DropdownLinkItem>;
-  placement?: Placement;
-  trigger: React.ReactElement;
-}
-
-export interface DropdownItem extends BaseItem {
-  type?: 'string';
-}
-
-export interface DropdownLinkItem extends BaseItem {
-  target?: HTMLAnchorElement['target'];
-  type: 'link';
-  url: string;
-}
-
-interface BaseItem extends Omit<ListItemProps, 'children' | 'content' | 'onClick' | 'value'> {
-  content: string;
-  icon?: React.ReactElement;
-  value?: any;
-  onClick?(item: DropdownItem | DropdownLinkItem): void;
 }
 
 export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> {
@@ -54,7 +31,7 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
   private listItemsRefs: Array<RefObject<HTMLLIElement>> = [];
 
   render() {
-    const { children, maxHeight, options, placement, trigger, ...rest } = this.props;
+    const { children, className, maxHeight, options, placement, style, trigger, ...rest } = this.props;
     const { highlightedItem, isOpen } = this.state;
 
     this.listItemsRefs = [];
@@ -94,7 +71,7 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
         }
 
         const id = this.getItemId(option, index);
-        const isHighlighted = !!(highlightedItem && id === highlightedItem.id);
+        const isHighlighted = Boolean(highlightedItem && id === highlightedItem.id);
         const ref = React.createRef<HTMLLIElement>();
 
         if (!option.disabled) {

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -101,12 +101,11 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
           this.listItemsRefs.push(ref);
         }
 
-        const { actionType = 'normal' as 'normal', content, icon, onClick, type, value, ...rest } = option;
+        const { content, icon, onClick, type, value, ...rest } = option;
 
         return (
           <ListItem
             {...rest}
-            actionType={actionType}
             data-highlighted={isHighlighted}
             id={id}
             key={index}
@@ -119,13 +118,13 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
             {option.type === 'link' && !option.disabled ? (
               <Link href={option.url} target={option.target}>
                 <Flex alignItems="center">
-                  {icon && <FlexItem paddingRight="small">{this.renderIcon(icon, isHighlighted, option)}</FlexItem>}
+                  {icon && <FlexItem paddingRight="small">{this.renderIcon(option, isHighlighted)}</FlexItem>}
                   {content}
                 </Flex>
               </Link>
             ) : (
               <Flex alignItems="center">
-                {icon && <FlexItem paddingRight="small">{this.renderIcon(icon, isHighlighted, option)}</FlexItem>}
+                {icon && <FlexItem paddingRight="small">{this.renderIcon(option, isHighlighted)}</FlexItem>}
                 {content}
               </Flex>
             )}
@@ -135,10 +134,10 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
     );
   }
 
-  private renderIcon(icon: React.ReactNode, isHighlighted: boolean, option: DropdownItem | DropdownLinkItem) {
+  private renderIcon(option: DropdownItem | DropdownLinkItem, isHighlighted: boolean) {
     return (
-      React.isValidElement(icon) &&
-      React.cloneElement(icon, {
+      React.isValidElement(option.icon) &&
+      React.cloneElement(option.icon, {
         color: option.disabled
           ? 'secondary40'
           : isHighlighted
@@ -238,13 +237,13 @@ export class Dropdown extends React.PureComponent<DropdownProps, DropdownState> 
     this.toggleList();
   };
 
-  private handleOnItemClick = (option: DropdownItem | DropdownLinkItem) => {
-    if (option.disabled) {
+  private handleOnItemClick = (item: DropdownItem | DropdownLinkItem) => {
+    if (item.disabled) {
       return;
     }
 
-    if (typeof option.onClick === 'function') {
-      option.onClick(option);
+    if (typeof item.onClick === 'function') {
+      item.onClick(item);
     }
 
     this.toggleList();

--- a/packages/big-design/src/components/Dropdown/index.ts
+++ b/packages/big-design/src/components/Dropdown/index.ts
@@ -1,1 +1,2 @@
-export { Dropdown, DropdownItem, DropdownLinkItem, DropdownProps } from './Dropdown';
+export { Dropdown } from './Dropdown';
+export { DropdownItem, DropdownLinkItem, DropdownProps } from './types';

--- a/packages/big-design/src/components/Dropdown/index.ts
+++ b/packages/big-design/src/components/Dropdown/index.ts
@@ -1,1 +1,1 @@
-export { Dropdown, DropdownProps } from './Dropdown';
+export { Dropdown, DropdownItem, DropdownLinkItem, DropdownProps } from './Dropdown';

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -13,8 +13,8 @@ const DropdownMock = (
   <Dropdown
     options={[
       { content: 'Option', type: 'string', value: '0' },
-      { content: 'Option', onClick, type: 'string', value: '1' },
-      { content: 'Option', type: 'string', value: '2' },
+      { content: 'Option', type: 'string', value: '1', onClick },
+      { content: 'Option', type: 'string', value: '2', actionType: 'destructive' },
       { content: 'Option', type: 'string', value: '3', icon: <CheckCircleIcon /> },
     ]}
     trigger={<Button>Button</Button>}

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -267,3 +267,12 @@ test('items renders icons', () => {
   const svg = container.querySelectorAll('svg');
   expect(svg.length).toBe(1);
 });
+
+test('does not forward styles', () => {
+  const { container, getByRole } = render(
+    <Dropdown className="test" style={{ background: 'red' }} options={[]} trigger={<Button>Button</Button>} />,
+  );
+
+  expect(container.getElementsByClassName('test').length).toBe(0);
+  expect(getByRole('listbox')).not.toHaveStyle('background: red');
+});

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -10,12 +10,11 @@ const onClick = jest.fn();
 
 const DropdownMock = (
   <Dropdown
-    onClick={onClick}
     options={[
-      { content: 'Option', onClick, type: 'string', value: '0' },
+      { content: 'Option', type: 'string', value: '0' },
       { content: 'Option', onClick, type: 'string', value: '1' },
-      { content: 'Option', onClick, type: 'string', value: '2' },
-      { content: 'Option', onClick, type: 'string', value: '3' },
+      { content: 'Option', type: 'string', value: '2' },
+      { content: 'Option', type: 'string', value: '3' },
     ]}
     trigger={<Button>Button</Button>}
   ></Dropdown>

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -1,3 +1,4 @@
+import { CheckCircleIcon } from '@bigcommerce/big-design-icons';
 import { fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 import React from 'react';
@@ -14,7 +15,7 @@ const DropdownMock = (
       { content: 'Option', type: 'string', value: '0' },
       { content: 'Option', onClick, type: 'string', value: '1' },
       { content: 'Option', type: 'string', value: '2' },
-      { content: 'Option', type: 'string', value: '3' },
+      { content: 'Option', type: 'string', value: '3', icon: <CheckCircleIcon /> },
     ]}
     trigger={<Button>Button</Button>}
   ></Dropdown>
@@ -258,4 +259,11 @@ test('dropdown menu renders 4 link when passed options of type link', () => {
   options.forEach(option => {
     expect(option.getAttribute('href')).toBe('#');
   });
+});
+
+test('items renders icons', () => {
+  const { container } = render(DropdownMock);
+
+  const svg = container.querySelectorAll('svg');
+  expect(svg.length).toBe(1);
 });

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -6,13 +6,19 @@ import { Button } from '../Button';
 
 import { Dropdown } from './Dropdown';
 
+const onClick = jest.fn();
+
 const DropdownMock = (
-  <Dropdown trigger={<Button>Button</Button>}>
-    <Dropdown.Item value={0}>Option</Dropdown.Item>
-    <Dropdown.Item value={1}>Option</Dropdown.Item>
-    <Dropdown.Item value={2}>Option</Dropdown.Item>
-    <Dropdown.Item value={3}>Option</Dropdown.Item>
-  </Dropdown>
+  <Dropdown
+    onClick={onClick}
+    options={[
+      { content: 'Option', onClick, type: 'string', value: '0' },
+      { content: 'Option', onClick, type: 'string', value: '1' },
+      { content: 'Option', onClick, type: 'string', value: '2' },
+      { content: 'Option', onClick, type: 'string', value: '3' },
+    ]}
+    trigger={<Button>Button</Button>}
+  ></Dropdown>
 );
 
 test('renders dropdown trigger', () => {
@@ -87,13 +93,6 @@ test('dropdown menu should have 4 dropdown items', () => {
 
   const options = getAllByRole('option');
   expect(options.length).toBe(4);
-});
-
-test('dropdown items should have values', () => {
-  const { getAllByRole } = render(DropdownMock);
-
-  const options = getAllByRole('option');
-  options.forEach((option, index) => expect(option.getAttribute('data-value')).toBe(`${index}`));
 });
 
 test('first dropdown item should be selected when dropdown is opened', () => {
@@ -183,14 +182,8 @@ test('end should select last dropdown item', () => {
   expect(menu.getAttribute('aria-activedescendant')).toEqual(options[3].id);
 });
 
-test('enter should trigger onItemClick', () => {
-  const onItemClick = jest.fn();
-  const { getAllByRole, getByRole } = render(
-    <Dropdown onItemClick={onItemClick} trigger={<Button>Button</Button>}>
-      <Dropdown.Item value={0}>Option</Dropdown.Item>
-      <Dropdown.Item value={1}>Option</Dropdown.Item>
-    </Dropdown>,
-  );
+test('enter should trigger onClick', () => {
+  const { getAllByRole, getByRole } = render(DropdownMock);
   const trigger = getByRole('button');
 
   fireEvent.click(trigger);
@@ -202,17 +195,11 @@ test('enter should trigger onItemClick', () => {
   expect(options[1].dataset.highlighted).toBe('true');
 
   fireEvent.keyDown(menu, { key: 'Enter' });
-  expect(onItemClick).toHaveBeenCalledWith('1');
+  expect(onClick).toHaveBeenCalledWith({ content: 'Option', onClick, type: 'string', value: '1' });
 });
 
-test('space should trigger onItemClick', () => {
-  const onItemClick = jest.fn();
-  const { getAllByRole, getByRole } = render(
-    <Dropdown onItemClick={onItemClick} trigger={<Button>Button</Button>}>
-      <Dropdown.Item value={0}>Option</Dropdown.Item>
-      <Dropdown.Item value={1}>Option</Dropdown.Item>
-    </Dropdown>,
-  );
+test('space should trigger onClick', () => {
+  const { getAllByRole, getByRole } = render(DropdownMock);
   const trigger = getByRole('button');
 
   fireEvent.click(trigger);
@@ -224,17 +211,11 @@ test('space should trigger onItemClick', () => {
   expect(options[1].dataset.highlighted).toBe('true');
 
   fireEvent.keyDown(menu, { key: ' ' });
-  expect(onItemClick).toHaveBeenCalledWith('1');
+  expect(onClick).toHaveBeenCalledWith({ content: 'Option', onClick, type: 'string', value: '1' });
 });
 
-test('clicking on dropdown items should trigger onItemClick', () => {
-  const onItemClick = jest.fn();
-  const { getAllByRole, getByRole } = render(
-    <Dropdown onItemClick={onItemClick} trigger={<Button>Button</Button>}>
-      <Dropdown.Item value={0}>Option</Dropdown.Item>
-      <Dropdown.Item value={1}>Option</Dropdown.Item>
-    </Dropdown>,
-  );
+test('clicking on dropdown items should trigger onClick', () => {
+  const { getAllByRole, getByRole } = render(DropdownMock);
   const trigger = getByRole('button');
 
   fireEvent.click(trigger);
@@ -243,7 +224,7 @@ test('clicking on dropdown items should trigger onItemClick', () => {
 
   fireEvent.mouseOver(options[1]);
   fireEvent.click(options[1]);
-  expect(onItemClick).toHaveBeenCalledWith('1');
+  expect(onClick).toHaveBeenCalledWith({ content: 'Option', onClick, type: 'string', value: '1' });
 });
 
 test('dropdown items should be highlighted when moused over', () => {
@@ -256,4 +237,26 @@ test('dropdown items should be highlighted when moused over', () => {
 
   fireEvent.mouseOver(option);
   expect(option.dataset.highlighted).toBe('true');
+});
+
+test('dropdown menu renders 4 link when passed options of type link', () => {
+  const { container } = render(
+    <Dropdown
+      onClick={onClick}
+      options={[
+        { content: 'Option', url: '#', type: 'link' },
+        { content: 'Option', url: '#', type: 'link' },
+        { content: 'Option', url: '#', type: 'link' },
+        { content: 'Option', url: '#', type: 'link' },
+      ]}
+      trigger={<Button>Button</Button>}
+    ></Dropdown>,
+  );
+
+  const options = container.querySelectorAll('a');
+  expect(options.length).toBe(4);
+
+  options.forEach(option => {
+    expect(option.getAttribute('href')).toBe('#');
+  });
 });

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -18,7 +18,7 @@ const DropdownMock = (
       { content: 'Option', type: 'string', value: '3', icon: <CheckCircleIcon /> },
     ]}
     trigger={<Button>Button</Button>}
-  ></Dropdown>
+  />
 );
 
 test('renders dropdown trigger', () => {
@@ -250,7 +250,7 @@ test('dropdown menu renders 4 link when passed options of type link', () => {
         { content: 'Option', url: '#', type: 'link' },
       ]}
       trigger={<Button>Button</Button>}
-    ></Dropdown>,
+    />,
   );
 
   const options = container.querySelectorAll('a');

--- a/packages/big-design/src/components/Dropdown/types.ts
+++ b/packages/big-design/src/components/Dropdown/types.ts
@@ -1,0 +1,27 @@
+import { Placement } from 'popper.js';
+
+import { ListItemProps } from '../List/Item';
+
+export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children'> {
+  maxHeight?: number;
+  options: Array<DropdownItem | DropdownLinkItem>;
+  placement?: Placement;
+  trigger: React.ReactElement;
+}
+
+export interface DropdownItem extends BaseItem {
+  type?: 'string';
+}
+
+export interface DropdownLinkItem extends BaseItem {
+  target?: HTMLAnchorElement['target'];
+  type: 'link';
+  url: string;
+}
+
+interface BaseItem extends Omit<ListItemProps, 'children' | 'content' | 'onClick' | 'value'> {
+  content: string;
+  icon?: React.ReactElement;
+  value?: any;
+  onClick?(item: DropdownItem | DropdownLinkItem): void;
+}

--- a/packages/big-design/src/components/Dropdown/types.ts
+++ b/packages/big-design/src/components/Dropdown/types.ts
@@ -9,6 +9,13 @@ export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLUListElemen
   trigger: React.ReactElement;
 }
 
+interface BaseItem extends Omit<ListItemProps, 'children' | 'content' | 'onClick' | 'value'> {
+  content: string;
+  icon?: React.ReactElement;
+  value?: any;
+  onClick?(item: DropdownItem | DropdownLinkItem): void;
+}
+
 export interface DropdownItem extends BaseItem {
   type?: 'string';
 }
@@ -17,11 +24,4 @@ export interface DropdownLinkItem extends BaseItem {
   target?: HTMLAnchorElement['target'];
   type: 'link';
   url: string;
-}
-
-interface BaseItem extends Omit<ListItemProps, 'children' | 'content' | 'onClick' | 'value'> {
-  content: string;
-  icon?: React.ReactElement;
-  value?: any;
-  onClick?(item: DropdownItem | DropdownLinkItem): void;
 }

--- a/packages/big-design/src/components/List/Item/Item.tsx
+++ b/packages/big-design/src/components/List/Item/Item.tsx
@@ -11,15 +11,13 @@ interface PrivateProps {
   forwardedRef: Ref<HTMLLIElement>;
 }
 
-const StyleableListItem: React.FC<ListItemProps & PrivateProps> = memo(({ children, forwardedRef, value, ...rest }) => {
-  return (
-    <StyledListItem ref={forwardedRef} tabIndex={-1} data-value={value} onMouseDown={preventFocus} {...rest}>
-      {children}
+const StyleableListItem: React.FC<ListItemProps & PrivateProps> = memo(({ children, forwardedRef, value, ...rest }) => (
+  <StyledListItem ref={forwardedRef} tabIndex={-1} data-value={value} onMouseDown={preventFocus} {...rest}>
+    {children}
 
-      {rest['aria-selected'] && <CheckIcon color="primary" size={'large'} />}
-    </StyledListItem>
-  );
-});
+    {rest['aria-selected'] && <CheckIcon color="primary" size="large" />}
+  </StyledListItem>
+));
 
 function preventFocus(event: React.MouseEvent<HTMLLIElement, MouseEvent>) {
   event.preventDefault();

--- a/packages/big-design/src/components/List/Item/Item.tsx
+++ b/packages/big-design/src/components/List/Item/Item.tsx
@@ -4,6 +4,7 @@ import React, { memo, Ref } from 'react';
 import { StyledListItem } from './styled';
 
 export interface ListItemProps extends React.LiHTMLAttributes<HTMLLIElement> {
+  actionType?: 'normal' | 'destructive';
   disabled?: boolean;
 }
 
@@ -11,13 +12,22 @@ interface PrivateProps {
   forwardedRef: Ref<HTMLLIElement>;
 }
 
-const StyleableListItem: React.FC<ListItemProps & PrivateProps> = memo(({ children, forwardedRef, value, ...rest }) => (
-  <StyledListItem ref={forwardedRef} tabIndex={-1} data-value={value} onMouseDown={preventFocus} {...rest}>
-    {children}
+const StyleableListItem: React.FC<ListItemProps & PrivateProps> = memo(
+  ({ actionType = 'normal' as 'normal', children, forwardedRef, value, ...rest }) => (
+    <StyledListItem
+      actionType={actionType}
+      ref={forwardedRef}
+      tabIndex={-1}
+      data-value={value}
+      onMouseDown={preventFocus}
+      {...rest}
+    >
+      {children}
 
-    {rest['aria-selected'] && <CheckIcon color="primary" size="large" />}
-  </StyledListItem>
-));
+      {rest['aria-selected'] && <CheckIcon color="primary" size="large" />}
+    </StyledListItem>
+  ),
+);
 
 function preventFocus(event: React.MouseEvent<HTMLLIElement, MouseEvent>) {
   event.preventDefault();

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -28,7 +28,6 @@ export const StyledListItem = styled.li<ListItemProps>`
 
   a {
     align-items: center;
-    color: ${({ theme }) => theme.colors.secondary70};
     cursor: pointer;
     display: flex;
     height: 100%;

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -18,7 +18,8 @@ export const StyledListItem = styled.li<ListItemProps>`
     font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   }
 
-  &[data-highlighted='true'] {
+  &[data-highlighted='true'],
+  &[data-highlighted='true'] a {
     ${({ actionType, disabled }) =>
       !disabled &&
       (actionType === 'normal'

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -6,7 +6,7 @@ import { ListItemProps } from './Item';
 export const StyledListItem = styled.li<ListItemProps>`
   align-items: center;
   box-sizing: border-box;
-  cursor: default;
+  cursor: pointer;
   display: flex;
   height: ${({ theme }) => theme.helpers.remCalc(36)};
   justify-content: space-between;
@@ -37,30 +37,18 @@ export const StyledListItem = styled.li<ListItemProps>`
     disabled &&
     css`
       color: ${theme.colors.secondary40};
+      cursor: not-allowed;
     `}
 
   a {
     align-items: center;
     color: ${({ theme }) => theme.colors.secondary70};
-    cursor: pointer;
     display: flex;
     height: 100%;
     margin: 0 -${({ theme }) => theme.spacing.medium};
     padding: 0 ${({ theme }) => theme.spacing.medium};
     text-decoration: none;
     width: 100%;
-
-    ${({ disabled, theme }) =>
-      disabled &&
-      css`
-        background-color: inherit;
-        color: ${theme.colors.secondary40};
-
-        :hover {
-          background-color: inherit;
-          cursor: default;
-        }
-      `}
   }
 `;
 

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -18,8 +18,7 @@ export const StyledListItem = styled.li<ListItemProps>`
     font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   }
 
-  &[data-highlighted='true'],
-  &[data-highlighted='true'] a {
+  &[data-highlighted='true'] {
     ${({ actionType, disabled }) =>
       !disabled &&
       (actionType === 'normal'
@@ -36,12 +35,7 @@ export const StyledListItem = styled.li<ListItemProps>`
   ${({ disabled, theme }) =>
     disabled &&
     css`
-      background-color: inherit;
       color: ${theme.colors.secondary40};
-
-      :hover {
-        background-color: inherit;
-      }
     `}
 
   a {

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -18,23 +18,19 @@ export const StyledListItem = styled.li<ListItemProps>`
     font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   }
 
-  &[data-highlighted='true'] {
-    ${({ disabled }) =>
+  &[data-highlighted='true'],
+  &[data-highlighted='true'] a {
+    ${({ actionType, disabled }) =>
       !disabled &&
-      css`
-        background-color: ${({ theme }) => theme.colors.secondary10};
-      `}
-  }
-
-  a {
-    align-items: center;
-    cursor: pointer;
-    display: flex;
-    height: 100%;
-    margin: 0 -${({ theme }) => theme.spacing.medium};
-    padding: 0 ${({ theme }) => theme.spacing.medium};
-    text-decoration: none;
-    width: 100%;
+      (actionType === 'normal'
+        ? css`
+            background-color: ${({ theme }) => theme.colors.secondary10};
+            color: ${({ theme }) => theme.colors.primary};
+          `
+        : css`
+            background-color: ${({ theme }) => theme.colors.danger10};
+            color: ${({ theme }) => theme.colors.danger50};
+          `)}
   }
 
   ${({ disabled, theme }) =>
@@ -47,6 +43,30 @@ export const StyledListItem = styled.li<ListItemProps>`
         background-color: inherit;
       }
     `}
+
+  a {
+    align-items: center;
+    color: ${({ theme }) => theme.colors.secondary70};
+    cursor: pointer;
+    display: flex;
+    height: 100%;
+    margin: 0 -${({ theme }) => theme.spacing.medium};
+    padding: 0 ${({ theme }) => theme.spacing.medium};
+    text-decoration: none;
+    width: 100%;
+
+    ${({ disabled, theme }) =>
+      disabled &&
+      css`
+        background-color: inherit;
+        color: ${theme.colors.secondary40};
+
+        :hover {
+          background-color: inherit;
+          cursor: default;
+        }
+      `}
+  }
 `;
 
 StyledListItem.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -24,7 +24,7 @@ export const StyledListItem = styled.li<ListItemProps>`
       !disabled &&
       (actionType === 'normal'
         ? css`
-            background-color: ${({ theme }) => theme.colors.secondary10};
+            background-color: ${({ theme }) => theme.colors.primary10};
             color: ${({ theme }) => theme.colors.primary};
           `
         : css`

--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -69,7 +69,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
     };
 
     const handleRangeChange = (item: DropdownItem) => {
-      return item.value && onItemsPerPageChange(item.value as number);
+      return item.value && onItemsPerPageChange(item.value);
     };
 
     const showRanges = () => {
@@ -82,15 +82,11 @@ export const Pagination: React.FC<PaginationProps> = memo(
       <Flex role="navigation" aria-label="pagination">
         <Flex.Item>
           <Dropdown
-            options={itemsPerPageOptions.map(
-              range =>
-                ({
-                  content: `${range} per page`,
-                  onClick: handleRangeChange,
-                  type: 'string',
-                  value: range,
-                } as DropdownItem),
-            )}
+            options={itemsPerPageOptions.map(range => ({
+              content: `${range} per page`,
+              onClick: handleRangeChange,
+              value: range,
+            }))}
             trigger={
               <StyledButton variant="subtle" iconRight={<ArrowDropDownIcon size="xxLarge" />}>
                 {showRanges()}

--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -2,7 +2,7 @@ import { ArrowDropDownIcon, ChevronLeftIcon, ChevronRightIcon } from '@bigcommer
 import React, { memo, useEffect, useState } from 'react';
 
 import { MarginProps } from '../../mixins';
-import { Dropdown } from '../Dropdown';
+import { Dropdown, DropdownItem } from '../Dropdown';
 import { Flex } from '../Flex';
 
 import { StyledButton } from './styled';
@@ -68,8 +68,8 @@ export const Pagination: React.FC<PaginationProps> = memo(
       onPageChange(currentPage - 1);
     };
 
-    const handleRangeChange = (range: number) => {
-      onItemsPerPageChange(range);
+    const handleRangeChange = (item: DropdownItem) => {
+      return item.value && onItemsPerPageChange(item.value as number);
     };
 
     const showRanges = () => {
@@ -82,19 +82,21 @@ export const Pagination: React.FC<PaginationProps> = memo(
       <Flex role="navigation" aria-label="pagination">
         <Flex.Item>
           <Dropdown
-            onItemClick={handleRangeChange}
+            options={itemsPerPageOptions.map(
+              range =>
+                ({
+                  content: `${range} per page`,
+                  onClick: handleRangeChange,
+                  type: 'string',
+                  value: range,
+                } as DropdownItem),
+            )}
             trigger={
               <StyledButton variant="subtle" iconRight={<ArrowDropDownIcon size="xxLarge" />}>
                 {showRanges()}
               </StyledButton>
             }
-          >
-            {itemsPerPageOptions.map((range, key) => (
-              <Dropdown.Item key={key} value={range}>
-                {range} per page
-              </Dropdown.Item>
-            ))}
-          </Dropdown>
+          />
         </Flex.Item>
         <Flex.Item>
           <StyledButton variant="subtle" disabled={currentPage <= 1} onClick={handlePageDecrease}>

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -64,8 +64,10 @@ exports[`render pagination component 1`] = `
   font-weight: 600;
 }
 
-.c8[data-highlighted='true'] {
+.c8[data-highlighted='true'],
+.c8[data-highlighted='true'] a {
   background-color: #F6F7FC;
+  color: #3C64F4;
 }
 
 .c8 a {
@@ -73,6 +75,7 @@ exports[`render pagination component 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  color: #313440;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -542,8 +545,10 @@ exports[`render pagination component with invalid page info 1`] = `
   font-weight: 600;
 }
 
-.c8[data-highlighted='true'] {
+.c8[data-highlighted='true'],
+.c8[data-highlighted='true'] a {
   background-color: #F6F7FC;
+  color: #3C64F4;
 }
 
 .c8 a {
@@ -551,6 +556,7 @@ exports[`render pagination component with invalid page info 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  color: #313440;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1020,8 +1026,10 @@ exports[`render pagination component with invalid range info 1`] = `
   font-weight: 600;
 }
 
-.c8[data-highlighted='true'] {
+.c8[data-highlighted='true'],
+.c8[data-highlighted='true'] a {
   background-color: #F6F7FC;
+  color: #3C64F4;
 }
 
 .c8 a {
@@ -1029,6 +1037,7 @@ exports[`render pagination component with invalid range info 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  color: #313440;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1499,8 +1508,10 @@ exports[`render pagination component with no items 1`] = `
   font-weight: 600;
 }
 
-.c8[data-highlighted='true'] {
+.c8[data-highlighted='true'],
+.c8[data-highlighted='true'] a {
   background-color: #F6F7FC;
+  color: #3C64F4;
 }
 
 .c8 a {
@@ -1508,6 +1519,7 @@ exports[`render pagination component with no items 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  color: #313440;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -7,10 +7,73 @@ exports[`render pagination component 1`] = `
   width: 2rem;
 }
 
-.c10 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  padding-right: 0.75rem;
+  box-sizing: border-box;
+}
+
+.c0 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
 }
 
 .c7 {
@@ -87,43 +150,6 @@ exports[`render pagination component 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   width: 100%;
-}
-
-.c1 {
-  box-sizing: border-box;
-}
-
-.c0 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
-  align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c4 {
@@ -203,7 +229,7 @@ exports[`render pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c9 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -249,32 +275,32 @@ exports[`render pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c9:focus {
+.c11:focus {
   outline: none;
 }
 
-.c9[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c9 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c9:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c9:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c9[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -314,6 +340,22 @@ exports[`render pagination component 1`] = `
   }
 }
 
+@media (min-width:0px) {
+  .c9 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:720px) {
+  .c9 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
 @media (min-width:720px) {
   .c4 + .bd-button {
     margin-top: 0;
@@ -328,14 +370,14 @@ exports[`render pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c9 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c9 {
+  .c11 {
     width: auto;
   }
 }
@@ -389,27 +431,51 @@ exports[`render pagination component 1`] = `
     >
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
       >
-        2 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          2 per page
+        </div>
       </li>
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
       >
-        3 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          3 per page
+        </div>
       </li>
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
       >
-        5 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          5 per page
+        </div>
       </li>
     </ul>
   </div>
@@ -417,7 +483,7 @@ exports[`render pagination component 1`] = `
     class="c2 c1"
   >
     <button
-      class="c3 c9"
+      class="c3 c11"
       disabled=""
       role="button"
       tabindex="0"
@@ -426,7 +492,7 @@ exports[`render pagination component 1`] = `
         class="c5"
       >
         <svg
-          class="c10"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -448,7 +514,7 @@ exports[`render pagination component 1`] = `
       </span>
     </button>
     <button
-      class="c3 c9"
+      class="c3 c11"
       role="button"
       tabindex="0"
     >
@@ -456,7 +522,7 @@ exports[`render pagination component 1`] = `
         class="c5"
       >
         <svg
-          class="c10"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -488,10 +554,73 @@ exports[`render pagination component with invalid page info 1`] = `
   width: 2rem;
 }
 
-.c10 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  padding-right: 0.75rem;
+  box-sizing: border-box;
+}
+
+.c0 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
 }
 
 .c7 {
@@ -568,43 +697,6 @@ exports[`render pagination component with invalid page info 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   width: 100%;
-}
-
-.c1 {
-  box-sizing: border-box;
-}
-
-.c0 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
-  align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c4 {
@@ -684,7 +776,7 @@ exports[`render pagination component with invalid page info 1`] = `
   color: #D9DCE9;
 }
 
-.c9 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -730,32 +822,32 @@ exports[`render pagination component with invalid page info 1`] = `
   color: #3C64F4;
 }
 
-.c9:focus {
+.c11:focus {
   outline: none;
 }
 
-.c9[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c9 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c9:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c9:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c9[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -795,6 +887,22 @@ exports[`render pagination component with invalid page info 1`] = `
   }
 }
 
+@media (min-width:0px) {
+  .c9 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:720px) {
+  .c9 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
 @media (min-width:720px) {
   .c4 + .bd-button {
     margin-top: 0;
@@ -809,14 +917,14 @@ exports[`render pagination component with invalid page info 1`] = `
 }
 
 @media (min-width:720px) {
-  .c9 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c9 {
+  .c11 {
     width: auto;
   }
 }
@@ -870,27 +978,51 @@ exports[`render pagination component with invalid page info 1`] = `
     >
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
       >
-        2 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          2 per page
+        </div>
       </li>
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
       >
-        3 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          3 per page
+        </div>
       </li>
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
       >
-        5 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          5 per page
+        </div>
       </li>
     </ul>
   </div>
@@ -898,7 +1030,7 @@ exports[`render pagination component with invalid page info 1`] = `
     class="c2 c1"
   >
     <button
-      class="c3 c9"
+      class="c3 c11"
       disabled=""
       role="button"
       tabindex="0"
@@ -907,7 +1039,7 @@ exports[`render pagination component with invalid page info 1`] = `
         class="c5"
       >
         <svg
-          class="c10"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -929,7 +1061,7 @@ exports[`render pagination component with invalid page info 1`] = `
       </span>
     </button>
     <button
-      class="c3 c9"
+      class="c3 c11"
       role="button"
       tabindex="0"
     >
@@ -937,7 +1069,7 @@ exports[`render pagination component with invalid page info 1`] = `
         class="c5"
       >
         <svg
-          class="c10"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -969,10 +1101,73 @@ exports[`render pagination component with invalid range info 1`] = `
   width: 2rem;
 }
 
-.c10 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  padding-right: 0.75rem;
+  box-sizing: border-box;
+}
+
+.c0 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
 }
 
 .c7 {
@@ -1049,43 +1244,6 @@ exports[`render pagination component with invalid range info 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   width: 100%;
-}
-
-.c1 {
-  box-sizing: border-box;
-}
-
-.c0 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
-  align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c4 {
@@ -1165,7 +1323,7 @@ exports[`render pagination component with invalid range info 1`] = `
   color: #D9DCE9;
 }
 
-.c9 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1211,32 +1369,32 @@ exports[`render pagination component with invalid range info 1`] = `
   color: #3C64F4;
 }
 
-.c9:focus {
+.c11:focus {
   outline: none;
 }
 
-.c9[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c9 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c9:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c9:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c9[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -1276,6 +1434,22 @@ exports[`render pagination component with invalid range info 1`] = `
   }
 }
 
+@media (min-width:0px) {
+  .c9 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:720px) {
+  .c9 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
 @media (min-width:720px) {
   .c4 + .bd-button {
     margin-top: 0;
@@ -1290,14 +1464,14 @@ exports[`render pagination component with invalid range info 1`] = `
 }
 
 @media (min-width:720px) {
-  .c9 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c9 {
+  .c11 {
     width: auto;
   }
 }
@@ -1351,27 +1525,51 @@ exports[`render pagination component with invalid range info 1`] = `
     >
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
       >
-        2 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          2 per page
+        </div>
       </li>
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
       >
-        3 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          3 per page
+        </div>
       </li>
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
       >
-        5 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          5 per page
+        </div>
       </li>
     </ul>
   </div>
@@ -1379,7 +1577,7 @@ exports[`render pagination component with invalid range info 1`] = `
     class="c2 c1"
   >
     <button
-      class="c3 c9"
+      class="c3 c11"
       disabled=""
       role="button"
       tabindex="0"
@@ -1388,7 +1586,7 @@ exports[`render pagination component with invalid range info 1`] = `
         class="c5"
       >
         <svg
-          class="c10"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1410,7 +1608,7 @@ exports[`render pagination component with invalid range info 1`] = `
       </span>
     </button>
     <button
-      class="c3 c9"
+      class="c3 c11"
       disabled=""
       role="button"
       tabindex="0"
@@ -1419,7 +1617,7 @@ exports[`render pagination component with invalid range info 1`] = `
         class="c5"
       >
         <svg
-          class="c10"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1451,10 +1649,73 @@ exports[`render pagination component with no items 1`] = `
   width: 2rem;
 }
 
-.c10 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  padding-right: 0.75rem;
+  box-sizing: border-box;
+}
+
+.c0 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
 }
 
 .c7 {
@@ -1531,43 +1792,6 @@ exports[`render pagination component with no items 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   width: 100%;
-}
-
-.c1 {
-  box-sizing: border-box;
-}
-
-.c0 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
-  align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c4 {
@@ -1647,7 +1871,7 @@ exports[`render pagination component with no items 1`] = `
   color: #D9DCE9;
 }
 
-.c9 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1693,32 +1917,32 @@ exports[`render pagination component with no items 1`] = `
   color: #3C64F4;
 }
 
-.c9:focus {
+.c11:focus {
   outline: none;
 }
 
-.c9[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c9 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c9:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c9:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c9[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -1758,6 +1982,22 @@ exports[`render pagination component with no items 1`] = `
   }
 }
 
+@media (min-width:0px) {
+  .c9 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:720px) {
+  .c9 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
 @media (min-width:720px) {
   .c4 + .bd-button {
     margin-top: 0;
@@ -1772,14 +2012,14 @@ exports[`render pagination component with no items 1`] = `
 }
 
 @media (min-width:720px) {
-  .c9 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c9 {
+  .c11 {
     width: auto;
   }
 }
@@ -1833,27 +2073,51 @@ exports[`render pagination component with no items 1`] = `
     >
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
       >
-        2 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          2 per page
+        </div>
       </li>
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
       >
-        3 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          3 per page
+        </div>
       </li>
       <li
         class="c8"
+        data-highlighted="false"
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
       >
-        5 per page
+        <div
+          class="c9 c1"
+        >
+          <div
+            class="c2 c10"
+          />
+          5 per page
+        </div>
       </li>
     </ul>
   </div>
@@ -1861,7 +2125,7 @@ exports[`render pagination component with no items 1`] = `
     class="c2 c1"
   >
     <button
-      class="c3 c9"
+      class="c3 c11"
       disabled=""
       role="button"
       tabindex="0"
@@ -1870,7 +2134,7 @@ exports[`render pagination component with no items 1`] = `
         class="c5"
       >
         <svg
-          class="c10"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1892,7 +2156,7 @@ exports[`render pagination component with no items 1`] = `
       </span>
     </button>
     <button
-      class="c3 c9"
+      class="c3 c11"
       disabled=""
       role="button"
       tabindex="0"
@@ -1901,7 +2165,7 @@ exports[`render pagination component with no items 1`] = `
         class="c5"
       >
         <svg
-          class="c10"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -7,18 +7,13 @@ exports[`render pagination component 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c11 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
 .c1 {
-  box-sizing: border-box;
-}
-
-.c10 {
-  padding-right: 0.75rem;
   box-sizing: border-box;
 }
 
@@ -129,7 +124,7 @@ exports[`render pagination component 1`] = `
 
 .c8[data-highlighted='true'],
 .c8[data-highlighted='true'] a {
-  background-color: #F6F7FC;
+  background-color: #F0F3FF;
   color: #3C64F4;
 }
 
@@ -229,7 +224,7 @@ exports[`render pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -275,32 +270,32 @@ exports[`render pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c10[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c10 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c10:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c10:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c10:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c10[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -370,14 +365,14 @@ exports[`render pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c10 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c10 {
     width: auto;
   }
 }
@@ -439,9 +434,6 @@ exports[`render pagination component 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           2 per page
         </div>
       </li>
@@ -455,9 +447,6 @@ exports[`render pagination component 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           3 per page
         </div>
       </li>
@@ -471,9 +460,6 @@ exports[`render pagination component 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           5 per page
         </div>
       </li>
@@ -483,7 +469,7 @@ exports[`render pagination component 1`] = `
     class="c2 c1"
   >
     <button
-      class="c3 c11"
+      class="c3 c10"
       disabled=""
       role="button"
       tabindex="0"
@@ -492,7 +478,7 @@ exports[`render pagination component 1`] = `
         class="c5"
       >
         <svg
-          class="c12"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -514,7 +500,7 @@ exports[`render pagination component 1`] = `
       </span>
     </button>
     <button
-      class="c3 c11"
+      class="c3 c10"
       role="button"
       tabindex="0"
     >
@@ -522,7 +508,7 @@ exports[`render pagination component 1`] = `
         class="c5"
       >
         <svg
-          class="c12"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -554,18 +540,13 @@ exports[`render pagination component with invalid page info 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c11 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
 .c1 {
-  box-sizing: border-box;
-}
-
-.c10 {
-  padding-right: 0.75rem;
   box-sizing: border-box;
 }
 
@@ -676,7 +657,7 @@ exports[`render pagination component with invalid page info 1`] = `
 
 .c8[data-highlighted='true'],
 .c8[data-highlighted='true'] a {
-  background-color: #F6F7FC;
+  background-color: #F0F3FF;
   color: #3C64F4;
 }
 
@@ -776,7 +757,7 @@ exports[`render pagination component with invalid page info 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -822,32 +803,32 @@ exports[`render pagination component with invalid page info 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c10[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c10 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c10:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c10:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c10:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c10[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -917,14 +898,14 @@ exports[`render pagination component with invalid page info 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c10 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c10 {
     width: auto;
   }
 }
@@ -986,9 +967,6 @@ exports[`render pagination component with invalid page info 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           2 per page
         </div>
       </li>
@@ -1002,9 +980,6 @@ exports[`render pagination component with invalid page info 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           3 per page
         </div>
       </li>
@@ -1018,9 +993,6 @@ exports[`render pagination component with invalid page info 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           5 per page
         </div>
       </li>
@@ -1030,7 +1002,7 @@ exports[`render pagination component with invalid page info 1`] = `
     class="c2 c1"
   >
     <button
-      class="c3 c11"
+      class="c3 c10"
       disabled=""
       role="button"
       tabindex="0"
@@ -1039,7 +1011,7 @@ exports[`render pagination component with invalid page info 1`] = `
         class="c5"
       >
         <svg
-          class="c12"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1061,7 +1033,7 @@ exports[`render pagination component with invalid page info 1`] = `
       </span>
     </button>
     <button
-      class="c3 c11"
+      class="c3 c10"
       role="button"
       tabindex="0"
     >
@@ -1069,7 +1041,7 @@ exports[`render pagination component with invalid page info 1`] = `
         class="c5"
       >
         <svg
-          class="c12"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1101,18 +1073,13 @@ exports[`render pagination component with invalid range info 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c11 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
 .c1 {
-  box-sizing: border-box;
-}
-
-.c10 {
-  padding-right: 0.75rem;
   box-sizing: border-box;
 }
 
@@ -1223,7 +1190,7 @@ exports[`render pagination component with invalid range info 1`] = `
 
 .c8[data-highlighted='true'],
 .c8[data-highlighted='true'] a {
-  background-color: #F6F7FC;
+  background-color: #F0F3FF;
   color: #3C64F4;
 }
 
@@ -1323,7 +1290,7 @@ exports[`render pagination component with invalid range info 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1369,32 +1336,32 @@ exports[`render pagination component with invalid range info 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c10[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c10 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c10:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c10:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c10:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c10[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -1464,14 +1431,14 @@ exports[`render pagination component with invalid range info 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c10 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c10 {
     width: auto;
   }
 }
@@ -1533,9 +1500,6 @@ exports[`render pagination component with invalid range info 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           2 per page
         </div>
       </li>
@@ -1549,9 +1513,6 @@ exports[`render pagination component with invalid range info 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           3 per page
         </div>
       </li>
@@ -1565,9 +1526,6 @@ exports[`render pagination component with invalid range info 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           5 per page
         </div>
       </li>
@@ -1577,7 +1535,7 @@ exports[`render pagination component with invalid range info 1`] = `
     class="c2 c1"
   >
     <button
-      class="c3 c11"
+      class="c3 c10"
       disabled=""
       role="button"
       tabindex="0"
@@ -1586,7 +1544,7 @@ exports[`render pagination component with invalid range info 1`] = `
         class="c5"
       >
         <svg
-          class="c12"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1608,7 +1566,7 @@ exports[`render pagination component with invalid range info 1`] = `
       </span>
     </button>
     <button
-      class="c3 c11"
+      class="c3 c10"
       disabled=""
       role="button"
       tabindex="0"
@@ -1617,7 +1575,7 @@ exports[`render pagination component with invalid range info 1`] = `
         class="c5"
       >
         <svg
-          class="c12"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1649,18 +1607,13 @@ exports[`render pagination component with no items 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c11 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
 .c1 {
-  box-sizing: border-box;
-}
-
-.c10 {
-  padding-right: 0.75rem;
   box-sizing: border-box;
 }
 
@@ -1771,7 +1724,7 @@ exports[`render pagination component with no items 1`] = `
 
 .c8[data-highlighted='true'],
 .c8[data-highlighted='true'] a {
-  background-color: #F6F7FC;
+  background-color: #F0F3FF;
   color: #3C64F4;
 }
 
@@ -1871,7 +1824,7 @@ exports[`render pagination component with no items 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1917,32 +1870,32 @@ exports[`render pagination component with no items 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c10[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c10 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c10:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c10:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c10:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c10[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -2012,14 +1965,14 @@ exports[`render pagination component with no items 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c10 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c10 {
     width: auto;
   }
 }
@@ -2081,9 +2034,6 @@ exports[`render pagination component with no items 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           2 per page
         </div>
       </li>
@@ -2097,9 +2047,6 @@ exports[`render pagination component with no items 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           3 per page
         </div>
       </li>
@@ -2113,9 +2060,6 @@ exports[`render pagination component with no items 1`] = `
         <div
           class="c9 c1"
         >
-          <div
-            class="c2 c10"
-          />
           5 per page
         </div>
       </li>
@@ -2125,7 +2069,7 @@ exports[`render pagination component with no items 1`] = `
     class="c2 c1"
   >
     <button
-      class="c3 c11"
+      class="c3 c10"
       disabled=""
       role="button"
       tabindex="0"
@@ -2134,7 +2078,7 @@ exports[`render pagination component with no items 1`] = `
         class="c5"
       >
         <svg
-          class="c12"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -2156,7 +2100,7 @@ exports[`render pagination component with no items 1`] = `
       </span>
     </button>
     <button
-      class="c3 c11"
+      class="c3 c10"
       disabled=""
       role="button"
       tabindex="0"
@@ -2165,7 +2109,7 @@ exports[`render pagination component with no items 1`] = `
         class="c5"
       >
         <svg
-          class="c12"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -103,7 +103,7 @@ exports[`render pagination component 1`] = `
   -ms-flex-align: center;
   align-items: center;
   box-sizing: border-box;
-  cursor: default;
+  cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -134,7 +134,6 @@ exports[`render pagination component 1`] = `
   -ms-flex-align: center;
   align-items: center;
   color: #313440;
-  cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -636,7 +635,7 @@ exports[`render pagination component with invalid page info 1`] = `
   -ms-flex-align: center;
   align-items: center;
   box-sizing: border-box;
-  cursor: default;
+  cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -667,7 +666,6 @@ exports[`render pagination component with invalid page info 1`] = `
   -ms-flex-align: center;
   align-items: center;
   color: #313440;
-  cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1169,7 +1167,7 @@ exports[`render pagination component with invalid range info 1`] = `
   -ms-flex-align: center;
   align-items: center;
   box-sizing: border-box;
-  cursor: default;
+  cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1200,7 +1198,6 @@ exports[`render pagination component with invalid range info 1`] = `
   -ms-flex-align: center;
   align-items: center;
   color: #313440;
-  cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1703,7 +1700,7 @@ exports[`render pagination component with no items 1`] = `
   -ms-flex-align: center;
   align-items: center;
   box-sizing: border-box;
-  cursor: default;
+  cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1734,7 +1731,6 @@ exports[`render pagination component with no items 1`] = `
   -ms-flex-align: center;
   align-items: center;
   color: #313440;
-  cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -389,7 +389,6 @@ exports[`render pagination component 1`] = `
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
-        type="string"
       >
         2 per page
       </li>
@@ -398,7 +397,6 @@ exports[`render pagination component 1`] = `
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
-        type="string"
       >
         3 per page
       </li>
@@ -407,7 +405,6 @@ exports[`render pagination component 1`] = `
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
-        type="string"
       >
         5 per page
       </li>
@@ -870,7 +867,6 @@ exports[`render pagination component with invalid page info 1`] = `
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
-        type="string"
       >
         2 per page
       </li>
@@ -879,7 +875,6 @@ exports[`render pagination component with invalid page info 1`] = `
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
-        type="string"
       >
         3 per page
       </li>
@@ -888,7 +883,6 @@ exports[`render pagination component with invalid page info 1`] = `
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
-        type="string"
       >
         5 per page
       </li>
@@ -1351,7 +1345,6 @@ exports[`render pagination component with invalid range info 1`] = `
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
-        type="string"
       >
         2 per page
       </li>
@@ -1360,7 +1353,6 @@ exports[`render pagination component with invalid range info 1`] = `
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
-        type="string"
       >
         3 per page
       </li>
@@ -1369,7 +1361,6 @@ exports[`render pagination component with invalid range info 1`] = `
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
-        type="string"
       >
         5 per page
       </li>
@@ -1833,7 +1824,6 @@ exports[`render pagination component with no items 1`] = `
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
-        type="string"
       >
         2 per page
       </li>
@@ -1842,7 +1832,6 @@ exports[`render pagination component with no items 1`] = `
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
-        type="string"
       >
         3 per page
       </li>
@@ -1851,7 +1840,6 @@ exports[`render pagination component with no items 1`] = `
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
-        type="string"
       >
         5 per page
       </li>

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -73,7 +73,6 @@ exports[`render pagination component 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  color: #313440;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -387,33 +386,30 @@ exports[`render pagination component 1`] = `
     >
       <li
         class="c8"
-        data-value="2"
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        2
-         per page
+        2 per page
       </li>
       <li
         class="c8"
-        data-value="3"
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        3
-         per page
+        3 per page
       </li>
       <li
         class="c8"
-        data-value="5"
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        5
-         per page
+        5 per page
       </li>
     </ul>
   </div>
@@ -558,7 +554,6 @@ exports[`render pagination component with invalid page info 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  color: #313440;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -872,33 +867,30 @@ exports[`render pagination component with invalid page info 1`] = `
     >
       <li
         class="c8"
-        data-value="2"
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        2
-         per page
+        2 per page
       </li>
       <li
         class="c8"
-        data-value="3"
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        3
-         per page
+        3 per page
       </li>
       <li
         class="c8"
-        data-value="5"
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        5
-         per page
+        5 per page
       </li>
     </ul>
   </div>
@@ -1043,7 +1035,6 @@ exports[`render pagination component with invalid range info 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  color: #313440;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1357,33 +1348,30 @@ exports[`render pagination component with invalid range info 1`] = `
     >
       <li
         class="c8"
-        data-value="2"
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        2
-         per page
+        2 per page
       </li>
       <li
         class="c8"
-        data-value="3"
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        3
-         per page
+        3 per page
       </li>
       <li
         class="c8"
-        data-value="5"
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        5
-         per page
+        5 per page
       </li>
     </ul>
   </div>
@@ -1529,7 +1517,6 @@ exports[`render pagination component with no items 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  color: #313440;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1843,33 +1830,30 @@ exports[`render pagination component with no items 1`] = `
     >
       <li
         class="c8"
-        data-value="2"
         id="dropdown_0-item-0"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        2
-         per page
+        2 per page
       </li>
       <li
         class="c8"
-        data-value="3"
         id="dropdown_0-item-1"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        3
-         per page
+        3 per page
       </li>
       <li
         class="c8"
-        data-value="5"
         id="dropdown_0-item-2"
         role="option"
         tabindex="-1"
+        type="string"
       >
-        5
-         per page
+        5 per page
       </li>
     </ul>
   </div>

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -46,6 +46,9 @@ exports[`render pagination component 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
@@ -328,22 +331,6 @@ exports[`render pagination component 1`] = `
 
 @media (min-width:720px) {
   .c0 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media (min-width:0px) {
-  .c9 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-  }
-}
-
-@media (min-width:720px) {
-  .c9 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -578,6 +565,9 @@ exports[`render pagination component with invalid page info 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
@@ -860,22 +850,6 @@ exports[`render pagination component with invalid page info 1`] = `
 
 @media (min-width:720px) {
   .c0 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media (min-width:0px) {
-  .c9 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-  }
-}
-
-@media (min-width:720px) {
-  .c9 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1110,6 +1084,9 @@ exports[`render pagination component with invalid range info 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
@@ -1392,22 +1369,6 @@ exports[`render pagination component with invalid range info 1`] = `
 
 @media (min-width:720px) {
   .c0 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media (min-width:0px) {
-  .c9 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-  }
-}
-
-@media (min-width:720px) {
-  .c9 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -1643,6 +1604,9 @@ exports[`render pagination component with no items 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
@@ -1925,22 +1889,6 @@ exports[`render pagination component with no items 1`] = `
 
 @media (min-width:720px) {
   .c0 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media (min-width:0px) {
-  .c9 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-  }
-}
-
-@media (min-width:720px) {
-  .c9 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;

--- a/packages/docs/PropTables/DropdownPropTable.tsx
+++ b/packages/docs/PropTables/DropdownPropTable.tsx
@@ -28,11 +28,10 @@ export const DropdownPropTable: React.FC = () => (
       ]}
       defaults="bottom-start"
     >
-      Sets the position of the Dropdown relative to the anchor.
+      Sets the placement of the Dropdown relative to the anchor.
     </PropTable.Prop>
     <PropTable.Prop name="options" types="Array<DropdownItem | DropdownLinkItem>">
-      Accepts an array of objects with <Code>LI</Code> props and an additional
-      <Code>content</Code> prop. See example for usage.
+      Accepts an array of <Code>DropdownItems</Code> and <Code>DropdownLinkItems</Code>. See example for usage.
     </PropTable.Prop>
     <PropTable.Prop name="trigger" types="ReactElement" required>
       Element used as anchor.

--- a/packages/docs/PropTables/DropdownPropTable.tsx
+++ b/packages/docs/PropTables/DropdownPropTable.tsx
@@ -41,11 +41,28 @@ export const DropdownPropTable: React.FC = () => (
 
 export const DropdownItemPropTable: React.FC = () => (
   <PropTable>
+    <PropTable.Prop name="actionType" types={['normal', 'destructive']} defaults="normal">
+      Indicates whether your item's action is of normal or destructive nature.
+    </PropTable.Prop>
     <PropTable.Prop name="content" types="string" required>
       Sets the text content of the Dropdown Item.
     </PropTable.Prop>
     <PropTable.Prop name="disabled" types="boolean">
       Sets the item to disabled.
+    </PropTable.Prop>
+    <PropTable.Prop
+      name="icon"
+      types={
+        <NextLink href="/Icons/IconsPage" as="/icons">
+          Icon
+        </NextLink>
+      }
+    >
+      Pass in an{' '}
+      <NextLink href="/Icons/IconsPage" as="/icons">
+        Icon
+      </NextLink>{' '}
+      component to display to the left of the text.
     </PropTable.Prop>
     <PropTable.Prop name="onClick" types="(item: DropdownItem): void">
       Returns the item object.
@@ -61,8 +78,28 @@ export const DropdownItemPropTable: React.FC = () => (
 
 export const DropdownLinkItemPropTable: React.FC = () => (
   <PropTable>
+    <PropTable.Prop name="actionType" types={['normal', 'destructive']} defaults="normal">
+      Indicates whether your item's action is of normal or destructive nature.
+    </PropTable.Prop>
     <PropTable.Prop name="content" types="string" required>
       Sets the text content of the Dropdown Item.
+    </PropTable.Prop>
+    <PropTable.Prop name="disabled" types="boolean">
+      Sets the item to disabled.
+    </PropTable.Prop>
+    <PropTable.Prop
+      name="icon"
+      types={
+        <NextLink href="/Icons/IconsPage" as="/icons">
+          Icon
+        </NextLink>
+      }
+    >
+      Pass in an{' '}
+      <NextLink href="/Icons/IconsPage" as="/icons">
+        Icon
+      </NextLink>{' '}
+      component to display to the left of the text.
     </PropTable.Prop>
     <PropTable.Prop name="onClick" types="(item: DropdownLinkItem): void">
       Returns the item object.

--- a/packages/docs/PropTables/DropdownPropTable.tsx
+++ b/packages/docs/PropTables/DropdownPropTable.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 
-import { PropTable } from '../components';
+import { Code, NextLink, PropTable } from '../components';
 
 export const DropdownPropTable: React.FC = () => (
   <PropTable>
     <PropTable.Prop name="maxHeight" types="number" defaults="250">
       Sets the max-height of the dropdown.
-    </PropTable.Prop>
-    <PropTable.Prop name="onItemClick" types="(value) => void">
-      Callback called with value of clicked item.
     </PropTable.Prop>
     <PropTable.Prop
       name="placement"
@@ -33,6 +30,10 @@ export const DropdownPropTable: React.FC = () => (
     >
       Sets the position of the Dropdown relative to the anchor.
     </PropTable.Prop>
+    <PropTable.Prop name="options" types="Array<DropdownItem | DropdownLinkItem>">
+      Accepts an array of objects with <Code>LI</Code> props and an additional
+      <Code>content</Code> prop. See example for usage.
+    </PropTable.Prop>
     <PropTable.Prop name="trigger" types="ReactElement" required>
       Element used as anchor.
     </PropTable.Prop>
@@ -41,8 +42,40 @@ export const DropdownPropTable: React.FC = () => (
 
 export const DropdownItemPropTable: React.FC = () => (
   <PropTable>
-    <PropTable.Prop name="value" types={['string', 'string[]', 'number']}>
-      Value of the item
+    <PropTable.Prop name="content" types="string" required>
+      Sets the text content of the Dropdown Item.
+    </PropTable.Prop>
+    <PropTable.Prop name="disabled" types="boolean">
+      Sets the item to disabled.
+    </PropTable.Prop>
+    <PropTable.Prop name="onClick" types="(item: DropdownItem): void">
+      Returns the item object.
+    </PropTable.Prop>
+    <PropTable.Prop name="type" types="'string'" defaults="'string'">
+      Type of the item.
+    </PropTable.Prop>
+    <PropTable.Prop name="value" types="any">
+      Stored value of the item.
+    </PropTable.Prop>
+  </PropTable>
+);
+
+export const DropdownLinkItemPropTable: React.FC = () => (
+  <PropTable>
+    <PropTable.Prop name="content" types="string" required>
+      Sets the text content of the Dropdown Item.
+    </PropTable.Prop>
+    <PropTable.Prop name="onClick" types="(item: DropdownLinkItem): void">
+      Returns the item object.
+    </PropTable.Prop>
+    <PropTable.Prop name="type" types="'link'" required>
+      Wraps the <Code>content</Code> in a <NextLink href="/link">Link</NextLink> component.
+    </PropTable.Prop>
+    <PropTable.Prop name="url" types="string" required>
+      Valid URL of a linked resource.
+    </PropTable.Prop>
+    <PropTable.Prop name="target" types="'_blank'">
+      Indicates where to display the linked resource.
     </PropTable.Prop>
   </PropTable>
 );

--- a/packages/docs/pages/Dropdown/DropdownPage.tsx
+++ b/packages/docs/pages/Dropdown/DropdownPage.tsx
@@ -1,5 +1,12 @@
 import { Button, Dropdown, Grid, H0, H1, H2, H3, Link, Panel, Text } from '@bigcommerce/big-design';
-import { AssignmentIcon, DeleteIcon, EditIcon, FileCopyIcon, OpenInNewIcon } from '@bigcommerce/big-design-icons';
+import {
+  AddIcon,
+  AssignmentIcon,
+  DeleteIcon,
+  EditIcon,
+  FileCopyIcon,
+  OpenInNewIcon,
+} from '@bigcommerce/big-design-icons';
 import React from 'react';
 
 import { Code, CodePreview, NextLink } from '../../components';
@@ -22,14 +29,25 @@ export default () => (
       <Dropdown
         maxHeight={250}
         options={[
-          { content: 'Edit', icon: <EditIcon />, onClick: item => item, value: 'edit' },
-          { content: 'Duplicate', icon: <FileCopyIcon />, onClick: item => item, value: 'duplicate' },
-          { content: 'Copy', icon: <AssignmentIcon />, onClick: item => item, value: '8', disabled: true },
+          { content: 'Edit', onClick: item => item, icon: <EditIcon />, value: 'edit' },
+          {
+            content: 'Duplicate',
+            onClick: item => item,
+            value: 'duplicate',
+            icon: <FileCopyIcon />,
+          },
+          {
+            content: 'Copy',
+            onClick: item => item,
+            value: 'copy',
+            icon: <AssignmentIcon />,
+            disabled: true,
+          },
           {
             content: 'Delete',
-            icon: <DeleteIcon />,
             onClick: item => item,
             value: 'delete',
+            icon: <DeleteIcon />,
             actionType: 'destructive',
           },
           { content: 'Link', icon: <OpenInNewIcon />, type: 'link', url: '#' },
@@ -74,6 +92,42 @@ export default () => (
         trigger={<Button>Button</Button>}
       />
 
+      {/* jsx-to-string:end */}
+    </CodePreview>
+
+    <H2>Icons</H2>
+
+    <Text>
+      A DropdownItem accepts an <NextLink href="/icons">Icon</NextLink> component to render.
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+
+      <Dropdown
+        options={[
+          { content: 'Option', icon: <EditIcon /> },
+          { content: 'Link', icon: <OpenInNewIcon />, type: 'link', url: '#' },
+        ]}
+        trigger={<Button>Button</Button>}
+      />
+
+      {/* jsx-to-string:end */}
+    </CodePreview>
+
+    <H2>Action Types</H2>
+
+    <Text>
+      There are two action types: <Code>normal</Code> &amp; <Code>destructive</Code>. They are used to indicate the
+      nature of the action when hovering on the item.
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      <Dropdown
+        options={[{ content: 'Save', actionType: 'normal' }, { content: 'Delete', actionType: 'destructive' }]}
+        trigger={<Button>Button</Button>}
+      />
       {/* jsx-to-string:end */}
     </CodePreview>
 

--- a/packages/docs/pages/Dropdown/DropdownPage.tsx
+++ b/packages/docs/pages/Dropdown/DropdownPage.tsx
@@ -21,14 +21,14 @@ export default () => (
       <Dropdown
         maxHeight={250}
         options={[
-          { content: 'Option', value: '1' },
-          { content: 'Option', value: '2' },
-          { content: 'Option', value: '3' },
-          { content: 'Option', value: '4' },
-          { content: 'Option', value: '5' },
-          { content: 'Option', value: '6' },
-          { content: 'Option', value: '7' },
-          { content: 'Option', value: '8', disabled: true },
+          { content: 'Option', onClick: item => item, value: '1' },
+          { content: 'Option', onClick: item => item, value: '2' },
+          { content: 'Option', onClick: item => item, value: '3' },
+          { content: 'Option', onClick: item => item, value: '4' },
+          { content: 'Option', onClick: item => item, value: '5' },
+          { content: 'Option', onClick: item => item, value: '6' },
+          { content: 'Option', onClick: item => item, value: '7' },
+          { content: 'Option', disabled: true, onClick: item => item, value: '8' },
         ]}
         placement="bottom-start"
         trigger={<Button>Open Menu</Button>}
@@ -55,8 +55,8 @@ export default () => (
     <H2>Links</H2>
 
     <Text>
-      A Dropdown can render a list of <NextLink href="/link">Links</NextLink> if it receives <Code>type: 'link'</Code>{' '}
-      and a <Code>url</Code>.
+      A Dropdown can render a list of <NextLink href="/link">Links</NextLink> if it receives an object of type{' '}
+      <Code>DropdownLinkItem</Code>.
     </Text>
 
     <CodePreview>
@@ -121,11 +121,11 @@ export default () => (
       {/* jsx-to-string:end */}
     </CodePreview>
 
-    <H2>Position</H2>
+    <H2>Placement</H2>
 
     <Text>
-      Dropdown can be anchored in different directions with the <Code primary>position</Code> property. It will
-      automatically find a position if there's not enough space in the chosen direction.
+      Dropdown can be anchored in different directions with the <Code primary>placement</Code> property. It will
+      automatically find a placement if there's not enough space in the chosen direction.
     </Text>
 
     <CodePreview>

--- a/packages/docs/pages/Dropdown/DropdownPage.tsx
+++ b/packages/docs/pages/Dropdown/DropdownPage.tsx
@@ -1,8 +1,8 @@
-import { Button, Dropdown, Grid, H0, H1, H2, Link, Panel, Text } from '@bigcommerce/big-design';
+import { Button, Dropdown, Grid, H0, H1, H2, H3, Link, Panel, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
-import { Code, CodePreview } from '../../components';
-import { DropdownItemPropTable, DropdownPropTable } from '../../PropTables';
+import { Code, CodePreview, NextLink } from '../../components';
+import { DropdownItemPropTable, DropdownLinkItemPropTable, DropdownPropTable } from '../../PropTables';
 
 export default () => (
   <>
@@ -20,21 +20,19 @@ export default () => (
       {/* jsx-to-string:start */}
       <Dropdown
         maxHeight={250}
-        onItemClick={value => value}
+        options={[
+          { content: 'Option', value: '1' },
+          { content: 'Option', value: '2' },
+          { content: 'Option', value: '3' },
+          { content: 'Option', value: '4' },
+          { content: 'Option', value: '5' },
+          { content: 'Option', value: '6' },
+          { content: 'Option', value: '7' },
+          { content: 'Option', value: '8', disabled: true },
+        ]}
         placement="bottom-start"
         trigger={<Button>Open Menu</Button>}
-      >
-        <Dropdown.Item value={1}>Option</Dropdown.Item>
-        <Dropdown.Item value={2}>Option</Dropdown.Item>
-        <Dropdown.Item value={3}>Option</Dropdown.Item>
-        <Dropdown.Item value={4}>Option</Dropdown.Item>
-        <Dropdown.Item value={5}>Option</Dropdown.Item>
-        <Dropdown.Item value={6}>Option</Dropdown.Item>
-        <Dropdown.Item value={7}>Option</Dropdown.Item>
-        <Dropdown.Item value={8} disabled>
-          Option
-        </Dropdown.Item>
-      </Dropdown>
+      />
       {/* jsx-to-string:end */}
     </CodePreview>
 
@@ -44,37 +42,81 @@ export default () => (
 
     <DropdownPropTable />
 
-    <H2>Dropdown.Item</H2>
+    <H3>DropdownItem</H3>
 
     <DropdownItemPropTable />
 
+    <H3>DropdownLinkItem</H3>
+
+    <DropdownLinkItemPropTable />
+
     <H1>Examples</H1>
+
+    <H2>Links</H2>
+
+    <Text>
+      A Dropdown can render a list of <NextLink href="/link">Links</NextLink> if it receives <Code>type: 'link'</Code>{' '}
+      and a <Code>url</Code>.
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      <Dropdown
+        options={[
+          { content: 'Option', type: 'link', url: '#' },
+          { content: 'Option', type: 'link', url: '#' },
+          { content: 'Option', type: 'link', url: '#' },
+        ]}
+        trigger={<Button>Button</Button>}
+      />
+
+      {/* jsx-to-string:end */}
+    </CodePreview>
 
     <H2>Trigger</H2>
 
     <Text>
-      Dropdown can be anchored to any <Code>ReactElement</Code>, including all types of buttons.
+      Dropdown can be anchored to any <Code>ReactElement</Code>, including all types of{' '}
+      <NextLink href="/button">Buttons</NextLink>.
     </Text>
 
     <CodePreview>
       {/* jsx-to-string:start */}
       <Grid gridColumns="repeat(4, min-content)">
-        <Dropdown trigger={<Button>Button</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-        </Dropdown>
-        <Dropdown trigger={<Button actionType="destructive">Button</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-        </Dropdown>
-        <Dropdown trigger={<Button variant="secondary">Button</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-        </Dropdown>
-        <Dropdown trigger={<Button variant="subtle">Button</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-        </Dropdown>
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+          ]}
+          trigger={<Button>Button</Button>}
+        />
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+          ]}
+          trigger={<Button actionType="destructive">Button</Button>}
+        />
+
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+          ]}
+          trigger={<Button variant="secondary">Button</Button>}
+        />
+
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+          ]}
+          trigger={<Button variant="subtle">Button</Button>}
+        />
       </Grid>
       {/* jsx-to-string:end */}
     </CodePreview>
@@ -89,22 +131,42 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Grid gridColumns="repeat(4, min-content)">
-        <Dropdown placement="right" trigger={<Button>Right</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-        </Dropdown>
-        <Dropdown placement="top" trigger={<Button>Top</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-        </Dropdown>
-        <Dropdown placement="bottom-start" trigger={<Button>Bottom-Start</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-        </Dropdown>
-        <Dropdown placement="bottom-end" trigger={<Button>Bottom-End</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-        </Dropdown>
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+          ]}
+          placement="right"
+          trigger={<Button>Right</Button>}
+        />
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+          ]}
+          placement="top"
+          trigger={<Button>Top</Button>}
+        />
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+          ]}
+          placement="bottom-start"
+          trigger={<Button>Bottom-Start</Button>}
+        />
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+          ]}
+          placement="bottom-end"
+          trigger={<Button>Bottom-End</Button>}
+        />
       </Grid>
       {/* jsx-to-string:end */}
     </CodePreview>
@@ -119,61 +181,47 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Grid gridColumns="repeat(3, min-content)">
-        <Dropdown trigger={<Button>Default</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-          <Dropdown.Item value={3}>Option</Dropdown.Item>
-          <Dropdown.Item value={4}>Option</Dropdown.Item>
-          <Dropdown.Item value={5}>Option</Dropdown.Item>
-          <Dropdown.Item value={6}>Option</Dropdown.Item>
-          <Dropdown.Item value={7}>Option</Dropdown.Item>
-          <Dropdown.Item value={8}>Option</Dropdown.Item>
-        </Dropdown>
-        <Dropdown maxHeight={150} trigger={<Button>Smaller</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-          <Dropdown.Item value={3}>Option</Dropdown.Item>
-          <Dropdown.Item value={4}>Option</Dropdown.Item>
-          <Dropdown.Item value={5}>Option</Dropdown.Item>
-          <Dropdown.Item value={6}>Option</Dropdown.Item>
-          <Dropdown.Item value={7}>Option</Dropdown.Item>
-          <Dropdown.Item value={8}>Option</Dropdown.Item>
-        </Dropdown>
-        <Dropdown maxHeight={350} trigger={<Button>Longer</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-          <Dropdown.Item value={3}>Option</Dropdown.Item>
-          <Dropdown.Item value={4}>Option</Dropdown.Item>
-          <Dropdown.Item value={5}>Option</Dropdown.Item>
-          <Dropdown.Item value={6}>Option</Dropdown.Item>
-          <Dropdown.Item value={7}>Option</Dropdown.Item>
-          <Dropdown.Item value={8}>Option</Dropdown.Item>
-        </Dropdown>
-      </Grid>
-      {/* jsx-to-string:end */}
-    </CodePreview>
-
-    <H2>Dropdown.Item</H2>
-
-    <Text>
-      Dropdown expects <Code>Dropdown.Item</Code> as children. An item can have optional values.
-    </Text>
-
-    <CodePreview>
-      {/* jsx-to-string:start */}
-      <Grid gridColumns="repeat(2, min-content)">
-        <Dropdown trigger={<Button>With Values</Button>}>
-          <Dropdown.Item value={1}>Option</Dropdown.Item>
-          <Dropdown.Item value={2}>Option</Dropdown.Item>
-        </Dropdown>
-        <Dropdown trigger={<Button>With Links</Button>}>
-          <Dropdown.Item>
-            <Link>Link</Link>
-          </Dropdown.Item>
-          <Dropdown.Item>
-            <Link>Link</Link>
-          </Dropdown.Item>
-        </Dropdown>
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+            { content: 'Option', value: '4' },
+            { content: 'Option', value: '5' },
+            { content: 'Option', value: '6' },
+            { content: 'Option', value: '7' },
+            { content: 'Option', value: '8' },
+          ]}
+          trigger={<Button>Default</Button>}
+        />
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+            { content: 'Option', value: '4' },
+            { content: 'Option', value: '5' },
+            { content: 'Option', value: '6' },
+            { content: 'Option', value: '7' },
+            { content: 'Option', value: '8' },
+          ]}
+          maxHeight={150}
+          trigger={<Button>Smaller</Button>}
+        />
+        <Dropdown
+          options={[
+            { content: 'Option', value: '1' },
+            { content: 'Option', value: '2' },
+            { content: 'Option', value: '3' },
+            { content: 'Option', value: '4' },
+            { content: 'Option', value: '5' },
+            { content: 'Option', value: '6' },
+            { content: 'Option', value: '7' },
+            { content: 'Option', value: '8' },
+          ]}
+          maxHeight={350}
+          trigger={<Button>Longer</Button>}
+        />
       </Grid>
       {/* jsx-to-string:end */}
     </CodePreview>

--- a/packages/docs/pages/Dropdown/DropdownPage.tsx
+++ b/packages/docs/pages/Dropdown/DropdownPage.tsx
@@ -21,14 +21,11 @@ export default () => (
       <Dropdown
         maxHeight={250}
         options={[
-          { content: 'Option', onClick: item => item, value: '1' },
-          { content: 'Option', onClick: item => item, value: '2' },
-          { content: 'Option', onClick: item => item, value: '3' },
-          { content: 'Option', onClick: item => item, value: '4' },
+          { content: 'Edit', onClick: item => item, value: 'edit' },
+          { content: 'Duplicate', onClick: item => item, value: 'duplicate' },
+          { content: 'Copy', onClick: item => item, value: '8', disabled: true },
+          { content: 'Delete', onClick: item => item, value: 'delete', actionType: 'destructive' },
           { content: 'Link', type: 'link', url: '#' },
-          { content: 'Link', type: 'link', url: '#' },
-          { content: 'Link', type: 'link', url: '#' },
-          { content: 'Option', onClick: item => item, value: '8', disabled: true },
         ]}
         placement="bottom-start"
         trigger={<Button>Open Menu</Button>}

--- a/packages/docs/pages/Dropdown/DropdownPage.tsx
+++ b/packages/docs/pages/Dropdown/DropdownPage.tsx
@@ -1,4 +1,5 @@
 import { Button, Dropdown, Grid, H0, H1, H2, H3, Link, Panel, Text } from '@bigcommerce/big-design';
+import { AssignmentIcon, DeleteIcon, EditIcon, FileCopyIcon, OpenInNewIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
 
 import { Code, CodePreview, NextLink } from '../../components';
@@ -21,11 +22,17 @@ export default () => (
       <Dropdown
         maxHeight={250}
         options={[
-          { content: 'Edit', onClick: item => item, value: 'edit' },
-          { content: 'Duplicate', onClick: item => item, value: 'duplicate' },
-          { content: 'Copy', onClick: item => item, value: '8', disabled: true },
-          { content: 'Delete', onClick: item => item, value: 'delete', actionType: 'destructive' },
-          { content: 'Link', type: 'link', url: '#' },
+          { content: 'Edit', icon: <EditIcon />, onClick: item => item, value: 'edit' },
+          { content: 'Duplicate', icon: <FileCopyIcon />, onClick: item => item, value: 'duplicate' },
+          { content: 'Copy', icon: <AssignmentIcon />, onClick: item => item, value: '8', disabled: true },
+          {
+            content: 'Delete',
+            icon: <DeleteIcon />,
+            onClick: item => item,
+            value: 'delete',
+            actionType: 'destructive',
+          },
+          { content: 'Link', icon: <OpenInNewIcon />, type: 'link', url: '#' },
         ]}
         placement="bottom-start"
         trigger={<Button>Open Menu</Button>}

--- a/packages/docs/pages/Dropdown/DropdownPage.tsx
+++ b/packages/docs/pages/Dropdown/DropdownPage.tsx
@@ -25,10 +25,10 @@ export default () => (
           { content: 'Option', onClick: item => item, value: '2' },
           { content: 'Option', onClick: item => item, value: '3' },
           { content: 'Option', onClick: item => item, value: '4' },
-          { content: 'Option', onClick: item => item, value: '5' },
-          { content: 'Option', onClick: item => item, value: '6' },
-          { content: 'Option', onClick: item => item, value: '7' },
-          { content: 'Option', disabled: true, onClick: item => item, value: '8' },
+          { content: 'Link', type: 'link', url: '#' },
+          { content: 'Link', type: 'link', url: '#' },
+          { content: 'Link', type: 'link', url: '#' },
+          { content: 'Option', onClick: item => item, value: '8', disabled: true },
         ]}
         placement="bottom-start"
         trigger={<Button>Open Menu</Button>}


### PR DESCRIPTION
Added new `options` prop that will restrict the usage of the items. The `onClick` for each item with return the `item` itself. No need to use `data-value` anymore.

Now also accepts `icons` as a DropdownItem prop.

<img width="312" alt="Screen Shot 2019-10-15 at 8 44 11 PM" src="https://user-images.githubusercontent.com/196129/66947766-15acb700-f019-11e9-9cae-e2f029fe4947.png">


Wasn't sure how to document the new `DropdownItem` and `DropdownLinkItem`. Feedback pls 🙏 .

![docs2](https://user-images.githubusercontent.com/196129/66931135-441b9980-effb-11e9-8bbe-20675cea171b.png)

