### PR TITLE
fix(docs): logo overflowing into side nav

### DIFF
--- a/packages/docs/components/SideNav/styled.tsx
+++ b/packages/docs/components/SideNav/styled.tsx
@@ -14,6 +14,7 @@ export const StyledFlex = styled(Flex)`
   ${({ theme }) => theme.breakpoints.tablet} {
     bottom: 0;
     box-shadow: none;
+    display: block;
     height: 100vh;
     overflow: auto;
     position: sticky;


### PR DESCRIPTION
## What
Fix logo overflowing into side nav in Safari.

Old:
![image](https://user-images.githubusercontent.com/10539418/67506873-7b212900-f653-11e9-8ed4-677f55210815.png)

New:
<img width="834" alt="Screen Shot 2019-10-24 at 11 44 58 AM" src="https://user-images.githubusercontent.com/10539418/67507013-bd4a6a80-f653-11e9-9fc8-5505e9d4c27c.png">
