### PR TITLE
fix: adds name prop to select

### DIFF
--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -131,10 +131,11 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
   }
 
   private renderInput() {
-    const { placeholder, error, filterable = true, required, disabled, onChange, options, value } = this.props;
+    const { name, placeholder, error, filterable = true, required, disabled, onChange, options, value } = this.props;
     const { highlightedItem, inputText, isOpen } = this.state;
     const ariaActiveDescendant = highlightedItem ? { 'aria-activedescendant': highlightedItem.id } : {};
     const ariaControls = isOpen ? { 'aria-controls': this.getSelectId() } : {};
+    const id = this.getInputId();
 
     const chips = this.renderChips();
 
@@ -162,7 +163,8 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
               disabled={disabled}
               error={error}
               iconRight={this.renderDropdownIcon()}
-              id={this.getInputId()}
+              id={id}
+              name={name || id}
               onChange={this.handleOnInputChange}
               onChipDelete={chips && onChipDelete}
               onClick={this.handleOnInputSelected}

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -10,6 +10,7 @@ export interface SelectProps<T> extends Omit<React.HTMLAttributes<HTMLUListEleme
   label?: string;
   maxHeight?: number;
   multi?: boolean;
+  name?: string;
   options: Array<Option<T>>;
   placement?: Placement;
   positionFixed?: boolean;


### PR DESCRIPTION
## What?
Adds a `name` prop to the `Select` component and forwards that to the rendered `input` element

## Testing done
- Verified the name prop is forwarded to the actual HTML input element