### PR TITLE
fix(component): table header not aligning properly

### DIFF
--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -50,14 +50,8 @@ const InternalHeaderCell = <T extends TableItem>({
   };
 
   return (
-    <StyledTableHeaderCell
-      align={align}
-      isSortable={isSortable}
-      stickyHeader={stickyHeader}
-      onClick={handleClick}
-      width={width}
-    >
-      <Flex alignItems="center" flexDirection="row">
+    <StyledTableHeaderCell isSortable={isSortable} stickyHeader={stickyHeader} onClick={handleClick} width={width}>
+      <Flex alignItems="center" flexDirection="row" justifyContent={align}>
         {children}
         {renderSortIcon()}
       </Flex>

--- a/packages/big-design/src/components/Table/HeaderCell/styled.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/styled.tsx
@@ -2,7 +2,6 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 interface StyledTableHeaderCellProps {
-  align?: 'left' | 'center' | 'right';
   isSortable?: boolean;
   width?: number | string;
   stickyHeader?: boolean;
@@ -17,12 +16,6 @@ export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   padding: ${({ theme }) => theme.spacing.small};
   white-space: nowrap;
-
-  ${({ align }) =>
-    align &&
-    css`
-      text-align: ${align};
-    `};
 
   ${({ isSortable }) =>
     isSortable &&

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -107,7 +107,7 @@ test('tweaks column styles with props', () => {
   const skuHeader = headers[0];
   const nameHeader = headers[1];
 
-  expect(skuHeader).toHaveStyle('text-align: right');
+  expect(skuHeader.childNodes[0]).toHaveStyle('justify-content: right');
   expect(skuHeader).not.toHaveStyle('vertical-align: center');
 
   expect(nameHeader).toHaveStyle('width: 100px');


### PR DESCRIPTION
`align` prop on table headers broke after introducing sorting.