### PR TITLE
feat(component): convert Form to FC and remove static members

### DIFF
--- a/packages/big-design/setupTests.ts
+++ b/packages/big-design/setupTests.ts
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom/extend-expect';
 
 import * as utils from './src/utils';
-import { warning } from './src/utils/warning';
 
 /**
  * Because this util generates straightforward IDs which are saved in the snapshots,
@@ -19,6 +18,7 @@ jest.mock('./src/utils', () => {
 
   return {
     ...jest.requireActual('./src/utils'),
+    warning: jest.fn(),
     resetCounter: () => (counter = 0),
     uniqueId: (context: string) => {
       return `${context}${counter++}`;
@@ -26,13 +26,7 @@ jest.mock('./src/utils', () => {
   };
 });
 
-jest.mock('./src/utils/warning', () => {
-  return {
-    warning: jest.fn(),
-  };
-});
-
 afterEach(() => {
   (utils as any).resetCounter();
-  (warning as any).mockClear();
+  jest.clearAllMocks();
 });

--- a/packages/big-design/src/components/Checkbox/spec.tsx
+++ b/packages/big-design/src/components/Checkbox/spec.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
-import { warning } from '../../utils/warning';
+import { warning } from '../../utils';
 
 import { Checkbox } from './index';
 import { CheckboxLabel } from './Label';

--- a/packages/big-design/src/components/Form/Form.tsx
+++ b/packages/big-design/src/components/Form/Form.tsx
@@ -1,12 +1,8 @@
-import hoistNonReactStatics from 'hoist-non-react-statics';
-import React, { Ref } from 'react';
+import React, { forwardRef, Ref } from 'react';
 
-import { Fieldset } from '../Fieldset';
+import { typedMemo } from '../../utils';
 
 import { StyledForm } from './styled';
-import { FormControlError } from './Error';
-import { FormGroup } from './Group';
-import { FormControlLabel } from './Label';
 
 interface PrivateProps {
   forwardedRef: Ref<HTMLFormElement>;
@@ -16,23 +12,12 @@ export type FormProps = React.FormHTMLAttributes<HTMLFormElement> & {
   fullWidth?: boolean;
 };
 
-class StyleableForm extends React.PureComponent<PrivateProps & FormProps> {
-  static Label = FormControlLabel;
-  static Error = FormControlError;
-  static Fieldset = Fieldset;
-  static Group = FormGroup;
+const StyleableForm: React.FC<PrivateProps & FormProps> = ({ forwardedRef, ...props }) => (
+  <StyledForm {...props} ref={forwardedRef} />
+);
 
-  render() {
-    const { forwardedRef, ...props } = this.props;
-
-    return <StyledForm {...props} ref={forwardedRef} />;
-  }
-}
-
-const FormWithForwardedRef = React.forwardRef<HTMLFormElement, FormProps>(({ className, style, ...props }, ref) => (
-  <StyleableForm {...props} forwardedRef={ref} />
-));
-
-export const Form = hoistNonReactStatics(FormWithForwardedRef, StyleableForm);
-
-Form.displayName = 'Form';
+export const Form = typedMemo(
+  forwardRef<HTMLFormElement, FormProps>(({ className, style, ...props }, ref) => (
+    <StyleableForm {...props} forwardedRef={ref} />
+  )),
+);

--- a/packages/big-design/src/components/Form/Group/Group.tsx
+++ b/packages/big-design/src/components/Form/Group/Group.tsx
@@ -1,7 +1,8 @@
 import { ErrorIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
 
-import { uniqueId } from '../../../utils';
+import { warning } from '../../../utils';
+import { useUniqueId } from '../../../utils/useUniqueId';
 import { Checkbox } from '../../Checkbox';
 import { Radio } from '../../Radio';
 import { FormControlError } from '../Error';
@@ -22,7 +23,7 @@ export const FormGroup: React.FC<GroupProps> = props => {
   const renderErrors = () => {
     // If Form.Group has errors prop, don't generate errors from children
     if (groupErrors) {
-      return generateErrors(groupErrors);
+      return generateErrors(groupErrors, true);
     }
 
     return React.Children.map(children, child => {
@@ -51,8 +52,8 @@ export const FormGroup: React.FC<GroupProps> = props => {
   );
 };
 
-function generateErrors(errors: GroupProps['errors']): React.ReactNode {
-  const errorKey = uniqueId('formGroup_error_');
+function generateErrors(errors: GroupProps['errors'], fromGroup = false): React.ReactNode {
+  const errorKey = useUniqueId('formGroup_error');
 
   if (typeof errors === 'string') {
     return (
@@ -73,8 +74,14 @@ function generateErrors(errors: GroupProps['errors']): React.ReactNode {
   }
 
   if (Array.isArray(errors)) {
-    return errors.map(error => error && generateErrors(error));
+    return errors.map(error => error && generateErrors(error, fromGroup));
   }
 
-  return null;
+  if (!errors) {
+    return null;
+  }
+
+  if (fromGroup) {
+    warning('errors must be either a string, FormControlError, or an array of strings or FormControlError components.');
+  }
 }

--- a/packages/big-design/src/components/Form/Group/spec.tsx
+++ b/packages/big-design/src/components/Form/Group/spec.tsx
@@ -2,6 +2,7 @@ import { render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
+import { warning } from '../../../utils';
 import { Input } from '../../Input';
 import { FormControlError } from '../Error';
 
@@ -78,4 +79,17 @@ test('renders error prop with an array of FormControlError elements', () => {
   );
 
   testIds.forEach(id => expect(getByTestId(id)).toBeInTheDocument());
+});
+
+test('does not render invalid errors', () => {
+  const testId = 'test';
+  const errors = ['Error', <FormControlError>Error</FormControlError>, <div data-testid="testId">Error</div>];
+  const { queryByTestId } = render(
+    <FormGroup errors={errors}>
+      <Input />
+    </FormGroup>,
+  );
+
+  expect(warning).toBeCalledTimes(1);
+  expect(queryByTestId(testId)).not.toBeInTheDocument();
 });

--- a/packages/big-design/src/components/Form/spec.tsx
+++ b/packages/big-design/src/components/Form/spec.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Fieldset } from '../Fieldset';
 import { Input } from '../Input';
 
-import { Form } from './index';
+import { Form, FormGroup } from './index';
 
 test('forwards ref', () => {
   const ref = React.createRef<HTMLFormElement>();
@@ -26,12 +26,6 @@ test('calls onSubmit', () => {
   expect(onSubmit).toHaveBeenCalled();
 });
 
-test('exposes expected statics', () => {
-  expect(Form.Error).toBeDefined();
-  expect(Form.Label).toBeDefined();
-  expect(Form.Group).toBeDefined();
-});
-
 test('simple form render', () => {
   const { container } = render(
     <Form>
@@ -39,21 +33,21 @@ test('simple form render', () => {
         legend="Primary contact"
         description="Minim velit quis aute adipisicing adipisicing do do exercitation cupidatat enim ex voluptate consequat labore."
       >
-        <Form.Group>
+        <FormGroup>
           <Input
             label="First Name"
             description="This is an example description for First Name"
             placeholder="Placeholder text"
           />
-        </Form.Group>
+        </FormGroup>
 
-        <Form.Group>
+        <FormGroup>
           <Input
             label="Middle Name"
             description="This is an example description for Last Name. Featuring a Left Icon."
             placeholder="Placeholder text"
           />
-        </Form.Group>
+        </FormGroup>
       </Fieldset>
     </Form>,
   );

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -7,20 +7,6 @@ exports[`renders all together 1`] = `
   width: 1.5rem;
 }
 
-.c1 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
-}
-
-.c1:last-child {
-  margin-bottom: 0;
-}
-
 .c2 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
@@ -117,6 +103,20 @@ exports[`renders all together 1`] = `
   flex: 1;
   height: 100%;
   margin-top: -0.25rem;
+}
+
+.c1 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c1:last-child {
+  margin-bottom: 0;
 }
 
 .c0 {

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -4,7 +4,7 @@ import 'jest-styled-components';
 import React from 'react';
 
 import { warning } from '../../utils';
-import { Form, FormControlDescription, FormControlError, FormControlLabel } from '../Form';
+import { FormControlDescription, FormControlError, FormControlLabel, FormGroup } from '../Form';
 
 import { Input } from './index';
 
@@ -76,9 +76,9 @@ test('renders a description', () => {
 test('renders an error', () => {
   const errorText = 'This is an error';
   const { queryByText } = render(
-    <Form.Group>
+    <FormGroup>
       <Input error={errorText} />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   expect(queryByText(errorText)).toBeInTheDocument();
@@ -155,9 +155,9 @@ test('accepts an Error Component', () => {
   );
 
   const { queryByTestId } = render(
-    <Form.Group>
+    <FormGroup>
       <Input error={CustomError} />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   expect(queryByTestId('test')).toBeInTheDocument();
@@ -174,9 +174,9 @@ test('does not accept non-Error Components', () => {
   );
 
   const { queryByTestId } = render(
-    <Form.Group>
+    <FormGroup>
       <Input error={NotAnError} />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   expect(queryByTestId('test')).not.toBeInTheDocument();
@@ -219,17 +219,17 @@ test('renders all together', () => {
 test('error shows with valid string', () => {
   const error = 'Error';
   const { container, rerender } = render(
-    <Form.Group>
+    <FormGroup>
       <Input error="" />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   expect(container.querySelector('[class*="StyledError"]')).not.toBeInTheDocument();
 
   rerender(
-    <Form.Group>
+    <FormGroup>
       <Input error={error} />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   expect(container.querySelector('[class*="StyledError"]')).toBeInTheDocument();
@@ -238,9 +238,9 @@ test('error shows with valid string', () => {
 test('error shows when an array of strings', () => {
   const errors = ['Error 0', 'Error 1'];
   const { getByText } = render(
-    <Form.Group>
+    <FormGroup>
       <Input error={errors} />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   errors.forEach(error => expect(getByText(error)).toBeInTheDocument());
@@ -250,9 +250,9 @@ test('error shows when an array of Errors', () => {
   const testIds = ['error_0', 'error_1'];
   const errors = testIds.map(id => <FormControlError data-testid={id}>Error</FormControlError>);
   const { getByTestId } = render(
-    <Form.Group>
+    <FormGroup>
       <Input error={errors} />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   testIds.forEach(id => expect(getByTestId(id)).toBeInTheDocument());
@@ -262,9 +262,9 @@ describe('error does not show when invalid type', () => {
   test('single element', () => {
     const error = <div data-testid="err">Error</div>;
     const { queryByTestId } = render(
-      <Form.Group>
+      <FormGroup>
         <Input error={error} />
-      </Form.Group>,
+      </FormGroup>,
     );
 
     expect(warning).toHaveBeenCalledTimes(1);
@@ -275,9 +275,9 @@ describe('error does not show when invalid type', () => {
     const errors = ['Error', <FormControlError>Error</FormControlError>, <div data-testid="err">Error</div>];
 
     const { queryByTestId } = render(
-      <Form.Group>
+      <FormGroup>
         <Input error={errors} />
-      </Form.Group>,
+      </FormGroup>,
     );
 
     expect(warning).toHaveBeenCalledTimes(1);

--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -3,7 +3,8 @@ import focusTrap, { FocusTrap } from 'focus-trap';
 import React, { createRef, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import { typedMemo, uniqueId } from '../../utils';
+import { typedMemo } from '../../utils';
+import { useUniqueId } from '../../utils/useUniqueId';
 import { Button, ButtonProps } from '../Button';
 import { H2 } from '../Typography';
 
@@ -46,7 +47,7 @@ export const Modal: React.FC<ModalProps> = typedMemo(
     const [internalTrap, setInternalTrap] = useState<FocusTrap | null>(null);
     const [initialBodyOverflowY, setInitialBodyOverflowY] = useState('');
     const [modalContainer, setModalContainer] = useState<HTMLDivElement | null>(null);
-    const headerUniqueId = useMemo(() => uniqueId('modal_header_'), []);
+    const headerUniqueId = useUniqueId('modal_header');
     const modalRef = createRef<HTMLDivElement>();
     const previousFocus = useRef(typeof document !== 'undefined' ? document.activeElement : null);
 

--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -231,7 +231,7 @@ exports[`render open modal 1`] = `
       tabindex="-1"
     >
       <div
-        aria-labelledby="modal_header_0"
+        aria-labelledby="bd-modal_header-1"
         class="c1 c2 c3"
       >
         <div
@@ -246,7 +246,7 @@ exports[`render open modal 1`] = `
               class="c6"
             >
               <svg
-                aria-labelledby="bd-icon-1"
+                aria-labelledby="bd-icon-3"
                 class="c7"
                 fill="currentColor"
                 height="24"
@@ -256,7 +256,7 @@ exports[`render open modal 1`] = `
                 width="24"
               >
                 <title
-                  id="bd-icon-1"
+                  id="bd-icon-3"
                 >
                   Close
                 </title>
@@ -503,7 +503,7 @@ exports[`render open modal without backdrop 1`] = `
       tabindex="-1"
     >
       <div
-        aria-labelledby="modal_header_0"
+        aria-labelledby="bd-modal_header-1"
         class="c1 c2 c3"
       >
         <div
@@ -518,7 +518,7 @@ exports[`render open modal without backdrop 1`] = `
               class="c6"
             >
               <svg
-                aria-labelledby="bd-icon-1"
+                aria-labelledby="bd-icon-3"
                 class="c7"
                 fill="currentColor"
                 height="24"
@@ -528,7 +528,7 @@ exports[`render open modal without backdrop 1`] = `
                 width="24"
               >
                 <title
-                  id="bd-icon-1"
+                  id="bd-icon-3"
                 >
                   Close
                 </title>

--- a/packages/big-design/src/components/Radio/spec.tsx
+++ b/packages/big-design/src/components/Radio/spec.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
-import { warning } from '../../utils/warning';
+import { warning } from '../../utils';
 
 import { Radio, RadioLabel } from './index';
 

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
-import { Form } from '../Form';
+import { FormGroup } from '../Form';
 
 import { Select } from './Select';
 
@@ -360,7 +360,7 @@ test('select action supports actionTypes', () => {
 
 test('select should render an error if one is provided', () => {
   const { getByText } = render(
-    <Form.Group>
+    <FormGroup>
       <Select
         onItemChange={onItemChange}
         label="Countries"
@@ -375,7 +375,7 @@ test('select should render an error if one is provided', () => {
         ]}
         required
       />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   expect(getByText('Required')).toBeInTheDocument();

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -1,8 +1,9 @@
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 import { MarginProps } from '../../mixins';
-import { typedMemo, uniqueId } from '../../utils';
+import { typedMemo } from '../../utils';
 import { useEventCallback } from '../../utils/useEventCallback';
+import { useUniqueId } from '../../utils/useUniqueId';
 
 import { StyledTable, StyledTableFigure } from './styled';
 import { TableColumn, TableItem, TableProps } from './types';
@@ -31,7 +32,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     ...rest
   } = props;
   const actionsRef = useRef<HTMLDivElement>(null);
-  const tableIdRef = useRef(id || uniqueId('table_'));
+  const tableIdRef = useRef(id || useUniqueId('table'));
   const isSelectable = Boolean(selectable);
   const [selectedItems, setSelectedItems] = useState<Set<T>>(new Set());
 

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -404,7 +404,7 @@ exports[`renders a pagination component 1`] = `
 }
 
 <div
-  aria-controls="table_0"
+  aria-controls="bd-table-1"
   class="c0"
 >
   <div
@@ -421,7 +421,7 @@ exports[`renders a pagination component 1`] = `
         <button
           aria-haspopup="true"
           class="c6 c7"
-          id="trigger_2"
+          id="trigger_1"
           role="button"
           tabindex="0"
         >
@@ -430,7 +430,7 @@ exports[`renders a pagination component 1`] = `
           >
             1 - 3 of 5
             <svg
-              aria-labelledby="bd-icon-1"
+              aria-labelledby="bd-icon-2"
               class="c9"
               fill="currentColor"
               height="24"
@@ -450,9 +450,9 @@ exports[`renders a pagination component 1`] = `
           </span>
         </button>
         <ul
-          aria-labelledby="trigger_2"
+          aria-labelledby="trigger_1"
           class="c10"
-          id="dropdown_1"
+          id="dropdown_0"
           role="listbox"
           style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
           tabindex="-1"
@@ -460,7 +460,7 @@ exports[`renders a pagination component 1`] = `
           <li
             class="c11"
             data-highlighted="false"
-            id="dropdown_1-item-0"
+            id="dropdown_0-item-0"
             role="option"
             tabindex="-1"
           >
@@ -473,7 +473,7 @@ exports[`renders a pagination component 1`] = `
           <li
             class="c11"
             data-highlighted="false"
-            id="dropdown_1-item-1"
+            id="dropdown_0-item-1"
             role="option"
             tabindex="-1"
           >
@@ -486,7 +486,7 @@ exports[`renders a pagination component 1`] = `
           <li
             class="c11"
             data-highlighted="false"
-            id="dropdown_1-item-2"
+            id="dropdown_0-item-2"
             role="option"
             tabindex="-1"
           >
@@ -511,7 +511,7 @@ exports[`renders a pagination component 1`] = `
             class="c8"
           >
             <svg
-              aria-labelledby="bd-icon-2"
+              aria-labelledby="bd-icon-3"
               class="c14"
               fill="currentColor"
               height="24"
@@ -521,7 +521,7 @@ exports[`renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id="bd-icon-2"
+                id="bd-icon-3"
               >
                 Previous page
               </title>
@@ -544,7 +544,7 @@ exports[`renders a pagination component 1`] = `
             class="c8"
           >
             <svg
-              aria-labelledby="bd-icon-3"
+              aria-labelledby="bd-icon-4"
               class="c14"
               fill="currentColor"
               height="24"
@@ -554,7 +554,7 @@ exports[`renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id="bd-icon-3"
+                id="bd-icon-4"
               >
                 Next page
               </title>
@@ -652,7 +652,7 @@ exports[`renders a simple table 1`] = `
 
 <table
   class="c0"
-  id="table_0"
+  id="bd-table-1"
 >
   <thead
     class=""
@@ -995,7 +995,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls="table_0"
+  aria-controls="bd-table-1"
   class="c0"
 >
   <div
@@ -1008,18 +1008,18 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         class="c5"
       >
         <input
-          aria-labelledby="bd-checkbox_label-2"
+          aria-labelledby="bd-checkbox_label-3"
           class="c6 c7"
-          id="bd-checkbox-1"
+          id="bd-checkbox-2"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8"
-          for="bd-checkbox-1"
+          for="bd-checkbox-2"
         >
           <svg
-            aria-labelledby="bd-icon-3"
+            aria-labelledby="bd-icon-4"
             class="c9"
             fill="currentColor"
             height="24"
@@ -1039,9 +1039,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         </label>
         <label
           class="c10"
-          for="bd-checkbox-1"
+          for="bd-checkbox-2"
           hidden=""
-          id="bd-checkbox_label-2"
+          id="bd-checkbox_label-3"
         >
           Select All
         </label>

--- a/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
@@ -1,20 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders all together 1`] = `
-.c1 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
-}
-
-.c1:last-child {
-  margin-bottom: 0;
-}
-
 .c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -79,6 +65,20 @@ exports[`renders all together 1`] = `
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
+}
+
+.c1 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c1:last-child {
+  margin-bottom: 0;
 }
 
 .c0 {

--- a/packages/big-design/src/components/Textarea/spec.tsx
+++ b/packages/big-design/src/components/Textarea/spec.tsx
@@ -3,7 +3,7 @@ import 'jest-styled-components';
 import React from 'react';
 
 import { warning } from '../../utils';
-import { Form, FormControlDescription, FormControlError, FormControlLabel } from '../Form';
+import { FormControlDescription, FormControlError, FormControlLabel, FormGroup } from '../Form';
 
 import { Textarea, TextareaProps } from './index';
 
@@ -31,12 +31,12 @@ test('renders an textarea with matched label', () => {
 test('create unique ids if not provided', () => {
   const { queryByTestId } = render(
     <>
-      <Form.Group>
+      <FormGroup>
         <Textarea label="Test Label" data-testid="item1" />
-      </Form.Group>
-      <Form.Group>
+      </FormGroup>
+      <FormGroup>
         <Textarea label="Test Label" data-testid="item2" />
-      </Form.Group>
+      </FormGroup>
     </>,
   );
 
@@ -79,9 +79,9 @@ test('renders a description', () => {
 test('renders an error', () => {
   const errorText = 'This is an error';
   const { queryByText } = render(
-    <Form.Group>
+    <FormGroup>
       <Textarea error={errorText} />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   expect(queryByText(errorText)).toBeInTheDocument();
@@ -158,9 +158,9 @@ test('accepts an Error Component', () => {
   );
 
   const { queryByTestId } = render(
-    <Form.Group>
+    <FormGroup>
       <Textarea error={CustomError} />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   expect(queryByTestId('test')).toBeInTheDocument();
@@ -177,9 +177,9 @@ test('does not accept non-Error Components', () => {
   );
 
   const { queryByTestId } = render(
-    <Form.Group>
+    <FormGroup>
       <Textarea error={NotAnError} />
-    </Form.Group>,
+    </FormGroup>,
   );
 
   expect(queryByTestId('test')).not.toBeInTheDocument();
@@ -189,9 +189,9 @@ describe('error does not show when invalid type', () => {
   test('single element', () => {
     const error = <div data-testid="err">Error</div>;
     const { queryByTestId } = render(
-      <Form.Group>
+      <FormGroup>
         <Textarea error={error} />
-      </Form.Group>,
+      </FormGroup>,
     );
 
     expect(warning).toHaveBeenCalledTimes(1);
@@ -202,9 +202,9 @@ describe('error does not show when invalid type', () => {
     const errors = ['Error', <FormControlError>Error</FormControlError>, <div data-testid="err">Error</div>];
 
     const { queryByTestId } = render(
-      <Form.Group>
+      <FormGroup>
         <Textarea error={errors} />
-      </Form.Group>,
+      </FormGroup>,
     );
 
     expect(warning).toHaveBeenCalledTimes(1);

--- a/packages/big-design/src/utils/uniqueId.ts
+++ b/packages/big-design/src/utils/uniqueId.ts
@@ -1,5 +1,6 @@
 let counter = 0;
 
+// TODO: Remove once all components use useUniqueId:
 export function uniqueId(prefix: string) {
   counter += 1;
 

--- a/packages/docs/PropTables/FormPropTable.tsx
+++ b/packages/docs/PropTables/FormPropTable.tsx
@@ -5,7 +5,7 @@ import { Code, Prop, PropTable, PropTableWrapper } from '../components';
 
 export const FormErrorPropTable: React.FC<{ id?: string }> = ({ id }) => (
   <>
-    <H2 id={id}>Form.Error</H2>
+    <H2 id={id}>FormControlError</H2>
     <Text>
       Supports all native <Code>&lt;p /&gt;</Code> element attributes.
     </Text>
@@ -40,9 +40,18 @@ export const FormFieldsetPropTable: React.FC<PropTableWrapper> = props => (
 
 export const FormLabelPropTable: React.FC<{ id?: string }> = ({ id }) => (
   <>
-    <H2 id={id}>Form.Label</H2>
+    <H2 id={id}>FormControlLabel</H2>
     <Text>
       Supports all native <Code>&lt;label /&gt;</Code> element attributes.
+    </Text>
+  </>
+);
+
+export const FormDescriptionPropTable: React.FC<{ id?: string }> = ({ id }) => (
+  <>
+    <H2 id={id}>FormControlDescription</H2>
+    <Text>
+      Supports all native <Code>&lt;p /&gt;</Code> element attributes.
     </Text>
   </>
 );
@@ -65,5 +74,5 @@ export const FormPropTable: React.FC<PropTableWrapper> = props => (
 );
 
 export const FormGroupPropTable: React.FC<PropTableWrapper> = props => (
-  <PropTable title="Form.Group" propList={formGroupProps} {...props} />
+  <PropTable title="FormGroup" propList={formGroupProps} {...props} />
 );

--- a/packages/docs/PropTables/InputPropTable.tsx
+++ b/packages/docs/PropTables/InputPropTable.tsx
@@ -14,7 +14,7 @@ const inputProps: Prop[] = [
     types: ['string', 'string[]', 'FormControlError', 'FormControlError[]'],
     description: (
       <>
-        Displays an error message for the field. Error message will be passed to the <Code>Form.Group</Code> for display
+        Displays an error message for the field. Error message will be passed to the <Code>FormGroup</Code> for display
         purposes.
       </>
     ),

--- a/packages/docs/pages/Checkbox/CheckboxPage.tsx
+++ b/packages/docs/pages/Checkbox/CheckboxPage.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Form, H0, H1, H2, Link, Text } from '@bigcommerce/big-design';
+import { Checkbox, Form, FormGroup, H0, H1, H2, Link, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { Code, CodePreview } from '../../components';
@@ -24,9 +24,9 @@ export default () => (
 
         return (
           <Form>
-            <Form.Group>
+            <FormGroup>
               <Checkbox label={checked ? 'Checked' : 'Unchecked'} checked={checked} onChange={handleChange} />
-            </Form.Group>
+            </FormGroup>
           </Form>
         );
       }}
@@ -47,9 +47,9 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Checkbox label="Indeterminate" isIndeterminate />
-        </Form.Group>
+        </FormGroup>
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>

--- a/packages/docs/pages/Form/FormPage.tsx
+++ b/packages/docs/pages/Form/FormPage.tsx
@@ -4,6 +4,7 @@ import {
   Checkbox,
   Fieldset,
   Form,
+  FormGroup,
   H0,
   H1,
   Input,
@@ -17,6 +18,7 @@ import React from 'react';
 
 import { Code, CodePreview } from '../../components';
 import {
+  FormDescriptionPropTable,
   FormErrorPropTable,
   FormFieldsetPropTable,
   FormGroupPropTable,
@@ -40,17 +42,17 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Input
             label="Email"
             type="email"
             description="Please provide a valid email address."
             placeholder="Email address"
           />
-        </Form.Group>
-        <Form.Group>
+        </FormGroup>
+        <FormGroup>
           <Input label="Password" type="password" placeholder="Password" />
-        </Form.Group>
+        </FormGroup>
         <Box marginTop="xxLarge">
           <Button>Sign In</Button>
         </Box>
@@ -62,6 +64,7 @@ export default () => (
     <FormPropTable />
     <FormErrorPropTable id="error" />
     <FormLabelPropTable id="label" />
+    <FormDescriptionPropTable id="label" />
     <FormGroupPropTable />
     <FormFieldsetPropTable />
 
@@ -75,16 +78,16 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Input label="Example Input" placeholder="Example" />
-        </Form.Group>
-        <Form.Group>
+        </FormGroup>
+        <FormGroup>
           <Checkbox checked={true} onChange={() => null} label="Example Checkbox" />
-        </Form.Group>
-        <Form.Group>
+        </FormGroup>
+        <FormGroup>
           <Radio checked={true} onChange={() => null} label="Example Radio" />
-        </Form.Group>
-        <Form.Group>
+        </FormGroup>
+        <FormGroup>
           <Select
             label="Example Select"
             onItemChange={() => null}
@@ -96,10 +99,10 @@ export default () => (
             ]}
             placeholder="Example"
           />
-        </Form.Group>
-        <Form.Group>
+        </FormGroup>
+        <FormGroup>
           <Textarea label="Example Textarea" placeholder="Example" />
-        </Form.Group>
+        </FormGroup>
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>
@@ -107,32 +110,31 @@ export default () => (
     <H1>Layout</H1>
 
     <Text>
-      You can up to 3 <Code>Input</Code> components in row to add more dimension to a <Code>Form.Group</Code>.{' '}
-      <Code>Radio</Code> and <Code>Checkbox</Code> components will never display inline inside a <Code>Form.Group</Code>
-      .
+      You can up to 3 <Code>Input</Code> components in row to add more dimension to a <Code>FormGroup</Code>.{' '}
+      <Code>Radio</Code> and <Code>Checkbox</Code> components will never display inline inside a <Code>FormGroup</Code>.
     </Text>
 
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Input label="Company" placeholder="BigCommerce" required />
-        </Form.Group>
-        <Form.Group>
+        </FormGroup>
+        <FormGroup>
           <Input label="First Name" placeholder="John" required />
           <Input label="Last Name" placeholder="Doe" required />
-        </Form.Group>
-        <Form.Group>
+        </FormGroup>
+        <FormGroup>
           <Input label="City" placeholder="Austin" required />
           <Input label="State" placeholder="Texas" required />
           <Input label="Postal Code" placeholder="78726" required />
-        </Form.Group>
-        <Fieldset legend="Shipping Method" description={<div />}>
-          <Form.Group>
+        </FormGroup>
+        <Fieldset legend="Shipping Method">
+          <FormGroup>
             <Radio label="Free – Three Day Shipping" checked onChange={() => null} />
             <Radio label="$4.99 – Two Day Shipping" />
             <Radio label="$9.99 – One Day Shipping" />
-          </Form.Group>
+          </FormGroup>
         </Fieldset>
       </Form>
       {/* jsx-to-string:end */}
@@ -142,7 +144,7 @@ export default () => (
 
     <Text>
       All form controls are tied to <Code primary>onChange</Code> or equivalent event handlers. Validation messages can
-      be passed through the <Code>error</Code> prop. All input errors in an <Code>Form.Group</Code> will appear at the
+      be passed through the <Code>error</Code> prop. All input errors in an <Code>FormGroup</Code> will appear at the
       bottom of the group component component.
     </Text>
 
@@ -174,7 +176,7 @@ export default () => (
 
         return (
           <Form onSubmit={handleSubmit}>
-            <Form.Group>
+            <FormGroup>
               <Input
                 label="Example"
                 description="Remove characters to preview validation."
@@ -184,12 +186,12 @@ export default () => (
                 pattern="^.{1,3}$"
                 required
               />
-            </Form.Group>
-            <Form.Group>
+            </FormGroup>
+            <FormGroup>
               <Input label="City" error="You must enter a valid City." placeholder="Austin" required />
               <Input label="State" placeholder="Texas" required />
               <Input label="Postal Code" error="You must enter a valid Postal Code." placeholder="78726" required />
-            </Form.Group>
+            </FormGroup>
           </Form>
         );
       }}

--- a/packages/docs/pages/Input/InputPage.tsx
+++ b/packages/docs/pages/Input/InputPage.tsx
@@ -1,4 +1,4 @@
-import { Form, H0, H1, Input, Link, Text } from '@bigcommerce/big-design';
+import { Form, FormGroup, H0, H1, Input, Link, Text } from '@bigcommerce/big-design';
 import { CheckCircleIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
 
@@ -26,7 +26,7 @@ export default () => (
 
         return (
           <Form>
-            <Form.Group>
+            <FormGroup>
               <Input
                 label="Label"
                 description="Description for the input."
@@ -35,7 +35,7 @@ export default () => (
                 value={value}
                 onChange={handleChange}
               />
-            </Form.Group>
+            </FormGroup>
           </Form>
         );
       }}
@@ -60,7 +60,7 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Input
             label="Email Address"
             description="Provide a valid email address."
@@ -68,7 +68,7 @@ export default () => (
             error="Email address must contain a domain name."
             onChange={() => null}
           />
-        </Form.Group>
+        </FormGroup>
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>
@@ -82,10 +82,10 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Input label="Example" placeholder="Example" iconLeft={<CheckCircleIcon color="success" />} />
           <Input label="Example" placeholder="Example" iconRight={<CheckCircleIcon color="success" />} />
-        </Form.Group>
+        </FormGroup>
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>

--- a/packages/docs/pages/Radio/RadioPage.tsx
+++ b/packages/docs/pages/Radio/RadioPage.tsx
@@ -1,4 +1,4 @@
-import { Fieldset, Form, H0, H1, Link, Radio, Text } from '@bigcommerce/big-design';
+import { Fieldset, Form, FormGroup, H0, H1, Link, Radio, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { Code, CodePreview } from '../../components';
@@ -25,10 +25,10 @@ export default () => (
 
         return (
           <Form>
-            <Form.Group>
+            <FormGroup>
               <Radio label="On" checked={selected === 'on'} value="on" onChange={handleChange} />
               <Radio label="Off" checked={selected === 'off'} value="off" onChange={handleChange} />
-            </Form.Group>
+            </FormGroup>
           </Form>
         );
       }}
@@ -61,16 +61,16 @@ export default () => (
         return (
           <Form>
             <Fieldset legend="First Group">
-              <Form.Group>
+              <FormGroup>
                 <Radio label="On" checked={firstRadio === 'on'} value="on" onChange={handleFirstChange} />
                 <Radio label="Off" checked={firstRadio === 'off'} value="off" onChange={handleFirstChange} />
-              </Form.Group>
+              </FormGroup>
             </Fieldset>
             <Fieldset legend="Second Group">
-              <Form.Group>
+              <FormGroup>
                 <Radio label="On" checked={secondRadio === 'on'} value="on" onChange={handleSecondChange} />
                 <Radio label="Off" checked={secondRadio === 'off'} value="off" onChange={handleSecondChange} />
-              </Form.Group>
+              </FormGroup>
             </Fieldset>
           </Form>
         );

--- a/packages/docs/pages/Select/SelectPage.tsx
+++ b/packages/docs/pages/Select/SelectPage.tsx
@@ -1,4 +1,4 @@
-import { Form, Grid, H0, H1, Link, Select, Text } from '@bigcommerce/big-design';
+import { Form, FormGroup, Grid, H0, H1, Link, Select, Text } from '@bigcommerce/big-design';
 import { DeleteIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
 
@@ -25,7 +25,7 @@ export default () => (
 
         return (
           <Form>
-            <Form.Group>
+            <FormGroup>
               <Select
                 action={{
                   actionType: 'destructive',
@@ -59,7 +59,7 @@ export default () => (
                 required
                 value={value}
               />
-            </Form.Group>
+            </FormGroup>
           </Form>
         );
       }}
@@ -86,7 +86,7 @@ export default () => (
 
         return (
           <Form>
-            <Form.Group>
+            <FormGroup>
               <Select
                 label="States"
                 maxHeight={300}
@@ -104,7 +104,7 @@ export default () => (
                 required
                 value={value}
               />
-            </Form.Group>
+            </FormGroup>
           </Form>
         );
       }}
@@ -239,7 +239,7 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Select
             disabled
             label="Select"
@@ -254,7 +254,7 @@ export default () => (
             placeholder="Larger"
             required
           />
-        </Form.Group>
+        </FormGroup>
       </Form>
 
       {/* jsx-to-string:end */}
@@ -269,7 +269,7 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Select
             action={{
               actionType: 'destructive',
@@ -289,7 +289,7 @@ export default () => (
             placement={'bottom-start'}
             required
           />
-        </Form.Group>
+        </FormGroup>
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>
@@ -303,7 +303,7 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Select
             label="Countries"
             error="Need to choose a country before proceeding"
@@ -318,7 +318,7 @@ export default () => (
             placement={'bottom-start'}
             required
           />
-        </Form.Group>
+        </FormGroup>
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>

--- a/packages/docs/pages/Textarea/TextareaPage.tsx
+++ b/packages/docs/pages/Textarea/TextareaPage.tsx
@@ -1,4 +1,4 @@
-import { Form, H0, H1, Link, Text, Textarea } from '@bigcommerce/big-design';
+import { Form, FormGroup, H0, H1, Link, Text, Textarea } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { Code, CodePreview } from '../../components';
@@ -25,7 +25,7 @@ export default () => (
 
         return (
           <Form>
-            <Form.Group>
+            <FormGroup>
               <Textarea
                 label="Label"
                 description="Description for the textarea."
@@ -35,7 +35,7 @@ export default () => (
                 value={value}
                 onChange={handleChange}
               />
-            </Form.Group>
+            </FormGroup>
           </Form>
         );
       }}
@@ -60,7 +60,7 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Textarea
             label="Description"
             description="Description needs to be at least 64 characters long."
@@ -69,7 +69,7 @@ export default () => (
             error="Field needs to contain at least 64 characters."
             onChange={() => null}
           />
-        </Form.Group>
+        </FormGroup>
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>
@@ -84,9 +84,9 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Textarea label="Label" description="Textarea with 5 rows." placeholder="Placeholder" rows={5} />
-        </Form.Group>
+        </FormGroup>
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>
@@ -101,9 +101,9 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       <Form>
-        <Form.Group>
+        <FormGroup>
           <Textarea label="Label" placeholder="Textarea cannot be resized." resize={false} />
-        </Form.Group>
+        </FormGroup>
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>


### PR DESCRIPTION
## What
Convert `Form` to a functional component and remove static members.

---

BREAKING CHANGE:
Use `FormControlError`, `FormControlLabel`, `FormGroup`, and `Fieldset`
instead of `Form.Error`, `Form.Label`, `Form.Group`, and `Form.Fieldset` respectively.