### PR TITLE
feat(component): add stickiness to table header and actions

### DIFF
--- a/packages/big-design/__mocks__/popper.js.ts
+++ b/packages/big-design/__mocks__/popper.js.ts
@@ -9,6 +9,10 @@ export default class Popper {
       destroy: () => {},
       // tslint:disable-next-line: no-empty
       scheduleUpdate: () => {},
+      // tslint:disable-next-line: no-empty
+      enableEventListeners: () => {},
+      // tslint:disable-next-line: no-empty
+      disableEventListeners: () => {},
     };
   }
 }

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -32,6 +32,7 @@ export const List: React.FC<ListProps> = memo(
       placement={selectedPlacement}
       positionFixed={positionFixed}
       modifiers={{ offset: { offset: '0, 10' } }}
+      eventsEnabled={isOpen}
     >
       {({ placement, ref, scheduleUpdate, style: popperStyle }) => (
         <StyledList

--- a/packages/big-design/src/components/Table/Actions/Actions.tsx
+++ b/packages/big-design/src/components/Table/Actions/Actions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { RefObject } from 'react';
 
 import { typedMemo } from '../../../utils';
 import { Flex } from '../../Flex';
@@ -7,22 +7,28 @@ import { TableItem, TablePaginationProps, TableSelectable } from '../types';
 import { SelectAll } from '../SelectAll';
 import { TablePagination } from '../TablePagination';
 
+import { StyledFlex } from './styled';
+
 export interface ActionsProps<T> {
+  forwardedRef: RefObject<HTMLDivElement>;
   itemName?: string;
   items: T[];
   pagination?: TablePaginationProps;
   onSelectionChange?: TableSelectable<T>['onSelectionChange'];
   selectedItems: Set<T>;
+  stickyHeader?: boolean;
   tableId: string;
 }
 
 const InternalActions = <T extends TableItem>({
   pagination,
   tableId,
+  forwardedRef,
   itemName,
   items = [],
   onSelectionChange,
   selectedItems,
+  stickyHeader,
   ...props
 }: ActionsProps<T>) => {
   const isSelectable = typeof onSelectionChange === 'function';
@@ -43,18 +49,19 @@ const InternalActions = <T extends TableItem>({
   };
 
   return (
-    <Flex
+    <StyledFlex
       alignItems="center"
       aria-controls={tableId}
       flexDirection="row"
       justifyContent="stretch"
-      padding="small"
+      stickyHeader={stickyHeader}
+      ref={forwardedRef}
       {...props}
     >
       <SelectAll onChange={onSelectionChange} selectedItems={selectedItems} items={items} totalItems={totalItems} />
       {renderItemName()}
       {pagination && <TablePagination {...pagination} />}
-    </Flex>
+    </StyledFlex>
   );
 };
 

--- a/packages/big-design/src/components/Table/Actions/styled.tsx
+++ b/packages/big-design/src/components/Table/Actions/styled.tsx
@@ -1,0 +1,25 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled, { css } from 'styled-components';
+
+import { FlexProps } from '../../Flex';
+import { withFlexedContainer } from '../../Flex/withFlex';
+
+export const StyledFlex = styled.div<FlexProps & { stickyHeader?: boolean }>`
+  ${withFlexedContainer()}
+
+  background-color: ${({ theme }) => theme.colors.white};
+  display: flex;
+  padding: ${({ theme }) => theme.spacing.small};
+
+  ${({ theme, stickyHeader }) =>
+    stickyHeader &&
+    css`
+      ${theme.breakpoints.tablet} {
+        position: sticky;
+        top: 0;
+        z-index: ${theme.zIndex.sticky + 1};
+      }
+    `}
+`;
+
+StyledFlex.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -1,13 +1,15 @@
 import { ArrowDownwardIcon, ArrowUpwardIcon } from '@bigcommerce/big-design-icons';
-import React, { memo } from 'react';
+import React, { memo, RefObject } from 'react';
 
 import { typedMemo } from '../../../utils';
+import { useComponentSize } from '../../../utils/useComponentSize';
 import { Flex } from '../../Flex';
 import { TableColumn, TableItem } from '../types';
 
 import { StyledTableHeaderCell, StyledTableHeaderCheckbox } from './styled';
 
 export interface HeaderCellProps<T> extends React.TableHTMLAttributes<HTMLTableCellElement> {
+  actionsRef: RefObject<HTMLDivElement>;
   column: TableColumn<T>;
   isSorted?: boolean;
   sortDirection?: 'ASC' | 'DESC';
@@ -16,6 +18,7 @@ export interface HeaderCellProps<T> extends React.TableHTMLAttributes<HTMLTableC
 }
 
 export interface HeaderCheckboxCellProps {
+  actionsRef: RefObject<HTMLDivElement>;
   stickyHeader?: boolean;
 }
 
@@ -26,8 +29,10 @@ const InternalHeaderCell = <T extends TableItem>({
   onSortClick,
   sortDirection,
   stickyHeader,
+  actionsRef,
 }: HeaderCellProps<T>) => {
   const { align, isSortable, width } = column;
+  const actionsSize = useComponentSize(actionsRef);
 
   const renderSortIcon = () => {
     if (!isSorted) {
@@ -50,7 +55,13 @@ const InternalHeaderCell = <T extends TableItem>({
   };
 
   return (
-    <StyledTableHeaderCell isSortable={isSortable} stickyHeader={stickyHeader} onClick={handleClick} width={width}>
+    <StyledTableHeaderCell
+      isSortable={isSortable}
+      stickyHeader={stickyHeader}
+      onClick={handleClick}
+      width={width}
+      stickyHeight={actionsSize.height}
+    >
       <Flex alignItems="center" flexDirection="row" justifyContent={align}>
         {children}
         {renderSortIcon()}
@@ -59,8 +70,10 @@ const InternalHeaderCell = <T extends TableItem>({
   );
 };
 
-export const HeaderCheckboxCell: React.FC<HeaderCheckboxCellProps> = memo(({ stickyHeader }) => (
-  <StyledTableHeaderCheckbox stickyHeader={stickyHeader} />
-));
+export const HeaderCheckboxCell: React.FC<HeaderCheckboxCellProps> = memo(({ stickyHeader, actionsRef }) => {
+  const actionsSize = useComponentSize(actionsRef);
+
+  return <StyledTableHeaderCheckbox stickyHeader={stickyHeader} stickyHeight={actionsSize.height} />;
+});
 
 export const HeaderCell = typedMemo(InternalHeaderCell);

--- a/packages/big-design/src/components/Table/HeaderCell/styled.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/styled.tsx
@@ -5,6 +5,7 @@ interface StyledTableHeaderCellProps {
   isSortable?: boolean;
   width?: number | string;
   stickyHeader?: boolean;
+  stickyHeight: number;
 }
 
 export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
@@ -29,11 +30,15 @@ export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
       width: ${typeof width === 'string' ? width : width + 'px'};
     `};
 
-  ${({ stickyHeader }) =>
+  ${({ theme, stickyHeader, stickyHeight }) =>
     stickyHeader &&
+    stickyHeight >= 0 &&
     css`
-      position: sticky;
-      top: 0;
+      ${theme.breakpoints.tablet} {
+        position: sticky;
+        top: ${theme.helpers.remCalc(stickyHeight)};
+        z-index: ${theme.zIndex.sticky};
+      }
     `}
 `;
 

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -28,6 +28,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     style,
     ...rest
   } = props;
+  const actionsRef = useRef<HTMLDivElement>(null);
   const tableIdRef = useRef(id || uniqueId('table_'));
   const isSelectable = Boolean(selectable);
   const [selectedItems, setSelectedItems] = useState<Set<T>>(new Set());
@@ -89,7 +90,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
   const renderHeaders = () => (
     <Head>
       <tr>
-        {isSelectable && <HeaderCheckboxCell stickyHeader={stickyHeader} />}
+        {isSelectable && <HeaderCheckboxCell stickyHeader={stickyHeader} actionsRef={actionsRef} />}
 
         {columns.map((column, index) => {
           const { hash, header, isSortable } = column;
@@ -104,6 +105,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
               onSortClick={onSortClick}
               sortDirection={sortDirection}
               stickyHeader={stickyHeader}
+              actionsRef={actionsRef}
             >
               {header}
             </HeaderCell>
@@ -143,6 +145,8 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
           items={items}
           itemName={itemName}
           tableId={tableIdRef.current}
+          stickyHeader={stickyHeader}
+          forwardedRef={actionsRef}
         />
       )}
       <StyledTable {...rest} id={tableIdRef.current}>

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -1,16 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a pagination component 1`] = `
-.c2 {
+.c1 {
   box-sizing: border-box;
 }
 
-.c0 {
-  padding: 0.75rem;
-  box-sizing: border-box;
-}
-
-.c12 {
+.c11 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
@@ -34,31 +29,7 @@ exports[`renders a pagination component 1`] = `
   display: flex;
 }
 
-.c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-box-pack: stretch;
-  -webkit-justify-content: stretch;
-  -ms-flex-pack: stretch;
-  justify-content: stretch;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c5 {
+.c4 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
@@ -82,7 +53,7 @@ exports[`renders a pagination component 1`] = `
   display: flex;
 }
 
-.c3 {
+.c2 {
   -webkit-align-self: auto;
   -ms-flex-item-align: auto;
   align-self: auto;
@@ -94,19 +65,19 @@ exports[`renders a pagination component 1`] = `
   flex-shrink: 1;
 }
 
-.c9 {
+.c8 {
   vertical-align: middle;
   height: 2rem;
   width: 2rem;
 }
 
-.c14 {
+.c13 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c10 {
+.c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   border: 0;
@@ -132,7 +103,7 @@ exports[`renders a pagination component 1`] = `
   z-index: 1060;
 }
 
-.c11 {
+.c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -153,25 +124,25 @@ exports[`renders a pagination component 1`] = `
   padding: 0 1rem;
 }
 
-.c11[aria-selected='true'] {
+.c10[aria-selected='true'] {
   font-weight: 600;
 }
 
-.c11[data-highlighted='true'],
-.c11[data-highlighted='true'] a {
+.c10[data-highlighted='true'],
+.c10[data-highlighted='true'] a {
   background-color: #F0F3FF;
   color: #3C64F4;
 }
 
-.c11 a {
+.c10 a {
   color: #313440;
 }
 
-.c11 label {
+.c10 label {
   cursor: pointer;
 }
 
-.c6 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -218,37 +189,37 @@ exports[`renders a pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c6:focus {
+.c5:focus {
   outline: none;
 }
 
-.c6[disabled] {
+.c5[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c6 + .bd-button {
+.c5 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c6:active {
+.c5:active {
   background-color: #DBE3FE;
 }
 
-.c6:focus {
+.c5:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c6:hover:not(:active) {
+.c5:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c6[disabled] {
+.c5[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
 
-.c13 {
+.c12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -294,37 +265,37 @@ exports[`renders a pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c13:focus {
+.c12:focus {
   outline: none;
 }
 
-.c13[disabled] {
+.c12[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c13 + .bd-button {
+.c12 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c13:active {
+.c12:active {
   background-color: #DBE3FE;
 }
 
-.c13:focus {
+.c12:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c13:hover:not(:active) {
+.c12:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c13[disabled] {
+.c12[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
 
-.c8 {
+.c7 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -338,69 +309,89 @@ exports[`renders a pagination component 1`] = `
   visibility: visible;
 }
 
-.c7 {
+.c6 {
   color: #313440;
   width: auto;
 }
 
-.c4 {
+.c3 {
   margin-left: auto;
 }
 
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: stretch;
+  -webkit-justify-content: stretch;
+  -ms-flex-pack: stretch;
+  justify-content: stretch;
+  background-color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0.75rem;
+}
+
 @media (min-width:720px) {
-  .c6 + .bd-button {
+  .c5 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c6 {
+  .c5 {
     width: auto;
   }
 }
 
 @media (min-width:720px) {
-  .c13 + .bd-button {
+  .c12 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c13 {
+  .c12 {
     width: auto;
   }
 }
 
 <div
   aria-controls="table_0"
-  class="c0 c1"
+  class="c0"
 >
   <div
-    class="c2 c3 c4"
+    class="c1 c2 c3"
   >
     <div
       aria-label="pagination"
-      class="c2 c5"
+      class="c1 c4"
       role="navigation"
     >
       <div
-        class="c2 c3"
+        class="c1 c2"
       >
         <button
           aria-haspopup="true"
-          class="c6 c7"
+          class="c5 c6"
           id="trigger_2"
           role="button"
           tabindex="0"
         >
           <span
-            class="c8"
+            class="c7"
           >
             1 - 3 of 5
             <svg
-              class="c9"
+              class="c8"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -421,47 +412,47 @@ exports[`renders a pagination component 1`] = `
         </button>
         <ul
           aria-labelledby="trigger_2"
-          class="c10"
+          class="c9"
           id="dropdown_1"
           role="listbox"
           style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
           tabindex="-1"
         >
           <li
-            class="c11"
+            class="c10"
             data-highlighted="false"
             id="dropdown_1-item-0"
             role="option"
             tabindex="-1"
           >
             <div
-              class="c2 c12"
+              class="c1 c11"
             >
               3 per page
             </div>
           </li>
           <li
-            class="c11"
+            class="c10"
             data-highlighted="false"
             id="dropdown_1-item-1"
             role="option"
             tabindex="-1"
           >
             <div
-              class="c2 c12"
+              class="c1 c11"
             >
               5 per page
             </div>
           </li>
           <li
-            class="c11"
+            class="c10"
             data-highlighted="false"
             id="dropdown_1-item-2"
             role="option"
             tabindex="-1"
           >
             <div
-              class="c2 c12"
+              class="c1 c11"
             >
               10 per page
             </div>
@@ -469,19 +460,19 @@ exports[`renders a pagination component 1`] = `
         </ul>
       </div>
       <div
-        class="c2 c3"
+        class="c1 c2"
       >
         <button
-          class="c13 c7"
+          class="c12 c6"
           disabled=""
           role="button"
           tabindex="0"
         >
           <span
-            class="c8"
+            class="c7"
           >
             <svg
-              class="c14"
+              class="c13"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -503,15 +494,15 @@ exports[`renders a pagination component 1`] = `
           </span>
         </button>
         <button
-          class="c13 c7"
+          class="c12 c6"
           role="button"
           tabindex="0"
         >
           <span
-            class="c8"
+            class="c7"
           >
             <svg
-              class="c14"
+              class="c13"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -744,45 +735,16 @@ exports[`renders a simple table 1`] = `
 `;
 
 exports[`selectable renders selectable actions and checkboxes 1`] = `
-.c4 {
-  box-sizing: border-box;
-}
-
-.c0 {
-  padding: 0.75rem;
-  box-sizing: border-box;
-}
-
-.c2 {
-  margin-right: 0.25rem;
+.c3 {
   box-sizing: border-box;
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-box-pack: stretch;
-  -webkit-justify-content: stretch;
-  -ms-flex-pack: stretch;
-  justify-content: stretch;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  margin-right: 0.25rem;
+  box-sizing: border-box;
 }
 
-.c5 {
+.c4 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
@@ -806,7 +768,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   display: flex;
 }
 
-.c3 {
+.c2 {
   -webkit-align-self: auto;
   -ms-flex-item-align: auto;
   align-self: auto;
@@ -818,7 +780,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   flex-shrink: 1;
 }
 
-.c12 {
+.c11 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -827,11 +789,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0;
 }
 
-.c12:last-child {
+.c11:last-child {
   margin-bottom: 0;
 }
 
-.c11 {
+.c10 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -840,17 +802,17 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin-left: 0.75rem;
 }
 
-.c11:last-child {
+.c10:last-child {
   margin-bottom: 0;
 }
 
-.c10 {
+.c9 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c6 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -861,7 +823,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   display: flex;
 }
 
-.c8 {
+.c7 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -876,7 +838,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   width: 1px;
 }
 
-.c9 {
+.c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -904,40 +866,60 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   width: 1.25rem;
 }
 
-.c7:focus + .c9 {
+.c6:focus + .c8 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9 svg {
+.c8 svg {
   visibility: hidden;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: stretch;
+  -webkit-justify-content: stretch;
+  -ms-flex-pack: stretch;
+  justify-content: stretch;
+  background-color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0.75rem;
 }
 
 <div
   aria-controls="table_0"
-  class="c0 c1"
+  class="c0"
 >
   <div
-    class="c2 c3"
+    class="c1 c2"
   >
     <div
-      class="c4 c5"
+      class="c3 c4"
     >
       <div
-        class="c6"
+        class="c5"
       >
         <input
           aria-labelledby="checkBox_label_2"
-          class="c7 c8"
+          class="c6 c7"
           id="checkBox_1"
           type="checkbox"
         />
         <label
           aria-hidden="true"
-          class="c9"
+          class="c8"
           for="checkBox_1"
         >
           <svg
-            class="c10"
+            class="c9"
             fill="currentColor"
             height="24"
             stroke="currentColor"
@@ -957,17 +939,17 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         </label>
       </div>
       <p
-        class="c11"
+        class="c10"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c4 c3"
+    class="c3 c2"
   >
     <p
-      class="c12"
+      class="c11"
     >
       Product
     </p>

--- a/packages/big-design/src/components/Tooltip/Tooltip.tsx
+++ b/packages/big-design/src/components/Tooltip/Tooltip.tsx
@@ -65,6 +65,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, State> {
               <Popper
                 placement={this.props.placement}
                 modifiers={{ offset: { offset: '0, 8' }, ...this.props.modifiers }}
+                eventsEnabled={this.state.visible}
               >
                 {({ placement, ref, style }) =>
                   this.state.visible && (

--- a/packages/big-design/src/utils/useComponentSize.ts
+++ b/packages/big-design/src/utils/useComponentSize.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState, RefObject } from 'react';
+
+interface ComponentSize {
+  height: HTMLElement['offsetHeight'];
+  width: HTMLElement['offsetWidth'];
+}
+
+const getSize = <T extends any>(element: RefObject<T>['current']): ComponentSize => ({
+  height: element ? element.offsetHeight : 0,
+  width: element ? element.offsetWidth : 0,
+});
+
+export const useComponentSize = <T extends any>(ref: RefObject<T>): ComponentSize => {
+  const [size, setSize] = useState(getSize(ref.current));
+
+  const handleResize = useCallback<() => void | MutationCallback>(() => {
+    if (ref.current) {
+      setSize(getSize(ref.current));
+    }
+  }, [ref.current]);
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    handleResize();
+
+    if (typeof MutationObserver === 'function') {
+      const observer = new MutationObserver(handleResize);
+
+      observer.observe((ref.current as unknown) as Node, { childList: true });
+
+      return () => {
+        observer.disconnect();
+      };
+    }
+  }, [ref.current, handleResize]);
+
+  return size;
+};

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -58,7 +58,7 @@ const tableProps: Prop[] = [
   {
     name: 'stickyHeader',
     types: 'boolean',
-    description: 'Makes the table header fixed.',
+    description: 'Makes the table header and actions fixed.',
   },
 ];
 

--- a/packages/docs/components/BetaRibbon/styled.tsx
+++ b/packages/docs/components/BetaRibbon/styled.tsx
@@ -18,5 +18,6 @@ export const StyledRibbon = styled.div`
     top: ${({ theme }) => theme.helpers.remCalc(RIBBON_POSITION / 2)};
     transform: rotate(45deg);
     width: ${({ theme }) => theme.helpers.remCalc(192)};
+    z-index: ${({ theme }) => theme.zIndex.tooltip + 1};
   }
 `;

--- a/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
+++ b/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
@@ -155,6 +155,7 @@ export default () => {
           items={items}
           pagination
           selectable
+          stickyHeader
         />
         {/* jsx-to-string:end */}
       </CodePreview>

--- a/packages/docs/pages/Table/TablePage.tsx
+++ b/packages/docs/pages/Table/TablePage.tsx
@@ -59,6 +59,7 @@ export default () => {
             { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
             { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
           ]}
+          stickyHeader
         />
         {/* jsx-to-string:end */}
       </CodePreview>
@@ -131,6 +132,7 @@ export default () => {
                 onItemsPerPageChange,
                 itemsPerPage,
               }}
+              stickyHeader
             />
           );
         }}


### PR DESCRIPTION
## What
Add stickiness to table actions.

Other changes:
- enable/disable Popper event listeners if the container is displaying or not. This was causing a rerender on scroll to the `InnerPopper` element.
- increased the z-index of the Beta Ribbon.

## Screenshot
<img width="949" alt="Screen Shot 2019-11-06 at 10 53 37 AM" src="https://user-images.githubusercontent.com/10539418/68319327-c7249280-0083-11ea-84ac-93cd0a69df68.png">
