### PR TITLE
feat(component):  add actions prop to Table and StatefulTable

### DIFF
--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -224,3 +224,12 @@ test('sorts numerically', () => {
   expect(firstItemContent).toBe('1');
   expect(lastItemContent).toBe('104');
 });
+
+test('renders custom actions', () => {
+  const { getByTestId } = render(getSimpleTable({ actions: () => <div data-testid="customAction">Test Action</div> }));
+
+  const customAction = getByTestId('customAction');
+
+  expect(customAction).toBeInTheDocument();
+  expect(customAction).toBeVisible();
+});

--- a/packages/big-design/src/components/Table/Actions/Actions.tsx
+++ b/packages/big-design/src/components/Table/Actions/Actions.tsx
@@ -10,6 +10,7 @@ import { TablePagination } from '../TablePagination';
 import { StyledFlex } from './styled';
 
 export interface ActionsProps<T> {
+  customActions?: React.ComponentType<any>;
   forwardedRef: RefObject<HTMLDivElement>;
   itemName?: string;
   items: T[];
@@ -21,14 +22,15 @@ export interface ActionsProps<T> {
 }
 
 const InternalActions = <T extends TableItem>({
-  pagination,
-  tableId,
+  customActions,
   forwardedRef,
   itemName,
   items = [],
   onSelectionChange,
+  pagination,
   selectedItems,
   stickyHeader,
+  tableId,
   ...props
 }: ActionsProps<T>) => {
   const isSelectable = typeof onSelectionChange === 'function';
@@ -42,10 +44,16 @@ const InternalActions = <T extends TableItem>({
     const text = Boolean(isSelectable) ? itemName : `${totalItems} ${itemName}`;
 
     return (
-      <Flex.Item>
+      <Flex.Item flexShrink={0} marginRight="medium">
         <Text margin="none">{text}</Text>
       </Flex.Item>
     );
+  };
+
+  const renderActions = () => {
+    const CustomActions = customActions;
+
+    return CustomActions ? <CustomActions /> : null;
   };
 
   return (
@@ -60,6 +68,8 @@ const InternalActions = <T extends TableItem>({
     >
       <SelectAll onChange={onSelectionChange} selectedItems={selectedItems} items={items} totalItems={totalItems} />
       {renderItemName()}
+      {renderActions()}
+
       {pagination && <TablePagination {...pagination} />}
     </StyledFlex>
   );

--- a/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
@@ -49,7 +49,7 @@ export const SelectAll = <T extends TableItem>({
   const totalSelectedItems = selectedItems.size;
 
   return (
-    <Flex.Item marginRight="xxSmall">
+    <Flex.Item marginRight="xxSmall" flexShrink={0}>
       <Flex flexDirection="row">
         <Checkbox isIndeterminate={someInPageSelected} checked={allInPageSelected} onChange={handleSelectAll} />
         <Text marginLeft="small">

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -17,6 +17,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
   const {
     className,
     columns,
+    actions,
     id,
     itemName,
     items,
@@ -76,7 +77,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
   );
 
   const shouldRenderActions = () => {
-    return Boolean(pagination) || Boolean(selectable) || Boolean(itemName);
+    return Boolean(actions) || Boolean(pagination) || Boolean(selectable) || Boolean(itemName);
   };
 
   const getItemKey = (item: T, index: number): string | number => {
@@ -139,6 +140,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     <>
       {shouldRenderActions() && (
         <Actions
+          customActions={actions}
           pagination={pagination}
           onSelectionChange={selectable && selectable.onSelectionChange}
           selectedItems={selectedItems}

--- a/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
@@ -8,7 +8,7 @@ import { StyledPaginationContainer } from './styled';
 export const TablePagination: React.FC<TablePaginationProps> = memo(
   ({ currentPage, itemsPerPage, itemsPerPageOptions, onItemsPerPageChange, onPageChange, totalItems }) => {
     return (
-      <StyledPaginationContainer>
+      <StyledPaginationContainer flexShrink={0}>
         <Pagination
           currentPage={currentPage}
           itemsPerPage={itemsPerPage}

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`renders a pagination component 1`] = `
   box-sizing: border-box;
 }
 
-.c11 {
+.c12 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
@@ -67,24 +67,43 @@ exports[`renders a pagination component 1`] = `
   -webkit-order: 0;
   -ms-flex-order: 0;
   order: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c5 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
-.c8 {
+.c9 {
   vertical-align: middle;
   height: 2rem;
   width: 2rem;
 }
 
-.c13 {
+.c14 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c9 {
+.c10 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   border: 0;
@@ -110,7 +129,7 @@ exports[`renders a pagination component 1`] = `
   z-index: 1060;
 }
 
-.c10 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -131,25 +150,25 @@ exports[`renders a pagination component 1`] = `
   padding: 0 1rem;
 }
 
-.c10[aria-selected='true'] {
+.c11[aria-selected='true'] {
   font-weight: 600;
 }
 
-.c10[data-highlighted='true'],
-.c10[data-highlighted='true'] a {
+.c11[data-highlighted='true'],
+.c11[data-highlighted='true'] a {
   background-color: #F0F3FF;
   color: #3C64F4;
 }
 
-.c10 a {
+.c11 a {
   color: #313440;
 }
 
-.c10 label {
+.c11 label {
   cursor: pointer;
 }
 
-.c5 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -196,37 +215,37 @@ exports[`renders a pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c5:focus {
+.c6:focus {
   outline: none;
 }
 
-.c5[disabled] {
+.c6[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c5 + .bd-button {
+.c6 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c5:active {
+.c6:active {
   background-color: #DBE3FE;
 }
 
-.c5:focus {
+.c6:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c5:hover:not(:active) {
+.c6:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c5[disabled] {
+.c6[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
 
-.c12 {
+.c13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -272,37 +291,37 @@ exports[`renders a pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c12:focus {
+.c13:focus {
   outline: none;
 }
 
-.c12[disabled] {
+.c13[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c12 + .bd-button {
+.c13 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c12:active {
+.c13:active {
   background-color: #DBE3FE;
 }
 
-.c12:focus {
+.c13:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c12:hover:not(:active) {
+.c13:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c12[disabled] {
+.c13[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
 
-.c7 {
+.c8 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -316,7 +335,7 @@ exports[`renders a pagination component 1`] = `
   visibility: visible;
 }
 
-.c6 {
+.c7 {
   color: #313440;
   width: auto;
 }
@@ -346,27 +365,27 @@ exports[`renders a pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c5 + .bd-button {
+  .c6 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c5 {
+  .c6 {
     width: auto;
   }
 }
 
 @media (min-width:720px) {
-  .c12 + .bd-button {
+  .c13 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c12 {
+  .c13 {
     width: auto;
   }
 }
@@ -384,21 +403,21 @@ exports[`renders a pagination component 1`] = `
       role="navigation"
     >
       <div
-        class="c1 c2"
+        class="c1 c5"
       >
         <button
           aria-haspopup="true"
-          class="c5 c6"
+          class="c6 c7"
           id="trigger_2"
           role="button"
           tabindex="0"
         >
           <span
-            class="c7"
+            class="c8"
           >
             1 - 3 of 5
             <svg
-              class="c8"
+              class="c9"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -419,47 +438,47 @@ exports[`renders a pagination component 1`] = `
         </button>
         <ul
           aria-labelledby="trigger_2"
-          class="c9"
+          class="c10"
           id="dropdown_1"
           role="listbox"
           style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
           tabindex="-1"
         >
           <li
-            class="c10"
+            class="c11"
             data-highlighted="false"
             id="dropdown_1-item-0"
             role="option"
             tabindex="-1"
           >
             <div
-              class="c1 c11"
+              class="c1 c12"
             >
               3 per page
             </div>
           </li>
           <li
-            class="c10"
+            class="c11"
             data-highlighted="false"
             id="dropdown_1-item-1"
             role="option"
             tabindex="-1"
           >
             <div
-              class="c1 c11"
+              class="c1 c12"
             >
               5 per page
             </div>
           </li>
           <li
-            class="c10"
+            class="c11"
             data-highlighted="false"
             id="dropdown_1-item-2"
             role="option"
             tabindex="-1"
           >
             <div
-              class="c1 c11"
+              class="c1 c12"
             >
               10 per page
             </div>
@@ -467,19 +486,19 @@ exports[`renders a pagination component 1`] = `
         </ul>
       </div>
       <div
-        class="c1 c2"
+        class="c1 c5"
       >
         <button
-          class="c12 c6"
+          class="c13 c7"
           disabled=""
           role="button"
           tabindex="0"
         >
           <span
-            class="c7"
+            class="c8"
           >
             <svg
-              class="c13"
+              class="c14"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -501,15 +520,15 @@ exports[`renders a pagination component 1`] = `
           </span>
         </button>
         <button
-          class="c12 c6"
+          class="c13 c7"
           role="button"
           tabindex="0"
         >
           <span
-            class="c7"
+            class="c8"
           >
             <svg
-              class="c13"
+              class="c14"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -753,6 +772,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   box-sizing: border-box;
 }
 
+.c11 {
+  margin-right: 1rem;
+  box-sizing: border-box;
+}
+
 .c1 {
   margin-right: 0.25rem;
   box-sizing: border-box;
@@ -796,12 +820,12 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   -webkit-order: 0;
   -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
-.c11 {
+.c12 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -810,7 +834,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0;
 }
 
-.c11:last-child {
+.c12:last-child {
   margin-bottom: 0;
 }
 
@@ -967,10 +991,10 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
     </div>
   </div>
   <div
-    class="c3 c2"
+    class="c11 c2"
   >
     <p
-      class="c11"
+      class="c12"
     >
       Product
     </p>

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -405,4 +405,15 @@ describe('sortable', () => {
 
     expect(onSort).toBeCalledWith('sku', 'DESC', columns[0]);
   });
+
+  test('renders custom actions', () => {
+    const { getByTestId } = render(
+      <Table columns={columns} items={items} actions={() => <div data-testid="customAction">Test Action</div>} />,
+    );
+
+    const customAction = getByTestId('customAction');
+
+    expect(customAction).toBeInTheDocument();
+    expect(customAction).toBeVisible();
+  });
 });

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -35,6 +35,7 @@ export interface TableColumn<T> {
 export type TablePaginationProps = Omit<PaginationProps, keyof MarginProps>;
 
 export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElement> {
+  actions?: React.ComponentType<T>;
   columns: Array<TableColumn<T>>;
   itemName?: string;
   items: T[];

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -55,6 +55,11 @@ const statefulTableProps: Prop[] = [
     types: '(selectedItems: Item[]) => void',
     description: 'Function to be called when item selection changes.',
   },
+  {
+    name: 'customActions',
+    types: 'React.ComponentType<any>',
+    description: 'Component to render custom actions.',
+  },
 ];
 
 const tableColumnsProps: Prop[] = [

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -60,6 +60,11 @@ const tableProps: Prop[] = [
     types: 'boolean',
     description: 'Makes the table header and actions fixed.',
   },
+  {
+    name: 'customActions',
+    types: 'React.ComponentType<any>',
+    description: 'Component to render custom actions.',
+  },
 ];
 
 const tableColumnsProps: Prop[] = [


### PR DESCRIPTION
Allow `customActions` in `<Table>` and `<StatefulTable>`

Example:
![image](https://user-images.githubusercontent.com/2752665/68792591-39135380-0611-11ea-995e-700d9cf2df9e.png)
