### PR TITLE
fix(component): textarea was missing optional text when not required

### DIFF
--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -71,11 +71,15 @@ class StyleableTextarea extends React.PureComponent<TextareaProps & PrivateProps
   }
 
   private renderLabel() {
-    const { label } = this.props;
+    const { label, required } = this.props;
     const id = this.getId();
 
     if (typeof label === 'string') {
-      return <Textarea.Label htmlFor={id}>{label}</Textarea.Label>;
+      return (
+        <Textarea.Label htmlFor={id} renderOptional={!required}>
+          {label}
+        </Textarea.Label>
+      );
     }
 
     if (React.isValidElement(label) && label.type === Textarea.Label) {

--- a/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
@@ -88,6 +88,12 @@ exports[`renders all together 1`] = `
   margin-bottom: 0.25rem;
 }
 
+.c0::after {
+  color: #5E637A;
+  content: ' (optional)';
+  font-weight: 400;
+}
+
 <div>
   <label
     class="c0"


### PR DESCRIPTION
## What
Fix `Textarea` not rendering `(optional)`.

## Screenshots
**Before:**
<img width="263" alt="Screen Shot 2019-11-12 at 2 41 54 PM" src="https://user-images.githubusercontent.com/10539418/68709309-11fa4a80-055b-11ea-8af4-5c54465890e7.png">
**After:**
<img width="263" alt="Screen Shot 2019-11-12 at 2 41 50 PM" src="https://user-images.githubusercontent.com/10539418/68709317-16266800-055b-11ea-8c38-2d38a30c88df.png">
