### PR TITLE
fix(component): modal crash with no focusable elements

### DIFF
--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -77,7 +77,7 @@ export class Modal extends React.PureComponent<ModalProps, ModalState> {
 
   componentDidUpdate(prevProps: ModalProps) {
     if (this.modalRef.current && !this.focusTrap) {
-      this.focusTrap = focusTrap(this.modalRef.current as HTMLElement);
+      this.focusTrap = focusTrap(this.modalRef.current as HTMLElement, { initialFocus: this.modalRef.current });
     }
 
     // Check that the previous state was not open and is now open before auto focusing on modal
@@ -110,6 +110,7 @@ export class Modal extends React.PureComponent<ModalProps, ModalState> {
         onKeyDown={this.onKeyDown}
         ref={this.modalRef}
         variant={variant}
+        tabIndex={-1}
       >
         <StyledModalContent variant={variant} aria-labelledby={this.headerUniqueId} flexDirection="column">
           {this.renderClose()}

--- a/packages/big-design/src/components/Modal/spec.tsx
+++ b/packages/big-design/src/components/Modal/spec.tsx
@@ -1,10 +1,8 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, wait } from '@testing-library/react';
 import 'jest-styled-components';
 import React from 'react';
 
 import { Modal } from './Modal';
-
-jest.mock('focus-trap');
 
 test('render open modal', () => {
   const text = 'This is a modal';
@@ -155,7 +153,7 @@ test('do not render close button on dialog variation', () => {
   expect(queryByTitle('Close')).not.toBeInTheDocument();
 });
 
-test('do not pull focus to open modal that is rerendered', () => {
+test('do not pull focus to open modal that is rerendered', async () => {
   const text = 'This is a modal';
   const { queryByText, queryByRole, rerender } = render(
     <Modal isOpen={false}>
@@ -177,7 +175,8 @@ test('do not pull focus to open modal that is rerendered', () => {
 
   // Expect Modal to have focus
   expect(queryByText(text)).toBeInTheDocument();
-  expect(document.activeElement).toBe(document.body);
+
+  await wait(() => expect(document.activeElement).toBe(queryByRole('dialog')));
 
   const input = document.getElementById('focusTest');
 


### PR DESCRIPTION
`focus-trap` requires at least one focusable element. Made the modal itself focusable and set it as `initialFocus`.