### PR TITLE
feat(component): update Tabs component to be more restrictive

### DIFF
--- a/packages/big-design/src/components/Tabs/Tabs.tsx
+++ b/packages/big-design/src/components/Tabs/Tabs.tsx
@@ -1,46 +1,51 @@
-import React from 'react';
+import { ThemeInterface } from '@bigcommerce/big-design-theme';
+import React, { memo } from 'react';
 
 import { StyledTab, StyledTabs } from './styled';
 
-const Tab = StyledTab;
-
-export interface TabProps {
-  activeTab?: string;
+export interface TabItem {
+  id: string;
+  title: string;
+  disabled?: boolean;
 }
 
 export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
-  activeTab?: string;
-  onTabClick(tabId: string): void;
+  activeTab?: TabItem['id'];
+  items?: TabItem[];
+  theme?: ThemeInterface;
+  onTabClick?(tabId: TabItem['id']): void;
 }
 
-export class Tabs extends React.PureComponent<TabsProps> {
-  static Tab = Tab;
+export const Tabs: React.FC<TabsProps> = memo(
+  ({ activeTab, children, className, items = [], onTabClick, style, role, ...props }) => {
+    const handleOnTabClick = (event: React.MouseEvent<HTMLElement>) => {
+      event.preventDefault();
 
-  render() {
-    const { children, className, onTabClick, style, role, ...props } = this.props;
+      const tabId = event.currentTarget.id;
 
-    return <StyledTabs {...props}>{this.renderChildren()}</StyledTabs>;
-  }
+      if (tabId !== activeTab && typeof onTabClick === 'function') {
+        onTabClick(tabId);
+      }
+    };
 
-  private renderChildren() {
-    const { activeTab, children } = this.props;
-
-    return React.Children.map(children, child =>
-      React.cloneElement(child as React.ReactElement<any>, {
-        activeTab,
-        onClick: this.handleOnTabClick,
-      }),
+    return (
+      <>
+        <StyledTabs {...props} flexDirection="row" role="tablist">
+          {items.map(({ id, title, disabled }) => (
+            <StyledTab
+              activeTab={activeTab}
+              id={id}
+              key={id}
+              onClick={handleOnTabClick}
+              role="tab"
+              tabIndex={id === activeTab ? -1 : 0}
+              disabled={disabled}
+            >
+              {title}
+            </StyledTab>
+          ))}
+        </StyledTabs>
+      </>
     );
-  }
-
-  private handleOnTabClick = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
-
-    const tabId = event.currentTarget.id;
-    const activeTab = this.props.activeTab;
-
-    if (tabId !== activeTab && typeof this.props.onTabClick === 'function') {
-      this.props.onTabClick(tabId);
-    }
-  };
-}
+  },
+);

--- a/packages/big-design/src/components/Tabs/index.ts
+++ b/packages/big-design/src/components/Tabs/index.ts
@@ -1,1 +1,1 @@
-export { Tabs, TabProps, TabsProps } from './Tabs';
+export { Tabs, TabItem, TabsProps } from './Tabs';

--- a/packages/big-design/src/components/Tabs/styled.tsx
+++ b/packages/big-design/src/components/Tabs/styled.tsx
@@ -2,21 +2,26 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { StyleableButton } from '../Button/private';
+import { Flex } from '../Flex';
 
-import { TabProps } from './Tabs';
+import { TabItem } from './Tabs';
 
-export const StyledTabs = styled.div.attrs({ role: 'tablist' })``;
+interface TabProps extends Omit<TabItem, 'title'> {
+  activeTab?: string;
+}
 
-export const StyledTab = styled(StyleableButton).attrs<TabProps>(props => ({
-  role: 'tab',
-  tabIndex: props.id === props.activeTab ? -1 : 0,
-}))<TabProps>`
+export const StyledTabs = styled(Flex)`
+  overflow: auto;
+`;
+
+export const StyledTab = styled(StyleableButton)<TabProps>`
   border: none;
   border-bottom: ${({ theme }) => theme.spacing.xxSmall} solid transparent;
   border-bottom-color: ${props => (props.id === props.activeTab ? props.theme.colors.primary40 : 'transparent')};
   border-radius: 0;
   color: ${({ theme }) => theme.colors.primary};
   pointer-events: ${props => (props.id === props.activeTab ? 'none' : 'auto')};
+  width: auto;
 
   ${props =>
     props.id === props.activeTab &&

--- a/packages/docs/PropTables/TabsPropTable.tsx
+++ b/packages/docs/PropTables/TabsPropTable.tsx
@@ -1,12 +1,21 @@
 import React from 'react';
 
-import { Prop, PropTable, PropTableWrapper } from '../components';
+import { NextLink, Prop, PropTable, PropTableWrapper } from '../components';
 
 const tabsProps: Prop[] = [
   {
     name: 'activeTab',
     types: 'string',
-    description: 'Determines the active tab by id.',
+    description: 'Determines the active tab by tab id.',
+  },
+  {
+    name: 'items',
+    types: <NextLink href="#tabs-items-prop-table">TabItem[]</NextLink>,
+    description: (
+      <>
+        See <NextLink href="#tabs-items-prop-table">below</NextLink> for usage.
+      </>
+    ),
   },
   {
     name: 'onTabClick',
@@ -19,11 +28,18 @@ export const TabsPropTable: React.FC<PropTableWrapper> = props => (
   <PropTable title="Tabs" propList={tabsProps} {...props} />
 );
 
-const tabProps: Prop[] = [
+const tabItemProps: Prop[] = [
   {
     name: 'id',
     types: 'string',
     description: 'Tab identifier, must be unique.',
+    required: true,
+  },
+  {
+    name: 'title',
+    types: 'string',
+    description: 'Title for the tab.',
+    required: true,
   },
   {
     name: 'disabled',
@@ -32,6 +48,6 @@ const tabProps: Prop[] = [
   },
 ];
 
-export const TabPropTable: React.FC<PropTableWrapper> = props => (
-  <PropTable title="Tabs.Tab" propList={tabProps} {...props} />
+export const TabItemPropTable: React.FC<PropTableWrapper> = props => (
+  <PropTable title="Tabs[TabItem]" propList={tabItemProps} {...props} />
 );

--- a/packages/docs/pages/Tabs/TabsPage.tsx
+++ b/packages/docs/pages/Tabs/TabsPage.tsx
@@ -2,15 +2,15 @@ import { Box, H0, H1, Link, Tabs, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { Code, CodePreview } from '../../components';
-import { TabsPropTable, TabPropTable } from '../../PropTables';
+import { TabsPropTable, TabItemPropTable } from '../../PropTables';
 
 export default () => (
   <>
     <H0>Tabs</H0>
 
     <Text>
-      The <Code primary>Tabs</Code> and <Code primary>Tabs.Tab</Code> components are used to organize and navigate
-      between content types that are related and at the same level of information architecture heirarchy.{' '}
+      The <Code primary>Tabs</Code> component is used to organize and navigate between content types that are related
+      and at the same level of information architecture heirarchy.{' '}
       <Link href="https://design.bigcommerce.com/components/tabs" target="_blank">
         Tabs Design Guidelines
       </Link>
@@ -22,16 +22,16 @@ export default () => (
       {function Example() {
         const [activeTab, setActiveTab] = React.useState('tab1');
 
+        const items = [
+          { id: 'tab1', title: 'Example 1' },
+          { id: 'tab2', title: 'Example 2' },
+          { id: 'tab3', title: 'Example 3' },
+          { id: 'tab4', title: 'Example 4', disabled: true },
+        ];
+
         return (
           <>
-            <Tabs activeTab={activeTab} onTabClick={setActiveTab}>
-              <Tabs.Tab id="tab1">Example 1</Tabs.Tab>
-              <Tabs.Tab id="tab2">Example 2</Tabs.Tab>
-              <Tabs.Tab id="tab3">Example 3</Tabs.Tab>
-              <Tabs.Tab id="tab4" disabled>
-                Example 4
-              </Tabs.Tab>
-            </Tabs>
+            <Tabs activeTab={activeTab} items={items} onTabClick={setActiveTab} />
             <Box marginTop="large">
               {activeTab === 'tab1' && <Text>Content 1</Text>}
               {activeTab === 'tab2' && <Text>Content 2</Text>}
@@ -46,6 +46,6 @@ export default () => (
 
     <H1>API</H1>
     <TabsPropTable />
-    <TabPropTable />
+    <TabItemPropTable id="tabs-items-prop-table" />
   </>
 );


### PR DESCRIPTION
## What
Restrict Tabs to accept a configurable object.

## Screenshot
![screencapture-localhost-3000-tabs-2019-10-23-09_25_37](https://user-images.githubusercontent.com/10539418/67403307-56f01a00-f577-11e9-920d-1320d6e92d42.jpg)

BREAKING CHANGE: Tabs now accepts an `items` prop to render tab items and omits children from being rendered.

Old:
```jsx
<Tabs>
  <Tabs.Tab id="tab1">Tab 1</Tabs.Tab>
  {/* ... */}
</Tabs>
```

New:
```jsx
<Tabs activeTab="tab1" items={[{ id: 'tab1', title: 'Tab 1' }]} onTabClick={() => {}} />
```
