### PR TITLE
feat(component): convert Radio to FC and remove static members

### DIFF
--- a/packages/big-design/src/components/Radio/Label/Label.tsx
+++ b/packages/big-design/src/components/Radio/Label/Label.tsx
@@ -1,0 +1,7 @@
+import React, { memo } from 'react';
+
+import { StyledLabel, StyledLabelProps } from './styled';
+
+export const RadioLabel: React.FC<StyledLabelProps> = memo(({ className, style, ...props }) => (
+  <StyledLabel {...props} />
+));

--- a/packages/big-design/src/components/Radio/Label/index.ts
+++ b/packages/big-design/src/components/Radio/Label/index.ts
@@ -1,0 +1,1 @@
+export * from './Label';

--- a/packages/big-design/src/components/Radio/Label/styled.tsx
+++ b/packages/big-design/src/components/Radio/Label/styled.tsx
@@ -1,0 +1,24 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
+
+import { StyleableText } from '../../Typography/private';
+
+export interface StyledLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  disabled?: boolean;
+}
+
+export const StyledLabel = styled(StyleableText).attrs({
+  as: 'label',
+})<StyledLabelProps>`
+  cursor: pointer;
+  margin-left: ${({ theme }) => theme.spacing.xSmall};
+
+  ${({ disabled, theme }) =>
+    disabled &&
+    css`
+      cursor: not-allowed;
+      color: ${theme.colors.secondary40};
+    `}
+` as StyledComponent<'label', DefaultTheme, StyledLabelProps>;
+
+StyledLabel.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
@@ -27,22 +27,6 @@ exports[`render Radio (checked + disabled) 1`] = `
   width: 1px;
 }
 
-.c4 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-  cursor: pointer;
-  margin-left: 0.5rem;
-  cursor: not-allowed;
-  color: #B4BAD1;
-}
-
-.c4:last-child {
-  margin-bottom: 0;
-}
-
 .c1:focus + .c5 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
@@ -100,15 +84,31 @@ exports[`render Radio (checked + disabled) 1`] = `
   opacity: 1;
 }
 
+.c4 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  cursor: pointer;
+  margin-left: 0.5rem;
+  cursor: not-allowed;
+  color: #B4BAD1;
+}
+
+.c4:last-child {
+  margin-bottom: 0;
+}
+
 <div
   class="c0"
 >
   <input
-    aria-labelledby="checkBox_label_1"
+    aria-labelledby="bd-radio_label-2"
     checked=""
     class="c1 c2"
     disabled=""
-    id="radio_0"
+    id="bd-radio-1"
     name="test-group"
     type="radio"
   />
@@ -116,14 +116,14 @@ exports[`render Radio (checked + disabled) 1`] = `
     aria-hidden="true"
     class="c3"
     disabled=""
-    for="radio_0"
+    for="bd-radio-1"
   />
   <label
     aria-hidden="true"
     class="c4"
     disabled=""
-    for="radio_0"
-    id="checkBox_label_1"
+    for="bd-radio-1"
+    id="bd-radio_label-2"
   >
     Checked
   </label>
@@ -155,20 +155,6 @@ exports[`render Radio (checked) 1`] = `
   position: absolute;
   white-space: nowrap;
   width: 1px;
-}
-
-.c4 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-  cursor: pointer;
-  margin-left: 0.5rem;
-}
-
-.c4:last-child {
-  margin-bottom: 0;
 }
 
 .c3 {
@@ -222,26 +208,40 @@ exports[`render Radio (checked) 1`] = `
   opacity: 1;
 }
 
+.c4 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  cursor: pointer;
+  margin-left: 0.5rem;
+}
+
+.c4:last-child {
+  margin-bottom: 0;
+}
+
 <div
   class="c0"
 >
   <input
-    aria-labelledby="checkBox_label_1"
+    aria-labelledby="bd-radio_label-2"
     checked=""
     class="c1 c2"
-    id="radio_0"
+    id="bd-radio-1"
     name="test-group"
     type="radio"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for="radio_0"
+    for="bd-radio-1"
   />
   <label
     class="c4"
-    for="radio_0"
-    id="checkBox_label_1"
+    for="bd-radio-1"
+    id="bd-radio_label-2"
   >
     Checked
   </label>
@@ -273,22 +273,6 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   position: absolute;
   white-space: nowrap;
   width: 1px;
-}
-
-.c4 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-  cursor: pointer;
-  margin-left: 0.5rem;
-  cursor: not-allowed;
-  color: #B4BAD1;
-}
-
-.c4:last-child {
-  margin-bottom: 0;
 }
 
 .c1:focus + .c5 {
@@ -348,14 +332,30 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   width: 0.75rem;
 }
 
+.c4 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  cursor: pointer;
+  margin-left: 0.5rem;
+  cursor: not-allowed;
+  color: #B4BAD1;
+}
+
+.c4:last-child {
+  margin-bottom: 0;
+}
+
 <div
   class="c0"
 >
   <input
-    aria-labelledby="checkBox_label_1"
+    aria-labelledby="bd-radio_label-2"
     class="c1 c2"
     disabled=""
-    id="radio_0"
+    id="bd-radio-1"
     name="test-group"
     type="radio"
   />
@@ -363,14 +363,14 @@ exports[`render Radio (unchecked + disabled) 1`] = `
     aria-hidden="true"
     class="c3"
     disabled=""
-    for="radio_0"
+    for="bd-radio-1"
   />
   <label
     aria-hidden="true"
     class="c4"
     disabled=""
-    for="radio_0"
-    id="checkBox_label_1"
+    for="bd-radio-1"
+    id="bd-radio_label-2"
   >
     Unchecked
   </label>
@@ -402,20 +402,6 @@ exports[`render Radio (unchecked) 1`] = `
   position: absolute;
   white-space: nowrap;
   width: 1px;
-}
-
-.c4 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-  cursor: pointer;
-  margin-left: 0.5rem;
-}
-
-.c4:last-child {
-  margin-bottom: 0;
 }
 
 .c1:focus + .c5 {
@@ -469,25 +455,39 @@ exports[`render Radio (unchecked) 1`] = `
   width: 0.75rem;
 }
 
+.c4 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  cursor: pointer;
+  margin-left: 0.5rem;
+}
+
+.c4:last-child {
+  margin-bottom: 0;
+}
+
 <div
   class="c0"
 >
   <input
-    aria-labelledby="checkBox_label_1"
+    aria-labelledby="bd-radio_label-2"
     class="c1 c2"
-    id="radio_0"
+    id="bd-radio-1"
     name="test-group"
     type="radio"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for="radio_0"
+    for="bd-radio-1"
   />
   <label
     class="c4"
-    for="radio_0"
-    id="checkBox_label_1"
+    for="bd-radio-1"
+    id="bd-radio_label-2"
   >
     Unchecked
   </label>

--- a/packages/big-design/src/components/Radio/index.ts
+++ b/packages/big-design/src/components/Radio/index.ts
@@ -1,4 +1,5 @@
 import { RadioProps as _RadioProps } from './Radio';
 
 export { Radio } from './Radio';
+export * from './Label';
 export type RadioProps = _RadioProps;

--- a/packages/big-design/src/components/Radio/private.ts
+++ b/packages/big-design/src/components/Radio/private.ts
@@ -1,1 +1,0 @@
-export { StyleableRadio } from './Radio';

--- a/packages/big-design/src/components/Radio/spec.tsx
+++ b/packages/big-design/src/components/Radio/spec.tsx
@@ -2,8 +2,9 @@ import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
-import { Radio } from './index';
-import { StyleableRadio } from './private';
+import { warning } from '../../utils/warning';
+
+import { Radio, RadioLabel } from './index';
 
 test('render Radio (checked)', () => {
   const { container } = render(<Radio label="Checked" name="test-group" checked={true} onChange={() => null} />);
@@ -68,6 +69,25 @@ test('triggers onChange when clicking styled and text label', () => {
   expect(onChange).toHaveBeenCalledTimes(2);
 });
 
+test('accepts valid RadioLabel component', () => {
+  const testId = 'test';
+  const label = <RadioLabel data-testid={testId}>Label</RadioLabel>;
+
+  const { queryByTestId } = render(<Radio label={label} />);
+
+  expect(queryByTestId(testId)).toBeInTheDocument();
+});
+
+test('does not accept invalid label component', () => {
+  const testId = 'test';
+  const label = <div data-testid={testId}>Label</div>;
+
+  const { queryByTestId } = render(<Radio label={label} />);
+
+  expect(warning).toBeCalledTimes(1);
+  expect(queryByTestId(testId)).not.toBeInTheDocument();
+});
+
 test('forwards ref', () => {
   const ref = React.createRef<HTMLInputElement>();
 
@@ -81,10 +101,4 @@ test('does not forward styles', () => {
   const { container } = render(<Radio label="Checked" className="test" />);
 
   expect(container.getElementsByClassName('test').length).toBe(0);
-});
-
-test('private version forwards styles', () => {
-  const { container } = render(<StyleableRadio label="Checked" className="test" />);
-
-  expect(container.getElementsByClassName('test').length).toBe(1);
 });

--- a/packages/big-design/src/components/Radio/styled.tsx
+++ b/packages/big-design/src/components/Radio/styled.tsx
@@ -1,16 +1,11 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { hideVisually } from 'polished';
-import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { withTransition } from '../../mixins/transitions';
-import { StyleableText } from '../Typography/private';
 
 interface StyledRadioProps {
   checked?: boolean;
-  disabled?: boolean;
-}
-
-export interface StyledLabelProps {
   disabled?: boolean;
 }
 
@@ -22,20 +17,6 @@ export const RadioContainer = styled.div`
 export const HiddenRadio = styled.input`
   ${hideVisually()}
 `;
-
-export const StyledLabel = styled(StyleableText).attrs({
-  as: 'label',
-})<React.LabelHTMLAttributes<HTMLLabelElement> & StyledLabelProps>`
-  cursor: pointer;
-  margin-left: ${({ theme }) => theme.spacing.xSmall};
-
-  ${({ disabled, theme }) =>
-    disabled &&
-    css`
-      cursor: not-allowed;
-      color: ${theme.colors.secondary40};
-    `}
-` as StyledComponent<'label', DefaultTheme, StyledLabelProps>;
 
 export const StyledRadio = styled.label<StyledRadioProps>`
   ${withTransition(['border-color', 'box-shadow'])}
@@ -92,4 +73,3 @@ export const StyledRadio = styled.label<StyledRadioProps>`
 `;
 
 StyledRadio.defaultProps = { theme: defaultTheme };
-StyledLabel.defaultProps = { theme: defaultTheme };

--- a/packages/docs/PropTables/RadioPropTable.tsx
+++ b/packages/docs/PropTables/RadioPropTable.tsx
@@ -5,7 +5,7 @@ import { Code, Prop, PropTable, PropTableWrapper } from '../components';
 const radioProps: Prop[] = [
   {
     name: 'label',
-    types: 'ReactChild',
+    types: ['string', 'RadioLabel'],
     required: true,
     description: (
       <>


### PR DESCRIPTION
## What
Convert `Radio` to a functional component and remove static members.

---

BREAKING CHANGE:
Use `RadioLabel` instead of `Radio.Label`.