### PR TITLE
fix(component): reduce radio/checkbox label margin

### DIFF
--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -75,7 +75,7 @@ exports[`render Checkbox checked 1`] = `
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  margin-left: 1rem;
+  margin-left: 0.5rem;
 }
 
 .c5:last-child {
@@ -205,7 +205,7 @@ exports[`render Checkbox indeterminate 1`] = `
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  margin-left: 1rem;
+  margin-left: 0.5rem;
 }
 
 .c5:last-child {
@@ -334,7 +334,7 @@ exports[`render Checkbox unchecked 1`] = `
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  margin-left: 1rem;
+  margin-left: 0.5rem;
 }
 
 .c5:last-child {

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -50,7 +50,7 @@ export const StyledCheckbox = styled.label<StyledCheckboxProps>`
 export const StyledLabel = styled(StyleableText).attrs({
   as: 'label',
 })<React.LabelHTMLAttributes<HTMLLabelElement> & StyledLabelProps>`
-  margin-left: ${({ theme }) => theme.spacing.medium};
+  margin-left: ${({ theme }) => theme.spacing.xSmall};
 
   ${({ disabled, theme }) =>
     disabled &&

--- a/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
@@ -33,7 +33,7 @@ exports[`render Radio (checked) 1`] = `
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  margin-left: 1rem;
+  margin-left: 0.5rem;
 }
 
 .c4:last-child {
@@ -134,7 +134,7 @@ exports[`render Radio (unchecked) 1`] = `
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  margin-left: 1rem;
+  margin-left: 0.5rem;
 }
 
 .c4:last-child {

--- a/packages/big-design/src/components/Radio/styled.tsx
+++ b/packages/big-design/src/components/Radio/styled.tsx
@@ -20,7 +20,7 @@ export const HiddenRadio = styled.input`
 export const StyledLabel = styled(StyleableText).attrs({
   as: 'label',
 })<React.LabelHTMLAttributes<HTMLLabelElement>>`
-  margin-left: ${({ theme }) => theme.spacing.medium};
+  margin-left: ${({ theme }) => theme.spacing.xSmall};
 ` as StyledComponent<'label', DefaultTheme>;
 
 export const StyledRadio = styled.label<StyledRadioProps>`


### PR DESCRIPTION
Spacing between checkbox/radio and their label should be `8px` and not `16px`.