### PR TITLE
chore: revert customValidity logic

### DIFF
--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -60,7 +60,6 @@ class StyleableInput extends React.PureComponent<InputProps & PrivateProps, Inpu
               error={error}
               id={id}
               onBlur={this.onInputBlur}
-              onChange={this.onInputChange}
               onFocus={this.onInputFocus}
               ref={forwardedRef}
             />
@@ -77,17 +76,6 @@ class StyleableInput extends React.PureComponent<InputProps & PrivateProps, Inpu
 
     return id ? id : this.uniqueId;
   }
-
-  private onInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const hasError = Boolean(this.props.error);
-    const errorMessage = typeof this.props.error === 'string' ? this.props.error : 'Invalid input';
-
-    event.target.setCustomValidity(hasError ? errorMessage : '');
-
-    if (typeof this.props.onChange === 'function') {
-      this.props.onChange(event);
-    }
-  };
 
   private onInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     const { onFocus } = this.props;

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -1,5 +1,5 @@
 import { AddIcon } from '@bigcommerce/big-design-icons';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -208,37 +208,6 @@ test('renders all together', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('is invalid when required and has no value', () => {
-  const { getByLabelText } = render(<Input label="Label" description="This is a description" required />);
-
-  const input = getByLabelText('Label') as HTMLInputElement;
-
-  expect(input.checkValidity()).toEqual(false);
-});
-
-test('is valid when required and has a value', () => {
-  const { getByLabelText } = render(
-    <Input label="Label" value="Hello world" description="This is a description" required />,
-  );
-
-  const input = getByLabelText('Label') as HTMLInputElement;
-
-  expect(input.checkValidity()).toEqual(true);
-});
-
-test('it is invalid when it was an error', () => {
-  const { getByLabelText } = render(
-    <Input label="Label" error="Some error" description="This is a description" required />,
-  );
-  const input = getByLabelText('Label') as HTMLInputElement;
-
-  expect(input.checkValidity()).toEqual(false);
-
-  fireEvent.change(input, { target: { value: 'Some new value ' } });
-
-  expect(input.checkValidity()).toEqual(false);
-});
-
 test('error shows with valid string', () => {
   const error = 'Error';
   const { container, rerender } = render(

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -172,19 +172,9 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
   private renderInput() {
     const { placeholder, children, error, required, disabled, onItemChange, value } = this.props;
     const { highlightedItem, inputText, isOpen } = this.state;
-
     const ariaActiveDescendant = highlightedItem ? { 'aria-activedescendant': highlightedItem.id } : {};
     const ariaControls = isOpen ? { 'aria-controls': this.getSelectId() } : {};
-
-    if (this.inputRef && this.inputRef.current) {
-      const hasError = Boolean(error);
-      const errorMessage = typeof error === 'string' ? error : 'Invalid input';
-
-      this.inputRef.current.setCustomValidity(hasError ? errorMessage : '');
-    }
-
     const chips = this.renderChips();
-
     const listItems = React.Children.map(children, child => {
       if (!React.isValidElement(child)) {
         return;

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -504,66 +504,6 @@ test('select should not have a disabled attr if not set as disabled', () => {
   expect(input.getAttribute('disabled')).toEqual(null);
 });
 
-test('should be valid if not required', () => {
-  const { getAllByLabelText } = render(
-    <Select onItemChange={() => null} label="Countries" placeholder="Choose country">
-      <Select.Option value="us">United States</Select.Option>
-      <Select.Option value="mx">Mexico</Select.Option>
-      <Select.Option value="en">England</Select.Option>
-    </Select>,
-  );
-
-  const input = getAllByLabelText('Countries')[0] as HTMLSelectElement;
-
-  expect(input.checkValidity()).toEqual(true);
-});
-
-test('should be invalid if required and has no value', () => {
-  const { getAllByLabelText } = render(
-    <Select onItemChange={() => null} label="Countries" placeholder="Choose country" required>
-      <Select.Option value="us">United States</Select.Option>
-      <Select.Option value="mx">Mexico</Select.Option>
-      <Select.Option value="en">England</Select.Option>
-    </Select>,
-  );
-
-  const input = getAllByLabelText('Countries')[0] as HTMLSelectElement;
-
-  expect(input.checkValidity()).toEqual(false);
-});
-
-test('should be valid if required and has a value', () => {
-  const { getAllByLabelText } = render(
-    <Select value="us" onItemChange={() => null} label="Countries" placeholder="Choose country" required>
-      <Select.Option value="us">United States</Select.Option>
-      <Select.Option value="mx">Mexico</Select.Option>
-      <Select.Option value="en">England</Select.Option>
-    </Select>,
-  );
-
-  const input = getAllByLabelText('Countries')[0] as HTMLSelectElement;
-
-  expect(input.checkValidity()).toEqual(true);
-});
-
-test('should be invalid when it has an error', () => {
-  const { getAllByLabelText } = render(
-    <Select error="Unrelated failure" onItemChange={() => null} label="Countries" placeholder="Choose country" required>
-      <Select.Option value="us">United States</Select.Option>
-      <Select.Option value="mx">Mexico</Select.Option>
-      <Select.Option value="en">England</Select.Option>
-    </Select>,
-  );
-
-  const input = getAllByLabelText('Countries')[0] as HTMLSelectElement;
-
-  expect(input.checkValidity()).toEqual(false);
-
-  fireEvent.change(input, { target: { value: 'us' } });
-
-  expect(input.checkValidity()).toEqual(false);
-});
-
 test('select input text should update if a matching child appears', () => {
   const { getAllByLabelText, rerender } = render(
     <Select onItemChange={onItemChange} label="Countries" placeholder="Choose country" value="mx">


### PR DESCRIPTION
## What?
Reverts the addition of customValidity logic for inputs and selects

## Why?
1) The logic is buggy
2) It is not something the input itself should handle
3) Clashes with design guidelines if users don't use `noValidate`, which is an issue