### PR TITLE
fix(component): set correct display names

### DIFF
--- a/packages/big-design/src/components/Badge/Badge.tsx
+++ b/packages/big-design/src/components/Badge/Badge.tsx
@@ -11,3 +11,5 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement>, Margi
 }
 
 export const Badge: React.FC<BadgeProps> = memo(({ className, style, ...props }) => <StyledBadge {...props} />);
+
+Badge.displayName = 'Badge';

--- a/packages/big-design/src/components/Box/Box.tsx
+++ b/packages/big-design/src/components/Box/Box.tsx
@@ -19,3 +19,5 @@ export interface BoxProps extends React.HTMLAttributes<HTMLDivElement>, DisplayP
 }
 
 export const Box: React.FC<BoxProps> = memo(props => <StyledBox {...props} />);
+
+Box.displayName = 'Box';

--- a/packages/big-design/src/components/Chip/Chip.tsx
+++ b/packages/big-design/src/components/Chip/Chip.tsx
@@ -53,3 +53,5 @@ export const Chip: React.FC<ChipProps> = memo(({ children, label, onDelete, them
     </StyledChip>
   );
 });
+
+Chip.displayName = 'Chip';

--- a/packages/big-design/src/components/Form/Form.tsx
+++ b/packages/big-design/src/components/Form/Form.tsx
@@ -33,3 +33,5 @@ const FormWithForwardedRef = React.forwardRef<HTMLFormElement, FormProps>(({ cla
 ));
 
 export const Form = hoistNonReactStatics(FormWithForwardedRef, StyleableForm);
+
+Form.displayName = 'Form';

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -170,3 +170,5 @@ const InputWithForwardedRef = React.forwardRef<HTMLInputElement, InputProps>(({ 
 ));
 
 export const Input = hoistNonReactStatics(InputWithForwardedRef, StyleableInput);
+
+Input.displayName = 'Input';

--- a/packages/big-design/src/components/Link/Link.tsx
+++ b/packages/big-design/src/components/Link/Link.tsx
@@ -26,3 +26,5 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(({ children, 
     </StyleableLink>
   );
 });
+
+Link.displayName = 'Link';

--- a/packages/big-design/src/components/List/Item/CheckboxItem.tsx
+++ b/packages/big-design/src/components/List/Item/CheckboxItem.tsx
@@ -42,3 +42,5 @@ function preventFocus(
 export const ListCheckboxItem = React.forwardRef<HTMLLIElement, ListCheckboxItemProps>((props, ref) => (
   <StyleableListCheckboxItem {...props} forwardedRef={ref} />
 ));
+
+ListCheckboxItem.displayName = 'ListCheckboxItem';

--- a/packages/big-design/src/components/List/Item/Item.tsx
+++ b/packages/big-design/src/components/List/Item/Item.tsx
@@ -29,3 +29,5 @@ function preventFocus(event: React.MouseEvent<HTMLLIElement, MouseEvent>) {
 export const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => (
   <StyleableListItem {...props} forwardedRef={ref} />
 ));
+
+ListItem.displayName = 'ListItem';

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -52,3 +52,5 @@ export const List: React.FC<ListProps> = memo(
     </Popper>
   ),
 );
+
+List.displayName = 'List';

--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -107,3 +107,5 @@ export const Pagination: React.FC<PaginationProps> = memo(
     );
   },
 );
+
+Pagination.displayName = 'Pagination';

--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -53,3 +53,5 @@ export const RawPanel: React.FC<PanelProps> = memo(props => {
 });
 
 export const Panel: React.FC<PanelProps> = ({ className, style, ...props }) => <RawPanel {...props} />;
+
+Panel.displayName = 'Panel';

--- a/packages/big-design/src/components/Tabs/Tabs.tsx
+++ b/packages/big-design/src/components/Tabs/Tabs.tsx
@@ -49,3 +49,5 @@ export const Tabs: React.FC<TabsProps> = memo(
     );
   },
 );
+
+Tabs.displayName = 'Tabs';

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -105,3 +105,5 @@ const TextareaWithForwardedRef = React.forwardRef<HTMLTextAreaElement, TextareaP
 );
 
 export const Textarea = hoistNonReactStatics(TextareaWithForwardedRef, StyleableTextarea);
+
+Textarea.displayName = 'Textarea';

--- a/packages/big-design/src/components/Typography/Typography.tsx
+++ b/packages/big-design/src/components/Typography/Typography.tsx
@@ -41,3 +41,12 @@ export const H4: React.FC<HeadingProps> = memo(({ className, style, as, ...props
 const getHeadingTag = (defaultTag: HeadingTag, tag?: HeadingTag): HeadingTag => {
   return tag && validHeadingTags.has(tag) ? tag : defaultTag;
 };
+
+Text.displayName = 'Text';
+Small.displayName = 'Small';
+
+H0.displayName = 'H0';
+H1.displayName = 'H1';
+H2.displayName = 'H2';
+H3.displayName = 'H3';
+H4.displayName = 'H4';


### PR DESCRIPTION
Cleans up React Dev Tools tree view.

Missing components:
- Table
- StatefulTable

We need a better way to memo a generic component and retain native react properties `eg: displayName`