### PR TITLE
feat(component): add forwardRef to box, flex and grid

### DIFF
--- a/packages/big-design/src/components/Box/Box.tsx
+++ b/packages/big-design/src/components/Box/Box.tsx
@@ -17,8 +17,16 @@ export interface BoxProps extends React.HTMLAttributes<HTMLDivElement>, DisplayP
   borderRadius?: keyof BorderRadius;
 }
 
-export const Box: React.FC<BoxProps> = memo(
-  React.forwardRef<HTMLDivElement, BoxProps>((props, ref) => <StyledBox forwardedRef={ref} {...props} />),
+interface PrivateProps {
+  forwardedRef: React.Ref<HTMLDivElement>;
+}
+
+const RawBox: React.FC<BoxProps & PrivateProps> = memo(
+  React.forwardRef<HTMLDivElement, BoxProps & PrivateProps>((props, ref) => (
+    <StyledBox forwardedRef={ref} {...props} />
+  )),
 );
+
+export const Box = React.forwardRef<HTMLDivElement, BoxProps>((props, ref) => <RawBox {...props} forwardedRef={ref} />);
 
 Box.displayName = 'Box';

--- a/packages/big-design/src/components/Box/Box.tsx
+++ b/packages/big-design/src/components/Box/Box.tsx
@@ -17,6 +17,8 @@ export interface BoxProps extends React.HTMLAttributes<HTMLDivElement>, DisplayP
   borderRadius?: keyof BorderRadius;
 }
 
-export const Box: React.FC<BoxProps> = memo(props => <StyledBox {...props} />);
+export const Box: React.FC<BoxProps> = memo(
+  React.forwardRef<HTMLDivElement, BoxProps>((props, ref) => <StyledBox forwardedRef={ref} {...props} />),
+);
 
 Box.displayName = 'Box';

--- a/packages/big-design/src/components/Box/Box.tsx
+++ b/packages/big-design/src/components/Box/Box.tsx
@@ -21,12 +21,10 @@ interface PrivateProps {
   forwardedRef: React.Ref<HTMLDivElement>;
 }
 
-const RawBox: React.FC<BoxProps & PrivateProps> = memo(
-  React.forwardRef<HTMLDivElement, BoxProps & PrivateProps>((props, ref) => (
-    <StyledBox forwardedRef={ref} {...props} />
-  )),
-);
+const RawBox: React.FC<BoxProps & PrivateProps> = props => <StyledBox ref={props.forwardedRef} {...props} />;
 
-export const Box = React.forwardRef<HTMLDivElement, BoxProps>((props, ref) => <RawBox {...props} forwardedRef={ref} />);
+export const Box = memo(
+  React.forwardRef<HTMLDivElement, BoxProps>((props, ref) => <RawBox {...props} forwardedRef={ref} />),
+);
 
 Box.displayName = 'Box';

--- a/packages/big-design/src/components/Box/spec.tsx
+++ b/packages/big-design/src/components/Box/spec.tsx
@@ -68,3 +68,12 @@ test('renders as a different tag', () => {
 
   expect(tag).toBe('SECTION');
 });
+
+test('box forwards ref', () => {
+  const ref = React.createRef<HTMLDivElement>();
+
+  const { container } = render(<Box ref={ref}>Hello</Box>);
+  const div = container.querySelector('div');
+
+  expect(div).toBe(ref.current);
+});

--- a/packages/big-design/src/components/Flex/Flex.tsx
+++ b/packages/big-design/src/components/Flex/Flex.tsx
@@ -7,6 +7,14 @@ import { FlexedProps } from './types';
 
 export type FlexProps = BoxProps & FlexedProps;
 
-export const Flex: React.FC<FlexProps> = React.forwardRef<HTMLDivElement, FlexProps>(({ as, ...rest }, ref) => (
-  <StyledFlex forwardedAs={as} forwardedRef={ref} {...rest} />
+interface PrivateProps {
+  forwardedRef: React.Ref<HTMLDivElement>;
+}
+
+const RawFlex: React.FC<FlexProps & PrivateProps> = React.forwardRef<HTMLDivElement, FlexProps & PrivateProps>(
+  ({ as, ...rest }, ref) => <StyledFlex forwardedAs={as} forwardedRef={ref} {...rest} />,
+);
+
+export const Flex = React.forwardRef<HTMLDivElement, FlexProps>((props, ref) => (
+  <RawFlex {...props} forwardedRef={ref} />
 ));

--- a/packages/big-design/src/components/Flex/Flex.tsx
+++ b/packages/big-design/src/components/Flex/Flex.tsx
@@ -11,8 +11,8 @@ interface PrivateProps {
   forwardedRef: React.Ref<HTMLDivElement>;
 }
 
-const RawFlex: React.FC<FlexProps & PrivateProps> = React.forwardRef<HTMLDivElement, FlexProps & PrivateProps>(
-  ({ as, ...rest }, ref) => <StyledFlex forwardedAs={as} forwardedRef={ref} {...rest} />,
+const RawFlex: React.FC<FlexProps & PrivateProps> = ({ as, forwardedRef, ...rest }) => (
+  <StyledFlex forwardedAs={as} ref={forwardedRef} {...rest} />
 );
 
 export const Flex = React.forwardRef<HTMLDivElement, FlexProps>((props, ref) => (

--- a/packages/big-design/src/components/Flex/Flex.tsx
+++ b/packages/big-design/src/components/Flex/Flex.tsx
@@ -7,4 +7,6 @@ import { FlexedProps } from './types';
 
 export type FlexProps = BoxProps & FlexedProps;
 
-export const Flex: React.FC<FlexProps> = ({ as, ...rest }) => <StyledFlex forwardedAs={as} {...rest} />;
+export const Flex: React.FC<FlexProps> = React.forwardRef<HTMLDivElement, FlexProps>(({ as, ...rest }, ref) => (
+  <StyledFlex forwardedAs={as} forwardedRef={ref} {...rest} />
+));

--- a/packages/big-design/src/components/Flex/Item/Item.tsx
+++ b/packages/big-design/src/components/Flex/Item/Item.tsx
@@ -5,6 +5,16 @@ import { FlexedItemProps } from '../types';
 
 import { StyledFlexItem } from './styled';
 
+interface PrivateProps {
+  forwardedRef: React.Ref<HTMLDivElement>;
+}
+
 export type FlexItemProps = BoxProps & FlexedItemProps;
 
-export const FlexItem: React.FC<FlexItemProps> = ({ as, ...props }) => <StyledFlexItem forwardedAs={as} {...props} />;
+const RawFlexItem: React.FC<FlexItemProps & PrivateProps> = ({ as, forwardedRef, ...props }) => (
+  <StyledFlexItem ref={forwardedRef} forwardedAs={as} {...props} />
+);
+
+export const FlexItem = React.forwardRef<HTMLDivElement, FlexItemProps>((props, ref) => (
+  <RawFlexItem {...props} forwardedRef={ref} />
+));

--- a/packages/big-design/src/components/Flex/spec.tsx
+++ b/packages/big-design/src/components/Flex/spec.tsx
@@ -54,3 +54,21 @@ test('Flex Item should handle falsy values (0)', () => {
 
   expect(flex).toHaveStyle('flex-shrink: 0');
 });
+
+test('Flex forwards ref', () => {
+  const ref = React.createRef<HTMLDivElement>();
+
+  const { container } = render(<Flex ref={ref}>Hello</Flex>);
+  const div = container.querySelector('div');
+
+  expect(div).toBe(ref.current);
+});
+
+test('FlexItem forwards ref', () => {
+  const ref = React.createRef<HTMLDivElement>();
+
+  const { container } = render(<FlexItem ref={ref}>Hello</FlexItem>);
+  const div = container.querySelector('div');
+
+  expect(div).toBe(ref.current);
+});

--- a/packages/big-design/src/components/Grid/Grid.tsx
+++ b/packages/big-design/src/components/Grid/Grid.tsx
@@ -11,8 +11,8 @@ interface PrivateProps {
   forwardedRef: React.Ref<HTMLDivElement>;
 }
 
-const RawGrid: React.FC<GridProps & PrivateProps> = React.forwardRef<HTMLDivElement, GridProps & PrivateProps>(
-  ({ as, ...rest }, ref) => <StyledGrid forwardedAs={as} forwardedRef={ref} {...rest} />,
+const RawGrid: React.FC<GridProps & PrivateProps> = ({ as, forwardedRef, ...rest }) => (
+  <StyledGrid forwardedAs={as} ref={forwardedRef} {...rest} />
 );
 
 export const Grid = React.forwardRef<HTMLDivElement, GridProps>((props, ref) => (

--- a/packages/big-design/src/components/Grid/Grid.tsx
+++ b/packages/big-design/src/components/Grid/Grid.tsx
@@ -7,4 +7,6 @@ import { GridedProps } from './types';
 
 export type GridProps = BoxProps & GridedProps;
 
-export const Grid: React.FC<GridProps> = ({ as, ...rest }) => <StyledGrid forwardedAs={as} {...rest} />;
+export const Grid: React.FC<GridProps> = React.forwardRef(({ as, ...rest }, ref) => (
+  <StyledGrid forwardedAs={as} forwardedRef={ref} {...rest} />
+));

--- a/packages/big-design/src/components/Grid/Grid.tsx
+++ b/packages/big-design/src/components/Grid/Grid.tsx
@@ -7,6 +7,14 @@ import { GridedProps } from './types';
 
 export type GridProps = BoxProps & GridedProps;
 
-export const Grid: React.FC<GridProps> = React.forwardRef(({ as, ...rest }, ref) => (
-  <StyledGrid forwardedAs={as} forwardedRef={ref} {...rest} />
+interface PrivateProps {
+  forwardedRef: React.Ref<HTMLDivElement>;
+}
+
+const RawGrid: React.FC<GridProps & PrivateProps> = React.forwardRef<HTMLDivElement, GridProps & PrivateProps>(
+  ({ as, ...rest }, ref) => <StyledGrid forwardedAs={as} forwardedRef={ref} {...rest} />,
+);
+
+export const Grid = React.forwardRef<HTMLDivElement, GridProps>((props, ref) => (
+  <RawGrid {...props} forwardedRef={ref} />
 ));

--- a/packages/big-design/src/components/Grid/spec.tsx
+++ b/packages/big-design/src/components/Grid/spec.tsx
@@ -53,3 +53,11 @@ test('rendering as another element retains inherited props and styles', () => {
   expect(grid.tagName).toBe('SECTION');
   expect(grid).toHaveStyle(`margin: 1rem`);
 });
+
+test('grid forwards ref', () => {
+  const ref = React.createRef<HTMLDivElement>();
+  const { getByTestId } = render(<Grid ref={ref} data-testid="grid" />);
+  const grid = getByTestId('grid');
+
+  expect(grid).toBe(ref.current);
+});


### PR DESCRIPTION
## What?
Adds a few missing `forwardRef`s

Example use-case I stumbled upon in my app is needing to scroll to certain elements. Since we don't provide users with the element refs we cannot scroll to them programmatically