### PR TITLE
fix(component): grid and flex forward as prop

### DIFF
--- a/packages/big-design-icons/package.json
+++ b/packages/big-design-icons/package.json
@@ -47,7 +47,7 @@
   "peerDependencies": {
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "styled-components": "^4.1.0"
+    "styled-components": "^4.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
@@ -79,7 +79,7 @@
     "rollup-plugin-filesize": "^6.0.1",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-replace": "^2.1.0",
-    "styled-components": "^4.1.3",
+    "styled-components": "^4.3.0",
     "tslint": "^5.14.0",
     "typescript": "^3.7.2",
     "typescript-styled-plugin": "^0.14.0"

--- a/packages/big-design-theme/package.json
+++ b/packages/big-design-theme/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "styled-components": "^4.1.0"
+    "styled-components": "^4.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
@@ -68,7 +68,7 @@
     "rollup-plugin-filesize": "^6.0.1",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-replace": "^2.1.0",
-    "styled-components": "^4.1.3",
+    "styled-components": "^4.3.0",
     "tslint": "^5.14.0",
     "typescript": "^3.7.2",
     "typescript-styled-plugin": "^0.14.0"

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "styled-components": "^4.1.0"
+    "styled-components": "^4.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
@@ -86,7 +86,7 @@
     "rollup-plugin-filesize": "^6.0.1",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-replace": "^2.1.0",
-    "styled-components": "^4.1.3",
+    "styled-components": "^4.3.0",
     "tslint": "^5.14.0",
     "typescript": "^3.7.2",
     "typescript-styled-plugin": "^0.14.0"

--- a/packages/big-design/src/components/Flex/Flex.tsx
+++ b/packages/big-design/src/components/Flex/Flex.tsx
@@ -12,6 +12,8 @@ export class Flex extends React.PureComponent<FlexProps> {
   static Item = FlexItem;
 
   render() {
-    return <StyledFlex {...this.props} />;
+    const { as, ...rest } = this.props;
+
+    return <StyledFlex forwardedAs={as} {...rest} />;
   }
 }

--- a/packages/big-design/src/components/Flex/Item/Item.tsx
+++ b/packages/big-design/src/components/Flex/Item/Item.tsx
@@ -7,4 +7,4 @@ import { StyledFlexItem } from './styled';
 
 export type FlexItemProps = BoxProps & FlexedItemProps;
 
-export const FlexItem: React.FC<FlexItemProps> = props => <StyledFlexItem {...props} />;
+export const FlexItem: React.FC<FlexItemProps> = ({ as, ...props }) => <StyledFlexItem forwardedAs={as} {...props} />;

--- a/packages/big-design/src/components/Flex/Item/styled.tsx
+++ b/packages/big-design/src/components/Flex/Item/styled.tsx
@@ -6,7 +6,8 @@ import { withFlexedItems } from '../withFlex';
 
 import { FlexItemProps } from './Item';
 
-export const StyledFlexItem = styled(Box)<FlexItemProps>`
+// TODO: Remove the `forwardedAs` manual prop definition when @types get updated
+export const StyledFlexItem = styled(Box)<FlexItemProps & { forwardedAs?: FlexItemProps['as'] }>`
   ${withFlexedItems()}
 `;
 

--- a/packages/big-design/src/components/Flex/spec.tsx
+++ b/packages/big-design/src/components/Flex/spec.tsx
@@ -37,3 +37,12 @@ test('Flex Item forwards styles', () => {
   expect(container.getElementsByClassName('test').length).toBe(1);
   expect(container.firstChild).toHaveStyle('background: red');
 });
+
+test('rendering as another element retains inherited props and styles', () => {
+  const { getByTestId } = render(<Flex as="section" margin="medium" data-testid="flex" />);
+
+  const grid = getByTestId('flex');
+
+  expect(grid.tagName).toBe('SECTION');
+  expect(grid).toHaveStyle(`margin: 1rem`);
+});

--- a/packages/big-design/src/components/Flex/styled.tsx
+++ b/packages/big-design/src/components/Flex/styled.tsx
@@ -7,7 +7,8 @@ import { Box } from '../Box';
 import { withFlexedContainer } from './withFlex';
 import { FlexProps } from './Flex';
 
-export const StyledFlex = styled(Box)<FlexProps>`
+// TODO: Remove the `forwardedAs` manual prop definition when @types get updated
+export const StyledFlex = styled(Box)<FlexProps & { forwardedAs?: FlexProps['as'] }>`
   ${withFlexedContainer()}
 
   display: flex;

--- a/packages/big-design/src/components/Grid/Grid.tsx
+++ b/packages/big-design/src/components/Grid/Grid.tsx
@@ -12,6 +12,8 @@ export class Grid extends React.PureComponent<GridProps> {
   static Item = GridItem;
 
   render() {
-    return <StyledGrid {...this.props} />;
+    const { as, ...rest } = this.props;
+
+    return <StyledGrid forwardedAs={as} {...rest} />;
   }
 }

--- a/packages/big-design/src/components/Grid/Item/Item.tsx
+++ b/packages/big-design/src/components/Grid/Item/Item.tsx
@@ -7,4 +7,4 @@ import { StyledGridItem } from './styled';
 
 export type GridItemProps = BoxProps & GridedItemProps;
 
-export const GridItem: React.FC<GridItemProps> = props => <StyledGridItem {...props} />;
+export const GridItem: React.FC<GridItemProps> = ({ as, ...rest }) => <StyledGridItem forwardedAs={as} {...rest} />;

--- a/packages/big-design/src/components/Grid/Item/styled.tsx
+++ b/packages/big-design/src/components/Grid/Item/styled.tsx
@@ -5,6 +5,7 @@ import { withGridedItems } from '../withGrid';
 
 import { GridItemProps } from './Item';
 
-export const StyledGridItem = styled(Box)<GridItemProps>`
+// TODO: Remove the `forwardedAs` manual prop definition when @types get updated
+export const StyledGridItem = styled(Box)<GridItemProps & { forwardedAs?: GridItemProps['as'] }>`
   ${withGridedItems()}
 `;

--- a/packages/big-design/src/components/Grid/spec.tsx
+++ b/packages/big-design/src/components/Grid/spec.tsx
@@ -43,3 +43,12 @@ test('Grid item forwards styles', () => {
   expect(container.getElementsByClassName('test').length).toBe(1);
   expect(container.firstChild).toHaveStyle('background: red');
 });
+
+test('rendering as another element retains inherited props and styles', () => {
+  const { getByTestId } = render(<Grid as="section" margin="medium" data-testid="grid" />);
+
+  const grid = getByTestId('grid');
+
+  expect(grid.tagName).toBe('SECTION');
+  expect(grid).toHaveStyle(`margin: 1rem`);
+});

--- a/packages/big-design/src/components/Grid/styled.tsx
+++ b/packages/big-design/src/components/Grid/styled.tsx
@@ -7,7 +7,8 @@ import { Box } from '../Box';
 import { withGridedContainer } from './withGrid';
 import { GridProps } from './Grid';
 
-export const StyledGrid = styled(Box)<GridProps>`
+// TODO: Remove the `forwardedAs` manual prop definition when @types get updated
+export const StyledGrid = styled(Box)<GridProps & { forwardedAs?: GridProps['as'] }>`
   ${withGridedContainer()}
 
   display: grid;

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -38,7 +38,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-live": "^2.2.0",
-    "styled-components": "^4.1.3"
+    "styled-components": "^4.3.0"
   },
   "devDependencies": {
     "@bigcommerce/configs": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10185,7 +10185,7 @@ strong-log-transformer@^2.0.0:
     minimist "^1.2.0"
     through "^2.3.4"
 
-styled-components@^4.1.3:
+styled-components@^4.3.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
   integrity sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==


### PR DESCRIPTION
`Grid` and `Flex` internally extend `Box` using `styled(Box)`. The issue is now that we introduced the `as` prop for util components when doing something like:
 ```jsx
<Flex as="section" />
```
This will swap that `styled(Box)` with `styled('section')`, which in this case is not exactly what we want since we lose all the functionality from `Box` like `margin` props, etc.

styled-components `4.3` introduced a `forwardedAs` prop for this specific use case. So doing something like this would work:
```jsx
<Flex forwardedAs="section" />
```

However, it is inconsistent with `Box` and requires the user to know how `Flex` and `Grid` are implemented. This PR makes `Grid` and `Flex` accept an `as` prop but internally swap them with `forwardedAs`.

Gotchas:
- Breaking change since had to bump SC peer dep version
- `@types/styled-components` doesn't have the definition for `forwardedAs` prop, in the meantime, I'm manually typing it, we should be able to remove the manual type in the future.