### PR TITLE
feat(icons): forwardRef to svg

### DIFF
--- a/packages/big-design-icons/package.json
+++ b/packages/big-design-icons/package.json
@@ -43,7 +43,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@bigcommerce/big-design-theme": "^0.4.0"
+    "@bigcommerce/big-design-theme": "^0.4.0",
+    "react-uid": "^2.2.0"
   },
   "peerDependencies": {
     "react": "^16.8.0",
@@ -62,10 +63,10 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.1.0",
     "@bigcommerce/configs": "^0.9.0",
-    "@svgr/core": "^4.3.2",
-    "@svgr/plugin-jsx": "^4.3.2",
-    "@svgr/plugin-prettier": "^4.3.2",
-    "@svgr/plugin-svgo": "^4.3.1",
+    "@svgr/core": "^5.0.1",
+    "@svgr/plugin-jsx": "^5.0.1",
+    "@svgr/plugin-prettier": "^5.0.1",
+    "@svgr/plugin-svgo": "^5.0.1",
     "@types/styled-components": "^4.1.12",
     "babel-plugin-styled-components": "^1.10.6",
     "camelcase": "^5.3.1",

--- a/packages/big-design-icons/scripts/svgr.config.js
+++ b/packages/big-design-icons/scripts/svgr.config.js
@@ -2,6 +2,7 @@ const prettierConfig = require('../prettier.config');
 
 module.exports = {
   titleProp: true,
+  ref: true,
   ext: 'tsx',
   svgProps: {
     stroke: 'currentColor',
@@ -16,23 +17,35 @@ module.exports = {
     // **********************************
     import React from 'react';
     BREAK
-    import { createStyledIcon, IconProps } from '../base';
+
+    import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+    import { useUniqueId } from '../utils';
     BREAK
 
-    const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-      JSX
-    ));
+    const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+      const titleId = useUniqueId('icon');
+
+      BREAK
+      return (
+        JSX
+      );
+    };
 
     BREAK
-    export const COMPONENT_NAME = createStyledIcon(Icon);
+    const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => <Icon {...iconProps} svgRef={ref} />);
+
+    BREAK
+    export const COMPONENT_NAME = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
     BREAK
     COMPONENT_NAME.displayName = '${componentName.name}';
     `;
 
     const typeScriptTpl = template.smart(code, {
-      plugins: ['typescript'],
+      plugins: ['jsx', 'typescript'],
       preserveComments: true,
+      placeholderPattern: false,
+      placeholderWhitelist: new Set(['BREAK', 'COMPONENT_NAME', 'JSX']),
     });
 
     return typeScriptTpl({

--- a/packages/big-design-icons/src/base/index.tsx
+++ b/packages/big-design-icons/src/base/index.tsx
@@ -3,14 +3,18 @@ import React from 'react';
 import styled from 'styled-components';
 
 export interface IconProps extends React.SVGProps<SVGSVGElement> {
-  className: string;
-  color: keyof Colors;
-  size: keyof Spacing | number;
-  theme: ThemeInterface;
-  title: string;
+  className?: string;
+  color?: keyof Colors;
+  size?: keyof Spacing | number;
+  theme?: ThemeInterface;
+  title?: string;
 }
 
-export function createStyledIcon(Icon: React.FC<Partial<IconProps>>) {
+export interface PrivateIconProps {
+  svgRef?: React.Ref<SVGSVGElement>;
+}
+
+export function createStyledIcon(Icon: React.FC<IconProps>) {
   const StyledIcon = styled(Icon)`
     vertical-align: middle;
 

--- a/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M12 7c-.55 0-1 .45-1 1v3H8c-.55 0-1 .45-1 1s.45 1 1 1h3v3c0 .55.45 1 1 1s1-.45 1-1v-3h3c.55 0 1-.45 1-1s-.45-1-1-1h-3V8c0-.55-.45-1-1-1zm0-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M12 7c-.55 0-1 .45-1 1v3H8c-.55 0-1 .45-1 1s.45 1 1 1h3v3c0 .55.45 1 1 1s1-.45 1-1v-3h3c.55 0 1-.45 1-1s-.45-1-1-1h-3V8c0-.55-.45-1-1-1zm0-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const AddCircleOutlineIcon = createStyledIcon(Icon);
+export const AddCircleOutlineIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 AddCircleOutlineIcon.displayName = 'AddCircleOutlineIcon';

--- a/packages/big-design-icons/src/components/AddIcon.tsx
+++ b/packages/big-design-icons/src/components/AddIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const AddIcon = createStyledIcon(Icon);
+export const AddIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 AddIcon.displayName = 'AddIcon';

--- a/packages/big-design-icons/src/components/ArrowBackIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowBackIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M19 11H7.83l4.88-4.88c.39-.39.39-1.03 0-1.42a.996.996 0 00-1.41 0l-6.59 6.59a.996.996 0 000 1.41l6.59 6.59a.996.996 0 101.41-1.41L7.83 13H19c.55 0 1-.45 1-1s-.45-1-1-1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M19 11H7.83l4.88-4.88c.39-.39.39-1.03 0-1.42a.996.996 0 00-1.41 0l-6.59 6.59a.996.996 0 000 1.41l6.59 6.59a.996.996 0 101.41-1.41L7.83 13H19c.55 0 1-.45 1-1s-.45-1-1-1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ArrowBackIcon = createStyledIcon(Icon);
+export const ArrowBackIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ArrowBackIcon.displayName = 'ArrowBackIcon';

--- a/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0a.996.996 0 000 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59a.996.996 0 10-1.41-1.41L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0a.996.996 0 000 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59a.996.996 0 10-1.41-1.41L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ArrowDownwardIcon = createStyledIcon(Icon);
+export const ArrowDownwardIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ArrowDownwardIcon.displayName = 'ArrowDownwardIcon';

--- a/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M8.71 11.71l2.59 2.59c.39.39 1.02.39 1.41 0l2.59-2.59c.63-.63.18-1.71-.71-1.71H9.41c-.89 0-1.33 1.08-.7 1.71z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M8.71 11.71l2.59 2.59c.39.39 1.02.39 1.41 0l2.59-2.59c.63-.63.18-1.71-.71-1.71H9.41c-.89 0-1.33 1.08-.7 1.71z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ArrowDropDownIcon = createStyledIcon(Icon);
+export const ArrowDropDownIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ArrowDropDownIcon.displayName = 'ArrowDropDownIcon';

--- a/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59a.996.996 0 000-1.41l-6.58-6.6a.996.996 0 10-1.41 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59a.996.996 0 000-1.41l-6.58-6.6a.996.996 0 10-1.41 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ArrowForwardIcon = createStyledIcon(Icon);
+export const ArrowForwardIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ArrowForwardIcon.displayName = 'ArrowForwardIcon';

--- a/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M13 19V7.83l4.88 4.88c.39.39 1.03.39 1.42 0a.996.996 0 000-1.41l-6.59-6.59a.996.996 0 00-1.41 0l-6.6 6.58a.996.996 0 101.41 1.41L11 7.83V19c0 .55.45 1 1 1s1-.45 1-1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M13 19V7.83l4.88 4.88c.39.39 1.03.39 1.42 0a.996.996 0 000-1.41l-6.59-6.59a.996.996 0 00-1.41 0l-6.6 6.58a.996.996 0 101.41 1.41L11 7.83V19c0 .55.45 1 1 1s1-.45 1-1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ArrowUpwardIcon = createStyledIcon(Icon);
+export const ArrowUpwardIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ArrowUpwardIcon.displayName = 'ArrowUpwardIcon';

--- a/packages/big-design-icons/src/components/AssignmentIcon.tsx
+++ b/packages/big-design-icons/src/components/AssignmentIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm1 14H8c-.55 0-1-.45-1-1s.45-1 1-1h5c.55 0 1 .45 1 1s-.45 1-1 1zm3-4H8c-.55 0-1-.45-1-1s.45-1 1-1h8c.55 0 1 .45 1 1s-.45 1-1 1zm0-4H8c-.55 0-1-.45-1-1s.45-1 1-1h8c.55 0 1 .45 1 1s-.45 1-1 1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm1 14H8c-.55 0-1-.45-1-1s.45-1 1-1h5c.55 0 1 .45 1 1s-.45 1-1 1zm3-4H8c-.55 0-1-.45-1-1s.45-1 1-1h8c.55 0 1 .45 1 1s-.45 1-1 1zm0-4H8c-.55 0-1-.45-1-1s.45-1 1-1h8c.55 0 1 .45 1 1s-.45 1-1 1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const AssignmentIcon = createStyledIcon(Icon);
+export const AssignmentIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 AssignmentIcon.displayName = 'AssignmentIcon';

--- a/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
+++ b/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path d="M0 0h24v24H0z" fill="none" />
-    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const BaselineHelpIcon = createStyledIcon(Icon);
+export const BaselineHelpIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 BaselineHelpIcon.displayName = 'BaselineHelpIcon';

--- a/packages/big-design-icons/src/components/CheckCircleIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckCircleIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM9.29 16.29L5.7 12.7a.996.996 0 111.41-1.41L10 14.17l6.88-6.88a.996.996 0 111.41 1.41l-7.59 7.59a.996.996 0 01-1.41 0z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM9.29 16.29L5.7 12.7a.996.996 0 111.41-1.41L10 14.17l6.88-6.88a.996.996 0 111.41 1.41l-7.59 7.59a.996.996 0 01-1.41 0z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const CheckCircleIcon = createStyledIcon(Icon);
+export const CheckCircleIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 CheckCircleIcon.displayName = 'CheckCircleIcon';

--- a/packages/big-design-icons/src/components/CheckIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const CheckIcon = createStyledIcon(Icon);
+export const CheckIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 CheckIcon.displayName = 'CheckIcon';

--- a/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M14.71 6.71a.996.996 0 00-1.41 0L8.71 11.3a.996.996 0 000 1.41l4.59 4.59a.996.996 0 101.41-1.41L10.83 12l3.88-3.88c.39-.39.38-1.03 0-1.41z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M14.71 6.71a.996.996 0 00-1.41 0L8.71 11.3a.996.996 0 000 1.41l4.59 4.59a.996.996 0 101.41-1.41L10.83 12l3.88-3.88c.39-.39.38-1.03 0-1.41z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ChevronLeftIcon = createStyledIcon(Icon);
+export const ChevronLeftIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ChevronLeftIcon.displayName = 'ChevronLeftIcon';

--- a/packages/big-design-icons/src/components/ChevronRightIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronRightIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M9.29 6.71a.996.996 0 000 1.41L13.17 12l-3.88 3.88a.996.996 0 101.41 1.41l4.59-4.59a.996.996 0 000-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M9.29 6.71a.996.996 0 000 1.41L13.17 12l-3.88 3.88a.996.996 0 101.41 1.41l4.59-4.59a.996.996 0 000-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ChevronRightIcon = createStyledIcon(Icon);
+export const ChevronRightIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ChevronRightIcon.displayName = 'ChevronRightIcon';

--- a/packages/big-design-icons/src/components/CloseIcon.tsx
+++ b/packages/big-design-icons/src/components/CloseIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M18.3 5.71a.996.996 0 00-1.41 0L12 10.59 7.11 5.7A.996.996 0 105.7 7.11L10.59 12 5.7 16.89a.996.996 0 101.41 1.41L12 13.41l4.89 4.89a.996.996 0 101.41-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M18.3 5.71a.996.996 0 00-1.41 0L12 10.59 7.11 5.7A.996.996 0 105.7 7.11L10.59 12 5.7 16.89a.996.996 0 101.41 1.41L12 13.41l4.89 4.89a.996.996 0 101.41-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const CloseIcon = createStyledIcon(Icon);
+export const CloseIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 CloseIcon.displayName = 'CloseIcon';

--- a/packages/big-design-icons/src/components/DeleteIcon.tsx
+++ b/packages/big-design-icons/src/components/DeleteIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V9c0-1.1-.9-2-2-2H8c-1.1 0-2 .9-2 2v10zM18 4h-2.5l-.71-.71c-.18-.18-.44-.29-.7-.29H9.91c-.26 0-.52.11-.7.29L8.5 4H6c-.55 0-1 .45-1 1s.45 1 1 1h12c.55 0 1-.45 1-1s-.45-1-1-1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V9c0-1.1-.9-2-2-2H8c-1.1 0-2 .9-2 2v10zM18 4h-2.5l-.71-.71c-.18-.18-.44-.29-.7-.29H9.91c-.26 0-.52.11-.7.29L8.5 4H6c-.55 0-1 .45-1 1s.45 1 1 1h12c.55 0 1-.45 1-1s-.45-1-1-1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const DeleteIcon = createStyledIcon(Icon);
+export const DeleteIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 DeleteIcon.displayName = 'DeleteIcon';

--- a/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
+++ b/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const DragIndicatorIcon = createStyledIcon(Icon);
+export const DragIndicatorIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 DragIndicatorIcon.displayName = 'DragIndicatorIcon';

--- a/packages/big-design-icons/src/components/EditIcon.tsx
+++ b/packages/big-design-icons/src/components/EditIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M3 17.46v3.04c0 .28.22.5.5.5h3.04c.13 0 .26-.05.35-.15L17.81 9.94l-3.75-3.75L3.15 17.1c-.1.1-.15.22-.15.36zM20.71 7.04a.996.996 0 000-1.41l-2.34-2.34a.996.996 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M3 17.46v3.04c0 .28.22.5.5.5h3.04c.13 0 .26-.05.35-.15L17.81 9.94l-3.75-3.75L3.15 17.1c-.1.1-.15.22-.15.36zM20.71 7.04a.996.996 0 000-1.41l-2.34-2.34a.996.996 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const EditIcon = createStyledIcon(Icon);
+export const EditIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 EditIcon.displayName = 'EditIcon';

--- a/packages/big-design-icons/src/components/ErrorIcon.tsx
+++ b/packages/big-design-icons/src/components/ErrorIcon.tsx
@@ -3,15 +3,34 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 11c-.55 0-1-.45-1-1V8c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1zm1 4h-2v-2h2v2z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 11c-.55 0-1-.45-1-1V8c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1zm1 4h-2v-2h2v2z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ErrorIcon = createStyledIcon(Icon);
+export const ErrorIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ErrorIcon.displayName = 'ErrorIcon';

--- a/packages/big-design-icons/src/components/ExpandLessIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandLessIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M11.29 8.71L6.7 13.3a.996.996 0 101.41 1.41L12 10.83l3.88 3.88a.996.996 0 101.41-1.41L12.7 8.71a.996.996 0 00-1.41 0z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M11.29 8.71L6.7 13.3a.996.996 0 101.41 1.41L12 10.83l3.88 3.88a.996.996 0 101.41-1.41L12.7 8.71a.996.996 0 00-1.41 0z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ExpandLessIcon = createStyledIcon(Icon);
+export const ExpandLessIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ExpandLessIcon.displayName = 'ExpandLessIcon';

--- a/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path opacity={0.87} fill="none" d="M24 24H0V0h24v24z" />
-    <path d="M15.88 9.29L12 13.17 8.12 9.29a.996.996 0 10-1.41 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 000-1.41c-.39-.38-1.03-.39-1.42 0z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path opacity={0.87} fill="none" d="M24 24H0V0h24v24z" />
+      <path d="M15.88 9.29L12 13.17 8.12 9.29a.996.996 0 10-1.41 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 000-1.41c-.39-.38-1.03-.39-1.42 0z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ExpandMoreIcon = createStyledIcon(Icon);
+export const ExpandMoreIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ExpandMoreIcon.displayName = 'ExpandMoreIcon';

--- a/packages/big-design-icons/src/components/FileCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/FileCopyIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M15 1H4c-1.1 0-2 .9-2 2v13c0 .55.45 1 1 1s1-.45 1-1V4c0-.55.45-1 1-1h10c.55 0 1-.45 1-1s-.45-1-1-1zm.59 4.59l4.83 4.83c.37.37.58.88.58 1.41V21c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h6.17c.53 0 1.04.21 1.42.59zM15 12h4.5L14 6.5V11c0 .55.45 1 1 1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M15 1H4c-1.1 0-2 .9-2 2v13c0 .55.45 1 1 1s1-.45 1-1V4c0-.55.45-1 1-1h10c.55 0 1-.45 1-1s-.45-1-1-1zm.59 4.59l4.83 4.83c.37.37.58.88.58 1.41V21c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h6.17c.53 0 1.04.21 1.42.59zM15 12h4.5L14 6.5V11c0 .55.45 1 1 1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const FileCopyIcon = createStyledIcon(Icon);
+export const FileCopyIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 FileCopyIcon.displayName = 'FileCopyIcon';

--- a/packages/big-design-icons/src/components/FilterListIcon.tsx
+++ b/packages/big-design-icons/src/components/FilterListIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M11 18h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM3 7c0 .55.45 1 1 1h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1zm4 6h10c.55 0 1-.45 1-1s-.45-1-1-1H7c-.55 0-1 .45-1 1s.45 1 1 1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M11 18h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM3 7c0 .55.45 1 1 1h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1zm4 6h10c.55 0 1-.45 1-1s-.45-1-1-1H7c-.55 0-1 .45-1 1s.45 1 1 1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const FilterListIcon = createStyledIcon(Icon);
+export const FilterListIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 FilterListIcon.displayName = 'FilterListIcon';

--- a/packages/big-design-icons/src/components/InvertColorsIcon.tsx
+++ b/packages/big-design-icons/src/components/InvertColorsIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M24 0H0v24h24V0z" />
-    <path d="M6.34 7.93c-3.12 3.12-3.12 8.19 0 11.31C7.9 20.8 9.95 21.58 12 21.58s4.1-.78 5.66-2.34c3.12-3.12 3.12-8.19 0-11.31l-4.95-4.95a.996.996 0 00-1.41 0L6.34 7.93zM12 19.59c-1.6 0-3.11-.62-4.24-1.76C6.62 16.69 6 15.19 6 13.59s.62-3.11 1.76-4.24L12 5.1v14.49z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M24 0H0v24h24V0z" />
+      <path d="M6.34 7.93c-3.12 3.12-3.12 8.19 0 11.31C7.9 20.8 9.95 21.58 12 21.58s4.1-.78 5.66-2.34c3.12-3.12 3.12-8.19 0-11.31l-4.95-4.95a.996.996 0 00-1.41 0L6.34 7.93zM12 19.59c-1.6 0-3.11-.62-4.24-1.76C6.62 16.69 6 15.19 6 13.59s.62-3.11 1.76-4.24L12 5.1v14.49z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const InvertColorsIcon = createStyledIcon(Icon);
+export const InvertColorsIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 InvertColorsIcon.displayName = 'InvertColorsIcon';

--- a/packages/big-design-icons/src/components/LanguageIcon.tsx
+++ b/packages/big-design-icons/src/components/LanguageIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm6.93 6h-2.95a15.65 15.65 0 00-1.38-3.56A8.03 8.03 0 0118.92 8zM12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96zM4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2s.06 1.34.14 2H4.26zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56A7.987 7.987 0 015.08 16zm2.95-8H5.08a7.987 7.987 0 014.33-3.56A15.65 15.65 0 008.03 8zM12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96zM14.34 14H9.66c-.09-.66-.16-1.32-.16-2s.07-1.35.16-2h4.68c.09.65.16 1.32.16 2s-.07 1.34-.16 2zm.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95a8.03 8.03 0 01-4.33 3.56zM16.36 14c.08-.66.14-1.32.14-2s-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2h-3.38z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm6.93 6h-2.95a15.65 15.65 0 00-1.38-3.56A8.03 8.03 0 0118.92 8zM12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96zM4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2s.06 1.34.14 2H4.26zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56A7.987 7.987 0 015.08 16zm2.95-8H5.08a7.987 7.987 0 014.33-3.56A15.65 15.65 0 008.03 8zM12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96zM14.34 14H9.66c-.09-.66-.16-1.32-.16-2s.07-1.35.16-2h4.68c.09.65.16 1.32.16 2s-.07 1.34-.16 2zm.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95a8.03 8.03 0 01-4.33 3.56zM16.36 14c.08-.66.14-1.32.14-2s-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2h-3.38z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const LanguageIcon = createStyledIcon(Icon);
+export const LanguageIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 LanguageIcon.displayName = 'LanguageIcon';

--- a/packages/big-design-icons/src/components/MenuIcon.tsx
+++ b/packages/big-design-icons/src/components/MenuIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M4 18h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1s.45 1 1 1zm0-5h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1s.45 1 1 1zM3 7c0 .55.45 1 1 1h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M4 18h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1s.45 1 1 1zm0-5h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1s.45 1 1 1zM3 7c0 .55.45 1 1 1h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const MenuIcon = createStyledIcon(Icon);
+export const MenuIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 MenuIcon.displayName = 'MenuIcon';

--- a/packages/big-design-icons/src/components/MoreHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/MoreHorizIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const MoreHorizIcon = createStyledIcon(Icon);
+export const MoreHorizIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 MoreHorizIcon.displayName = 'MoreHorizIcon';

--- a/packages/big-design-icons/src/components/NotificationsIcon.tsx
+++ b/packages/big-design-icons/src/components/NotificationsIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M12 22c1.1 0 2-.9 2-2h-4a2 2 0 002 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-1.29 1.29c-.63.63-.19 1.71.7 1.71h13.17c.89 0 1.34-1.08.71-1.71L18 16z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M12 22c1.1 0 2-.9 2-2h-4a2 2 0 002 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-1.29 1.29c-.63.63-.19 1.71.7 1.71h13.17c.89 0 1.34-1.08.71-1.71L18 16z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const NotificationsIcon = createStyledIcon(Icon);
+export const NotificationsIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 NotificationsIcon.displayName = 'NotificationsIcon';

--- a/packages/big-design-icons/src/components/OpenInNewIcon.tsx
+++ b/packages/big-design-icons/src/components/OpenInNewIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5a2 2 0 00-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1zM14 4c0 .55.45 1 1 1h2.59l-9.13 9.13a.996.996 0 101.41 1.41L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5a2 2 0 00-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1zM14 4c0 .55.45 1 1 1h2.59l-9.13 9.13a.996.996 0 101.41 1.41L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const OpenInNewIcon = createStyledIcon(Icon);
+export const OpenInNewIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 OpenInNewIcon.displayName = 'OpenInNewIcon';

--- a/packages/big-design-icons/src/components/PublicIcon.tsx
+++ b/packages/big-design-icons/src/components/PublicIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const PublicIcon = createStyledIcon(Icon);
+export const PublicIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 PublicIcon.displayName = 'PublicIcon';

--- a/packages/big-design-icons/src/components/ReceiptIcon.tsx
+++ b/packages/big-design-icons/src/components/ReceiptIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M21 2.21a.47.47 0 00-.35.15l-.79.79c-.2.2-.51.2-.71 0l-.79-.79c-.2-.2-.51-.2-.71 0l-.79.79c-.2.2-.51.2-.71 0l-.79-.79c-.2-.2-.51-.2-.71 0l-.79.79c-.2.2-.51.2-.71 0l-.79-.79c-.2-.2-.51-.2-.71 0l-.79.79c-.2.2-.51.2-.71 0l-.8-.8c-.2-.2-.51-.2-.71 0l-.79.8c-.2.2-.51.2-.71 0l-.79-.8c-.2-.2-.51-.2-.71 0l-.79.8c-.2.2-.51.2-.71 0l-.79-.8A.5.5 0 003 2.21V21.8c.13 0 .26-.05.35-.15l.79-.79c.2-.2.51-.2.71 0l.79.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l.79.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l.79.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l.79.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l.79.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l.79.79c.1.1.23.15.35.15V2.21zM17 17H7c-.55 0-1-.45-1-1s.45-1 1-1h10c.55 0 1 .45 1 1s-.45 1-1 1zm0-4H7c-.55 0-1-.45-1-1s.45-1 1-1h10c.55 0 1 .45 1 1s-.45 1-1 1zm0-4H7c-.55 0-1-.45-1-1s.45-1 1-1h10c.55 0 1 .45 1 1s-.45 1-1 1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M21 2.21a.47.47 0 00-.35.15l-.79.79c-.2.2-.51.2-.71 0l-.79-.79c-.2-.2-.51-.2-.71 0l-.79.79c-.2.2-.51.2-.71 0l-.79-.79c-.2-.2-.51-.2-.71 0l-.79.79c-.2.2-.51.2-.71 0l-.79-.79c-.2-.2-.51-.2-.71 0l-.79.79c-.2.2-.51.2-.71 0l-.8-.8c-.2-.2-.51-.2-.71 0l-.79.8c-.2.2-.51.2-.71 0l-.79-.8c-.2-.2-.51-.2-.71 0l-.79.8c-.2.2-.51.2-.71 0l-.79-.8A.5.5 0 003 2.21V21.8c.13 0 .26-.05.35-.15l.79-.79c.2-.2.51-.2.71 0l.79.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l.79.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l.79.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l.79.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l.79.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l.79.79c.1.1.23.15.35.15V2.21zM17 17H7c-.55 0-1-.45-1-1s.45-1 1-1h10c.55 0 1 .45 1 1s-.45 1-1 1zm0-4H7c-.55 0-1-.45-1-1s.45-1 1-1h10c.55 0 1 .45 1 1s-.45 1-1 1zm0-4H7c-.55 0-1-.45-1-1s.45-1 1-1h10c.55 0 1 .45 1 1s-.45 1-1 1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const ReceiptIcon = createStyledIcon(Icon);
+export const ReceiptIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 ReceiptIcon.displayName = 'ReceiptIcon';

--- a/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M7 12c0 .55.45 1 1 1h8c.55 0 1-.45 1-1s-.45-1-1-1H8c-.55 0-1 .45-1 1zm5-10C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M7 12c0 .55.45 1 1 1h8c.55 0 1-.45 1-1s-.45-1-1-1H8c-.55 0-1 .45-1 1zm5-10C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const RemoveCircleOutlineIcon = createStyledIcon(Icon);
+export const RemoveCircleOutlineIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 RemoveCircleOutlineIcon.displayName = 'RemoveCircleOutlineIcon';

--- a/packages/big-design-icons/src/components/RemoveIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M18 13H6c-.55 0-1-.45-1-1s.45-1 1-1h12c.55 0 1 .45 1 1s-.45 1-1 1z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M18 13H6c-.55 0-1-.45-1-1s.45-1 1-1h12c.55 0 1 .45 1 1s-.45 1-1 1z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const RemoveIcon = createStyledIcon(Icon);
+export const RemoveIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 RemoveIcon.displayName = 'RemoveIcon';

--- a/packages/big-design-icons/src/components/RestoreIcon.tsx
+++ b/packages/big-design-icons/src/components/RestoreIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M13.25 3a9.003 9.003 0 00-9.26 9H2.2c-.45 0-.67.54-.35.85l2.79 2.8c.2.2.51.2.71 0l2.79-2.8c.32-.31.09-.85-.35-.85h-1.8c0-3.9 3.18-7.05 7.1-7 3.72.05 6.85 3.18 6.9 6.9.05 3.91-3.1 7.1-7 7.1-1.61 0-3.1-.55-4.28-1.48a.994.994 0 00-1.32.08c-.42.43-.39 1.13.08 1.5a8.931 8.931 0 005.52 1.9c5.05 0 9.14-4.17 9-9.26-.13-4.69-4.05-8.61-8.74-8.74zm-.51 5c-.41 0-.75.34-.75.75v3.68c0 .35.19.68.49.86l3.12 1.85c.36.21.82.09 1.03-.26.21-.36.09-.82-.26-1.03l-2.88-1.71v-3.4c0-.4-.33-.74-.75-.74z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M13.25 3a9.003 9.003 0 00-9.26 9H2.2c-.45 0-.67.54-.35.85l2.79 2.8c.2.2.51.2.71 0l2.79-2.8c.32-.31.09-.85-.35-.85h-1.8c0-3.9 3.18-7.05 7.1-7 3.72.05 6.85 3.18 6.9 6.9.05 3.91-3.1 7.1-7 7.1-1.61 0-3.1-.55-4.28-1.48a.994.994 0 00-1.32.08c-.42.43-.39 1.13.08 1.5a8.931 8.931 0 005.52 1.9c5.05 0 9.14-4.17 9-9.26-.13-4.69-4.05-8.61-8.74-8.74zm-.51 5c-.41 0-.75.34-.75.75v3.68c0 .35.19.68.49.86l3.12 1.85c.36.21.82.09 1.03-.26.21-.36.09-.82-.26-1.03l-2.88-1.71v-3.4c0-.4-.33-.74-.75-.74z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const RestoreIcon = createStyledIcon(Icon);
+export const RestoreIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 RestoreIcon.displayName = 'RestoreIcon';

--- a/packages/big-design-icons/src/components/SearchIcon.tsx
+++ b/packages/big-design-icons/src/components/SearchIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 001.48-5.34c-.47-2.78-2.79-5-5.59-5.34a6.505 6.505 0 00-7.27 7.27c.34 2.8 2.56 5.12 5.34 5.59a6.5 6.5 0 005.34-1.48l.27.28v.79l4.25 4.25c.41.41 1.08.41 1.49 0 .41-.41.41-1.08 0-1.49L15.5 14zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 001.48-5.34c-.47-2.78-2.79-5-5.59-5.34a6.505 6.505 0 00-7.27 7.27c.34 2.8 2.56 5.12 5.34 5.59a6.5 6.5 0 005.34-1.48l.27.28v.79l4.25 4.25c.41.41 1.08.41 1.49 0 .41-.41.41-1.08 0-1.49L15.5 14zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const SearchIcon = createStyledIcon(Icon);
+export const SearchIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 SearchIcon.displayName = 'SearchIcon';

--- a/packages/big-design-icons/src/components/SettingsIcon.tsx
+++ b/packages/big-design-icons/src/components/SettingsIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M19.43 12.98c.04-.32.07-.64.07-.98s-.03-.66-.07-.98l2.11-1.65c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.3-.61-.22l-2.49 1c-.52-.4-1.08-.73-1.69-.98l-.38-2.65A.488.488 0 0014 2h-4c-.25 0-.46.18-.49.42l-.38 2.65c-.61.25-1.17.59-1.69.98l-2.49-1c-.23-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64l2.11 1.65c-.04.32-.07.65-.07.98s.03.66.07.98l-2.11 1.65c-.19.15-.24.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1c.52.4 1.08.73 1.69.98l.38 2.65c.03.24.24.42.49.42h4c.25 0 .46-.18.49-.42l.38-2.65c.61-.25 1.17-.59 1.69-.98l2.49 1c.23.09.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.65zM12 15.5c-1.93 0-3.5-1.57-3.5-3.5s1.57-3.5 3.5-3.5 3.5 1.57 3.5 3.5-1.57 3.5-3.5 3.5z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M19.43 12.98c.04-.32.07-.64.07-.98s-.03-.66-.07-.98l2.11-1.65c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.3-.61-.22l-2.49 1c-.52-.4-1.08-.73-1.69-.98l-.38-2.65A.488.488 0 0014 2h-4c-.25 0-.46.18-.49.42l-.38 2.65c-.61.25-1.17.59-1.69.98l-2.49-1c-.23-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64l2.11 1.65c-.04.32-.07.65-.07.98s.03.66.07.98l-2.11 1.65c-.19.15-.24.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1c.52.4 1.08.73 1.69.98l.38 2.65c.03.24.24.42.49.42h4c.25 0 .46-.18.49-.42l.38-2.65c.61-.25 1.17-.59 1.69-.98l2.49 1c.23.09.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.65zM12 15.5c-1.93 0-3.5-1.57-3.5-3.5s1.57-3.5 3.5-3.5 3.5 1.57 3.5 3.5-1.57 3.5-3.5 3.5z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const SettingsIcon = createStyledIcon(Icon);
+export const SettingsIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 SettingsIcon.displayName = 'SettingsIcon';

--- a/packages/big-design-icons/src/components/StarBorderIcon.tsx
+++ b/packages/big-design-icons/src/components/StarBorderIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M19.65 9.04l-4.84-.42-1.89-4.45c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08l4.15-2.5 4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.73 3.67-3.18c.67-.58.32-1.68-.56-1.75zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M19.65 9.04l-4.84-.42-1.89-4.45c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08l4.15-2.5 4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.73 3.67-3.18c.67-.58.32-1.68-.56-1.75zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const StarBorderIcon = createStyledIcon(Icon);
+export const StarBorderIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 StarBorderIcon.displayName = 'StarBorderIcon';

--- a/packages/big-design-icons/src/components/StarHalfIcon.tsx
+++ b/packages/big-design-icons/src/components/StarHalfIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0z" />
-    <path d="M19.65 9.04l-4.84-.42-1.89-4.45c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08l4.15-2.5 4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.73 3.67-3.18c.67-.58.32-1.68-.56-1.75zM12 15.4V6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0z" />
+      <path d="M19.65 9.04l-4.84-.42-1.89-4.45c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08l4.15-2.5 4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.73 3.67-3.18c.67-.58.32-1.68-.56-1.75zM12 15.4V6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const StarHalfIcon = createStyledIcon(Icon);
+export const StarHalfIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 StarHalfIcon.displayName = 'StarHalfIcon';

--- a/packages/big-design-icons/src/components/StarIcon.tsx
+++ b/packages/big-design-icons/src/components/StarIcon.tsx
@@ -3,15 +3,34 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path d="M12 17.27l4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.72 3.67-3.18c.67-.58.31-1.68-.57-1.75l-4.83-.41-1.89-4.46c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08l4.15-2.5z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path d="M12 17.27l4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.72 3.67-3.18c.67-.58.31-1.68-.57-1.75l-4.83-.41-1.89-4.46c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08l4.15-2.5z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const StarIcon = createStyledIcon(Icon);
+export const StarIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 StarIcon.displayName = 'StarIcon';

--- a/packages/big-design-icons/src/components/StoreIcon.tsx
+++ b/packages/big-design-icons/src/components/StoreIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M5 6h14c.55 0 1-.45 1-1s-.45-1-1-1H5c-.55 0-1 .45-1 1s.45 1 1 1zm15.16 1.8c-.09-.46-.5-.8-.98-.8H4.82c-.48 0-.89.34-.98.8l-1 5c-.12.62.35 1.2.98 1.2H4v5c0 .55.45 1 1 1h8c.55 0 1-.45 1-1v-5h4v5c0 .55.45 1 1 1s1-.45 1-1v-5h.18c.63 0 1.1-.58.98-1.2l-1-5zM12 18H6v-4h6v4z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M5 6h14c.55 0 1-.45 1-1s-.45-1-1-1H5c-.55 0-1 .45-1 1s.45 1 1 1zm15.16 1.8c-.09-.46-.5-.8-.98-.8H4.82c-.48 0-.89.34-.98.8l-1 5c-.12.62.35 1.2.98 1.2H4v5c0 .55.45 1 1 1h8c.55 0 1-.45 1-1v-5h4v5c0 .55.45 1 1 1s1-.45 1-1v-5h.18c.63 0 1.1-.58.98-1.2l-1-5zM12 18H6v-4h6v4z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const StoreIcon = createStyledIcon(Icon);
+export const StoreIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 StoreIcon.displayName = 'StoreIcon';

--- a/packages/big-design-icons/src/components/VisibilityIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M12 4C7 4 2.73 7.11 1 11.5 2.73 15.89 7 19 12 19s9.27-3.11 11-7.5C21.27 7.11 17 4 12 4zm0 12.5c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0z" />
+      <path d="M12 4C7 4 2.73 7.11 1 11.5 2.73 15.89 7 19 12 19s9.27-3.11 11-7.5C21.27 7.11 17 4 12 4zm0 12.5c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const VisibilityIcon = createStyledIcon(Icon);
+export const VisibilityIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 VisibilityIcon.displayName = 'VisibilityIcon';

--- a/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
@@ -3,16 +3,35 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0zm0 0h24v24H0V0zm0 0h24v24H0V0z" />
-    <path d="M12 6.5c2.76 0 5 2.24 5 5 0 .51-.1 1-.24 1.46l3.06 3.06c1.39-1.23 2.49-2.77 3.18-4.53C21.27 7.11 17 4 12 4c-1.27 0-2.49.2-3.64.57l2.17 2.17c.47-.14.96-.24 1.47-.24zM2.71 3.16a.996.996 0 000 1.41l1.97 1.97A11.892 11.892 0 001 11.5C2.73 15.89 7 19 12 19c1.52 0 2.97-.3 4.31-.82l2.72 2.72a.996.996 0 101.41-1.41L4.13 3.16c-.39-.39-1.03-.39-1.42 0zM12 16.5c-2.76 0-5-2.24-5-5 0-.77.18-1.5.49-2.14l1.57 1.57c-.03.18-.06.37-.06.57 0 1.66 1.34 3 3 3 .2 0 .38-.03.57-.07L14.14 16c-.65.32-1.37.5-2.14.5zm2.97-5.33a2.97 2.97 0 00-2.64-2.64l2.64 2.64z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0zm0 0h24v24H0V0zm0 0h24v24H0V0z" />
+      <path d="M12 6.5c2.76 0 5 2.24 5 5 0 .51-.1 1-.24 1.46l3.06 3.06c1.39-1.23 2.49-2.77 3.18-4.53C21.27 7.11 17 4 12 4c-1.27 0-2.49.2-3.64.57l2.17 2.17c.47-.14.96-.24 1.47-.24zM2.71 3.16a.996.996 0 000 1.41l1.97 1.97A11.892 11.892 0 001 11.5C2.73 15.89 7 19 12 19c1.52 0 2.97-.3 4.31-.82l2.72 2.72a.996.996 0 101.41-1.41L4.13 3.16c-.39-.39-1.03-.39-1.42 0zM12 16.5c-2.76 0-5-2.24-5-5 0-.77.18-1.5.49-2.14l1.57 1.57c-.03.18-.06.37-.06.57 0 1.66 1.34 3 3 3 .2 0 .38-.03.57-.07L14.14 16c-.65.32-1.37.5-2.14.5zm2.97-5.33a2.97 2.97 0 00-2.64-2.64l2.64 2.64z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const VisibilityOffIcon = createStyledIcon(Icon);
+export const VisibilityOffIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 VisibilityOffIcon.displayName = 'VisibilityOffIcon';

--- a/packages/big-design-icons/src/components/WarningIcon.tsx
+++ b/packages/big-design-icons/src/components/WarningIcon.tsx
@@ -3,15 +3,34 @@
 // **********************************
 import React from 'react';
 
-import { createStyledIcon, IconProps } from '../base';
+import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { useUniqueId } from '../utils';
 
-const Icon = React.memo<Partial<IconProps>>(({ title, theme, ...props }) => (
-  <svg width={24} height={24} viewBox="0 0 24 24" stroke="currentColor" fill="currentColor" strokeWidth="0" {...props}>
-    {title ? <title>{title}</title> : null}
-    <path d="M4.47 21h15.06c1.54 0 2.5-1.67 1.73-3L13.73 4.99c-.77-1.33-2.69-1.33-3.46 0L2.74 18c-.77 1.33.19 3 1.73 3zM12 14c-.55 0-1-.45-1-1v-2c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1zm1 4h-2v-2h2v2z" />
-  </svg>
+const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
+  const titleId = useUniqueId('icon');
+
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path d="M4.47 21h15.06c1.54 0 2.5-1.67 1.73-3L13.73 4.99c-.77-1.33-2.69-1.33-3.46 0L2.74 18c-.77 1.33.19 3 1.73 3zM12 14c-.55 0-1-.45-1-1v-2c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1zm1 4h-2v-2h2v2z" />
+    </svg>
+  );
+};
+
+const IconWithForwardedRef = React.forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
-export const WarningIcon = createStyledIcon(Icon);
+export const WarningIcon = React.memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));
 
 WarningIcon.displayName = 'WarningIcon';

--- a/packages/big-design-icons/src/index.ts
+++ b/packages/big-design-icons/src/index.ts
@@ -1,2 +1,6 @@
+import { IconProps as _IconProps } from './base';
+
 export * from './components';
-export * from './base';
+export * from './utils';
+export { createStyledIcon } from './base';
+export type IconProps = _IconProps;

--- a/packages/big-design-icons/src/utils/index.ts
+++ b/packages/big-design-icons/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './useUniqueId';

--- a/packages/big-design-icons/src/utils/useUniqueId.ts
+++ b/packages/big-design-icons/src/utils/useUniqueId.ts
@@ -1,0 +1,7 @@
+import { useUID } from 'react-uid';
+
+export function useUniqueId(prefix: string) {
+  const uid = useUID();
+
+  return `bd-${prefix}-${uid}`;
+}

--- a/packages/big-design/jest.config.js
+++ b/packages/big-design/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: {
     '@src/(.*)': '<rootDir>/src/$1',
+    '@test/utils': '<rootDir>/tests/utils',
   },
   coverageDirectory: '<rootDir>/coverage',
   setupFilesAfterEnv: ['<rootDir>/setupTests.ts', '@testing-library/react/cleanup-after-each'],

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -50,6 +50,7 @@
     "hoist-non-react-statics": "^3.3.0",
     "polished": "^3.0.3",
     "react-popper": "^1.3.6",
+    "react-uid": "^2.2.0",
     "scroll-into-view-if-needed": "^2.2.20"
   },
   "peerDependencies": {

--- a/packages/big-design/src/components/Badge/spec.tsx
+++ b/packages/big-design/src/components/Badge/spec.tsx
@@ -1,5 +1,5 @@
 import { theme } from '@bigcommerce/big-design-theme';
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Box/spec.tsx
+++ b/packages/big-design/src/components/Box/spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
@@ -606,6 +606,7 @@ exports[`render icon left and right button 1`] = `
     class="c1"
   >
     <svg
+      aria-labelledby="bd-icon-1"
       class="c2"
       fill="currentColor"
       height="24"
@@ -624,6 +625,7 @@ exports[`render icon left and right button 1`] = `
     </svg>
     Button
     <svg
+      aria-labelledby="bd-icon-2"
       class="c2"
       fill="currentColor"
       height="24"
@@ -767,6 +769,7 @@ exports[`render icon left button 1`] = `
     class="c1"
   >
     <svg
+      aria-labelledby="bd-icon-1"
       class="c2"
       fill="currentColor"
       height="24"
@@ -911,6 +914,7 @@ exports[`render icon only button 1`] = `
     class="c1"
   >
     <svg
+      aria-labelledby="bd-icon-1"
       class="c2"
       fill="currentColor"
       height="24"
@@ -1055,6 +1059,7 @@ exports[`render icon right button 1`] = `
   >
     Button
     <svg
+      aria-labelledby="bd-icon-1"
       class="c2"
       fill="currentColor"
       height="24"

--- a/packages/big-design/src/components/Button/spec.tsx
+++ b/packages/big-design/src/components/Button/spec.tsx
@@ -1,5 +1,5 @@
 import { AddIcon } from '@bigcommerce/big-design-icons';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -106,6 +106,7 @@ exports[`render Checkbox checked 1`] = `
     for="checkBox_0"
   >
     <svg
+      aria-labelledby="bd-icon-1"
       class="c4"
       fill="currentColor"
       height="24"
@@ -250,6 +251,7 @@ exports[`render Checkbox disabled checked 1`] = `
     for="checkBox_0"
   >
     <svg
+      aria-labelledby="bd-icon-1"
       class="c4"
       fill="currentColor"
       height="24"
@@ -399,6 +401,7 @@ exports[`render Checkbox disabled indeterminate 1`] = `
     for="checkBox_0"
   >
     <svg
+      aria-labelledby="bd-icon-1"
       class="c4"
       fill="currentColor"
       height="24"
@@ -548,6 +551,7 @@ exports[`render Checkbox disabled unchecked 1`] = `
     for="checkBox_0"
   >
     <svg
+      aria-labelledby="bd-icon-1"
       class="c4"
       fill="currentColor"
       height="24"
@@ -686,6 +690,7 @@ exports[`render Checkbox indeterminate 1`] = `
     for="checkBox_0"
   >
     <svg
+      aria-labelledby="bd-icon-1"
       class="c4"
       fill="currentColor"
       height="24"
@@ -822,6 +827,7 @@ exports[`render Checkbox unchecked 1`] = `
     for="checkBox_0"
   >
     <svg
+      aria-labelledby="bd-icon-1"
       class="c4"
       fill="currentColor"
       height="24"

--- a/packages/big-design/src/components/Checkbox/spec.tsx
+++ b/packages/big-design/src/components/Checkbox/spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
@@ -178,6 +178,7 @@ exports[`renders with close button if onRemove is present 1`] = `
       class="c5"
     >
       <svg
+        aria-labelledby="bd-icon-1"
         class="c6"
         fill="currentColor"
         height="24"
@@ -186,7 +187,9 @@ exports[`renders with close button if onRemove is present 1`] = `
         viewBox="0 0 24 24"
         width="24"
       >
-        <title>
+        <title
+          id="bd-icon-1"
+        >
           Delete
         </title>
         <path

--- a/packages/big-design/src/components/Chip/spec.tsx
+++ b/packages/big-design/src/components/Chip/spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -1,5 +1,5 @@
 import { CheckCircleIcon } from '@bigcommerce/big-design-icons';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Flex/spec.tsx
+++ b/packages/big-design/src/components/Flex/spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Form/Fieldset/spec.tsx
+++ b/packages/big-design/src/components/Form/Fieldset/spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Form/Group/spec.tsx
+++ b/packages/big-design/src/components/Form/Group/spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Form/Label/spec.tsx
+++ b/packages/big-design/src/components/Form/Label/spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Form/spec.tsx
+++ b/packages/big-design/src/components/Form/spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Grid/spec.tsx
+++ b/packages/big-design/src/components/Grid/spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -156,6 +156,7 @@ exports[`renders all together 1`] = `
       class="c3"
     >
       <svg
+        aria-labelledby="bd-icon-1"
         class="c4"
         data-testid="icon-left"
         fill="currentColor"
@@ -186,6 +187,7 @@ exports[`renders all together 1`] = `
       class="c3"
     >
       <svg
+        aria-labelledby="bd-icon-2"
         class="c4"
         data-testid="icon-right"
         fill="currentColor"

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -1,5 +1,5 @@
 import { AddIcon } from '@bigcommerce/big-design-icons';
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Link/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Link/__snapshots__/spec.tsx.snap
@@ -82,6 +82,7 @@ exports[`renders with external icon 1`] = `
     Link
   </span>
   <svg
+    aria-labelledby="bd-icon-1"
     class="c1"
     fill="currentColor"
     height="24"

--- a/packages/big-design/src/components/Link/spec.tsx
+++ b/packages/big-design/src/components/Link/spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -246,6 +246,7 @@ exports[`render open modal 1`] = `
               class="c6"
             >
               <svg
+                aria-labelledby="bd-icon-1"
                 class="c7"
                 fill="currentColor"
                 height="24"
@@ -254,7 +255,9 @@ exports[`render open modal 1`] = `
                 viewBox="0 0 24 24"
                 width="24"
               >
-                <title>
+                <title
+                  id="bd-icon-1"
+                >
                   Close
                 </title>
                 <path
@@ -515,6 +518,7 @@ exports[`render open modal without backdrop 1`] = `
               class="c6"
             >
               <svg
+                aria-labelledby="bd-icon-1"
                 class="c7"
                 fill="currentColor"
                 height="24"
@@ -523,7 +527,9 @@ exports[`render open modal without backdrop 1`] = `
                 viewBox="0 0 24 24"
                 width="24"
               >
-                <title>
+                <title
+                  id="bd-icon-1"
+                >
                   Close
                 </title>
                 <path

--- a/packages/big-design/src/components/Modal/spec.tsx
+++ b/packages/big-design/src/components/Modal/spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, wait } from '@testing-library/react';
+import { fireEvent, render, wait } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -380,6 +380,7 @@ exports[`render pagination component 1`] = `
       >
         1 - 3 of 10
         <svg
+          aria-labelledby="bd-icon-1"
           class="c6"
           fill="currentColor"
           height="24"
@@ -460,6 +461,7 @@ exports[`render pagination component 1`] = `
         class="c5"
       >
         <svg
+          aria-labelledby="bd-icon-2"
           class="c11"
           fill="currentColor"
           height="24"
@@ -468,7 +470,9 @@ exports[`render pagination component 1`] = `
           viewBox="0 0 24 24"
           width="24"
         >
-          <title>
+          <title
+            id="bd-icon-2"
+          >
             Previous page
           </title>
           <path
@@ -490,6 +494,7 @@ exports[`render pagination component 1`] = `
         class="c5"
       >
         <svg
+          aria-labelledby="bd-icon-3"
           class="c11"
           fill="currentColor"
           height="24"
@@ -498,7 +503,9 @@ exports[`render pagination component 1`] = `
           viewBox="0 0 24 24"
           width="24"
         >
-          <title>
+          <title
+            id="bd-icon-3"
+          >
             Next page
           </title>
           <path
@@ -895,6 +902,7 @@ exports[`render pagination component with invalid page info 1`] = `
       >
         -8 - -6 of 10
         <svg
+          aria-labelledby="bd-icon-1"
           class="c6"
           fill="currentColor"
           height="24"
@@ -975,6 +983,7 @@ exports[`render pagination component with invalid page info 1`] = `
         class="c5"
       >
         <svg
+          aria-labelledby="bd-icon-2"
           class="c11"
           fill="currentColor"
           height="24"
@@ -983,7 +992,9 @@ exports[`render pagination component with invalid page info 1`] = `
           viewBox="0 0 24 24"
           width="24"
         >
-          <title>
+          <title
+            id="bd-icon-2"
+          >
             Previous page
           </title>
           <path
@@ -1005,6 +1016,7 @@ exports[`render pagination component with invalid page info 1`] = `
         class="c5"
       >
         <svg
+          aria-labelledby="bd-icon-3"
           class="c11"
           fill="currentColor"
           height="24"
@@ -1013,7 +1025,9 @@ exports[`render pagination component with invalid page info 1`] = `
           viewBox="0 0 24 24"
           width="24"
         >
-          <title>
+          <title
+            id="bd-icon-3"
+          >
             Next page
           </title>
           <path
@@ -1410,6 +1424,7 @@ exports[`render pagination component with invalid range info 1`] = `
       >
         1 - -5 of 10
         <svg
+          aria-labelledby="bd-icon-1"
           class="c6"
           fill="currentColor"
           height="24"
@@ -1490,6 +1505,7 @@ exports[`render pagination component with invalid range info 1`] = `
         class="c5"
       >
         <svg
+          aria-labelledby="bd-icon-2"
           class="c11"
           fill="currentColor"
           height="24"
@@ -1498,7 +1514,9 @@ exports[`render pagination component with invalid range info 1`] = `
           viewBox="0 0 24 24"
           width="24"
         >
-          <title>
+          <title
+            id="bd-icon-2"
+          >
             Previous page
           </title>
           <path
@@ -1521,6 +1539,7 @@ exports[`render pagination component with invalid range info 1`] = `
         class="c5"
       >
         <svg
+          aria-labelledby="bd-icon-3"
           class="c11"
           fill="currentColor"
           height="24"
@@ -1529,7 +1548,9 @@ exports[`render pagination component with invalid range info 1`] = `
           viewBox="0 0 24 24"
           width="24"
         >
-          <title>
+          <title
+            id="bd-icon-3"
+          >
             Next page
           </title>
           <path
@@ -1926,6 +1947,7 @@ exports[`render pagination component with no items 1`] = `
       >
         0 of 0
         <svg
+          aria-labelledby="bd-icon-1"
           class="c6"
           fill="currentColor"
           height="24"
@@ -2006,6 +2028,7 @@ exports[`render pagination component with no items 1`] = `
         class="c5"
       >
         <svg
+          aria-labelledby="bd-icon-2"
           class="c11"
           fill="currentColor"
           height="24"
@@ -2014,7 +2037,9 @@ exports[`render pagination component with no items 1`] = `
           viewBox="0 0 24 24"
           width="24"
         >
-          <title>
+          <title
+            id="bd-icon-2"
+          >
             Previous page
           </title>
           <path
@@ -2037,6 +2062,7 @@ exports[`render pagination component with no items 1`] = `
         class="c5"
       >
         <svg
+          aria-labelledby="bd-icon-3"
           class="c11"
           fill="currentColor"
           height="24"
@@ -2045,7 +2071,9 @@ exports[`render pagination component with no items 1`] = `
           viewBox="0 0 24 24"
           width="24"
         >
-          <title>
+          <title
+            id="bd-icon-3"
+          >
             Next page
           </title>
           <path

--- a/packages/big-design/src/components/Pagination/spec.tsx
+++ b/packages/big-design/src/components/Pagination/spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Panel/spec.tsx
+++ b/packages/big-design/src/components/Panel/spec.tsx
@@ -1,5 +1,5 @@
 import { theme } from '@bigcommerce/big-design-theme';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/ProgressBar/spec.tsx
+++ b/packages/big-design/src/components/ProgressBar/spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`render completed determinant progress circle 1`] = `
 
 <div>
   <svg
+    aria-labelledby="bd-icon-1"
     aria-valuemax="100"
     aria-valuemin="0"
     aria-valuenow="100"
@@ -113,6 +114,7 @@ exports[`render error determinant progress circle 1`] = `
 
 <div>
   <svg
+    aria-labelledby="bd-icon-1"
     aria-valuemax="100"
     aria-valuemin="0"
     aria-valuenow="0"

--- a/packages/big-design/src/components/ProgressCircle/spec.tsx
+++ b/packages/big-design/src/components/ProgressCircle/spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Radio/spec.tsx
+++ b/packages/big-design/src/components/Radio/spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Select/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Select/__snapshots__/spec.tsx.snap
@@ -67,6 +67,7 @@ exports[`select action supports actionTypes 1`] = `
     class="c2 c3"
   >
     <svg
+      aria-labelledby="bd-icon-3"
       class="c4"
       color="danger50"
       fill="currentColor"
@@ -216,6 +217,7 @@ exports[`select action supports icons 1`] = `
         class="c4 c5"
       >
         <svg
+          aria-labelledby="bd-icon-3"
           class="c6"
           color="secondary60"
           fill="currentColor"

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -1,5 +1,5 @@
 import { DeleteIcon } from '@bigcommerce/big-design-icons';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -430,6 +430,7 @@ exports[`renders a pagination component 1`] = `
           >
             1 - 3 of 5
             <svg
+              aria-labelledby="bd-icon-1"
               class="c9"
               fill="currentColor"
               height="24"
@@ -510,6 +511,7 @@ exports[`renders a pagination component 1`] = `
             class="c8"
           >
             <svg
+              aria-labelledby="bd-icon-2"
               class="c14"
               fill="currentColor"
               height="24"
@@ -518,7 +520,9 @@ exports[`renders a pagination component 1`] = `
               viewBox="0 0 24 24"
               width="24"
             >
-              <title>
+              <title
+                id="bd-icon-2"
+              >
                 Previous page
               </title>
               <path
@@ -540,6 +544,7 @@ exports[`renders a pagination component 1`] = `
             class="c8"
           >
             <svg
+              aria-labelledby="bd-icon-3"
               class="c14"
               fill="currentColor"
               height="24"
@@ -548,7 +553,9 @@ exports[`renders a pagination component 1`] = `
               viewBox="0 0 24 24"
               width="24"
             >
-              <title>
+              <title
+                id="bd-icon-3"
+              >
                 Next page
               </title>
               <path
@@ -1012,6 +1019,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
           for="checkBox_1"
         >
           <svg
+            aria-labelledby="bd-icon-1"
             class="c9"
             fill="currentColor"
             height="24"

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React, { CSSProperties } from 'react';
 

--- a/packages/big-design/src/components/Tabs/spec.tsx
+++ b/packages/big-design/src/components/Tabs/spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Textarea/spec.tsx
+++ b/packages/big-design/src/components/Textarea/spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/components/Typography/spec.tsx
+++ b/packages/big-design/src/components/Typography/spec.tsx
@@ -1,5 +1,5 @@
 import { theme } from '@bigcommerce/big-design-theme';
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 

--- a/packages/big-design/src/mixins/display/spec.tsx
+++ b/packages/big-design/src/mixins/display/spec.tsx
@@ -1,5 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 import styled from 'styled-components';

--- a/packages/big-design/src/mixins/margins/spec.tsx
+++ b/packages/big-design/src/mixins/margins/spec.tsx
@@ -1,5 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 import styled from 'styled-components';

--- a/packages/big-design/src/mixins/paddings/spec.tsx
+++ b/packages/big-design/src/mixins/paddings/spec.tsx
@@ -1,5 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 import styled from 'styled-components';

--- a/packages/big-design/tests/utils.tsx
+++ b/packages/big-design/tests/utils.tsx
@@ -1,0 +1,16 @@
+import { render, RenderOptions } from '@testing-library/react';
+import React from 'react';
+import { UIDReset } from 'react-uid';
+
+const BigDesignWrapper: React.FC = ({ children }) => {
+  return <UIDReset>{children}</UIDReset>;
+};
+
+const customRender = (ui: React.ReactElement<any>, options: RenderOptions = {}) =>
+  render(ui, { wrapper: BigDesignWrapper, ...options });
+
+// re-export everything
+export * from '@testing-library/react';
+
+// override render method
+export { customRender as render };

--- a/packages/big-design/tsconfig.json
+++ b/packages/big-design/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "./tsconfig.base.json",
-  "include": ["src", "src/**/__tests__", "setupTests.ts"],
-  "exclude": ["dist"]
+  "include": ["src", "src/**/__tests__", "setupTests.ts", "tests"],
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@test/utils": ["../tests/utils"]
+    }
+  }
 }

--- a/packages/docs/PropTables/IconPropTable.tsx
+++ b/packages/docs/PropTables/IconPropTable.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 
-import { NextLink, PropTable, PropTableWrapper } from '../components';
+import { NextLink, Prop, PropTable, PropTableWrapper } from '../components';
 
-const iconProps = [
+const iconProps: Prop[] = [
+  {
+    name: 'title',
+    types: 'string',
+    description: 'SVG Title, for accessibility purposes.',
+  },
   {
     name: 'color',
     types: (

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -41,6 +41,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-live": "^2.2.0",
+    "react-uid": "^2.2.0",
     "styled-components": "^4.3.0"
   },
   "devDependencies": {

--- a/packages/docs/pages/_app.tsx
+++ b/packages/docs/pages/_app.tsx
@@ -4,6 +4,7 @@ import App from 'next/app';
 import Head from 'next/head';
 import { default as Router } from 'next/router';
 import React from 'react';
+import { UIDFork, UIDReset } from 'react-uid';
 import { ThemeProvider } from 'styled-components';
 
 import { BetaRibbon, SideNav, StoryWrapper } from '../components';
@@ -46,38 +47,42 @@ export default class MyApp extends App {
             }
           `}
         </style>
-        <ThemeProvider theme={theme}>
-          <>
-            <GlobalStyles />
-            {router.query.noNav ? (
-              <Component {...pageProps} />
-            ) : (
+        <UIDReset>
+          <UIDFork>
+            <ThemeProvider theme={theme}>
               <>
-                <Grid
-                  gridTemplate={gridTemplate}
-                  backgroundColor="secondary10"
-                  gridGap="0"
-                  style={{ minHeight: '100%' }}
-                >
-                  <Grid.Item gridArea="nav">
-                    <SideNav />
-                  </Grid.Item>
-                  <Grid.Item
-                    gridArea="main"
-                    marginVertical="medium"
-                    marginHorizontal={{ mobile: 'none', tablet: 'xxLarge' }}
-                    style={{ maxWidth: '100%' }}
-                  >
-                    <StoryWrapper>
-                      <Component {...pageProps} />
-                    </StoryWrapper>
-                  </Grid.Item>
-                </Grid>
-                <BetaRibbon />
+                <GlobalStyles />
+                {router.query.noNav ? (
+                  <Component {...pageProps} />
+                ) : (
+                  <>
+                    <Grid
+                      gridTemplate={gridTemplate}
+                      backgroundColor="secondary10"
+                      gridGap="0"
+                      style={{ minHeight: '100%' }}
+                    >
+                      <Grid.Item gridArea="nav">
+                        <SideNav />
+                      </Grid.Item>
+                      <Grid.Item
+                        gridArea="main"
+                        marginVertical="medium"
+                        marginHorizontal={{ mobile: 'none', tablet: 'xxLarge' }}
+                        style={{ maxWidth: '100%' }}
+                      >
+                        <StoryWrapper>
+                          <Component {...pageProps} />
+                        </StoryWrapper>
+                      </Grid.Item>
+                    </Grid>
+                    <BetaRibbon />
+                  </>
+                )}
               </>
-            )}
-          </>
-        </ThemeProvider>
+            </ThemeProvider>
+          </UIDFork>
+        </UIDReset>
       </>
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,7 +76,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.4.5", "@babel/core@^7.7.0":
+"@babel/core@^7.1.0", "@babel/core@^7.7.0":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.4.tgz#37e864532200cb6b50ee9a4045f5f817840166ab"
   integrity sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==
@@ -116,6 +116,26 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.7.5":
+  version "7.7.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.7.tgz#ee155d2e12300bcc0cff6a8ad46f2af5063803e9"
+  integrity sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.7.7"
+    "@babel/helpers" "^7.7.4"
+    "@babel/parser" "^7.7.7"
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.4.0", "@babel/generator@^7.4.4", "@babel/generator@^7.6.4", "@babel/generator@^7.7.0", "@babel/generator@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.4.tgz#db651e2840ca9aa66f327dcec1dc5f5fa9611369"
@@ -132,6 +152,16 @@
   integrity sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==
   dependencies:
     "@babel/types" "^7.7.2"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.7.7":
+  version "7.7.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.7.tgz#859ac733c44c74148e1a72980a64ec84b85f4f45"
+  integrity sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==
+  dependencies:
+    "@babel/types" "^7.7.4"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -346,6 +376,11 @@
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.3.tgz#5fad457c2529de476a248f75b0f090b3060af043"
   integrity sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==
+
+"@babel/parser@^7.7.7":
+  version "7.7.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.7.tgz#1b886595419cf92d811316d5b715a53ff38b4937"
+  integrity sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0", "@babel/plugin-proposal-async-generator-functions@^7.7.0", "@babel/plugin-proposal-async-generator-functions@^7.7.4":
   version "7.7.4"
@@ -2375,100 +2410,100 @@
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
   integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
-"@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"
-  integrity sha512-j7KnilGyZzYr/jhcrSYS3FGWMZVaqyCG0vzMCwzvei0coIkczuYMcniK07nI0aHJINciujjH11T72ICW5eL5Ig==
+"@svgr/babel-plugin-add-jsx-attribute@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.0.1.tgz#744853b6533e83ce712d41d1873200b3e0a0b6fc"
+  integrity sha512-av76JbSudaN2CUOGuKQp5BVqLFidtojg4ApRTg1PBOVsskXK2ORwKnBYhIu0JLA6ynmuNDprlHNCD6IwLiYidw==
 
-"@svgr/babel-plugin-remove-jsx-attribute@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-4.2.0.tgz#297550b9a8c0c7337bea12bdfc8a80bb66f85abc"
-  integrity sha512-3XHLtJ+HbRCH4n28S7y/yZoEQnRpl0tvTZQsHqvaeNXPra+6vE5tbRliH3ox1yZYPCxrlqaJT/Mg+75GpDKlvQ==
+"@svgr/babel-plugin-remove-jsx-attribute@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.0.1.tgz#5df0ccf99e4745e105f76059025986d4da8443cd"
+  integrity sha512-oXyByaDQEK4Ut/eC75698MDKnaadbWmp/LS2w22cZAaoObCkkiwYYgZTZ+bvb3moo//AxvKkBtNrlz6+xBb9ZQ==
 
-"@svgr/babel-plugin-remove-jsx-empty-expression@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-4.2.0.tgz#c196302f3e68eab6a05e98af9ca8570bc13131c7"
-  integrity sha512-yTr2iLdf6oEuUE9MsRdvt0NmdpMBAkgK8Bjhl6epb+eQWk6abBaX3d65UZ3E3FWaOwePyUgNyNCMVG61gGCQ7w==
+"@svgr/babel-plugin-remove-jsx-empty-expression@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-5.0.1.tgz#25621a8915ed7ad70da6cea3d0a6dbc2ea933efd"
+  integrity sha512-LA72+88A11ND/yFIMzyuLRSMJ+tRKeYKeQ+mR3DcAZ5I4h5CPWN9AHyUzJbWSYp/u2u0xhmgOe0+E41+GjEueA==
 
-"@svgr/babel-plugin-replace-jsx-attribute-value@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.2.0.tgz#310ec0775de808a6a2e4fd4268c245fd734c1165"
-  integrity sha512-U9m870Kqm0ko8beHawRXLGLvSi/ZMrl89gJ5BNcT452fAjtF2p4uRzXkdzvGJJJYBgx7BmqlDjBN/eCp5AAX2w==
+"@svgr/babel-plugin-replace-jsx-attribute-value@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-5.0.1.tgz#0b221fc57f9fcd10e91fe219e2cd0dd03145a897"
+  integrity sha512-PoiE6ZD2Eiy5mK+fjHqwGOS+IXX0wq/YDtNyIgOrc6ejFnxN4b13pRpiIPbtPwHEc+NT2KCjteAcq33/F1Y9KQ==
 
-"@svgr/babel-plugin-svg-dynamic-title@^4.3.3":
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.3.3.tgz#2cdedd747e5b1b29ed4c241e46256aac8110dd93"
-  integrity sha512-w3Be6xUNdwgParsvxkkeZb545VhXEwjGMwExMVBIdPQJeyMQHqm9Msnb2a1teHBqUYL66qtwfhNkbj1iarCG7w==
+"@svgr/babel-plugin-svg-dynamic-title@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.0.1.tgz#221abd28898130c6466b018bf19e905648100c38"
+  integrity sha512-IbFiDBvq5WpANPndjEom1Y9k1pHCNfJs87jCN1Lt8NEA7yrNVPSoAjBVmmfi0aVBERfp8IT/lgjn2a/S85lXGg==
 
-"@svgr/babel-plugin-svg-em-dimensions@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.2.0.tgz#9a94791c9a288108d20a9d2cc64cac820f141391"
-  integrity sha512-C0Uy+BHolCHGOZ8Dnr1zXy/KgpBOkEUYY9kI/HseHVPeMbluaX3CijJr7D4C5uR8zrc1T64nnq/k63ydQuGt4w==
+"@svgr/babel-plugin-svg-em-dimensions@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.0.1.tgz#bd77607634deb1d970dbd8c0b1397b41e28c59dd"
+  integrity sha512-7kL9LtqCm1ca+zAbBsrD4ME3EQeVcRxkdrf2GsbKPgkzWJ+399vS4VqCP462+WvFRbG13jSwpNCrvhekdyvXsA==
 
-"@svgr/babel-plugin-transform-react-native-svg@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.2.0.tgz#151487322843359a1ca86b21a3815fd21a88b717"
-  integrity sha512-7YvynOpZDpCOUoIVlaaOUU87J4Z6RdD6spYN4eUb5tfPoKGSF9OG2NuhgYnq4jSkAxcpMaXWPf1cePkzmqTPNw==
+"@svgr/babel-plugin-transform-react-native-svg@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.0.1.tgz#8c593dcfe17179f5a87734a76c9174aac91d2a2b"
+  integrity sha512-ITG1jJ0zHQ4yft6ISQqlMW4fHIzsrSB/FmrMxAcJtkTjh9M2/9M8wfKxQya9NnTfZ5WMSlQjXMQNZmGQsuxRrw==
 
-"@svgr/babel-plugin-transform-svg-component@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.2.0.tgz#5f1e2f886b2c85c67e76da42f0f6be1b1767b697"
-  integrity sha512-hYfYuZhQPCBVotABsXKSCfel2slf/yvJY8heTVX1PCTaq/IgASq1IyxPPKJ0chWREEKewIU/JMSsIGBtK1KKxw==
+"@svgr/babel-plugin-transform-svg-component@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.0.1.tgz#31c7c7ad82f12ae09df14bbf9e3ac42a694b0f98"
+  integrity sha512-TYJ5L0QJgWqeMnuc8GEVy2jorwj/jp7y/mGLPwJhNrvrtAuVN7wEvc/Dzi1o1krsKKN7h6WpW/w3AQ6Na7qYEw==
 
-"@svgr/babel-preset@^4.3.3":
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-preset/-/babel-preset-4.3.3.tgz#a75d8c2f202ac0e5774e6bfc165d028b39a1316c"
-  integrity sha512-6PG80tdz4eAlYUN3g5GZiUjg2FMcp+Wn6rtnz5WJG9ITGEF1pmFdzq02597Hn0OmnQuCVaBYQE1OVFAnwOl+0A==
+"@svgr/babel-preset@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-preset/-/babel-preset-5.0.1.tgz#16aff48213b83573c2b438457c60a79dc4522e6b"
+  integrity sha512-V2u6rAHLD//0xu+p/Il6laOLfuU5ySpaU1t2HBBXsRp6G9GTTNpAjxUw0iRulfd56AoWcr2j+Fap/J1yz/cx0w==
   dependencies:
-    "@svgr/babel-plugin-add-jsx-attribute" "^4.2.0"
-    "@svgr/babel-plugin-remove-jsx-attribute" "^4.2.0"
-    "@svgr/babel-plugin-remove-jsx-empty-expression" "^4.2.0"
-    "@svgr/babel-plugin-replace-jsx-attribute-value" "^4.2.0"
-    "@svgr/babel-plugin-svg-dynamic-title" "^4.3.3"
-    "@svgr/babel-plugin-svg-em-dimensions" "^4.2.0"
-    "@svgr/babel-plugin-transform-react-native-svg" "^4.2.0"
-    "@svgr/babel-plugin-transform-svg-component" "^4.2.0"
+    "@svgr/babel-plugin-add-jsx-attribute" "^5.0.1"
+    "@svgr/babel-plugin-remove-jsx-attribute" "^5.0.1"
+    "@svgr/babel-plugin-remove-jsx-empty-expression" "^5.0.1"
+    "@svgr/babel-plugin-replace-jsx-attribute-value" "^5.0.1"
+    "@svgr/babel-plugin-svg-dynamic-title" "^5.0.1"
+    "@svgr/babel-plugin-svg-em-dimensions" "^5.0.1"
+    "@svgr/babel-plugin-transform-react-native-svg" "^5.0.1"
+    "@svgr/babel-plugin-transform-svg-component" "^5.0.1"
 
-"@svgr/core@^4.3.2":
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/@svgr/core/-/core-4.3.3.tgz#b37b89d5b757dc66e8c74156d00c368338d24293"
-  integrity sha512-qNuGF1QON1626UCaZamWt5yedpgOytvLj5BQZe2j1k1B8DUG4OyugZyfEwBeXozCUwhLEpsrgPrE+eCu4fY17w==
+"@svgr/core@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/core/-/core-5.0.1.tgz#b7ec46665de21248b650fe94a2325a30b25569a9"
+  integrity sha512-F/HXJpKbN6Cab31ngiSFiUXYV9y+yiJaDaOZuc7Yqzc19+ncIrM+wSKoytjwcwc+Haj8gvEHsPqRX9L4yM1ftA==
   dependencies:
-    "@svgr/plugin-jsx" "^4.3.3"
+    "@svgr/plugin-jsx" "^5.0.1"
     camelcase "^5.3.1"
-    cosmiconfig "^5.2.1"
+    cosmiconfig "^6.0.0"
 
-"@svgr/hast-util-to-babel-ast@^4.3.2":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.3.2.tgz#1d5a082f7b929ef8f1f578950238f630e14532b8"
-  integrity sha512-JioXclZGhFIDL3ddn4Kiq8qEqYM2PyDKV0aYno8+IXTLuYt6TOgHUbUAAFvqtb0Xn37NwP0BTHglejFoYr8RZg==
+"@svgr/hast-util-to-babel-ast@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.0.1.tgz#0dce60a955465f0bd86bcd9c523b21472d6531d3"
+  integrity sha512-G7UHNPNhLyDK5p6RJvSh4TRpHszTxG8jPp5lAxC6Ez6O6rj1plEAjrCDdYj50mvilUuT9IKjqn87F8+agpKaSw==
   dependencies:
     "@babel/types" "^7.4.4"
 
-"@svgr/plugin-jsx@^4.3.2", "@svgr/plugin-jsx@^4.3.3":
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/@svgr/plugin-jsx/-/plugin-jsx-4.3.3.tgz#e2ba913dbdfbe85252a34db101abc7ebd50992fa"
-  integrity sha512-cLOCSpNWQnDB1/v+SUENHH7a0XY09bfuMKdq9+gYvtuwzC2rU4I0wKGFEp1i24holdQdwodCtDQdFtJiTCWc+w==
+"@svgr/plugin-jsx@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/plugin-jsx/-/plugin-jsx-5.0.1.tgz#a60b20983bef86fc021554f365b88d88c45300ea"
+  integrity sha512-9mEinzosJshc/VdLqVkoBZQgs2d+ASbL61sX/2XCxcJ+/81KXdZcxmxSycJN37BvlM7F5fuj2ZF7IZwZ7ZOKaQ==
   dependencies:
-    "@babel/core" "^7.4.5"
-    "@svgr/babel-preset" "^4.3.3"
-    "@svgr/hast-util-to-babel-ast" "^4.3.2"
-    svg-parser "^2.0.0"
+    "@babel/core" "^7.7.5"
+    "@svgr/babel-preset" "^5.0.1"
+    "@svgr/hast-util-to-babel-ast" "^5.0.1"
+    svg-parser "^2.0.2"
 
-"@svgr/plugin-prettier@^4.3.2":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@svgr/plugin-prettier/-/plugin-prettier-4.3.2.tgz#41a95cf0c52a58e2d9841434d227e120d7d533f7"
-  integrity sha512-GErOZQ0n/OinFDjyXg9svfVRNWP+18qqIxsc/9xRoRY7R/cPlnXkadLF7NdgDgSP2BYtt7XGcZ9TU+Skr1B3tw==
+"@svgr/plugin-prettier@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/plugin-prettier/-/plugin-prettier-5.0.1.tgz#4522e5d457c1b893b6ed19094ce9c95c7506b737"
+  integrity sha512-d74rQ7RQZ8bFsbgF9fGaWdMYkQtZK6NBbTqNfHTtqpvjjDG4+GKLFiXr0o8axwUcMoP2koTntCA7kxI4M6MvKg==
   dependencies:
     merge-deep "^3.0.2"
     prettier "^1.17.1"
 
-"@svgr/plugin-svgo@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@svgr/plugin-svgo/-/plugin-svgo-4.3.1.tgz#daac0a3d872e3f55935c6588dd370336865e9e32"
-  integrity sha512-PrMtEDUWjX3Ea65JsVCwTIXuSqa3CG9px+DluF1/eo9mlDrgrtFE7NE/DjdhjJgSM9wenlVBzkzneSIUgfUI/w==
+"@svgr/plugin-svgo@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@svgr/plugin-svgo/-/plugin-svgo-5.0.1.tgz#37cd74b7c337efbed9e29ee8b36944b4469189b6"
+  integrity sha512-h/V30j1swWANLV1mB0w+1YYZ0U0CnWm721xyUKVHJrvMe4wl5XronZdvVAD2hhQf9+JgaQARrRJ0Vg1Dxi+SFg==
   dependencies:
-    cosmiconfig "^5.2.1"
+    cosmiconfig "^6.0.0"
     merge-deep "^3.0.2"
     svgo "^1.2.2"
 
@@ -2607,6 +2642,11 @@
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prettier@^1.18.3":
   version "1.19.0"
@@ -4376,6 +4416,17 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.1.0, cosmiconfig@^5.2.0, cosmiconfig@^5.2.1:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
+
+cosmiconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
+  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.7.2"
 
 create-ecdh@^4.0.0:
   version "4.0.3"
@@ -6462,7 +6513,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -10633,6 +10684,11 @@ react-simple-code-editor@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
   integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
 
+react-uid@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.2.0.tgz#0f77e1e0594fbf29fc4fe528cc9aa415c5bf9159"
+  integrity sha512-z+g5+hFOQ08hCfrGcJ1PNs+cmvH8Uq2CVzCmPeWBsUi5A4W4NWXR5jouledzy3oSKGMU9HOzf8zFuGi15TXJoQ==
+
 react@^16.8.4:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
@@ -11960,7 +12016,7 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-svg-parser@^2.0.0:
+svg-parser@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.2.tgz#d134cc396fa2681dc64f518330784e98bd801ec8"
   integrity sha512-1gtApepKFweigFZj3sGO8KT8LvVZK8io146EzXrpVuWCDAbISz/yMucco3hWTkpZNoPabM+dnMOpy6Swue68Zg==
@@ -13071,6 +13127,13 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.7.2.tgz#f26aabf738590ab61efaca502358e48dc9f348b2"
+  integrity sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
 
 yargs-parser@^10.0.0:
   version "10.1.0"


### PR DESCRIPTION
- Forward ref to `svg` in all Icons
- Add `titleId` prop to icons which is used as a title id and `aria-labelledb` of the svg.
- Add `useUniqueId` hook.