### PR TITLE
fix(docs): prevent hashes on links from being overwritten

### DIFF
--- a/packages/docs/components/NextLink/NextLink.tsx
+++ b/packages/docs/components/NextLink/NextLink.tsx
@@ -13,7 +13,11 @@ export const NextLink: React.FC<{ href: string; as?: string }> = props => {
 
   return (
     <NLink href={href} as={getLinkAs(as)}>
-      {typeof children === 'string' ? <Link href="">{children}</Link> : children}
+      {typeof children === 'string' ? <Link href={isHash(href) ? href : ''}>{children}</Link> : children}
     </NLink>
   );
 };
+
+function isHash(href: string) {
+  return href && href.charAt(0) === '#';
+}


### PR DESCRIPTION
This fixes the issue of `NextLinks` with hashes not working in live docs. 

I wasn't able to reproduce this issue locally while `yarn run start`, but verified they don't work on production.