### PR TITLE
feat(component): convert Checkbox to FC and remove static members

### DIFF
--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -1,10 +1,11 @@
 import { CheckIcon, RemoveIcon } from '@bigcommerce/big-design-icons';
-import hoistNonReactStatics from 'hoist-non-react-statics';
-import React, { memo, Ref } from 'react';
+import React, { forwardRef, useMemo, Ref } from 'react';
 
-import { uniqueId } from '../../utils';
+import { typedMemo, warning } from '../../utils';
+import { useUniqueId } from '../../utils/useUniqueId';
 
-import { CheckboxContainer, HiddenCheckbox, StyledCheckbox, StyledLabel } from './styled';
+import { CheckboxContainer, HiddenCheckbox, StyledCheckbox } from './styled';
+import { CheckboxLabel } from './Label';
 
 interface Props {
   hiddenLabel?: boolean;
@@ -18,102 +19,87 @@ interface PrivateProps {
 
 export type CheckboxProps = Props & React.InputHTMLAttributes<HTMLInputElement>;
 
-class RawCheckbox extends React.PureComponent<CheckboxProps & PrivateProps> {
-  static Label = memo(StyledLabel);
-  private readonly uniqueId = uniqueId('checkBox_');
-  private readonly labelUniqueId = uniqueId('checkBox_label_');
+const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
+  checked,
+  className,
+  disabled,
+  hiddenLabel,
+  isIndeterminate,
+  label,
+  forwardedRef,
+  style,
+  ...props
+}) => {
+  const id = props.id ? props.id : useUniqueId('checkbox');
+  const labelId = useUniqueId('checkbox_label');
 
-  render() {
-    const { checked, className, disabled, isIndeterminate, label, forwardedRef, style, ...props } = this.props;
-    const id = this.getInputId();
-
-    return (
-      <CheckboxContainer className={className} style={style}>
-        <HiddenCheckbox
-          type="checkbox"
-          checked={checked}
-          id={id}
-          disabled={disabled}
-          {...props}
-          aria-labelledby={this.labelUniqueId}
-          ref={checkbox => {
-            if (checkbox && typeof isIndeterminate === 'boolean') {
-              checkbox.indeterminate = !checked && isIndeterminate;
-            }
-
-            if (forwardedRef) {
-              if (typeof forwardedRef === 'function') {
-                forwardedRef(checkbox);
-              } else {
-                // RefObject.current is readonly in DefinitelyTyped but in practice you
-                // can still write to it.
-                // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
-                // @ts-ignore
-                forwardedRef.current = checkbox;
-              }
-            }
-          }}
-        />
-
-        <StyledCheckbox
-          disabled={disabled}
-          isIndeterminate={isIndeterminate}
-          checked={checked}
-          htmlFor={id}
-          aria-hidden={true}
-        >
-          {!checked && isIndeterminate ? <RemoveIcon /> : <CheckIcon />}
-        </StyledCheckbox>
-        {this.renderLabel()}
-      </CheckboxContainer>
-    );
-  }
-
-  private getInputId() {
-    const { id } = this.props;
-
-    return id ? id : this.uniqueId;
-  }
-
-  private renderLabel() {
-    const htmlFor = this.getInputId();
-    const { disabled, hiddenLabel, label } = this.props;
+  const renderedLabel = useMemo(() => {
+    if (!label) {
+      return null;
+    }
 
     if (typeof label === 'string') {
       return (
-        <StyledLabel
-          disabled={disabled}
-          hidden={hiddenLabel}
-          htmlFor={htmlFor}
-          aria-hidden={disabled}
-          id={this.labelUniqueId}
-        >
+        <CheckboxLabel disabled={disabled} hidden={hiddenLabel} htmlFor={id} aria-hidden={disabled} id={labelId}>
           {label}
-        </StyledLabel>
+        </CheckboxLabel>
       );
     }
 
-    if (React.isValidElement(label) && label.type === Checkbox.Label) {
+    if (React.isValidElement(label) && label.type === CheckboxLabel) {
       return React.cloneElement(label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>, {
         hidden: hiddenLabel,
-        htmlFor,
-        id: this.labelUniqueId,
+        htmlFor: id,
+        id: labelId,
       });
     }
 
-    return null;
-  }
-}
+    warning('label must be either a string or a CheckboxLabel component.');
+  }, [disabled, hiddenLabel, id, label, labelId]);
 
-const CheckboxWithForwardedRef = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ className, style, ...props }, ref) => <RawCheckbox {...props} forwardedRef={ref} />,
+  return (
+    <CheckboxContainer className={className} style={style}>
+      <HiddenCheckbox
+        type="checkbox"
+        checked={checked}
+        id={id}
+        disabled={disabled}
+        {...props}
+        aria-labelledby={labelId}
+        ref={checkbox => {
+          if (checkbox && typeof isIndeterminate === 'boolean') {
+            checkbox.indeterminate = !checked && isIndeterminate;
+          }
+
+          if (forwardedRef) {
+            if (typeof forwardedRef === 'function') {
+              forwardedRef(checkbox);
+            } else {
+              // RefObject.current is readonly in DefinitelyTyped
+              // but in practice you can still write to it.
+              // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
+              (forwardedRef as React.MutableRefObject<HTMLInputElement | null>).current = checkbox;
+            }
+          }
+        }}
+      />
+
+      <StyledCheckbox
+        disabled={disabled}
+        isIndeterminate={isIndeterminate}
+        checked={checked}
+        htmlFor={id}
+        aria-hidden={true}
+      >
+        {!checked && isIndeterminate ? <RemoveIcon /> : <CheckIcon />}
+      </StyledCheckbox>
+      {renderedLabel}
+    </CheckboxContainer>
+  );
+};
+
+export const Checkbox = typedMemo(
+  forwardRef<HTMLInputElement, CheckboxProps>(({ className, style, ...props }, ref) => (
+    <RawCheckbox {...props} forwardedRef={ref} />
+  )),
 );
-
-export const Checkbox = hoistNonReactStatics(CheckboxWithForwardedRef, RawCheckbox);
-
-export const StyleableCheckbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => (
-  <RawCheckbox {...props} forwardedRef={ref} />
-));
-
-Checkbox.displayName = 'Checkbox';
-StyleableCheckbox.displayName = 'StyleableCheckbox';

--- a/packages/big-design/src/components/Checkbox/Label/Label.tsx
+++ b/packages/big-design/src/components/Checkbox/Label/Label.tsx
@@ -1,0 +1,7 @@
+import React, { memo } from 'react';
+
+import { StyledLabel, StyledLabelProps } from './styled';
+
+export const CheckboxLabel: React.FC<StyledLabelProps> = memo(({ className, style, ...props }) => (
+  <StyledLabel {...props} />
+));

--- a/packages/big-design/src/components/Checkbox/Label/index.ts
+++ b/packages/big-design/src/components/Checkbox/Label/index.ts
@@ -1,0 +1,1 @@
+export * from './Label';

--- a/packages/big-design/src/components/Checkbox/Label/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/Label/styled.tsx
@@ -1,0 +1,28 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { hideVisually } from 'polished';
+import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
+
+import { StyleableText } from '../../Typography/private';
+
+export interface StyledLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  hidden?: boolean;
+  disabled?: boolean;
+}
+
+export const StyledLabel = styled(StyleableText).attrs({
+  as: 'label',
+})<StyledLabelProps>`
+  cursor: pointer;
+  margin-left: ${({ theme }) => theme.spacing.xSmall};
+
+  ${({ disabled, theme }) =>
+    disabled &&
+    css`
+      cursor: not-allowed;
+      color: ${theme.colors.secondary40};
+    `}
+
+  ${({ hidden }) => hidden && hideVisually()}
+` as StyledComponent<'label', DefaultTheme, StyledLabelProps>;
+
+StyledLabel.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -94,19 +94,19 @@ exports[`render Checkbox checked 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="checkBox_label_1"
+    aria-labelledby="bd-checkbox_label-2"
     checked=""
     class="c1 c2"
-    id="checkBox_0"
+    id="bd-checkbox-1"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for="checkBox_0"
+    for="bd-checkbox-1"
   >
     <svg
-      aria-labelledby="bd-icon-1"
+      aria-labelledby="bd-icon-3"
       class="c4"
       fill="currentColor"
       height="24"
@@ -126,8 +126,8 @@ exports[`render Checkbox checked 1`] = `
   </label>
   <label
     class="c5"
-    for="checkBox_0"
-    id="checkBox_label_1"
+    for="bd-checkbox-1"
+    id="bd-checkbox_label-2"
   >
     Checked
   </label>
@@ -237,21 +237,21 @@ exports[`render Checkbox disabled checked 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="checkBox_label_1"
+    aria-labelledby="bd-checkbox_label-2"
     checked=""
     class="c1 c2"
     disabled=""
-    id="checkBox_0"
+    id="bd-checkbox-1"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
     disabled=""
-    for="checkBox_0"
+    for="bd-checkbox-1"
   >
     <svg
-      aria-labelledby="bd-icon-1"
+      aria-labelledby="bd-icon-3"
       class="c4"
       fill="currentColor"
       height="24"
@@ -273,8 +273,8 @@ exports[`render Checkbox disabled checked 1`] = `
     aria-hidden="true"
     class="c5"
     disabled=""
-    for="checkBox_0"
-    id="checkBox_label_1"
+    for="bd-checkbox-1"
+    id="bd-checkbox_label-2"
   >
     Checked
   </label>
@@ -388,20 +388,20 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="checkBox_label_1"
+    aria-labelledby="bd-checkbox_label-2"
     class="c1 c2"
     disabled=""
-    id="checkBox_0"
+    id="bd-checkbox-1"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
     disabled=""
-    for="checkBox_0"
+    for="bd-checkbox-1"
   >
     <svg
-      aria-labelledby="bd-icon-1"
+      aria-labelledby="bd-icon-3"
       class="c4"
       fill="currentColor"
       height="24"
@@ -423,8 +423,8 @@ exports[`render Checkbox disabled indeterminate 1`] = `
     aria-hidden="true"
     class="c5"
     disabled=""
-    for="checkBox_0"
-    id="checkBox_label_1"
+    for="bd-checkbox-1"
+    id="bd-checkbox_label-2"
   >
     Unchecked
   </label>
@@ -538,20 +538,20 @@ exports[`render Checkbox disabled unchecked 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="checkBox_label_1"
+    aria-labelledby="bd-checkbox_label-2"
     class="c1 c2"
     disabled=""
-    id="checkBox_0"
+    id="bd-checkbox-1"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
     disabled=""
-    for="checkBox_0"
+    for="bd-checkbox-1"
   >
     <svg
-      aria-labelledby="bd-icon-1"
+      aria-labelledby="bd-icon-3"
       class="c4"
       fill="currentColor"
       height="24"
@@ -573,8 +573,8 @@ exports[`render Checkbox disabled unchecked 1`] = `
     aria-hidden="true"
     class="c5"
     disabled=""
-    for="checkBox_0"
-    id="checkBox_label_1"
+    for="bd-checkbox-1"
+    id="bd-checkbox_label-2"
   >
     Checked
   </label>
@@ -679,18 +679,18 @@ exports[`render Checkbox indeterminate 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="checkBox_label_1"
+    aria-labelledby="bd-checkbox_label-2"
     class="c1 c2"
-    id="checkBox_0"
+    id="bd-checkbox-1"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for="checkBox_0"
+    for="bd-checkbox-1"
   >
     <svg
-      aria-labelledby="bd-icon-1"
+      aria-labelledby="bd-icon-3"
       class="c4"
       fill="currentColor"
       height="24"
@@ -710,8 +710,8 @@ exports[`render Checkbox indeterminate 1`] = `
   </label>
   <label
     class="c5"
-    for="checkBox_0"
-    id="checkBox_label_1"
+    for="bd-checkbox-1"
+    id="bd-checkbox_label-2"
   >
     Unchecked
   </label>
@@ -816,18 +816,18 @@ exports[`render Checkbox unchecked 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="checkBox_label_1"
+    aria-labelledby="bd-checkbox_label-2"
     class="c1 c2"
-    id="checkBox_0"
+    id="bd-checkbox-1"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for="checkBox_0"
+    for="bd-checkbox-1"
   >
     <svg
-      aria-labelledby="bd-icon-1"
+      aria-labelledby="bd-icon-3"
       class="c4"
       fill="currentColor"
       height="24"
@@ -847,8 +847,8 @@ exports[`render Checkbox unchecked 1`] = `
   </label>
   <label
     class="c5"
-    for="checkBox_0"
-    id="checkBox_label_1"
+    for="bd-checkbox-1"
+    id="bd-checkbox_label-2"
   >
     Unchecked
   </label>

--- a/packages/big-design/src/components/Checkbox/index.ts
+++ b/packages/big-design/src/components/Checkbox/index.ts
@@ -1,4 +1,5 @@
 import { CheckboxProps as _CheckboxProps } from './Checkbox';
 
 export { Checkbox } from './Checkbox';
+export * from './Label';
 export type CheckboxProps = _CheckboxProps;

--- a/packages/big-design/src/components/Checkbox/private.ts
+++ b/packages/big-design/src/components/Checkbox/private.ts
@@ -1,1 +1,0 @@
-export { StyleableCheckbox } from './Checkbox';

--- a/packages/big-design/src/components/Checkbox/spec.tsx
+++ b/packages/big-design/src/components/Checkbox/spec.tsx
@@ -2,8 +2,10 @@ import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
+import { warning } from '../../utils/warning';
+
 import { Checkbox } from './index';
-import { StyleableCheckbox } from './private';
+import { CheckboxLabel } from './Label';
 
 describe('render Checkbox', () => {
   test('checked', () => {
@@ -93,6 +95,25 @@ test('triggers onChange when clicking styled and text label', () => {
   expect(onChange).toHaveBeenCalledTimes(2);
 });
 
+test('accepts valid CheckboxLabel component', () => {
+  const testId = 'test';
+  const label = <CheckboxLabel data-testid={testId}>Label</CheckboxLabel>;
+
+  const { queryByTestId } = render(<Checkbox label={label} />);
+
+  expect(queryByTestId(testId)).toBeInTheDocument();
+});
+
+test('does not accept invalid label component', () => {
+  const testId = 'test';
+  const label = <div data-testid={testId}>Label</div>;
+
+  const { queryByTestId } = render(<Checkbox label={label} />);
+
+  expect(warning).toBeCalledTimes(1);
+  expect(queryByTestId(testId)).not.toBeInTheDocument();
+});
+
 test('forwards ref', () => {
   const ref = React.createRef<HTMLInputElement>();
 
@@ -107,11 +128,4 @@ test('does not forward styles', () => {
 
   expect(container.getElementsByClassName('test').length).toBe(0);
   expect(container.firstChild).not.toHaveStyle('background: red');
-});
-
-test('private StyleableCheckbox forwards styles', () => {
-  const { container } = render(<StyleableCheckbox label="Checked" className="test" style={{ background: 'red' }} />);
-
-  expect(container.getElementsByClassName('test').length).toBe(1);
-  expect(container.firstChild).toHaveStyle('background: red');
 });

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -1,9 +1,8 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { hideVisually } from 'polished';
-import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { withTransition } from '../../mixins/transitions';
-import { StyleableText } from '../Typography/private';
 
 interface StyledCheckboxProps {
   checked?: boolean;
@@ -66,21 +65,4 @@ export const StyledCheckbox = styled.label<StyledCheckboxProps>`
   }
 `;
 
-export const StyledLabel = styled(StyleableText).attrs({
-  as: 'label',
-})<React.LabelHTMLAttributes<HTMLLabelElement> & StyledLabelProps>`
-  cursor: pointer;
-  margin-left: ${({ theme }) => theme.spacing.xSmall};
-
-  ${({ disabled, theme }) =>
-    disabled &&
-    css`
-      cursor: not-allowed;
-      color: ${theme.colors.secondary40};
-    `}
-
-  ${({ hidden }) => hidden && hideVisually()}
-` as StyledComponent<'label', DefaultTheme, StyledLabelProps>;
-
 StyledCheckbox.defaultProps = { theme: defaultTheme };
-StyledLabel.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -1008,18 +1008,18 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         class="c5"
       >
         <input
-          aria-labelledby="checkBox_label_2"
+          aria-labelledby="bd-checkbox_label-2"
           class="c6 c7"
-          id="checkBox_1"
+          id="bd-checkbox-1"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8"
-          for="checkBox_1"
+          for="bd-checkbox-1"
         >
           <svg
-            aria-labelledby="bd-icon-1"
+            aria-labelledby="bd-icon-3"
             class="c9"
             fill="currentColor"
             height="24"
@@ -1039,9 +1039,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         </label>
         <label
           class="c10"
-          for="checkBox_1"
+          for="bd-checkbox-1"
           hidden=""
-          id="checkBox_label_2"
+          id="bd-checkbox_label-2"
         >
           Select All
         </label>

--- a/packages/docs/PropTables/CheckboxPropTable.tsx
+++ b/packages/docs/PropTables/CheckboxPropTable.tsx
@@ -6,7 +6,7 @@ import { Code, Prop, PropTable, PropTableWrapper } from '../components';
 const checkboxProps: Prop[] = [
   {
     name: 'label',
-    types: 'ReactChild',
+    types: ['string', 'CheckboxLabel'],
     required: true,
     description: 'Label to display next to a <Code>Checkbox</Code> component.',
   },


### PR DESCRIPTION
## What
Convert `Checkbox` to a functional component and remove static members.

---

BREAKING CHANGE:
Use `CheckboxLabel` instead of `Checkbox.Label`.