### PR TITLE
feat(component): stateful table

### DIFF
--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -1,0 +1,95 @@
+import React, { useCallback, useMemo, useReducer } from 'react';
+
+import { typedMemo } from '../../utils';
+import { useDidUpdate } from '../../utils/useDidUpdate';
+import { Table, TableColumn, TableItem, TableProps, TableSelectable, TableSortDirection } from '../Table';
+
+import { createReducer, createReducerInit } from './reducer';
+
+export interface StatefulTableColumn<T> extends Omit<TableColumn<T>, 'isSortable'> {
+  sortKey?: keyof T;
+}
+
+export interface StatefulTableProps<T>
+  extends Omit<TableProps<T>, 'columns' | 'pagination' | 'selectable' | 'sortable'> {
+  columns: Array<StatefulTableColumn<T>>;
+  pagination?: boolean;
+  selectable?: boolean;
+  defaultSelected?: T[];
+  onSelectionChange?: TableSelectable<T>['onSelectionChange'];
+}
+
+const InternalStatefulTable = <T extends TableItem>({
+  columns = [],
+  defaultSelected = [],
+  itemName,
+  items = [],
+  keyField,
+  onSelectionChange,
+  pagination = false,
+  selectable = false,
+  stickyHeader = false,
+  ...rest
+}: StatefulTableProps<T>): React.ReactElement<StatefulTableProps<T>> => {
+  const reducer = useMemo(() => createReducer<T>(), []);
+  const reducerInit = useMemo(() => createReducerInit<T>(), []);
+  const sortable = useMemo(() => columns.some(column => column.sortKey), [columns]);
+
+  const [state, dispatch] = useReducer(reducer, { columns, defaultSelected, items, pagination }, reducerInit);
+
+  useDidUpdate(() => dispatch({ type: 'COLUMNS_CHANGED', columns }), [columns]);
+  useDidUpdate(() => dispatch({ type: 'ITEMS_CHANGED', items, isPaginationEnabled: pagination }), [items, pagination]);
+
+  const onPageChange = useCallback((page: number) => dispatch({ type: 'PAGE_CHANGE', page }), []);
+  const onItemsPerPageChange = useCallback(
+    (itemsPerPage: number) => dispatch({ type: 'ITEMS_PER_PAGE_CHANGE', itemsPerPage }),
+    [],
+  );
+
+  const onItemSelect = useCallback(
+    (selectedItems: T[]) => {
+      dispatch({ type: 'SELECTED_ITEMS', selectedItems });
+
+      if (typeof onSelectionChange === 'function') {
+        onSelectionChange(selectedItems);
+      }
+    },
+    [onSelectionChange],
+  );
+
+  const onSort = useCallback((columnHash: string, direction: TableSortDirection, column: StatefulTableColumn<T>) => {
+    dispatch({ type: 'SORT', columnHash, direction, sortKey: column.sortKey });
+  }, []);
+
+  const paginationOptions = useMemo(
+    () => (pagination ? { ...state.pagination, onItemsPerPageChange, onPageChange } : undefined),
+    [pagination, state.pagination, onItemsPerPageChange, onPageChange],
+  );
+
+  const selectableOptions = useMemo(
+    () => (selectable ? { selectedItems: state.selectedItems, onSelectionChange: onItemSelect } : undefined),
+    [selectable, state.selectedItems, onItemSelect],
+  );
+
+  const sortableOptions = useMemo(() => (sortable ? { ...state.sortable, onSort } : undefined), [
+    sortable,
+    state.sortable,
+    onSort,
+  ]);
+
+  return (
+    <Table
+      {...rest}
+      columns={state.columns}
+      itemName={itemName}
+      items={state.currentItems}
+      keyField={keyField}
+      stickyHeader={stickyHeader}
+      pagination={paginationOptions}
+      selectable={selectableOptions}
+      sortable={sortableOptions}
+    />
+  );
+};
+
+export const StatefulTable = typedMemo(InternalStatefulTable);

--- a/packages/big-design/src/components/StatefulTable/index.ts
+++ b/packages/big-design/src/components/StatefulTable/index.ts
@@ -1,0 +1,1 @@
+export { StatefulTable, StatefulTableProps, StatefulTableColumn } from './StatefulTable';

--- a/packages/big-design/src/components/StatefulTable/reducer.ts
+++ b/packages/big-design/src/components/StatefulTable/reducer.ts
@@ -1,0 +1,212 @@
+import { Reducer } from 'react';
+
+import { TableSortDirection } from '../Table';
+
+import { StatefulTableColumn } from './StatefulTable';
+
+interface State<T> {
+  currentItems: T[];
+  columns: Array<StatefulTableColumn<T> & { isSortable: boolean }>;
+  isPaginationEnabled: boolean;
+  items: T[];
+  pagination: {
+    currentPage: number;
+    itemsPerPage: number;
+    itemsPerPageOptions: number[];
+    totalItems: number;
+  };
+  selectedItems: T[];
+  sortable: {
+    direction: TableSortDirection;
+    columnHash?: string;
+  };
+}
+
+interface InitArgs<T> {
+  columns: Array<StatefulTableColumn<T>>;
+  defaultSelected: T[];
+  items: T[];
+  pagination: boolean;
+}
+
+export const createReducerInit = <T>() => ({ columns, defaultSelected, items, pagination }: InitArgs<T>): State<T> => {
+  const currentPage = 1;
+  const itemsPerPage = 25;
+  const currentItems = getItems(items, pagination, { currentPage, itemsPerPage });
+
+  return {
+    currentItems,
+    columns: augmentColumns(columns),
+    isPaginationEnabled: pagination,
+    items,
+    pagination: {
+      currentPage,
+      itemsPerPage,
+      itemsPerPageOptions: [25, 50, 100, 250],
+      totalItems: items.length,
+    },
+    selectedItems: defaultSelected,
+    sortable: {
+      direction: 'ASC',
+    },
+  };
+};
+
+export type Action<T> =
+  | { type: 'COLUMNS_CHANGED'; columns: Array<StatefulTableColumn<T>> }
+  | { type: 'ITEMS_CHANGED'; items: T[]; isPaginationEnabled: boolean }
+  | { type: 'ITEMS_PER_PAGE_CHANGE'; itemsPerPage: number }
+  | { type: 'PAGE_CHANGE'; page: number }
+  | { type: 'SELECTED_ITEMS'; selectedItems: T[] }
+  | { type: 'SORT'; direction: TableSortDirection; columnHash: string; sortKey?: keyof T };
+
+export const createReducer = <T>(): Reducer<State<T>, Action<T>> => (state, action) => {
+  switch (action.type) {
+    case 'COLUMNS_CHANGED': {
+      const columns = action.columns;
+
+      return {
+        ...state,
+        columns: augmentColumns(columns),
+      };
+    }
+
+    case 'ITEMS_CHANGED': {
+      const currentPage = 1;
+      const items = action.items;
+      const isPaginationEnabled = action.isPaginationEnabled;
+
+      const currentItems = getItems(items, isPaginationEnabled, {
+        currentPage,
+        itemsPerPage: state.pagination.itemsPerPage,
+      });
+
+      return {
+        ...state,
+        currentItems,
+        isPaginationEnabled,
+        items,
+        pagination: {
+          ...state.pagination,
+          currentPage,
+          totalItems: items.length,
+        },
+        sortable: {
+          direction: state.sortable.direction,
+        },
+      };
+    }
+
+    case 'PAGE_CHANGE': {
+      const currentPage = action.page;
+      const currentItems = getItems(state.items, true, {
+        currentPage,
+        itemsPerPage: state.pagination.itemsPerPage,
+      });
+
+      return {
+        ...state,
+        currentItems,
+        pagination: {
+          ...state.pagination,
+          currentPage,
+        },
+      };
+    }
+
+    case 'ITEMS_PER_PAGE_CHANGE': {
+      const currentPage = 1;
+      const itemsPerPage = action.itemsPerPage;
+      const currentItems = getItems(state.items, true, {
+        currentPage,
+        itemsPerPage,
+      });
+
+      return {
+        ...state,
+        currentItems,
+        pagination: {
+          ...state.pagination,
+          currentPage,
+          itemsPerPage,
+        },
+      };
+    }
+
+    case 'SELECTED_ITEMS': {
+      return { ...state, selectedItems: action.selectedItems };
+    }
+
+    case 'SORT': {
+      const sortKey = action.sortKey;
+      const direction = action.direction;
+      const columnHash = action.columnHash;
+
+      if (!sortKey) {
+        return state;
+      }
+
+      const items = sort(state.items, direction, sortKey);
+
+      const currentItems = getItems(items, state.isPaginationEnabled, {
+        currentPage: 1,
+        itemsPerPage: state.pagination.itemsPerPage,
+      });
+
+      return {
+        ...state,
+        currentItems,
+        items,
+        pagination: {
+          ...state.pagination,
+          currentPage: 1,
+        },
+        sortable: {
+          direction,
+          columnHash,
+        },
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+function augmentColumns<T>(columns: Array<StatefulTableColumn<T>>) {
+  return columns.map(column => ({ ...column, isSortable: Boolean(column.sortKey) }));
+}
+
+function getItems<T>(
+  items: T[],
+  isPaginationEnabled: boolean,
+  paginationOptions: { currentPage: number; itemsPerPage: number },
+) {
+  if (!isPaginationEnabled) {
+    return items;
+  }
+
+  const maxItems = paginationOptions.currentPage * paginationOptions.itemsPerPage;
+  const lastItem = Math.min(maxItems, items.length);
+  const firstItem = Math.max(0, maxItems - paginationOptions.itemsPerPage);
+
+  return items.slice(firstItem, lastItem);
+}
+
+function sort<T>(items: T[], direction: TableSortDirection, sortKey: keyof T) {
+  return [...items].sort((firstItem, secondItem) => {
+    const firstValue = firstItem[sortKey];
+    const secondValue = secondItem[sortKey];
+
+    if (typeof firstValue === 'number' && typeof secondValue === 'number') {
+      return direction === 'ASC' ? firstValue - secondValue : secondValue - firstValue;
+    }
+
+    const firstValueString = String(firstValue);
+    const secondValueString = String(secondValue);
+
+    return direction === 'ASC'
+      ? firstValueString.localeCompare(secondValueString)
+      : secondValueString.localeCompare(firstValueString);
+  });
+}

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -1,0 +1,226 @@
+import { fireEvent, render } from '@testing-library/react';
+import 'jest-styled-components';
+import React from 'react';
+
+import { StatefulTable, StatefulTableProps } from './StatefulTable';
+
+interface TestItem {
+  name: string;
+  stock: number;
+}
+
+/**
+ * Generate items (104 so we can do A-Z * 4) that looks like:
+ * [
+ *    { name: 'Product A - 1', stock: 1 },
+ *    { name: 'Product B - 2', stock: 2 },
+ *    ...
+ *    { name: 'Product A - 2', stock: 27 },
+ *    { name: 'Product B - 2', stock: 28 },
+ * ]
+ */
+const generateItems = (): TestItem[] =>
+  [...Array(104)].map((_, index) => ({
+    name: `Product ${String.fromCharCode(65 + (index % 26))} - ${Math.ceil((index + 1) / 26)}`,
+    stock: index + 1,
+  }));
+
+const getSimpleTable = (props: Partial<StatefulTableProps<TestItem>> = {}) => (
+  <StatefulTable
+    columns={[
+      { header: 'Name', hash: 'name', render: ({ name }) => <span data-testid="name">{name}</span>, sortKey: 'name' },
+      {
+        header: 'Stock',
+        hash: 'stock',
+        render: ({ stock }) => <span data-testid="stock">{stock}</span>,
+        sortKey: 'stock',
+      },
+    ]}
+    items={generateItems()}
+    {...props}
+  />
+);
+
+test('renders a non-paginated table by default', () => {
+  const { container } = render(getSimpleTable());
+
+  const rows = container.querySelectorAll('tbody > tr');
+
+  expect(rows.length).toBe(104);
+});
+
+test('pagination can be enabled', () => {
+  const { container } = render(getSimpleTable({ pagination: true }));
+
+  const rows = container.querySelectorAll('tbody > tr');
+
+  expect(rows.length).toBe(25);
+});
+
+test('changing pagination page changes the displayed items', () => {
+  const { getByTitle, getAllByTestId } = render(getSimpleTable({ pagination: true }));
+
+  const pageOneItemName = getAllByTestId('name')[0].textContent;
+  fireEvent.click(getByTitle('Next page'));
+  const pageTwoItemName = getAllByTestId('name')[0].textContent;
+
+  expect(pageOneItemName).not.toBe(pageTwoItemName);
+});
+
+test('renders rows without checkboxes by default', () => {
+  const { queryAllByRole } = render(getSimpleTable());
+
+  expect(queryAllByRole('checkbox').length).toBe(0);
+});
+
+test('renders rows without checkboxes when opting in to selectable', () => {
+  const { queryAllByRole } = render(getSimpleTable({ selectable: true, pagination: false }));
+
+  // 104 tbody rows + Select all checkbox
+  expect(queryAllByRole('checkbox').length).toBe(105);
+});
+
+test('items are unselected by default', () => {
+  const { container } = render(getSimpleTable({ selectable: true }));
+  const checkbox = container.querySelector('tbody > tr input') as HTMLInputElement;
+
+  expect(checkbox.checked).toBe(false);
+});
+
+test('items can be selected by default', () => {
+  const testItem = { name: 'Test Item', stock: 1 };
+  const items: TestItem[] = [testItem];
+  const { container } = render(getSimpleTable({ selectable: true, items, defaultSelected: [testItem] }));
+  const checkbox = container.querySelector('tbody > tr input') as HTMLInputElement;
+
+  expect(checkbox.checked).toBe(true);
+});
+
+test('onSelectionChange gets called when an item selection happens', () => {
+  const testItemOne = { name: 'Test Item', stock: 1 };
+  const testItemTwo = { name: 'Test Item Two', stock: 2 };
+  const testItemThree = { name: 'Test Item Three', stock: 3 };
+  const items: TestItem[] = [testItemOne, testItemTwo, testItemThree];
+  const onSelectionChange = jest.fn();
+
+  const { container } = render(
+    getSimpleTable({ selectable: true, items, defaultSelected: [testItemThree], onSelectionChange }),
+  );
+
+  const checkbox = container.querySelector('tbody > tr input') as HTMLInputElement;
+
+  fireEvent.click(checkbox);
+
+  expect(onSelectionChange).toHaveBeenCalledWith([testItemThree, testItemOne]);
+});
+
+test('multi-page select', () => {
+  const onSelectionChange = jest.fn();
+
+  const { container, getByTitle } = render(getSimpleTable({ selectable: true, onSelectionChange, pagination: true }));
+
+  let checkbox = container.querySelector('tbody > tr input') as HTMLInputElement;
+
+  fireEvent.click(checkbox);
+  fireEvent.click(getByTitle('Next page'));
+
+  checkbox = container.querySelector('tbody > tr input') as HTMLInputElement;
+  fireEvent.click(checkbox);
+
+  expect(onSelectionChange).toHaveBeenCalledWith([
+    { name: 'Product A - 1', stock: 1 },
+    { name: 'Product Z - 1', stock: 26 },
+  ]);
+});
+
+test('select all selects all items in the current page', () => {
+  const testItemOne = { name: 'Test Item', stock: 1 };
+  const testItemTwo = { name: 'Test Item Two', stock: 2 };
+  const testItemThree = { name: 'Test Item Three', stock: 3 };
+  const items: TestItem[] = [testItemOne, testItemTwo, testItemThree];
+  const onSelectionChange = jest.fn();
+
+  const { getAllByRole } = render(getSimpleTable({ selectable: true, items, onSelectionChange, pagination: true }));
+
+  const checkbox = getAllByRole('checkbox')[0];
+
+  fireEvent.click(checkbox);
+
+  expect(onSelectionChange).toHaveBeenCalledWith([testItemOne, testItemTwo, testItemThree]);
+});
+
+test('unselect all should unselect all items in page', () => {
+  const testItemOne = { name: 'Test Item', stock: 1 };
+  const testItemTwo = { name: 'Test Item Two', stock: 2 };
+  const testItemThree = { name: 'Test Item Three', stock: 3 };
+  const items: TestItem[] = [testItemOne, testItemTwo, testItemThree];
+  const onSelectionChange = jest.fn();
+
+  const { getAllByRole } = render(
+    getSimpleTable({
+      selectable: true,
+      items,
+      onSelectionChange,
+      defaultSelected: [testItemOne, testItemTwo, testItemThree],
+      pagination: true,
+    }),
+  );
+
+  const checkbox = getAllByRole('checkbox')[0];
+
+  fireEvent.click(checkbox);
+
+  expect(onSelectionChange).toHaveBeenCalledWith([]);
+});
+
+test('sorts alphabetically', () => {
+  const { getAllByTestId, getByText } = render(getSimpleTable({ pagination: false }));
+
+  let items = getAllByTestId('name');
+  let firstItemContent = items[0].textContent;
+  let lastItemContent = items[items.length - 1].textContent;
+
+  // Descending order
+  fireEvent.click(getByText('Name'));
+  items = getAllByTestId('name');
+  firstItemContent = items[0].textContent;
+  lastItemContent = items[items.length - 1].textContent;
+
+  expect(firstItemContent).toBe('Product Z - 4');
+  expect(lastItemContent).toBe('Product A - 1');
+
+  // Ascending order
+  fireEvent.click(getByText('Name'));
+  items = getAllByTestId('name');
+  firstItemContent = items[0].textContent;
+  lastItemContent = items[items.length - 1].textContent;
+
+  expect(firstItemContent).toBe('Product A - 1');
+  expect(lastItemContent).toBe('Product Z - 4');
+});
+
+test('sorts numerically', () => {
+  const { getAllByTestId, getByText } = render(getSimpleTable({ pagination: false }));
+
+  let items = getAllByTestId('stock');
+  let firstItemContent = items[0].textContent;
+  let lastItemContent = items[items.length - 1].textContent;
+
+  // Descending order
+  fireEvent.click(getByText('Stock'));
+  items = getAllByTestId('stock');
+  firstItemContent = items[0].textContent;
+  lastItemContent = items[items.length - 1].textContent;
+
+  expect(firstItemContent).toBe('104');
+  expect(lastItemContent).toBe('1');
+
+  // Ascending order
+  fireEvent.click(getByText('Stock'));
+  items = getAllByTestId('stock');
+  firstItemContent = items[0].textContent;
+  lastItemContent = items[items.length - 1].textContent;
+
+  expect(firstItemContent).toBe('1');
+  expect(lastItemContent).toBe('104');
+});

--- a/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
@@ -19,8 +19,8 @@ export const SelectAll = <T extends TableItem>({
   selectedItems,
   totalItems,
 }: SelectAllProps<T>) => {
-  const allInPageSelected = items.every(item => selectedItems.has(item));
-  const someInPageSelected = items.some(item => selectedItems.has(item));
+  const allInPageSelected = items.length > 0 && items.every(item => selectedItems.has(item));
+  const someInPageSelected = items.length > 0 && items.some(item => selectedItems.has(item));
 
   const handleSelectAll = () => {
     if (typeof onChange !== 'function') {

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 
+import { MarginProps } from '../../mixins';
 import { typedMemo, uniqueId } from '../../utils';
 import { useEventCallback } from '../../utils/useEventCallback';
 
@@ -153,4 +154,4 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
 };
 
 export const Table = typedMemo(InternalTable);
-export const TableFigure: React.FC = memo(props => <StyledTableFigure {...props} />);
+export const TableFigure: React.FC<MarginProps> = memo(props => <StyledTableFigure {...props} />);

--- a/packages/big-design/src/components/Table/styled.tsx
+++ b/packages/big-design/src/components/Table/styled.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { withMargins, MarginProps } from '../../mixins';
 
-export const StyledTableFigure = styled.figure`
+export const StyledTableFigure = styled.figure<MarginProps>`
   margin: 0;
   margin-bottom: ${({ theme }) => `${theme.spacing.xLarge}`};
   max-width: 100%;
@@ -14,11 +14,11 @@ export const StyledTableFigure = styled.figure`
   ${({ theme }) => theme.breakpoints.tablet} {
     white-space: normal;
   }
+
+  ${withMargins()};
 `;
 
-export const StyledTable = styled.table<MarginProps>`
-  ${withMargins()};
-
+export const StyledTable = styled.table`
   border-collapse: collapse;
   border-color: transparent;
   color: ${({ theme }) => theme.colors.secondary70};

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -34,7 +34,7 @@ export interface TableColumn<T> {
 
 export type TablePaginationProps = Omit<PaginationProps, keyof MarginProps>;
 
-export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElement>, MarginProps {
+export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElement> {
   columns: Array<TableColumn<T>>;
   itemName?: string;
   items: T[];

--- a/packages/big-design/src/components/index.ts
+++ b/packages/big-design/src/components/index.ts
@@ -17,6 +17,7 @@ export * from './ProgressBar';
 export * from './ProgressCircle';
 export * from './Radio';
 export * from './Select';
+export * from './StatefulTable';
 export * from './Table';
 export * from './Tabs';
 export * from './Textarea';

--- a/packages/big-design/src/utils/useDidUpdate.ts
+++ b/packages/big-design/src/utils/useDidUpdate.ts
@@ -1,0 +1,13 @@
+import { useEffect, useRef, DependencyList, EffectCallback } from 'react';
+
+export const useDidUpdate = (effect: EffectCallback, deps?: DependencyList) => {
+  const isInitialRender = useRef(true);
+
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+    } else {
+      effect();
+    }
+  }, deps);
+};

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -1,0 +1,115 @@
+import { NextLink, Prop, PropTable, PropTableWrapper } from '../components';
+
+const statefulTableProps: Prop[] = [
+  {
+    name: 'columns',
+    types: <NextLink href="#stateful-table-columns-prop-table">Columns[]</NextLink>,
+    description: (
+      <>
+        See <NextLink href="#stateful-table-columns-prop-table">below</NextLink> for usage.
+      </>
+    ),
+    required: true,
+  },
+  {
+    name: 'items',
+    types: 'any[]',
+    description: 'The array of items to display.',
+    required: true,
+  },
+  {
+    name: 'itemName',
+    types: 'string',
+    description: 'Item name displayed on the table actions section.',
+  },
+  {
+    name: 'keyField',
+    types: 'string',
+    defaultValue: 'id',
+    description: 'Unique property identifier for items.',
+  },
+  {
+    name: 'pagination',
+    types: 'boolean',
+    defaultValue: 'false',
+    description: 'Defines if table should be paginated.',
+  },
+  {
+    name: 'selectable',
+    types: 'boolean',
+    defaultValue: 'false',
+    description: 'Defines if table should be selectable.',
+  },
+  {
+    name: 'stickyHeader',
+    types: 'boolean',
+    description: 'Makes the table header fixed.',
+  },
+  {
+    name: 'defaultSelected',
+    types: 'Item[]',
+    description: 'Defines which items are selected by default on initial render.',
+  },
+  {
+    name: 'onSelectionChange',
+    types: '(selectedItems: Item[]) => void',
+    description: 'Function to be called when item selection changes.',
+  },
+];
+
+const tableColumnsProps: Prop[] = [
+  {
+    name: 'render',
+    types: 'React.ComponentType<Item>',
+    required: true,
+    description: 'Component used to render a column.',
+  },
+  {
+    name: 'header',
+    types: 'string',
+    required: true,
+    description: 'Header title.',
+  },
+  {
+    name: 'align',
+    types: ['left', 'center', 'right'],
+    defaultValue: 'left',
+    description: 'Sets alignment for column.',
+  },
+  {
+    name: 'hash',
+    types: 'string',
+    required: true,
+    description: 'Unique identifier for column.',
+  },
+  {
+    name: 'sortKey',
+    types: 'string',
+    description: 'Enables sorting on the column using item[sortKey].',
+  },
+  {
+    name: 'verticalAlign',
+    types: ['top', 'center'],
+    defaultValue: 'top',
+    description: 'Sets vertical alignment for column (td only).',
+  },
+  {
+    name: 'width',
+    types: ['string', 'number'],
+    description: 'Sets column width.',
+  },
+  {
+    name: 'withPadding',
+    types: 'boolean',
+    defaultValue: true,
+    description: 'Toggles padding on td elements.',
+  },
+];
+
+export const StatefulTablePropTable: React.FC<PropTableWrapper> = props => (
+  <PropTable title="StatefulTable" propList={statefulTableProps} {...props} />
+);
+
+export const StatefulTableColumnsPropTable: React.FC<PropTableWrapper> = props => (
+  <PropTable title="StatefulTable[Columns]" propList={tableColumnsProps} {...props} />
+);

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -125,11 +125,6 @@ const tableSelectableProps: Prop[] = [
     description: 'Function to be called when item selection changes.',
     required: true,
   },
-  {
-    name: 'selectAllState',
-    types: ['ALL', 'PARTIAL', 'NONE'],
-    description: 'Used to manually override the select all checkbox state. Useful for multi-page selects.',
-  },
 ];
 
 const tableSortableProps: Prop[] = [

--- a/packages/docs/PropTables/index.ts
+++ b/packages/docs/PropTables/index.ts
@@ -17,6 +17,7 @@ export * from './ProgressBarPropTable';
 export * from './ProgressCirclePropTable';
 export * from './RadioPropTable';
 export * from './SelectPropTable';
+export * from './StatefulTablePropTable';
 export * from './TablePropTable';
 export * from './TabsPropTable';
 export * from './TextareaPropTable';

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -1,6 +1,5 @@
 import { Flex } from '@bigcommerce/big-design';
 import React from 'react';
-import { StyledComponent } from 'styled-components';
 
 import { BigDesignLogoIcon, GithubLogoIcon } from '../Icons';
 import { List } from '../List';
@@ -58,6 +57,9 @@ export const SideNav: React.FC = () => {
           </SideNavLink>
           <SideNavLink href="/Table/TablePage" as="/table">
             Table
+          </SideNavLink>
+          <SideNavLink href="/StatefulTable/StatefulTablePage" as="/statefulTable">
+            StatefulTable
           </SideNavLink>
           <SideNavLink href="/Tabs/TabsPage" as="/tabs">
             Tabs

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -39,6 +39,7 @@ module.exports = {
     '/radio': { page: '/Radio/RadioPage' },
     '/select': { page: '/Select/SelectPage' },
     '/spacing': { page: '/Spacing/SpacingPage' },
+    '/statefulTable': { page: '/StatefulTable/StatefulTablePage' },
     '/table': { page: '/Table/TablePage' },
     '/tabs': { page: '/Tabs/TabsPage' },
     '/textarea': { page: '/Textarea/TextareaPage' },

--- a/packages/docs/pages/Button/ButtonPage.tsx
+++ b/packages/docs/pages/Button/ButtonPage.tsx
@@ -2,7 +2,7 @@ import { Button, H0, H1, H2, Link, Text } from '@bigcommerce/big-design';
 import { AddIcon, ArrowDropDownIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
 
-import { Code, CodePreview, Collapsible } from '../../components';
+import { Code, CodePreview } from '../../components';
 import { ButtonPropTable, MarginPropTable } from '../../PropTables';
 
 export default () => (

--- a/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
+++ b/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
@@ -1,0 +1,163 @@
+import { H0, H1, H2, StatefulTable, Text } from '@bigcommerce/big-design';
+import React from 'react';
+
+import { CodePreview, NextLink } from '../../components';
+import { StatefulTableColumnsPropTable, StatefulTablePropTable } from '../../PropTables';
+
+const items = [
+  { sku: '3137737c', name: 'Rice - Wild', stock: 29 },
+  { sku: 'd23bfc4c', name: 'Wine - Rioja Campo Viejo', stock: 5 },
+  { sku: 'cb8ca0f9', name: 'Wine - Baron De Rothschild', stock: 17 },
+  { sku: '3951a57f', name: 'Steampan - Foil', stock: 30 },
+  { sku: '04f48630', name: 'Nut - Walnut, Pieces', stock: 11 },
+  { sku: '38392ba4', name: 'Wine - Conde De Valdemar', stock: 8 },
+  { sku: '134b820c', name: 'Pepper - Chili Powder', stock: 35 },
+  { sku: 'b0aeabb4', name: 'Broom And Brush Rack Black', stock: 16 },
+  { sku: '70e8a5a7', name: 'Cardamon Ground', stock: 26 },
+  { sku: '8371ad15', name: 'Tamarillo', stock: 10 },
+  { sku: '3ddfe9d4', name: 'Sardines', stock: 19 },
+  { sku: '64bb2c0d', name: 'Steam Pan - Half Size Deep', stock: 30 },
+  { sku: '5d63640f', name: 'Yeast - Fresh, Fleischman', stock: 26 },
+  { sku: '1c7f113e', name: 'Table Cloth 81x81 Colour', stock: 24 },
+  { sku: '5d18a49a', name: 'Baking Soda', stock: 24 },
+  { sku: 'b1ac58c4', name: 'Red Snapper - Fresh, Whole', stock: 23 },
+  { sku: '358a6371', name: 'Chips Potato All Dressed - 43g', stock: 18 },
+  { sku: '964d3d8c', name: 'Cream Of Tartar', stock: 3 },
+  { sku: '673f56ca', name: 'Muffin Batt - Blueberry Passion', stock: 28 },
+  { sku: 'a358ab58', name: 'Puree - Kiwi', stock: 25 },
+  { sku: 'e17535d0', name: 'Beer - Creemore', stock: 26 },
+  { sku: '6b3d83b1', name: 'Goulash Seasoning', stock: 30 },
+  { sku: '4e7a378d', name: 'Beef - Striploin Aa', stock: 9 },
+  { sku: '5ed9e628', name: 'Beer - Maudite', stock: 21 },
+  { sku: '147728a2', name: 'Beans - Kidney, Red Dry', stock: 31 },
+  { sku: 'f8690bd1', name: 'Cheese - Brick With Onion', stock: 19 },
+  { sku: '45a4878d', name: 'Grenadillo', stock: 1 },
+  { sku: '4ed3bbfd', name: 'Stock - Beef, Brown', stock: 16 },
+  { sku: 'b229deb6', name: 'Soup Campbells Turkey Veg.', stock: 2 },
+  { sku: 'b0b10316', name: 'Juice - Happy Planet', stock: 16 },
+  { sku: '38e8b7e8', name: 'Tofu - Soft', stock: 13 },
+  { sku: '8030a286', name: 'Cake - Lemon Chiffon', stock: 19 },
+  { sku: '3b7a1aa1', name: 'Appetizer - Escargot Puff', stock: 15 },
+  { sku: '12dc80f4', name: 'Grenadine', stock: 1 },
+  { sku: '762803b1', name: 'Sauce - Bernaise, Mix', stock: 1 },
+  { sku: '202df318', name: 'Steam Pan - Half Size Deep', stock: 14 },
+  { sku: '2096e4e3', name: 'Tequila - Sauza Silver', stock: 33 },
+  { sku: '7401e1fd', name: 'Coffee - Flavoured', stock: 21 },
+  { sku: 'e16260a8', name: 'Veal - Slab Bacon', stock: 1 },
+  { sku: '2cdbe616', name: 'Wonton Wrappers', stock: 14 },
+  { sku: '2fb211e8', name: 'Bread - Malt', stock: 33 },
+  { sku: '88c3cfe7', name: 'Sugar - Cubes', stock: 17 },
+  { sku: '0c7de951', name: 'Cookie Trail Mix', stock: 5 },
+  { sku: '915867e1', name: 'Chinese Foods - Chicken Wing', stock: 31 },
+  { sku: 'a72f791f', name: 'Buffalo - Tenderloin', stock: 23 },
+  { sku: 'a0dd1467', name: 'Pastry - French Mini Assorted', stock: 24 },
+  { sku: 'fac53a91', name: 'Wine - Stoneliegh Sauvignon', stock: 25 },
+  { sku: '4bb2916d', name: 'Sugar - Palm', stock: 20 },
+  { sku: '573bf5e3', name: 'Beer - Camerons Auburn', stock: 21 },
+  { sku: 'b16e6a30', name: 'Cucumber - Pickling Ontario', stock: 10 },
+  { sku: '9a9313d3', name: 'Beef - Short Ribs', stock: 16 },
+  { sku: '267cc895', name: 'Beer - Fruli', stock: 8 },
+  { sku: '2ea62a23', name: 'Octopus', stock: 8 },
+  { sku: '67b803a4', name: 'Cherries - Maraschino,jar', stock: 17 },
+  { sku: '5ae8f844', name: 'Sherbet - Raspberry', stock: 11 },
+  { sku: 'be06efaa', name: 'Rice Pilaf, Dry,package', stock: 5 },
+  { sku: '8f56d3e1', name: 'Foil Cont Round', stock: 27 },
+  { sku: '2be4e147', name: 'Milk - Chocolate 500ml', stock: 7 },
+  { sku: 'afba0e3a', name: 'Veal - Inside', stock: 3 },
+  { sku: 'bee8a490', name: 'Jolt Cola', stock: 36 },
+  { sku: 'f95c3876', name: 'Coffee - Hazelnut Cream', stock: 28 },
+  { sku: 'c9c10646', name: 'Brandy Apricot', stock: 15 },
+  { sku: '910c9f96', name: 'Peppercorns - Green', stock: 20 },
+  { sku: '593507e5', name: 'Browning Caramel Glace', stock: 24 },
+  { sku: '3a0bbebf', name: 'Halibut - Fletches', stock: 35 },
+  { sku: '7d811897', name: 'Lid Coffeecup 12oz D9542b', stock: 33 },
+  { sku: '43a128ca', name: 'Oil - Hazelnut', stock: 18 },
+  { sku: 'bbcab107', name: 'Saskatoon Berries - Frozen', stock: 24 },
+  { sku: 'd046d959', name: 'Soup - Campbells, Chix Gumbo', stock: 16 },
+  { sku: 'b2b0531c', name: 'Rum - Spiced, Captain Morgan', stock: 1 },
+  { sku: '5425fd56', name: 'Wine - Riesling Dr. Pauly', stock: 35 },
+  { sku: '046d807e', name: 'Skirt - 29 Foot', stock: 27 },
+  { sku: 'd109ada7', name: 'Ham - Virginia', stock: 22 },
+  { sku: 'ddd11eee', name: 'Pomegranates', stock: 9 },
+  { sku: '8a7f119d', name: 'Lidsoupcont Rp12dn', stock: 25 },
+  { sku: '85559c3a', name: 'Quail - Jumbo', stock: 20 },
+  { sku: 'f2e1dafc', name: 'Cheese - Brie Roitelet', stock: 26 },
+  { sku: 'ac35dd42', name: 'Tomatoes - Roma', stock: 35 },
+  { sku: '2806465d', name: 'Oven Mitt - 13 Inch', stock: 21 },
+  { sku: 'f1dc1d8f', name: 'Samosa - Veg', stock: 13 },
+  { sku: '61c4fba7', name: 'Loquat', stock: 20 },
+  { sku: 'a0865469', name: 'Ice Cream Bar - Rolo Cone', stock: 32 },
+  { sku: '3d84f8b3', name: 'Cherries - Bing, Canned', stock: 18 },
+  { sku: '592e5f21', name: 'Juice - Apple, 500 Ml', stock: 11 },
+  { sku: '8d345eea', name: 'Chinese Lemon Pork', stock: 26 },
+  { sku: '2947c625', name: 'Bread - Frozen Basket Variety', stock: 33 },
+  { sku: '8d8144ce', name: 'Paper Towel Touchless', stock: 14 },
+  { sku: '543a0480', name: 'Onions - Cooking', stock: 36 },
+  { sku: '24a5c0bc', name: 'Lettuce - Romaine', stock: 17 },
+  { sku: '8e8b22bf', name: 'Spinach - Frozen', stock: 19 },
+  { sku: '1477f081', name: 'Zucchini - Yellow', stock: 13 },
+  { sku: 'f3d638f6', name: 'Wild Boar - Tenderloin', stock: 3 },
+  { sku: '90f71f26', name: 'Rice - Wild', stock: 26 },
+  { sku: '3c275810', name: 'Wine - Fino Tio Pepe Gonzalez', stock: 2 },
+  { sku: '2e11de76', name: 'Petit Baguette', stock: 5 },
+  { sku: '8e6cb56a', name: 'Clams - Littleneck, Whole', stock: 28 },
+  { sku: '5450b12a', name: 'Squid - U 5', stock: 12 },
+  { sku: '96043b83', name: 'Wine - Red, Wolf Blass, Yellow', stock: 20 },
+  { sku: '87c85429', name: 'Cheese - Cambozola', stock: 36 },
+  { sku: 'be1652e5', name: 'Wine - Cahors Ac 2000, Clos', stock: 21 },
+];
+
+export default () => {
+  return (
+    <>
+      <H0>StatefulTable</H0>
+
+      <Text>
+        StatefulTable is a wrapper of <NextLink href="/table">Table</NextLink> that simplifies it's usage when having
+        the full list of items in memory. It supports pagination, row selection, and sorting out of the box.
+      </Text>
+
+      <CodePreview>
+        {/* jsx-to-string:start */}
+        <StatefulTable
+          columns={[
+            { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+            { header: 'Name', hash: 'name', render: ({ name }) => name },
+            { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+          ]}
+          items={[
+            { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+            { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+            { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+            { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+            { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+          ]}
+        />
+        {/* jsx-to-string:end */}
+      </CodePreview>
+
+      <H1>API</H1>
+      <StatefulTablePropTable />
+      <StatefulTableColumnsPropTable id="stateful-table-columns-prop-table" />
+
+      <H1>Examples</H1>
+      <H2>Usage with pagination, selection, and sorting.</H2>
+
+      <CodePreview scope={{ items }}>
+        {/* jsx-to-string:start */}
+        <StatefulTable
+          itemName="Products"
+          columns={[
+            { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+            { header: 'Name', hash: 'name', render: ({ name }) => name },
+            { header: 'Stock', hash: 'stock', render: ({ stock }) => stock, sortKey: 'stock' },
+          ]}
+          items={items}
+          pagination
+          selectable
+        />
+        {/* jsx-to-string:end */}
+      </CodePreview>
+    </>
+  );
+};

--- a/packages/docs/pages/Table/TablePage.tsx
+++ b/packages/docs/pages/Table/TablePage.tsx
@@ -1,9 +1,8 @@
-import { H0, H1, H2, Table, TableItem, Text } from '@bigcommerce/big-design';
+import { H0, H1, Table, TableItem, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { CodePreview } from '../../components';
 import {
-  MarginPropTable,
   TableColumnsPropTable,
   TablePropTable,
   TableSelectablePropTable,
@@ -75,9 +74,6 @@ export default () => {
       <TableColumnsPropTable id="table-columns-prop-table" />
       <TableSelectablePropTable id="table-selectable-prop-table" />
       <TableSortablePropTable id="table-sortable-prop-table" />
-
-      <H2>Inherited Props</H2>
-      <MarginPropTable collapsible />
 
       <H1>Using pagination and selectable</H1>
 


### PR DESCRIPTION
Adds a `<StatefulTable />` component to be used when having access to the full items list in memory. Handles all pagination, sorting, selection logic internally.

BREAKING CHANGE: `<Table />` no longer accepts Margin props.