### PR TITLE
feat(component): convert Input to FC and remove static members

### DIFF
--- a/packages/big-design/src/components/Form/Group/spec.tsx
+++ b/packages/big-design/src/components/Form/Group/spec.tsx
@@ -3,6 +3,7 @@ import 'jest-styled-components';
 import React from 'react';
 
 import { Input } from '../../Input';
+import { FormControlError } from '../Error';
 
 import { FormGroup } from './';
 
@@ -55,9 +56,9 @@ test('renders error prop with an array of errors', () => {
   errors.forEach(error => expect(getByText(error)).toBeInTheDocument());
 });
 
-test('renders error with Input.Error element', () => {
+test('renders error with FormControlError element', () => {
   const testId = 'test';
-  const errors = <Input.Error data-testid={testId}>Error</Input.Error>;
+  const errors = <FormControlError data-testid={testId}>Error</FormControlError>;
   const { getByTestId } = render(
     <FormGroup errors={errors}>
       <Input />
@@ -67,9 +68,9 @@ test('renders error with Input.Error element', () => {
   expect(getByTestId(testId)).toBeInTheDocument();
 });
 
-test('renders error prop with an array of Input.Error elements', () => {
+test('renders error prop with an array of FormControlError elements', () => {
   const testIds = ['test_1', 'test_2', 'test_3'];
-  const errors = testIds.map(id => <Input.Error data-testid={id}>Error</Input.Error>);
+  const errors = testIds.map(id => <FormControlError data-testid={id}>Error</FormControlError>);
   const { getByTestId } = render(
     <FormGroup errors={errors}>
       <Input />

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -3,7 +3,8 @@ import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
-import { Form } from '../Form';
+import { warning } from '../../utils/warning';
+import { Form, FormControlDescription, FormControlError, FormControlLabel } from '../Form';
 
 import { Input } from './index';
 
@@ -85,12 +86,12 @@ test('renders an error', () => {
 
 test('accepts a Label Component', () => {
   const CustomLabel = (
-    <Input.Label>
+    <FormControlLabel>
       This is a custom Label
       <a href="#" data-testid="test">
         has a url
       </a>
-    </Input.Label>
+    </FormControlLabel>
   );
 
   const { queryByTestId } = render(<Input label={CustomLabel} />);
@@ -115,12 +116,12 @@ test('does not accept non-Label Components', () => {
 
 test('accepts a Description Component', () => {
   const CustomDescription = (
-    <Input.Description>
+    <FormControlDescription>
       This is a custom Description
       <a href="#" data-testid="test">
         has a url
       </a>
-    </Input.Description>
+    </FormControlDescription>
   );
 
   const { queryByTestId } = render(<Input description={CustomDescription} />);
@@ -145,12 +146,12 @@ test('does not accept non-Description Components', () => {
 
 test('accepts an Error Component', () => {
   const CustomError = (
-    <Input.Error>
+    <FormControlError>
       This is a custom Error Component
       <a href="#" data-testid="test">
         has a url
       </a>
-    </Input.Error>
+    </FormControlError>
   );
 
   const { queryByTestId } = render(
@@ -247,7 +248,7 @@ test('error shows when an array of strings', () => {
 
 test('error shows when an array of Errors', () => {
   const testIds = ['error_0', 'error_1'];
-  const errors = testIds.map(id => <Input.Error data-testid={id}>Error</Input.Error>);
+  const errors = testIds.map(id => <FormControlError data-testid={id}>Error</FormControlError>);
   const { getByTestId } = render(
     <Form.Group>
       <Input error={errors} />
@@ -255,6 +256,33 @@ test('error shows when an array of Errors', () => {
   );
 
   testIds.forEach(id => expect(getByTestId(id)).toBeInTheDocument());
+});
+
+describe('error does not show when invalid type', () => {
+  test('single element', () => {
+    const error = <div data-testid="err">Error</div>;
+    const { queryByTestId } = render(
+      <Form.Group>
+        <Input error={error} />
+      </Form.Group>,
+    );
+
+    expect(warning).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('err')).not.toBeInTheDocument();
+  });
+
+  test('array of elements', () => {
+    const errors = ['Error', <FormControlError>Error</FormControlError>, <div data-testid="err">Error</div>];
+
+    const { queryByTestId } = render(
+      <Form.Group>
+        <Input error={errors} />
+      </Form.Group>,
+    );
+
+    expect(warning).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('err')).not.toBeInTheDocument();
+  });
 });
 
 test('appends (optional) text to label if input is not required', () => {

--- a/packages/docs/PropTables/InputPropTable.tsx
+++ b/packages/docs/PropTables/InputPropTable.tsx
@@ -6,12 +6,12 @@ import { Code, NextLink, Prop, PropTable, PropTableWrapper } from '../components
 const inputProps: Prop[] = [
   {
     name: 'description',
-    types: 'ReactChild',
+    types: ['string', 'FormControlDescription'],
     description: 'Append a description to the input field.',
   },
   {
     name: 'error',
-    types: ['ReactChild', 'ReactChild[]'],
+    types: ['string', 'string[]', 'FormControlError', 'FormControlError[]'],
     description: (
       <>
         Displays an error message for the field. Error message will be passed to the <Code>Form.Group</Code> for display
@@ -55,7 +55,7 @@ const inputProps: Prop[] = [
   },
   {
     name: 'label',
-    types: 'ReactChild',
+    types: ['string', 'FormControlLabel'],
     description: (
       <>
         Label element for inputs. Component with auto generate <Code>id</Code>'s for the accessibility API.
@@ -75,39 +75,4 @@ const inputProps: Prop[] = [
 
 export const InputPropTable: React.FC<PropTableWrapper> = props => (
   <PropTable title="Input" propList={inputProps} {...props} />
-);
-
-export const InputDescriptionPropTable: React.FC = () => (
-  <>
-    <H2>Input.Description</H2>
-    <Text>
-      Supports all native <Code>&lt;p /&gt;</Code> element attributes.
-    </Text>
-  </>
-);
-
-export const InputErrorPropTable: React.FC = () => (
-  <>
-    <H2>Input.Error</H2>
-    <Text>
-      See{' '}
-      <NextLink href="/Form/FormPage" as="/form#error">
-        Forms.Error
-      </NextLink>
-      .
-    </Text>
-  </>
-);
-
-export const InputLabelPropTable: React.FC = () => (
-  <>
-    <H2>Input.Label</H2>
-    <Text>
-      See{' '}
-      <NextLink href="/Form/FormPage" as="/form#label">
-        Forms.Label
-      </NextLink>
-      .
-    </Text>
-  </>
 );

--- a/packages/docs/pages/Input/InputPage.tsx
+++ b/packages/docs/pages/Input/InputPage.tsx
@@ -3,7 +3,7 @@ import { CheckCircleIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
 
 import { Code, CodePreview } from '../../components';
-import { InputDescriptionPropTable, InputErrorPropTable, InputLabelPropTable, InputPropTable } from '../../PropTables';
+import { InputPropTable } from '../../PropTables';
 
 export default () => (
   <>
@@ -49,9 +49,6 @@ export default () => (
     </Text>
 
     <InputPropTable />
-    <InputDescriptionPropTable />
-    <InputErrorPropTable />
-    <InputLabelPropTable />
 
     <H1>Error State</H1>
 


### PR DESCRIPTION
## What
Convert `Input` to functional component and remove static members.

---

BREAKING CHANGE:
Use `FormControlDescription`, `FormControlError`, and `FormControlLabel`
instead of `Input.Description`, `Input.Error`, and `Input.Label` respectively.