### PR TITLE
fix: extra spacing in Select components

### DIFF
--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -48,7 +48,7 @@
     "@types/hoist-non-react-statics": "^3.3.0",
     "hoist-non-react-statics": "^3.3.0",
     "polished": "^3.0.3",
-    "react-popper": "^1.3.3",
+    "react-popper": "^1.3.6",
     "scroll-into-view-if-needed": "^2.2.20"
   },
   "peerDependencies": {

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -1,12 +1,12 @@
 import { Placement } from 'popper.js';
 import React, { memo } from 'react';
-import { Popper, RefHandler } from 'react-popper';
+import { Popper } from 'react-popper';
 
 import { StyledList } from './styled';
 import { ListPopperElement } from './ListPopperElement';
 
 interface Props {
-  handleListRef: RefHandler;
+  handleListRef: React.RefObject<HTMLUListElement>;
   isOpen: boolean;
   maxHeight?: number;
   placement?: Placement;

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -41,7 +41,7 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
 
   private callbackRef?: HTMLInputElement;
   private defaultRef: RefObject<HTMLInputElement> = React.createRef();
-  private listRef: HTMLUListElement | null = null;
+  private listRef: RefObject<HTMLUListElement> = React.createRef();
 
   private readonly uniqueInputId = uniqueId('input_');
   private readonly uniqueLabelId = uniqueId('label_');
@@ -96,7 +96,7 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
           {this.renderInput()}
           <List
             {...rest}
-            handleListRef={this.handleListRef}
+            handleListRef={this.listRef}
             id={selectId}
             isOpen={isOpen}
             maxHeight={maxHeight}
@@ -215,6 +215,7 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
         <StyledDropdownIcon
           aria-haspopup={true}
           aria-label="toggle menu" // Will need to translate this label in the future
+          disabled={this.props.disabled}
           onClick={this.toggleList}
           role="button"
           style={{ outline: 'none' }}
@@ -482,10 +483,6 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
     }
   }
 
-  private handleListRef = (node: HTMLElement | null) => {
-    this.listRef = node as HTMLUListElement;
-  };
-
   private handleOnActionClick = (action: Action) => {
     if (action.onClick) {
       action.onClick(this.state.inputText);
@@ -502,7 +499,7 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
     const input = this.getInput();
 
     if (
-      (this.listRef && this.listRef.contains(event.target as Node)) ||
+      (this.listRef.current && this.listRef.current.contains(event.target as Node)) ||
       (input &&
         input.parentElement &&
         input.parentElement.parentElement &&
@@ -576,7 +573,7 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
         return;
       }
 
-      const length = this.listRef.children.length;
+      const length = this.listRef.current ? this.listRef.current.children.length : 0;
       const status = document.getElementById(`a11y-status-message-${this.getSelectId()}`);
 
       if (!status) {

--- a/packages/big-design/src/components/Select/styled.tsx
+++ b/packages/big-design/src/components/Select/styled.tsx
@@ -1,18 +1,26 @@
 import { ArrowDropDownIcon } from '@bigcommerce/big-design-icons';
 import { hideVisually } from 'polished';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const StyledStatusMessage = styled.div`
   ${hideVisually()}
 `;
 
-export const StyledDropdownIcon = styled(ArrowDropDownIcon)`
+export const StyledDropdownIcon = styled(ArrowDropDownIcon)<{ disabled?: boolean }>`
   :hover {
     cursor: pointer;
   }
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      :hover {
+        cursor: default;
+      }
+    `}
 `;
 
-export const StyledInputContainer = styled.span`
+export const StyledInputContainer = styled.div`
   input[readonly] {
     cursor: pointer;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4262,13 +4262,21 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-context@0.2.2, create-react-context@<=0.2.2:
+create-react-context@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
   integrity sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==
   dependencies:
     fbjs "^0.8.0"
     gud "^1.0.0"
+
+create-react-context@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
+  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
+  dependencies:
+    gud "^1.0.0"
+    warning "^4.0.3"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -8633,9 +8641,9 @@ polished@^3.0.3:
     "@babel/runtime" "^7.4.5"
 
 popper.js@^1.14.4:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
-  integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.0.tgz#2e1816bcbbaa518ea6c2e15a466f4cb9c6e2fbb3"
+  integrity sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -8947,13 +8955,13 @@ react-live@^2.2.0:
     react-simple-code-editor "^0.9.0"
     unescape "^0.2.0"
 
-react-popper@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.3.tgz#2c6cef7515a991256b4f0536cd4bdcb58a7b6af6"
-  integrity sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==
+react-popper@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.6.tgz#32122f83af8fda01bdd4f86625ddacaf64fdd06d"
+  integrity sha512-kLTfa9z8n+0jJvRVal9+vIuirg41rObg4Bbrvv/ZfsGPQDN9reyVVSxqnHF1ZNgXgV7x11PeUfd5ItF8DZnqhg==
   dependencies:
     "@babel/runtime" "^7.1.2"
-    create-react-context "<=0.2.2"
+    create-react-context "^0.3.0"
     popper.js "^1.14.4"
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
@@ -10801,7 +10809,7 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-warning@^4.0.2:
+warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
Fix issue with `Selects` having extra spacing, by updating `react-popper` and dependencies and swapping container from `span` to `div`. Using new references as well. Fixed small bug.

![image](https://user-images.githubusercontent.com/196129/68901522-b0251680-06fb-11ea-9534-c42fcf993d09.png)
