### PR TITLE
feat(component): add display prop to utility components

### DIFF
--- a/packages/big-design/src/components/Box/Box.tsx
+++ b/packages/big-design/src/components/Box/Box.tsx
@@ -1,11 +1,11 @@
 import { Border, BorderRadius, Colors, Shadow, ThemeInterface } from '@bigcommerce/big-design-theme';
 import React, { memo } from 'react';
 
-import { MarginProps, PaddingProps } from '../../mixins';
+import { DisplayProps, MarginProps, PaddingProps } from '../../mixins';
 
 import { StyledBox } from './styled';
 
-export interface BoxProps extends React.HTMLAttributes<HTMLDivElement>, MarginProps, PaddingProps {
+export interface BoxProps extends React.HTMLAttributes<HTMLDivElement>, DisplayProps, MarginProps, PaddingProps {
   as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
   backgroundColor?: keyof Colors;
   shadow?: keyof Shadow;

--- a/packages/big-design/src/components/Box/styled.tsx
+++ b/packages/big-design/src/components/Box/styled.tsx
@@ -1,13 +1,14 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { withMargins, withPaddings } from '../../mixins';
+import { withDisplay, withMargins, withPaddings } from '../../mixins';
 
 import { BoxProps } from './Box';
 
 export const StyledBox = styled.div<BoxProps>`
-  ${withMargins()};
-  ${withPaddings()};
+  ${withDisplay()}
+  ${withMargins()}
+  ${withPaddings()}
   box-sizing: border-box;
 
   ${({ backgroundColor, theme }) =>

--- a/packages/big-design/src/components/Flex/styled.tsx
+++ b/packages/big-design/src/components/Flex/styled.tsx
@@ -1,6 +1,7 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
+import { withDisplay } from '../../mixins';
 import { Box } from '../Box';
 
 import { withFlexedContainer } from './withFlex';
@@ -10,6 +11,8 @@ export const StyledFlex = styled(Box)<FlexProps>`
   ${withFlexedContainer()}
 
   display: flex;
+
+  ${withDisplay()}
 `;
 
 StyledFlex.defaultProps = {

--- a/packages/big-design/src/components/Grid/styled.tsx
+++ b/packages/big-design/src/components/Grid/styled.tsx
@@ -1,6 +1,7 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
+import { withDisplay } from '../../mixins';
 import { Box } from '../Box';
 
 import { withGridedContainer } from './withGrid';
@@ -10,6 +11,8 @@ export const StyledGrid = styled(Box)<GridProps>`
   ${withGridedContainer()}
 
   display: grid;
+
+  ${withDisplay()}
 `;
 
 StyledGrid.defaultProps = { theme: defaultTheme, gridGap: defaultTheme.spacing.medium };

--- a/packages/big-design/src/mixins/display/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/mixins/display/__snapshots__/spec.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`responsive display 1`] = `
+@media (min-width:0px) {
+  .c0 {
+    display: none;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+<div
+  class="c0"
+  display="[object Object]"
+/>
+`;

--- a/packages/big-design/src/mixins/display/display.tsx
+++ b/packages/big-design/src/mixins/display/display.tsx
@@ -1,0 +1,49 @@
+import { breakpointsOrder, Breakpoints, ThemeInterface } from '@bigcommerce/big-design-theme';
+import { css, FlattenSimpleInterpolation } from 'styled-components';
+
+import { DisplayOverload, DisplayProps } from './types';
+
+export const withDisplay = () => css<DisplayProps>`
+  ${({ display, theme }) => display && getDisplayStyles(display, theme, 'display')};
+`;
+
+const getDisplayStyles: DisplayOverload = (
+  displayProp: any,
+  theme: ThemeInterface,
+  cssKey: any,
+): FlattenSimpleInterpolation => {
+  if (typeof displayProp === 'object') {
+    return getResponsiveDisplay(displayProp, theme, cssKey);
+  }
+
+  if (typeof displayProp === 'string' || typeof displayProp === 'number') {
+    return getSimpleDisplay(displayProp, cssKey);
+  }
+
+  return [];
+};
+
+const getSimpleDisplay = (displayProp: string | number, cssKey: string): FlattenSimpleInterpolation => css`
+  ${cssKey}: ${displayProp}
+`;
+
+const getResponsiveDisplay: DisplayOverload = (
+  displayProp: any,
+  theme: ThemeInterface,
+  cssKey: string,
+): FlattenSimpleInterpolation[] => {
+  const breakpointKeys = Object.keys(displayProp).sort(
+    (firstBreakpoint, secondBreakpoint) =>
+      breakpointsOrder.indexOf(firstBreakpoint as keyof Breakpoints) -
+      breakpointsOrder.indexOf(secondBreakpoint as keyof Breakpoints),
+  );
+
+  return (breakpointKeys as Array<keyof Breakpoints>).map(
+    breakpointKey =>
+      css`
+        ${theme.breakpoints[breakpointKey]} {
+          ${getSimpleDisplay(displayProp[breakpointKey], cssKey)}
+        }
+      `,
+  );
+};

--- a/packages/big-design/src/mixins/display/index.ts
+++ b/packages/big-design/src/mixins/display/index.ts
@@ -1,0 +1,5 @@
+import { DisplayProps as _DisplayProps } from './types';
+
+export { withDisplay } from './display';
+
+export type DisplayProps = _DisplayProps;

--- a/packages/big-design/src/mixins/display/spec.tsx
+++ b/packages/big-design/src/mixins/display/spec.tsx
@@ -1,0 +1,26 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { render } from '@testing-library/react';
+import 'jest-styled-components';
+import React from 'react';
+import styled from 'styled-components';
+
+import { withDisplay } from './display';
+import { DisplayProps } from './types';
+
+const TestComponent = styled.div<DisplayProps>`
+  ${withDisplay()};
+`;
+
+TestComponent.defaultProps = { theme: defaultTheme };
+
+test('display', () => {
+  const { container } = render(<TestComponent display="inline-block" />);
+
+  expect(container.firstChild).toHaveStyle('display: inline-block');
+});
+
+test('responsive display', () => {
+  const { container } = render(<TestComponent display={{ mobile: 'none', tablet: 'flex' }} />);
+
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/packages/big-design/src/mixins/display/types.ts
+++ b/packages/big-design/src/mixins/display/types.ts
@@ -1,0 +1,18 @@
+import { ThemeInterface } from '@bigcommerce/big-design-theme';
+import { FlattenSimpleInterpolation } from 'styled-components';
+
+import { Responsive } from '../../types';
+
+type SingleDisplayProp = 'block' | 'inline-block' | 'inline' | 'inline-flex' | 'flex' | 'grid' | 'inline-grid' | 'none';
+type ResponsiveDisplayProp = Responsive<SingleDisplayProp>;
+type DisplayProp = SingleDisplayProp | ResponsiveDisplayProp;
+
+export type DisplayProps = Partial<{
+  display: DisplayProp;
+}>;
+
+export type DisplayOverload = (
+  displayProp: DisplayProp,
+  theme: ThemeInterface,
+  cssKey: 'display',
+) => FlattenSimpleInterpolation;

--- a/packages/big-design/src/mixins/index.ts
+++ b/packages/big-design/src/mixins/index.ts
@@ -1,2 +1,3 @@
+export * from './display';
 export * from './margins';
 export * from './paddings';

--- a/packages/docs/PropTables/DisplayPropTable.tsx
+++ b/packages/docs/PropTables/DisplayPropTable.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { Prop, PropTable, PropTableWrapper } from '../components';
+
+const displayProps: Prop[] = [
+  {
+    name: 'display',
+    types: ['block', 'inline-block', 'inline', 'inline-flex', 'flex', 'grid', 'inline-grid', 'none'],
+    description: 'Sets the CSS display property of a component.',
+  },
+];
+
+export const DisplayPropTable: React.FC<PropTableWrapper> = props => (
+  <PropTable title="Display" propList={displayProps} {...props} />
+);

--- a/packages/docs/PropTables/index.ts
+++ b/packages/docs/PropTables/index.ts
@@ -2,6 +2,7 @@ export * from './BadgePropTable';
 export * from './BoxPropTable';
 export * from './ButtonPropTable';
 export * from './CheckboxPropTable';
+export * from './DisplayPropTable';
 export * from './DropdownPropTable';
 export * from './FlexPropTable';
 export * from './FormPropTable';

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -118,6 +118,9 @@ export const SideNav: React.FC = () => {
           <SideNavLink href="/Breakpoints/BreakpointsPage" as="/breakpoints">
             Breakpoints
           </SideNavLink>
+          <SideNavLink href="/Display/DisplayPage" as="/display">
+            Display
+          </SideNavLink>
           <SideNavLink href="/Flex/FlexPage" as="/flex">
             Flex
           </SideNavLink>

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -23,6 +23,7 @@ module.exports = {
     '/button': { page: '/Button/ButtonPage' },
     '/checkbox': { page: '/Checkbox/CheckboxPage' },
     '/colors': { page: '/Colors/ColorsPage' },
+    '/display': { page: '/Display/DisplayPage' },
     '/dropdown': { page: '/Dropdown/DropdownPage' },
     '/flex': { page: '/Flex/FlexPage' },
     '/form': { page: '/Form/FormPage' },

--- a/packages/docs/pages/Box/BoxPage.tsx
+++ b/packages/docs/pages/Box/BoxPage.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { CodePreview } from '../../components';
-import { BoxPropTable, MarginPropTable, PaddingPropTable } from '../../PropTables';
+import { BoxPropTable, DisplayPropTable, MarginPropTable, PaddingPropTable } from '../../PropTables';
 
 export default () => (
   <>
@@ -23,6 +23,7 @@ export default () => (
     <BoxPropTable />
 
     <H2>Inherited Props</H2>
+    <DisplayPropTable collapsible />
     <MarginPropTable collapsible />
     <PaddingPropTable collapsible />
 

--- a/packages/docs/pages/Display/DisplayPage.tsx
+++ b/packages/docs/pages/Display/DisplayPage.tsx
@@ -1,0 +1,50 @@
+import { Box, H0, Text } from '@bigcommerce/big-design';
+
+import { Code, CodePreview, NextLink } from '../../components';
+import { DisplayPropTable } from '../../PropTables';
+
+export default () => (
+  <>
+    <H0>Display</H0>
+
+    <Text>
+      A few of our components expose a <Code primary>display</Code> prop in order to change the CSS display property.
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      <Box display="inline-block" backgroundColor="secondary20" border="box" padding="medium">
+        Boxed content
+      </Box>
+      {/* jsx-to-string:end */}
+    </CodePreview>
+
+    <Text>
+      It's also possible to use the prop with responsive{' '}
+      <NextLink href="/Breakpoint/BreakpointPage" as="/breakpoints">
+        breakpoints
+      </NextLink>
+      :
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      <>
+        <Box
+          display={{ mobile: 'none', tablet: 'inline-block' }}
+          backgroundColor="secondary20"
+          border="box"
+          padding="medium"
+        >
+          Boxed content hidden on mobile.
+        </Box>
+        <Box display={{ mobile: 'block', tablet: 'none' }} backgroundColor="primary10" border="box" padding="medium">
+          Boxed content hidden on tablet.
+        </Box>
+      </>
+      {/* jsx-to-string:end */}
+    </CodePreview>
+
+    <DisplayPropTable />
+  </>
+);

--- a/packages/docs/pages/Flex/FlexPage.tsx
+++ b/packages/docs/pages/Flex/FlexPage.tsx
@@ -2,7 +2,14 @@ import { Box, Flex, H0, H1, H2, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { Code, CodePreview } from '../../components';
-import { BoxPropTable, FlexItemPropTable, FlexPropTable, MarginPropTable, PaddingPropTable } from '../../PropTables';
+import {
+  BoxPropTable,
+  DisplayPropTable,
+  FlexItemPropTable,
+  FlexPropTable,
+  MarginPropTable,
+  PaddingPropTable,
+} from '../../PropTables';
 
 const ExampleBox: React.FC<{ vertical?: boolean }> = ({ children, vertical }) => (
   <Box
@@ -53,6 +60,7 @@ export default () => (
 
     <H2>Inherited Props</H2>
     <BoxPropTable collapsible />
+    <DisplayPropTable collapsible />
     <MarginPropTable collapsible />
     <PaddingPropTable collapsible />
 

--- a/packages/docs/pages/Grid/GridPage.tsx
+++ b/packages/docs/pages/Grid/GridPage.tsx
@@ -1,8 +1,15 @@
 import { Box, Grid, H0, H1, H2, Link, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
-import { Code, CodePreview, Collapsible } from '../../components';
-import { BoxPropTable, GridItemPropTable, GridPropTable, MarginPropTable, PaddingPropTable } from '../../PropTables';
+import { Code, CodePreview } from '../../components';
+import {
+  BoxPropTable,
+  DisplayPropTable,
+  GridItemPropTable,
+  GridPropTable,
+  MarginPropTable,
+  PaddingPropTable,
+} from '../../PropTables';
 
 const ExampleBox: React.FC = ({ children }) => (
   <Box backgroundColor="secondary20" border="box" padding="small" style={{ height: '100%' }}>
@@ -49,6 +56,7 @@ export default () => (
 
     <H2>Inherited Props</H2>
     <BoxPropTable collapsible />
+    <DisplayPropTable collapsible />
     <MarginPropTable collapsible />
     <PaddingPropTable collapsible />
 


### PR DESCRIPTION
## What
Adds a `display` prop to some of our utility components. Useful for layouts that require responsive displays (i.e. "none" on mobile, "block" on table+) and other usefulness.

## Screenshot
![screencapture-localhost-3000-display-2019-11-07-15_44_39](https://user-images.githubusercontent.com/10539418/68431929-fbc64600-0178-11ea-8cd3-1a084c366a39.jpg)
