### PR TITLE
feat(component): rename and expose form controls

### DIFF
--- a/packages/big-design/src/components/Form/Description/Description.tsx
+++ b/packages/big-design/src/components/Form/Description/Description.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import { Small, TextProps } from '../../Typography';
+
+export const FormControlDescription: React.FC<TextProps> = ({ className, style, ...props }) => <Small {...props} />;

--- a/packages/big-design/src/components/Form/Description/index.ts
+++ b/packages/big-design/src/components/Form/Description/index.ts
@@ -1,0 +1,1 @@
+export { FormControlDescription } from './Description';

--- a/packages/big-design/src/components/Form/Error/Error.tsx
+++ b/packages/big-design/src/components/Form/Error/Error.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 
 import { Small, TextProps } from '../../Typography';
 
-export const Error: React.FC<TextProps> = ({ className, style, ...props }) => (
+export const FormControlError: React.FC<TextProps> = ({ className, style, ...props }) => (
   <Small color="danger" margin="none" marginLeft="xxSmall" {...props} />
 );

--- a/packages/big-design/src/components/Form/Error/index.ts
+++ b/packages/big-design/src/components/Form/Error/index.ts
@@ -1,1 +1,1 @@
-export { Error } from './Error';
+export { FormControlError } from './Error';

--- a/packages/big-design/src/components/Form/Form.tsx
+++ b/packages/big-design/src/components/Form/Form.tsx
@@ -2,10 +2,10 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import React, { Ref } from 'react';
 
 import { StyledForm } from './styled';
-import { Error as FormError } from './Error';
+import { FormControlError } from './Error';
 import { Fieldset } from './Fieldset';
-import { Group } from './Group';
-import { Label } from './Label';
+import { FormGroup } from './Group';
+import { FormControlLabel } from './Label';
 
 interface PrivateProps {
   forwardedRef: Ref<HTMLFormElement>;
@@ -16,10 +16,10 @@ export type FormProps = React.FormHTMLAttributes<HTMLFormElement> & {
 };
 
 class StyleableForm extends React.PureComponent<PrivateProps & FormProps> {
-  static Label = Label;
-  static Error = FormError;
+  static Label = FormControlLabel;
+  static Error = FormControlError;
   static Fieldset = Fieldset;
-  static Group = Group;
+  static Group = FormGroup;
 
   render() {
     const { forwardedRef, ...props } = this.props;

--- a/packages/big-design/src/components/Form/Group/Group.tsx
+++ b/packages/big-design/src/components/Form/Group/Group.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { uniqueId } from '../../../utils';
 import { Checkbox } from '../../Checkbox';
 import { Radio } from '../../Radio';
-import { Error as FormError } from '../Error';
+import { FormControlError } from '../Error';
 
 import { StyledError, StyledGroup, StyledInlineGroup } from './styled';
 
@@ -12,7 +12,7 @@ export interface GroupProps extends React.HTMLAttributes<HTMLDivElement> {
   errors?: React.ReactChild | React.ReactChild[];
 }
 
-export const Group: React.FC<GroupProps> = props => {
+export const FormGroup: React.FC<GroupProps> = props => {
   const { children, errors: groupErrors } = props;
   const childrenCount = React.Children.count(children);
   const inline = !React.Children.toArray(children).every(child => {
@@ -58,12 +58,12 @@ function generateErrors(errors: GroupProps['errors']): React.ReactNode {
     return (
       <StyledError alignItems="center" key={errorKey}>
         <ErrorIcon color="danger" />
-        <FormError>{errors}</FormError>
+        <FormControlError>{errors}</FormControlError>
       </StyledError>
     );
   }
 
-  if (React.isValidElement(errors) && errors.type === FormError) {
+  if (React.isValidElement(errors) && errors.type === FormControlError) {
     return (
       <StyledError alignItems="center" key={errorKey}>
         <ErrorIcon color="danger" />

--- a/packages/big-design/src/components/Form/Group/spec.tsx
+++ b/packages/big-design/src/components/Form/Group/spec.tsx
@@ -4,19 +4,19 @@ import React from 'react';
 
 import { Input } from '../../Input';
 
-import { Group } from './';
+import { FormGroup } from './';
 
 test('renders a form group', () => {
-  const { container } = render(<Group />);
+  const { container } = render(<FormGroup />);
 
   expect(container.firstChild).toMatchSnapshot();
 });
 
 test('renders group with input', () => {
   const { container } = render(
-    <Group>
+    <FormGroup>
       <Input />
-    </Group>,
+    </FormGroup>,
   );
 
   expect(container.querySelector('input')).toBeInTheDocument();
@@ -25,9 +25,9 @@ test('renders group with input', () => {
 test('renders group and input with error', () => {
   const error = 'Error';
   const { getByText } = render(
-    <Group>
+    <FormGroup>
       <Input error={error} />
-    </Group>,
+    </FormGroup>,
   );
 
   expect(getByText(error)).toBeInTheDocument();
@@ -36,9 +36,9 @@ test('renders group and input with error', () => {
 test('renders group with error prop', () => {
   const error = 'Error';
   const { getByText } = render(
-    <Group errors={error}>
+    <FormGroup errors={error}>
       <Input />
-    </Group>,
+    </FormGroup>,
   );
 
   expect(getByText(error)).toBeInTheDocument();
@@ -47,9 +47,9 @@ test('renders group with error prop', () => {
 test('renders error prop with an array of errors', () => {
   const errors = ['Error 1', 'Error 2', 'Error 3'];
   const { getByText } = render(
-    <Group errors={errors}>
+    <FormGroup errors={errors}>
       <Input />
-    </Group>,
+    </FormGroup>,
   );
 
   errors.forEach(error => expect(getByText(error)).toBeInTheDocument());
@@ -59,9 +59,9 @@ test('renders error with Input.Error element', () => {
   const testId = 'test';
   const errors = <Input.Error data-testid={testId}>Error</Input.Error>;
   const { getByTestId } = render(
-    <Group errors={errors}>
+    <FormGroup errors={errors}>
       <Input />
-    </Group>,
+    </FormGroup>,
   );
 
   expect(getByTestId(testId)).toBeInTheDocument();
@@ -71,9 +71,9 @@ test('renders error prop with an array of Input.Error elements', () => {
   const testIds = ['test_1', 'test_2', 'test_3'];
   const errors = testIds.map(id => <Input.Error data-testid={id}>Error</Input.Error>);
   const { getByTestId } = render(
-    <Group errors={errors}>
+    <FormGroup errors={errors}>
       <Input />
-    </Group>,
+    </FormGroup>,
   );
 
   testIds.forEach(id => expect(getByTestId(id)).toBeInTheDocument());

--- a/packages/big-design/src/components/Form/Label/Label.tsx
+++ b/packages/big-design/src/components/Form/Label/Label.tsx
@@ -6,4 +6,4 @@ export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> 
   renderOptional?: boolean;
 }
 
-export const Label: React.FC<LabelProps> = ({ className, style, ...props }) => <StyledLabel {...props} />;
+export const FormControlLabel: React.FC<LabelProps> = ({ className, style, ...props }) => <StyledLabel {...props} />;

--- a/packages/big-design/src/components/Form/Label/index.ts
+++ b/packages/big-design/src/components/Form/Label/index.ts
@@ -1,1 +1,1 @@
-export { Label } from './Label';
+export { FormControlLabel } from './Label';

--- a/packages/big-design/src/components/Form/Label/spec.tsx
+++ b/packages/big-design/src/components/Form/Label/spec.tsx
@@ -2,24 +2,24 @@ import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
-import { Label } from './index';
+import { FormControlLabel } from './index';
 
 test('renders a label', () => {
-  const { container } = render(<Label>This is a label</Label>);
+  const { container } = render(<FormControlLabel>This is a label</FormControlLabel>);
   const label = container.querySelector('label');
 
   expect(label).toBeInTheDocument();
 });
 
 test('does not forward styles', () => {
-  const { container } = render(<Label className="test" style={{ background: 'red' }} />);
+  const { container } = render(<FormControlLabel className="test" style={{ background: 'red' }} />);
 
   expect(container.getElementsByClassName('test').length).toBe(0);
   expect(container.firstChild).not.toHaveStyle('background: red');
 });
 
 test('appends (optional) text when renderOptional', () => {
-  const { container } = render(<Label renderOptional>This is a label</Label>);
+  const { container } = render(<FormControlLabel renderOptional>This is a label</FormControlLabel>);
   const label = container.querySelector('label');
 
   expect(label).toHaveStyleRule('content', "' (optional)'", { modifier: '::after' });

--- a/packages/big-design/src/components/Form/index.ts
+++ b/packages/big-design/src/components/Form/index.ts
@@ -1,4 +1,8 @@
 import { FormProps as _FormProps } from './Form';
 
 export { Form } from './Form';
+export { FormControlDescription } from './Description';
+export { FormControlError } from './Error';
+export { FormGroup } from './Group';
+export { FormControlLabel } from './Label';
 export type FormProps = _FormProps;

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -3,8 +3,7 @@ import React, { Ref } from 'react';
 
 import { uniqueId } from '../../utils';
 import { Chip } from '../Chip';
-import { Form } from '../Form';
-import { Small } from '../Typography';
+import { FormControlDescription, FormControlError, FormControlLabel } from '../Form';
 
 import { StyledIconWrapper, StyledInput, StyledInputContent, StyledInputWrapper } from './styled';
 
@@ -30,9 +29,9 @@ interface InputState {
 export type InputProps = Props & React.InputHTMLAttributes<HTMLInputElement>;
 
 class StyleableInput extends React.PureComponent<InputProps & PrivateProps, InputState> {
-  static Description = Small;
-  static Error = Form.Error;
-  static Label = Form.Label;
+  static Description = FormControlDescription;
+  static Error = FormControlError;
+  static Label = FormControlLabel;
 
   readonly state: InputState = {
     focus: false,

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -6,7 +6,7 @@ import { uniqueId } from '../../utils';
 import { Box } from '../Box';
 import { Flex } from '../Flex/Flex';
 import { FlexItem } from '../Flex/Item';
-import { Label } from '../Form/Label';
+import { FormControlLabel } from '../Form';
 import { Input } from '../Input';
 import { ListCheckboxItem } from '../List/Item/CheckboxItem';
 import { ListItem } from '../List/Item/Item';
@@ -126,9 +126,9 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
     const labelId = this.getLabelId();
 
     return typeof label === 'string' ? (
-      <Label htmlFor={inputId} id={labelId} renderOptional={!required}>
+      <FormControlLabel htmlFor={inputId} id={labelId} renderOptional={!required}>
         {label}
-      </Label>
+      </FormControlLabel>
     ) : null;
   }
 

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -2,8 +2,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import React, { Ref } from 'react';
 
 import { uniqueId } from '../../utils';
-import { Form } from '../Form';
-import { Small } from '../Typography';
+import { FormControlDescription, FormControlError, FormControlLabel } from '../Form';
 
 import { StyledTextarea, StyledTextareaWrapper } from './styled';
 
@@ -28,9 +27,9 @@ class StyleableTextarea extends React.PureComponent<TextareaProps & PrivateProps
     resize: true,
   };
 
-  static Description = Small;
-  static Error = Form.Error;
-  static Label = Form.Label;
+  static Description = FormControlDescription;
+  static Error = FormControlError;
+  static Label = FormControlLabel;
   private readonly uniqueId = uniqueId('textarea_');
   private readonly MAX_ROWS = 7;
 


### PR DESCRIPTION
## What
Rename and expose form controls in preparation for removing static members on form fields.

_This is how we do it_