### PR TITLE
feat: add hiddenLabel prop to Checkbox component

### DIFF
--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -10,7 +10,7 @@ import { CheckboxContainer, HiddenCheckbox, StyledCheckbox, StyledLabel } from '
 interface Props {
   hiddenLabel?: boolean;
   isIndeterminate?: boolean;
-  label?: React.ReactChild;
+  label: React.ReactChild;
   theme?: ThemeInterface;
 }
 

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -8,6 +8,7 @@ import { uniqueId } from '../../utils';
 import { CheckboxContainer, HiddenCheckbox, StyledCheckbox, StyledLabel } from './styled';
 
 interface Props {
+  hiddenLabel?: boolean;
   isIndeterminate?: boolean;
   label?: React.ReactChild;
   theme?: ThemeInterface;
@@ -77,11 +78,18 @@ class RawCheckbox extends React.PureComponent<CheckboxProps & PrivateProps> {
 
   private renderLabel() {
     const htmlFor = this.getInputId();
-    const { disabled, label, theme } = this.props;
+    const { disabled, hiddenLabel, label, theme } = this.props;
 
     if (typeof label === 'string') {
       return (
-        <StyledLabel disabled={disabled} htmlFor={htmlFor} aria-hidden={disabled} id={this.labelUniqueId} theme={theme}>
+        <StyledLabel
+          disabled={disabled}
+          hidden={hiddenLabel}
+          htmlFor={htmlFor}
+          aria-hidden={disabled}
+          id={this.labelUniqueId}
+          theme={theme}
+        >
           {label}
         </StyledLabel>
       );
@@ -89,6 +97,7 @@ class RawCheckbox extends React.PureComponent<CheckboxProps & PrivateProps> {
 
     if (React.isValidElement(label) && label.type === Checkbox.Label) {
       return React.cloneElement(label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>, {
+        hidden: hiddenLabel,
         htmlFor,
         id: this.labelUniqueId,
       });

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -10,6 +10,7 @@ interface StyledCheckboxProps {
 }
 
 export interface StyledLabelProps {
+  hidden?: boolean;
   disabled?: boolean;
 }
 
@@ -57,6 +58,8 @@ export const StyledLabel = styled(StyleableText).attrs({
     css`
       color: ${theme.colors.secondary40};
     `}
+
+  ${({ hidden }) => hidden && hideVisually()}
 ` as StyledComponent<'label', DefaultTheme, StyledLabelProps>;
 
 StyledCheckbox.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Table/Row/Row.tsx
+++ b/packages/big-design/src/components/Table/Row/Row.tsx
@@ -30,7 +30,7 @@ const InternalRow = <T extends TableItem>({
     }
   };
 
-  const label = isSelected ? `Deslect item number ${itemIndex + 1}` : `Select item number ${itemIndex + 1}`;
+  const label = isSelected ? `Deselect row ${itemIndex + 1}` : `Select row ${itemIndex + 1}`;
 
   return (
     <StyledTableRow isSelected={isSelected}>

--- a/packages/big-design/src/components/Table/Row/Row.tsx
+++ b/packages/big-design/src/components/Table/Row/Row.tsx
@@ -11,6 +11,7 @@ export interface RowProps<T> extends React.TableHTMLAttributes<HTMLTableRowEleme
   isSelected?: boolean;
   isSelectable?: boolean;
   item: T;
+  itemIndex: number;
   columns: Array<TableColumn<T>>;
   onItemSelect?(item: T): void;
 }
@@ -20,6 +21,7 @@ const InternalRow = <T extends TableItem>({
   isSelectable = false,
   isSelected = false,
   item,
+  itemIndex,
   onItemSelect,
 }: RowProps<T>) => {
   const onChange = () => {
@@ -28,18 +30,20 @@ const InternalRow = <T extends TableItem>({
     }
   };
 
+  const label = isSelected ? `Deslect item number ${itemIndex + 1}` : `Select item number ${itemIndex + 1}`;
+
   return (
     <StyledTableRow isSelected={isSelected}>
       {isSelectable && (
         <DataCell key="data-checkbox" isCheckbox={true}>
-          <Checkbox checked={isSelected} onChange={onChange} />
+          <Checkbox checked={isSelected} hiddenLabel label={label} onChange={onChange} />
         </DataCell>
       )}
 
       {columns.map(({ render: CellContent, align, verticalAlign, width, withPadding = true }, columnIndex) => (
         <DataCell key={columnIndex} align={align} verticalAlign={verticalAlign} width={width} withPadding={withPadding}>
           {/* https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
-          {/* 
+          {/*
         // @ts-ignore */}
           <CellContent {...item} />
         </DataCell>

--- a/packages/big-design/src/components/Table/Row/Row.tsx
+++ b/packages/big-design/src/components/Table/Row/Row.tsx
@@ -11,7 +11,6 @@ export interface RowProps<T> extends React.TableHTMLAttributes<HTMLTableRowEleme
   isSelected?: boolean;
   isSelectable?: boolean;
   item: T;
-  itemIndex: number;
   columns: Array<TableColumn<T>>;
   onItemSelect?(item: T): void;
 }
@@ -21,7 +20,6 @@ const InternalRow = <T extends TableItem>({
   isSelectable = false,
   isSelected = false,
   item,
-  itemIndex,
   onItemSelect,
 }: RowProps<T>) => {
   const onChange = () => {
@@ -30,7 +28,7 @@ const InternalRow = <T extends TableItem>({
     }
   };
 
-  const label = isSelected ? `Deselect row ${itemIndex + 1}` : `Select row ${itemIndex + 1}`;
+  const label = isSelected ? `Selected` : `Unselected`;
 
   return (
     <StyledTableRow isSelected={isSelected}>

--- a/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
@@ -51,7 +51,13 @@ export const SelectAll = <T extends TableItem>({
   return (
     <Flex.Item marginRight="xxSmall">
       <Flex flexDirection="row">
-        <Checkbox isIndeterminate={someInPageSelected} checked={allInPageSelected} onChange={handleSelectAll} />
+        <Checkbox
+          isIndeterminate={someInPageSelected}
+          hiddenLabel
+          label="Select All"
+          checked={allInPageSelected}
+          onChange={handleSelectAll}
+        />
         <Text marginLeft="small">
           {totalSelectedItems === 0 ? `${totalItems}` : `${totalSelectedItems}/${totalItems}`}
         </Text>

--- a/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
@@ -48,13 +48,15 @@ export const SelectAll = <T extends TableItem>({
 
   const totalSelectedItems = selectedItems.size;
 
+  const label = allInPageSelected ? 'Deselect All' : 'Select All';
+
   return (
     <Flex.Item marginRight="xxSmall">
       <Flex flexDirection="row">
         <Checkbox
           isIndeterminate={someInPageSelected}
           hiddenLabel
-          label="Select All"
+          label={label}
           checked={allInPageSelected}
           onChange={handleSelectAll}
         />

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -123,7 +123,6 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
 
         return (
           <Row
-            itemIndex={index}
             columns={columns}
             isSelectable={isSelectable}
             isSelected={isSelected}

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -123,6 +123,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
 
         return (
           <Row
+            itemIndex={index}
             columns={columns}
             isSelectable={isSelectable}
             isSelected={isSelected}

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -801,7 +801,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   flex-shrink: 1;
 }
 
-.c11 {
+.c12 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -810,11 +810,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0;
 }
 
-.c11:last-child {
+.c12:last-child {
   margin-bottom: 0;
 }
 
-.c10 {
+.c11 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -823,7 +823,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin-left: 0.75rem;
 }
 
-.c10:last-child {
+.c11:last-child {
   margin-bottom: 0;
 }
 
@@ -895,6 +895,31 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   visibility: hidden;
 }
 
+.c10 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin-left: 0.5rem;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c10:last-child {
+  margin-bottom: 0;
+}
+
 .c0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -958,9 +983,17 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
             />
           </svg>
         </label>
+        <label
+          class="c10"
+          for="checkBox_1"
+          hidden=""
+          id="checkBox_label_2"
+        >
+          Select All
+        </label>
       </div>
       <p
-        class="c10"
+        class="c11"
       >
         5
       </p>
@@ -970,7 +1003,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
     class="c3 c2"
   >
     <p
-      class="c11"
+      class="c12"
     >
       Product
     </p>

--- a/packages/docs/PropTables/CheckboxPropTable.tsx
+++ b/packages/docs/PropTables/CheckboxPropTable.tsx
@@ -11,6 +11,15 @@ const checkboxProps: Prop[] = [
     description: 'Label to display next to a <Code>Checkbox</Code> component.',
   },
   {
+    name: 'hiddenLabel',
+    types: 'boolean',
+    description: (
+      <>
+        Renders <Code primary>Checkbox</Code> with a visually hidden label, retains accessibility for screen readers.
+      </>
+    ),
+  },
+  {
     name: 'isIndeterminate',
     types: 'boolean',
     description: (


### PR DESCRIPTION
#WHAT 
Adds `hiddenLabel` prop to Checkbox component to allow for visually hidden label, maintain accessibility. Closes #203.

#TESTING 
Tested locally to ensure prop allows component to render correctly