### PR TITLE
feat: CHI-696 select component accepts an inputRef prop

### DIFF
--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -40,7 +40,6 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
   };
 
   private callbackRef?: HTMLInputElement;
-  // private inputRef?: RefObject<HTMLInputElement>;
   private defaultRef: RefObject<HTMLInputElement> = React.createRef();
   private listRef: HTMLUListElement | null = null;
 

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -559,3 +559,50 @@ test('should render a non filterable select', () => {
   const input = getAllByLabelText('Countries')[0];
   expect(input.getAttribute('readonly')).toBe('');
 });
+
+test('should use the passed in ref object if provided', () => {
+  const ref = React.createRef<HTMLInputElement>();
+  const { getAllByLabelText } = render(
+    <Select
+      inputRef={ref}
+      label="Countries"
+      onChange={onChange}
+      options={[
+        { value: 'us', content: 'United States' },
+        { value: 'mx', content: 'Mexico' },
+        { value: 'ca', content: 'Canada' },
+        { value: 'en', content: 'England' },
+        { value: 'fr', content: 'France', disabled: true },
+      ]}
+      placeholder="Choose country"
+    />,
+  );
+
+  const input = getAllByLabelText('Countries')[0];
+
+  expect(ref.current).toEqual(input);
+});
+
+test('should call the provided refSetter if any', () => {
+  let inputRef: HTMLInputElement | null = null;
+  const refSetter = (ref: HTMLInputElement) => (inputRef = ref);
+  const { getAllByLabelText } = render(
+    <Select
+      inputRef={refSetter}
+      label="Countries"
+      onChange={onChange}
+      options={[
+        { value: 'us', content: 'United States' },
+        { value: 'mx', content: 'Mexico' },
+        { value: 'ca', content: 'Canada' },
+        { value: 'en', content: 'England' },
+        { value: 'fr', content: 'France', disabled: true },
+      ]}
+      placeholder="Choose country"
+    />,
+  );
+
+  const input = getAllByLabelText('Countries')[0];
+
+  expect(inputRef).toEqual(input);
+});

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -1,13 +1,14 @@
 import { Placement } from 'popper.js';
-import React from 'react';
+import { RefObject } from 'react';
 
 import { ListItemProps } from '../List/Item';
 
-export interface SelectProps<T> extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children' | 'onChange' | 'ref'> {
+export interface SelectProps<T> extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children' | 'onChange'> {
   action?: Action;
   disabled?: boolean;
   error?: string;
   filterable?: boolean;
+  inputRef?: RefObject<HTMLInputElement> | React.Ref<HTMLInputElement>;
   label?: string;
   maxHeight?: number;
   multi?: boolean;
@@ -15,7 +16,6 @@ export interface SelectProps<T> extends Omit<React.HTMLAttributes<HTMLUListEleme
   options: Array<Option<T>>;
   placement?: Placement;
   positionFixed?: boolean;
-  inputRef?: React.RefObject<HTMLInputElement> | React.Ref<HTMLInputElement>;
   required?: boolean;
   value?: T | T[];
   onChange(value: T | T[], option: Option<T> | Array<Option<T>>): void;

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -1,8 +1,9 @@
 import { Placement } from 'popper.js';
+import React from 'react';
 
 import { ListItemProps } from '../List/Item';
 
-export interface SelectProps<T> extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children' | 'onChange'> {
+export interface SelectProps<T> extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children' | 'onChange' | 'ref'> {
   action?: Action;
   disabled?: boolean;
   error?: string;
@@ -14,6 +15,7 @@ export interface SelectProps<T> extends Omit<React.HTMLAttributes<HTMLUListEleme
   options: Array<Option<T>>;
   placement?: Placement;
   positionFixed?: boolean;
+  inputRef?: React.RefObject<HTMLInputElement> | React.Ref<HTMLInputElement>;
   required?: boolean;
   value?: T | T[];
   onChange(value: T | T[], option: Option<T> | Array<Option<T>>): void;

--- a/packages/docs/PropTables/SelectPropTable.tsx
+++ b/packages/docs/PropTables/SelectPropTable.tsx
@@ -25,6 +25,15 @@ const selectProps: Prop[] = [
     ),
   },
   {
+    name: 'inputRef',
+    types: 'React.Ref<HTMLInputElement> | React.RefObject<HTMLInputElement>',
+    description: (
+      <>
+        The provided ref will be used for the underlying input element used in the <Code>Select</Code>.
+      </>
+    ),
+  },
+  {
     name: 'label',
     types: 'string',
     description: 'Adds a label to the field.',


### PR DESCRIPTION
## What?
The `Select` component now accepts an optional `inputRef` of type `RefObject<HTMLInputElement> | React.Ref<HTMLInputElement>`

## Usage:
The prop accepts three usages:
- `inputRef={undefined}`
- `inputRef={React.createRef<HTMLInputElement>()}`
- `inputRef={(input: HTMLInputElement) => void}`