### PR TITLE
fix(component): icon alignment and autofill input fixes

### DIFF
--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -55,7 +55,7 @@ exports[`simple form render 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 2.25rem;
-  padding: 0.25rem 0.75rem;
+  position: relative;
   width: 100%;
   border: 1px solid #D9DCE9;
 }
@@ -76,10 +76,11 @@ exports[`simple form render 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  height: 1.5rem;
-  margin-top: 0.25rem;
+  height: 100%;
   padding: 0;
+  padding-left: 0.5rem;
   width: 100%;
+  min-height: 2.125rem;
 }
 
 .c9:focus {
@@ -106,11 +107,20 @@ exports[`simple form render 1`] = `
   font-size: 1rem;
 }
 
+.c9:-webkit-autofill {
+  background-color: #F0F3FF !important;
+  -webkit-box-shadow: 0 0 0px 1000px #F0F3FF inset;
+}
+
 .c9[disabled] {
   background-color: #ECEEF5;
 }
 
 .c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -123,7 +133,6 @@ exports[`simple form render 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
-  margin-top: -0.25rem;
 }
 
 .c4 {

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -98,7 +98,11 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
       return null;
     }
 
-    return <StyledIconWrapper>{props.iconLeft}</StyledIconWrapper>;
+    return (
+      <StyledIconWrapper paddingLeft="xSmall" paddingRight="xxSmall">
+        {props.iconLeft}
+      </StyledIconWrapper>
+    );
   }, [props.iconLeft]);
 
   const renderedIconRight = useMemo(() => {
@@ -106,7 +110,11 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
       return null;
     }
 
-    return <StyledIconWrapper>{props.iconRight}</StyledIconWrapper>;
+    return (
+      <StyledIconWrapper paddingLeft="xxSmall" paddingRight="xSmall">
+        {props.iconRight}
+      </StyledIconWrapper>
+    );
   }, [props.iconRight]);
 
   const renderedChips = useMemo(() => {

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`renders all together 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 2.25rem;
-  padding: 0.25rem 0.75rem;
+  position: relative;
   width: 100%;
   border: 1px solid #D9DCE9;
 }
@@ -45,12 +45,13 @@ exports[`renders all together 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  height: 1.5rem;
-  margin-top: 0.25rem;
+  height: 100%;
   padding: 0;
+  padding-left: 0.5rem;
   width: 100%;
-  padding-right: 0.25rem;
-  padding-left: 0.25rem;
+  padding-right: 2.25rem;
+  padding-left: 2.25rem;
+  min-height: 2.125rem;
 }
 
 .c6:focus {
@@ -77,19 +78,56 @@ exports[`renders all together 1`] = `
   font-size: 1rem;
 }
 
+.c6:-webkit-autofill {
+  background-color: #F0F3FF !important;
+  -webkit-box-shadow: 0 0 0px 1000px #F0F3FF inset;
+}
+
 .c6[disabled] {
   background-color: #ECEEF5;
 }
 
 .c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   color: #5E637A;
-  -webkit-flex: 0 0 1.5rem;
-  -ms-flex: 0 0 1.5rem;
-  flex: 0 0 1.5rem;
-  height: 1.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  padding-right: 0.25rem;
+  padding-left: 0.5rem;
+  left: 0;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #5E637A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  padding-right: 0.5rem;
+  padding-left: 0.25rem;
+  right: 0;
 }
 
 .c5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -102,7 +140,6 @@ exports[`renders all together 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
-  margin-top: -0.25rem;
 }
 
 .c1 {
@@ -184,7 +221,7 @@ exports[`renders all together 1`] = `
       />
     </div>
     <div
-      class="c3"
+      class="c7"
     >
       <svg
         aria-labelledby="bd-icon-3"

--- a/packages/big-design/src/components/Input/styled.tsx
+++ b/packages/big-design/src/components/Input/styled.tsx
@@ -1,6 +1,7 @@
-import { addValues, theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { addValues, remCalc, theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
+import { withPaddings, PaddingProps } from '../../mixins';
 import { withTransition } from '../../mixins/transitions';
 
 import { InputProps } from './Input';
@@ -18,7 +19,7 @@ export const StyledInputWrapper = styled.span<StyledInputWrapperProps>`
   box-sizing: border-box;
   display: flex;
   min-height: ${({ theme }) => addValues(theme.spacing.xxLarge, theme.spacing.xxSmall)};
-  padding: ${({ theme }) => `${theme.spacing.xxSmall} ${theme.spacing.small}`};
+  position: relative;
   width: 100%;
 
   ${({ error, theme }) => css`
@@ -54,9 +55,9 @@ export const StyledInput = styled.input<InputProps>`
   box-sizing: border-box;
   color: ${({ theme }) => theme.colors.secondary70};
   flex: 1;
-  height: ${({ theme }) => theme.spacing.xLarge};
-  margin-top: ${({ theme }) => theme.spacing.xxSmall};
+  height: 100%;
   padding: 0;
+  padding-left: ${({ theme }) => theme.spacing.xSmall};
   width: 100%;
 
   &:focus {
@@ -68,22 +69,44 @@ export const StyledInput = styled.input<InputProps>`
     font-size: ${({ theme }) => theme.typography.fontSize.medium};
   }
 
-  ${props =>
-    props.iconRight &&
+  &:-webkit-autofill {
+    /* !important overrides user agent style sheets that use !important in their :-webkit-autofill implementation */
+    /* See https://developer.mozilla.org/en-US/docs/Web/CSS/:-webkit-autofill */
+    background-color: ${({ theme }) => theme.colors.primary10} !important;
+    -webkit-box-shadow: 0 0 0px 1000px ${({ theme }) => theme.colors.primary10} inset;
+  }
+
+  ${({ iconRight, theme }) =>
+    iconRight &&
     css`
-      padding-right: ${props.theme.spacing.xxSmall};
+      padding-right: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
     `};
 
-  ${props =>
-    props.iconLeft &&
+  ${({ iconLeft, theme }) =>
+    iconLeft &&
     css`
-      padding-left: ${props.theme.spacing.xxSmall};
+      padding-left: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
     `};
 
-  ${props =>
-    props.chips &&
+  ${({ chips, theme }) =>
+    chips &&
     css`
-      padding-left: ${props.theme.spacing.xxSmall};
+      min-height: ${theme.spacing.xLarge};
+      padding-left: ${theme.spacing.xxSmall};
+      padding-right: ${theme.spacing.none};
+    `};
+
+  ${({ chips, theme }) =>
+    chips &&
+    chips.length &&
+    css`
+      margin-top: ${theme.spacing.xxSmall};
+    `};
+
+  ${({ chips }) =>
+    !chips &&
+    css`
+      min-height: ${remCalc(34)};
     `};
 
   &[disabled] {
@@ -91,24 +114,49 @@ export const StyledInput = styled.input<InputProps>`
   }
 `;
 
-export const StyledIconWrapper = styled.div`
+export const StyledIconWrapper = styled.div<PaddingProps>`
+  align-items: center;
   color: ${({ theme }) => theme.colors.secondary60};
-  flex: 0 0 ${({ theme }) => theme.spacing.xLarge};
-  height: ${({ theme }) => theme.spacing.xLarge};
+  display: flex;
+  height: 100%;
+  position: absolute;
+  top: 0;
+
+  ${withPaddings()}
+
+  ${({ paddingLeft }) =>
+    paddingLeft === 'xSmall' &&
+    css`
+      left: 0;
+    `}
+
+  ${({ paddingRight }) =>
+    paddingRight === 'xSmall' &&
+    css`
+      right: 0;
+    `}
 `;
 
 export const StyledInputContent = styled.div<InputProps>`
+  align-items: center;
   box-sizing: border-box;
   display: flex;
   flex-wrap: wrap;
   flex: 1;
   height: 100%;
-  margin-top: -${({ theme }) => theme.spacing.xxSmall};
 
-  ${props =>
-    props.chips &&
+  ${({ chips, theme }) =>
+    chips &&
     css`
-      margin-left: -${props.theme.spacing.xxSmall};
+      margin-left: ${theme.spacing.xxSmall};
+      padding-right: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
+    `};
+
+  ${({ chips, theme }) =>
+    chips &&
+    chips.length &&
+    css`
+      margin-bottom: ${theme.spacing.xxSmall};
     `};
 `;
 

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -170,7 +170,7 @@ export class Select<T extends any> extends React.PureComponent<SelectProps<T>, S
           <StyledInputContainer ref={ref}>
             <Input
               aria-autocomplete="list"
-              autoComplete="off"
+              autoComplete="no"
               chips={chips}
               disabled={disabled}
               error={error}


### PR DESCRIPTION
## What
Inputs with `Icons` are not perfectly aligned and have extra margins / paddings. This PR is an attempt to resolve that, alongside ensuring the whole field upon autocomplete is filled.

## Screenshot
<img width="452" alt="Screen Shot 2020-01-15 at 2 41 20 PM" src="https://user-images.githubusercontent.com/10539418/72470269-1edb2a80-37a6-11ea-911b-643da561a1f6.png">
