### PR TITLE
fix(component): add flex-shrink 0 to external link icon

### DIFF
--- a/packages/big-design/src/components/Link/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Link/__snapshots__/spec.tsx.snap
@@ -67,6 +67,9 @@ exports[`renders with external icon 1`] = `
 }
 
 .c0 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   margin-left: 0.25rem;
 }
 

--- a/packages/big-design/src/components/Link/styled.tsx
+++ b/packages/big-design/src/components/Link/styled.tsx
@@ -31,6 +31,7 @@ export const StyledLink = styled.a<LinkProps & { isExternal?: boolean }>`
       align-items: center;
 
       svg {
+        flex-shrink: 0;
         margin-left: ${theme.spacing.xxSmall};
       }
     `}


### PR DESCRIPTION
## What?
Fixing a small bug in the `Link` component when `external=true`.

## Why?
Without `flex-shrink: 0` CSS property external icon brings smaller when` Link` component width decrease (pls see example below).
![Screen Shot 2020-01-02 at 5 32 31 PM](https://user-images.githubusercontent.com/9980803/71676029-cceadb80-2d87-11ea-8a49-bd1aa6afebbc.png)

## Result (with `flex-shrin: 0`)
![Screen Shot 2020-01-02 at 6 02 45 PM](https://user-images.githubusercontent.com/9980803/71676968-323fcc00-2d8a-11ea-8f71-18694bacfe1d.png)
