### PR TITLE
Add transitions to theme

### DIFF
--- a/packages/big-design-theme/src/index.ts
+++ b/packages/big-design-theme/src/index.ts
@@ -7,6 +7,7 @@ import * as keyframes from './system/keyframes';
 import { createLineHeight, LineHeight } from './system/line-height';
 import { shadow, Shadow } from './system/shadow';
 import { createSpacing, Spacing } from './system/spacing';
+import { transition, Transition } from './system/transition';
 import { createTypography, Typography } from './system/typography';
 import { zIndex, ZIndex } from './system/z-index';
 
@@ -24,6 +25,7 @@ export interface ThemeInterface {
   lineHeight: LineHeight;
   shadow: Shadow;
   spacing: Spacing;
+  transition: Transition;
   typography: Typography;
   zIndex: ZIndex;
 }
@@ -42,6 +44,7 @@ export const createTheme = (customOptions: Partial<ThemeOptions> = {}): ThemeInt
     lineHeight: createLineHeight(),
     shadow,
     spacing: createSpacing(),
+    transition,
     typography: createTypography(),
     zIndex,
   };

--- a/packages/big-design-theme/src/system/index.ts
+++ b/packages/big-design-theme/src/system/index.ts
@@ -5,5 +5,6 @@ export * from './keyframes';
 export * from './line-height';
 export * from './shadow';
 export * from './spacing';
+export * from './transition';
 export * from './typography';
 export * from './z-index';

--- a/packages/big-design-theme/src/system/transition.ts
+++ b/packages/big-design-theme/src/system/transition.ts
@@ -1,0 +1,15 @@
+import { css } from 'styled-components';
+
+export type Transition = typeof transition;
+
+export const transition = {
+  small: css`
+    all 150ms ease-out;
+  `,
+  medium: css`
+    all 300ms ease-out;
+  `,
+  large: css`
+    all 600ms ease-out;
+  `,
+};


### PR DESCRIPTION
Add transitions to theme. Initally `small` transitions that should be applied to small components (buttons, inputs..). Added medium transition for bigger components (dropdowns) and large for modals.