### PR TITLE
[POC] QPT-7 Establish basic test structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages/docs/.next
 packages/docs/out
 packages/docs/pages/Dev
 .idea
+packages/tests/artifacts

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "diff": "lerna diff",
     "lint": "lerna run lint --stream",
     "start": "lerna run start --stream --parallel --ignore @bigcommerce/examples",
-    "test": "lerna run test --stream"
+    "test": "lerna run test --stream",
+    "test:functional": "lerna run --scope tests test:functional"
   },
   "husky": {
     "hooks": {

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -1,0 +1,18 @@
+# `tests`
+
+> TODO: description
+
+## Usage
+
+```
+// Preparation
+yarn lerna bootstrap
+yarn lerna link
+yarn build
+
+// Execution (under project root directory)
+yarn test:functional
+
+// Execution (under ./packages/tests)
+npm run test:functional
+```

--- a/packages/tests/babel.config.js
+++ b/packages/tests/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    presets: [
+        ['@babel/preset-env', {
+            targets: {
+                node: 12
+            }
+        }]
+    ]
+}

--- a/packages/tests/functional/basic.ts
+++ b/packages/tests/functional/basic.ts
@@ -1,0 +1,7 @@
+describe('Bigcommerce page', () => {
+    it('should have the right title', async () => {
+        await browser.url('https://www.bigcommerce.com/')
+        const title = await browser.getTitle()
+        expect(title).toEqual('The Future of Commerce Is Yours | BigCommerce')
+    })
+})

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "tests",
+  "version": "0.0.1",
+  "author": "Bigcommerce",
+  "private": true,
+  "description": "BigDesign Functional Tests",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bigcommerce/big-design.git"
+  },
+  "scripts": {
+    "test:functional": "yarn wdio wdio.conf.js"
+  },
+  "dependencies": {
+    "@wdio/cli": "^5.16.10"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.7.4",
+    "@babel/core": "^7.7.4",
+    "@babel/preset-env": "^7.7.4",
+    "@babel/register": "^7.7.4",
+    "@wdio/browserstack-service": "^5.16.10",
+    "@wdio/jasmine-framework": "^5.16.10",
+    "@wdio/junit-reporter": "^5.15.5",
+    "@wdio/local-runner": "^5.16.10",
+    "@wdio/selenium-standalone-service": "^5.16.10",
+    "@wdio/spec-reporter": "^5.16.5"
+  }
+}

--- a/packages/tests/wdio.conf.js
+++ b/packages/tests/wdio.conf.js
@@ -1,0 +1,294 @@
+exports.config = {
+    //
+    // ====================
+    // Runner Configuration
+    // ====================
+    //
+    // WebdriverIO allows it to run your tests in arbitrary locations (e.g. locally or
+    // on a remote machine).
+    runner: 'local',
+    //
+    // ==================
+    // Specify Test Files
+    // ==================
+    // Define which test specs should run. The pattern is relative to the directory
+    // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+    // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+    // directory is where your package.json resides, so `wdio` will be called from there.
+    //
+    specs: [
+        './functional/**/*.ts'
+    ],
+    // Patterns to exclude.
+    exclude: [
+        // 'path/to/excluded/files'
+    ],
+    //
+    // ============
+    // Capabilities
+    // ============
+    // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
+    // time. Depending on the number of capabilities, WebdriverIO launches several test
+    // sessions. Within your capabilities you can overwrite the spec and exclude options in
+    // order to group specific specs to a specific capability.
+    //
+    // First, you can define how many instances should be started at the same time. Let's
+    // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
+    // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
+    // files and you set maxInstances to 10, all spec files will get tested at the same time
+    // and 30 processes will get spawned. The property handles how many capabilities
+    // from the same test should run tests.
+    //
+    maxInstances: 1,
+    //
+    // If you have trouble getting all important capabilities together, check out the
+    // Sauce Labs platform configurator - a great tool to configure your capabilities:
+    // https://docs.saucelabs.com/reference/platforms-configurator
+    //
+    capabilities: [{
+        // maxInstances can get overwritten per capability. So if you have an in-house Selenium
+        // grid with only 5 firefox instances available you can make sure that not more than
+        // 5 instances get started at a time.
+        maxInstances: 5,
+        //
+        browserName: 'firefox',
+        // If outputDir is provided WebdriverIO can capture driver session logs
+        // it is possible to configure which logTypes to include/exclude.
+        // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
+        // excludeDriverLogs: ['bugreport', 'server'],
+    }],
+    //
+    // ===================
+    // Test Configurations
+    // ===================
+    // Define all options that are relevant for the WebdriverIO instance here
+    //
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
+    logLevel: 'info',
+
+    outputDir: './artifacts/logs',
+    //
+    // Set specific log levels per logger
+    // loggers:
+    // - webdriver, webdriverio
+    // - @wdio/applitools-service, @wdio/browserstack-service, @wdio/devtools-service, @wdio/sauce-service
+    // - @wdio/mocha-framework, @wdio/jasmine-framework
+    // - @wdio/local-runner, @wdio/lambda-runner
+    // - @wdio/sumologic-reporter
+    // - @wdio/cli, @wdio/config, @wdio/sync, @wdio/utils
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
+    // logLevels: {
+    //     webdriver: 'info',
+    //     '@wdio/applitools-service': 'info'
+    // },
+    //
+    // If you only want to run your tests until a specific amount of tests have failed use
+    // bail (default is 0 - don't bail, run all tests).
+    bail: 0,
+
+    screenshotPath: './artifacts/screenshots/',
+
+    screenshotOnReject: false,
+    //
+    // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+    // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+    // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+    // gets prepended directly.
+    baseUrl: 'http://localhost',
+    //
+    // Default timeout for all waitFor* commands.
+    waitforTimeout: 10000,
+    //
+    // Default timeout in milliseconds for request
+    // if Selenium Grid doesn't send response
+    connectionRetryTimeout: 90000,
+    //
+    // Default request retries count
+    connectionRetryCount: 3,
+    //
+    // Test runner services
+    // Services take over a specific job you don't want to take care of. They enhance
+    // your test setup with almost no effort. Unlike plugins, they don't add new
+    // commands. Instead, they hook themselves up into the test process.
+    services: ['selenium-standalone','browserstack'],
+    seleniumLogs: './artifacts/logs',
+    seleniumInstallArgs: {
+        drivers: {
+            chrome: { version: '77.0.3865.40' },
+            firefox: { version: '0.25.0' },
+        }
+    },
+    seleniumArgs: {
+        drivers: {
+            chrome: { version: '77.0.3865.40' },
+            firefox: { version: '0.25.0' },
+        }
+    },
+
+    // Framework you want to run your specs with.
+    // The following are supported: Mocha, Jasmine, and Cucumber
+    // see also: https://webdriver.io/docs/frameworks.html
+    //
+    // Make sure you have the wdio adapter package for the specific framework installed
+    // before running any tests.
+    framework: 'jasmine',
+    //
+    // The number of times to retry the entire specfile when it fails as a whole
+    // specFileRetries: 1,
+    //
+    // Test reporter for stdout.
+    // The only one supported by default is 'dot'
+    // see also: https://webdriver.io/docs/dot-reporter.html
+    reporters: [
+        'spec',
+        [
+            'junit',
+            {
+                outputDir: './artifacts/test-results/',
+                outputFileFormat: function(options) {
+                    return 'test-result.xml'
+                },
+                errorOptions: {
+                    error: 'message',
+                    failure: 'message',
+                    stacktrace: 'stack'
+                }
+            }
+        ]
+    ],
+ 
+    //
+    // Options to be passed to Jasmine.
+    jasmineNodeOpts: {
+        //
+        // Jasmine default timeout
+        defaultTimeoutInterval: 60000,
+        //
+        // The Jasmine framework allows interception of each assertion in order to log the state of the application
+        // or website depending on the result. For example, it is pretty handy to take a screenshot every time
+        // an assertion fails.
+        expectationResultHandler: function(passed, assertion) {
+            // do something
+        }
+    },
+    
+    //
+    // =====
+    // Hooks
+    // =====
+    // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+    // it and to build services around it. You can either apply a single function or an array of
+    // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+    // resolved to continue.
+    /**
+     * Gets executed once before all workers get launched.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     */
+    // onPrepare: function (config, capabilities) {
+    // },
+    /**
+     * Gets executed just before initialising the webdriver session and test framework. It allows you
+     * to manipulate configurations depending on the capability or spec.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
+    // beforeSession: function (config, capabilities, specs) {
+    // },
+    /**
+     * Gets executed before test execution begins. At this point you can access to all global
+     * variables like `browser`. It is the perfect place to define custom commands.
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
+    before: function (capabilities, specs) {
+        require('@babel/register')
+    },
+    /**
+     * Runs before a WebdriverIO command gets executed.
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     */
+    // beforeCommand: function (commandName, args) {
+    // },
+    /**
+     * Hook that gets executed before the suite starts
+     * @param {Object} suite suite details
+     */
+    // beforeSuite: function (suite) {
+    // },
+    /**
+     * Function to be executed before a test (in Mocha/Jasmine) starts.
+     */
+    // beforeTest: function (test, context) {
+    // },
+    /**
+     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+     * beforeEach in Mocha)
+     */
+    // beforeHook: function (test, context) {
+    // },
+    /**
+     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * afterEach in Mocha)
+     */
+    // afterHook: function (test, context, { error, result, duration, passed, retries }) {
+    // },
+    /**
+     * Function to be executed after a test (in Mocha/Jasmine).
+     */
+    // afterTest: function(test, context, { error, result, duration, passed, retries }) {
+    // },
+
+
+    /**
+     * Hook that gets executed after the suite has ended
+     * @param {Object} suite suite details
+     */
+    // afterSuite: function (suite) {
+    // },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     * @param {Number} result 0 - command success, 1 - command error
+     * @param {Object} error error object if any
+     */
+    // afterCommand: function (commandName, args, result, error) {
+    // },
+    /**
+     * Gets executed after all tests are done. You still have access to all global variables from
+     * the test.
+     * @param {Number} result 0 - test pass, 1 - test fail
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
+    // after: function (result, capabilities, specs) {
+    // },
+    /**
+     * Gets executed right after terminating the webdriver session.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
+    // afterSession: function (config, capabilities, specs) {
+    // },
+    /**
+     * Gets executed after all workers got shut down and the process is about to exit. An error
+     * thrown in the onComplete hook will result in the test run failing.
+     * @param {Object} exitCode 0 - success, 1 - fail
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {<Object>} results object containing test results
+     */
+    // onComplete: function(exitCode, config, capabilities, results) {
+    // },
+    /**
+    * Gets executed when a refresh happens.
+    * @param {String} oldSessionId session ID of the old session
+    * @param {String} newSessionId session ID of the new session
+    */
+    //onReload: function(oldSessionId, newSessionId) {
+    //}
+}


### PR DESCRIPTION
1. Adding functional tests in a seperate package
2. Enable standalone-selenium
3. Enable Typescript
4. Enable logging

@aaron-humerickhouse @lorentzkim 

https://github.com/bigcommerce/big-design/pull/278 represents the other approach. However I'm not sure whether browserstack will work well with this approach or not.