### PR TITLE
feat(component): convert Textarea to FC and remove static members

### DIFF
--- a/packages/big-design/src/components/Fieldset/Fieldset.tsx
+++ b/packages/big-design/src/components/Fieldset/Fieldset.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from 'react';
 
-import { warning } from '../../utils/warning';
+import { warning } from '../../utils';
 
 import { StyledFieldset } from './styled';
 import { FieldsetDescription } from './Description';

--- a/packages/big-design/src/components/Fieldset/spec.tsx
+++ b/packages/big-design/src/components/Fieldset/spec.tsx
@@ -2,7 +2,7 @@ import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
-import { warning } from '../../utils/warning';
+import { warning } from '../../utils';
 
 import { Fieldset } from './index';
 import { FieldsetDescription } from './Description';

--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -183,7 +183,7 @@ exports[`simple form render 1`] = `
       <div>
         <label
           class="c5"
-          for="input_0"
+          for="bd-input-1"
         >
           First Name
         </label>
@@ -200,7 +200,7 @@ exports[`simple form render 1`] = `
           >
             <input
               class="c9"
-              id="input_0"
+              id="bd-input-1"
               placeholder="Placeholder text"
             />
           </div>
@@ -213,7 +213,7 @@ exports[`simple form render 1`] = `
       <div>
         <label
           class="c5"
-          for="input_1"
+          for="bd-input-2"
         >
           Middle Name
         </label>
@@ -230,7 +230,7 @@ exports[`simple form render 1`] = `
           >
             <input
               class="c9"
-              id="input_1"
+              id="bd-input-2"
               placeholder="Placeholder text"
             />
           </div>

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useMemo, useState, Ref } from 'react';
 
-import { typedMemo, uniqueId } from '../../utils';
-import { warning } from '../../utils/warning';
+import { typedMemo, warning } from '../../utils';
+import { useUniqueId } from '../../utils/useUniqueId';
 import { Chip } from '../Chip';
 import { FormControlDescription, FormControlError, FormControlLabel } from '../Form';
 
@@ -36,7 +36,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
   ...props
 }) => {
   const [focus, setFocus] = useState(false);
-  const id = useMemo(() => (props.id ? props.id : uniqueId('input_')), [props.id]);
+  const id = props.id ? props.id : useUniqueId('input');
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     const { onFocus } = props;
@@ -55,6 +55,10 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
   };
 
   const renderedLabel = useMemo(() => {
+    if (!label) {
+      return null;
+    }
+
     if (typeof label === 'string') {
       return (
         <FormControlLabel id={labelId} htmlFor={id} renderOptional={!props.required}>
@@ -70,24 +74,20 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
       });
     }
 
-    if (!label) {
-      return null;
-    }
-
     warning('label must be either a string or a FormControlLabel component.');
   }, [label, labelId, props.required]);
 
   const renderedDescription = useMemo(() => {
+    if (!description) {
+      return null;
+    }
+
     if (typeof description === 'string') {
       return <FormControlDescription>{description}</FormControlDescription>;
     }
 
     if (React.isValidElement(description) && description.type === FormControlDescription) {
       return description;
-    }
-
-    if (!description) {
-      return null;
     }
 
     warning('description must be either a string or a FormControlDescription component.');

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -140,7 +140,7 @@ exports[`renders all together 1`] = `
 <div>
   <label
     class="c0"
-    for="input_0"
+    for="bd-input-1"
   >
     This is a label
   </label>
@@ -156,7 +156,7 @@ exports[`renders all together 1`] = `
       class="c3"
     >
       <svg
-        aria-labelledby="bd-icon-1"
+        aria-labelledby="bd-icon-2"
         class="c4"
         data-testid="icon-left"
         fill="currentColor"
@@ -180,14 +180,14 @@ exports[`renders all together 1`] = `
     >
       <input
         class="c6"
-        id="input_0"
+        id="bd-input-1"
       />
     </div>
     <div
       class="c3"
     >
       <svg
-        aria-labelledby="bd-icon-2"
+        aria-labelledby="bd-icon-3"
         class="c4"
         data-testid="icon-right"
         fill="currentColor"

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -3,7 +3,7 @@ import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
-import { warning } from '../../utils/warning';
+import { warning } from '../../utils';
 import { Form, FormControlDescription, FormControlError, FormControlLabel } from '../Form';
 
 import { Input } from './index';

--- a/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
@@ -102,7 +102,7 @@ exports[`renders all together 1`] = `
 <div>
   <label
     class="c0"
-    for="textarea_0"
+    for="bd-textarea-1"
   >
     This is a label
   </label>
@@ -116,7 +116,7 @@ exports[`renders all together 1`] = `
   >
     <textarea
       class="c3"
-      id="textarea_0"
+      id="bd-textarea-1"
       rows="3"
     />
   </span>

--- a/packages/big-design/src/components/Textarea/spec.tsx
+++ b/packages/big-design/src/components/Textarea/spec.tsx
@@ -2,7 +2,8 @@ import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
-import { Form } from '../Form';
+import { warning } from '../../utils';
+import { Form, FormControlDescription, FormControlError, FormControlLabel } from '../Form';
 
 import { Textarea, TextareaProps } from './index';
 
@@ -88,12 +89,12 @@ test('renders an error', () => {
 
 test('accepts a Label Component', () => {
   const CustomLabel = (
-    <Textarea.Label>
+    <FormControlLabel>
       This is a custom Label
       <a href="#" data-testid="test">
         has a url
       </a>
-    </Textarea.Label>
+    </FormControlLabel>
   );
 
   const { queryByTestId } = render(<Textarea label={CustomLabel} />);
@@ -118,12 +119,12 @@ test('does not accept non-Label Components', () => {
 
 test('accepts a Description Component', () => {
   const CustomDescription = (
-    <Textarea.Description>
+    <FormControlDescription>
       This is a custom Description
       <a href="#" data-testid="test">
         has a url
       </a>
-    </Textarea.Description>
+    </FormControlDescription>
   );
 
   const { queryByTestId } = render(<Textarea description={CustomDescription} />);
@@ -148,12 +149,12 @@ test('does not accept non-Description Components', () => {
 
 test('accepts an Error Component', () => {
   const CustomError = (
-    <Textarea.Error>
+    <FormControlError>
       This is a custom Error Component
       <a href="#" data-testid="test">
         has a url
       </a>
-    </Textarea.Error>
+    </FormControlError>
   );
 
   const { queryByTestId } = render(
@@ -182,6 +183,33 @@ test('does not accept non-Error Components', () => {
   );
 
   expect(queryByTestId('test')).not.toBeInTheDocument();
+});
+
+describe('error does not show when invalid type', () => {
+  test('single element', () => {
+    const error = <div data-testid="err">Error</div>;
+    const { queryByTestId } = render(
+      <Form.Group>
+        <Textarea error={error} />
+      </Form.Group>,
+    );
+
+    expect(warning).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('err')).not.toBeInTheDocument();
+  });
+
+  test('array of elements', () => {
+    const errors = ['Error', <FormControlError>Error</FormControlError>, <div data-testid="err">Error</div>];
+
+    const { queryByTestId } = render(
+      <Form.Group>
+        <Textarea error={errors} />
+      </Form.Group>,
+    );
+
+    expect(warning).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('err')).not.toBeInTheDocument();
+  });
 });
 
 test('accepts valid row property', () => {

--- a/packages/big-design/src/utils/index.ts
+++ b/packages/big-design/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './typedMemo';
 export * from './uniqueId';
+export * from './warning';

--- a/packages/big-design/src/utils/useUniqueId.ts
+++ b/packages/big-design/src/utils/useUniqueId.ts
@@ -1,0 +1,7 @@
+import { useUID } from 'react-uid';
+
+export function useUniqueId(prefix: string) {
+  const uid = useUID();
+
+  return `bd-${prefix}-${uid}`;
+}

--- a/packages/docs/PropTables/TextareaPropTable.tsx
+++ b/packages/docs/PropTables/TextareaPropTable.tsx
@@ -6,17 +6,17 @@ import { Code, NextLink, Prop, PropTable, PropTableWrapper } from '../components
 const textareaProps: Prop[] = [
   {
     name: 'description',
-    types: 'ReactChild',
+    types: ['string', 'FormControlDescription'],
     description: 'Append a description to the textarea field.',
   },
   {
     name: 'error',
-    types: 'ReactChild',
+    types: ['string', 'string[]', 'FormControlError', 'FormControlError[]'],
     description: 'Displays an error message for the field.',
   },
   {
     name: 'label',
-    types: 'ReactChild',
+    types: ['string', 'FormControlLabel'],
     description: (
       <>
         Label element for textareas. Component with auto generate <Code>id</Code>'s for the accessibility API.
@@ -52,39 +52,4 @@ const textareaProps: Prop[] = [
 
 export const TextareaPropTable: React.FC<PropTableWrapper> = props => (
   <PropTable title="Textarea" propList={textareaProps} {...props} />
-);
-
-export const TextareaDescriptionPropTable: React.FC = () => (
-  <>
-    <H2>Textarea.Description</H2>
-    <Text>
-      Supports all native <Code>&lt;p /&gt;</Code> element attributes.
-    </Text>
-  </>
-);
-
-export const TextareaErrorPropTable: React.FC = () => (
-  <>
-    <H2>Textarea.Error</H2>
-    <Text>
-      See{' '}
-      <NextLink href="/Form/FormPage" as="/form#error">
-        Forms.Error
-      </NextLink>
-      .
-    </Text>
-  </>
-);
-
-export const TextareaLabelPropTable: React.FC = () => (
-  <>
-    <H2>Textarea.Label</H2>
-    <Text>
-      See{' '}
-      <NextLink href="/Form/FormPage" as="/form#label">
-        Forms.Label
-      </NextLink>
-      .
-    </Text>
-  </>
 );

--- a/packages/docs/pages/Textarea/TextareaPage.tsx
+++ b/packages/docs/pages/Textarea/TextareaPage.tsx
@@ -2,12 +2,7 @@ import { Form, H0, H1, Link, Text, Textarea } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { Code, CodePreview } from '../../components';
-import {
-  TextareaDescriptionPropTable,
-  TextareaErrorPropTable,
-  TextareaLabelPropTable,
-  TextareaPropTable,
-} from '../../PropTables';
+import { TextareaPropTable } from '../../PropTables';
 
 export default () => (
   <>
@@ -54,9 +49,6 @@ export default () => (
     </Text>
 
     <TextareaPropTable />
-    <TextareaDescriptionPropTable />
-    <TextareaErrorPropTable />
-    <TextareaLabelPropTable />
 
     <H1>Error State</H1>
 


### PR DESCRIPTION
## What
Convert `Input` to functional component and remove static members.

---

BREAKING CHANGE:
Use `FormControlDescription`, `FormControlError`, and `FormControlLabel`
instead of `Textarea.Description`, `Textarea.Error`, and `Textarea.Label` respectively.