### PR TITLE
fix(component): properly handle Dropdown if all options are disabled

### DIFF
--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -180,7 +180,7 @@ export class Dropdown<T extends any> extends React.PureComponent<DropdownProps<T
   };
 
   private openList() {
-    const firstItem = this.listItemsRefs[0].current;
+    const firstItem = this.listItemsRefs.length > 0 ? this.listItemsRefs[0].current : null;
 
     this.setState({ highlightedItem: firstItem, isOpen: true }, () => {
       document.addEventListener('mousedown', this.handleOnClickOutside, false);

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -329,3 +329,19 @@ test("doesn't render tooltip on enabled item", () => {
 
   expect(queryByText(tooltipText)).not.toBeInTheDocument();
 });
+
+test('no errors expected if all options are disabled', () => {
+  const { getByRole } = render(
+    <Dropdown
+      onClick={onClick}
+      options={[
+        { content: 'Option 1', value: '0', disabled: true },
+        { content: 'Option 2', value: '1', disabled: true },
+      ]}
+      trigger={<Button>Button</Button>}
+    />,
+  );
+
+  const trigger = getByRole('button');
+  fireEvent.click(trigger);
+});

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -343,5 +343,7 @@ test('no errors expected if all options are disabled', () => {
   );
 
   const trigger = getByRole('button');
-  fireEvent.click(trigger);
+  expect(() => {
+    fireEvent.click(trigger);
+  }).not.toThrow();
 });


### PR DESCRIPTION
When all `options` are disabled, no items are "available" for selection. Now properly validate if `listItemRefs` has items. 