### PR TITLE
feat(component): add text-transform props to Text and Small

### DIFF
--- a/packages/big-design/src/components/Typography/spec.tsx
+++ b/packages/big-design/src/components/Typography/spec.tsx
@@ -175,10 +175,10 @@ test('Text and Small can change their tag', () => {
 test('Text and Small accept text modifiers', () => {
   const { getByTestId } = render(
     <>
-      <Text bold italic underline data-testid="text">
+      <Text bold italic underline uppercase data-testid="text">
         Some Text
       </Text>
-      <Small strikethrough data-testid="small">
+      <Small strikethrough lowercase data-testid="small">
         Some Text
       </Small>
     </>,
@@ -191,7 +191,11 @@ test('Text and Small accept text modifiers', () => {
     font-weight: 600;
     font-style: italic;
     text-decoration: underline;
+    text-transform: uppercase;
   `);
 
-  expect(small).toHaveStyle('text-decoration: line-through');
+  expect(small).toHaveStyle(`
+    text-decoration: line-through;
+    text-transform: lowercase;
+  `);
 });

--- a/packages/big-design/src/components/Typography/styled.tsx
+++ b/packages/big-design/src/components/Typography/styled.tsx
@@ -37,6 +37,25 @@ const textModifiers = (props: TextProps) => css`
     css`
       text-decoration: line-through;
     `}
+
+  ${() =>
+    props.capitalize &&
+    css`
+      text-transform: capitalize;
+    `}
+
+  ${() =>
+    props.lowercase &&
+    css`
+      text-transform: lowercase;
+    `}
+
+  ${() =>
+    props.uppercase &&
+    css`
+      text-transform: uppercase;
+    `}
+
 `;
 
 export const StyledH0 = styled.h1<HeadingProps>`

--- a/packages/big-design/src/components/Typography/types.ts
+++ b/packages/big-design/src/components/Typography/types.ts
@@ -11,9 +11,12 @@ export interface TypographyProps {
 
 export interface TextModifiers {
   bold?: boolean;
+  capitalize?: boolean;
   italic?: boolean;
+  lowercase?: boolean;
   strikethrough?: boolean;
   underline?: boolean;
+  uppercase?: boolean;
 }
 
 export type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';

--- a/packages/docs/PropTables/TypographyPropTable.tsx
+++ b/packages/docs/PropTables/TypographyPropTable.tsx
@@ -66,6 +66,24 @@ const textProps: Prop[] = [
     defaultValue: 'false',
     description: 'Changes text style to underline.',
   },
+  {
+    name: 'capitalize',
+    types: 'boolean',
+    defaultValue: 'false',
+    description: 'Changes text transform to capitalize.',
+  },
+  {
+    name: 'lowercase',
+    types: 'boolean',
+    defaultValue: 'false',
+    description: 'Changes text transform to lowercase.',
+  },
+  {
+    name: 'uppercase',
+    types: 'boolean',
+    defaultValue: 'false',
+    description: 'Changes text transform to uppercase.',
+  },
 ];
 
 export const TypographyPropTable: React.FC<PropTableWrapper> = props => (

--- a/packages/docs/pages/Typography/TypographyPage.tsx
+++ b/packages/docs/pages/Typography/TypographyPage.tsx
@@ -78,7 +78,13 @@ export default () => (
         <Text bold>This text is bold.</Text>
         <Text italic>This text is italic.</Text>
         <Text strikethrough>This text is strikethrough.</Text>
-        <Text underline>This color is underline.</Text>
+        <Text underline>This text is underlined.</Text>
+        <Text uppercase>This text is uppercase.</Text>
+        <Text lowercase>This text is lowercase.</Text>
+        <Text capitalize>This text is capitalized.</Text>
+        <Text bold uppercase>
+          This text is bold and uppercase.
+        </Text>
       </>
       {/* jsx-to-string:end */}
     </CodePreview>


### PR DESCRIPTION
New text modifiers:

- uppercase
- lowercase
- capitalize



<img width="950" alt="Screen Shot 2020-01-02 at 12 35 17 PM" src="https://user-images.githubusercontent.com/2752665/71686201-0e679080-2d60-11ea-9f3b-71ce5cb28942.png">
