### PR TITLE
fix(component): unmount Modals appropriately by deactivating focus trap

### DIFF
--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -71,6 +71,10 @@ export const Modal: React.FC<ModalProps> = typedMemo(
     }, []);
 
     useEffect(() => {
+      return internalTrap?.deactivate;
+    }, [internalTrap]);
+
+    useEffect(() => {
       const prevFocus = previousFocus.current as HTMLElement;
 
       return () => {

--- a/packages/big-design/src/components/Modal/spec.tsx
+++ b/packages/big-design/src/components/Modal/spec.tsx
@@ -274,6 +274,6 @@ test('unmounts appropriately', () => {
   const button = getByTestId('button');
   button.click();
 
-  // Make sure events still work for other components
+  // Make sure mouse events still work for other components
   expect(onClick).toHaveBeenCalledTimes(1);
 });

--- a/packages/big-design/src/components/Modal/spec.tsx
+++ b/packages/big-design/src/components/Modal/spec.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, wait } from '@test/utils';
 import 'jest-styled-components';
 import React from 'react';
 
+import { Button } from '../Button';
+
 import { Modal } from './Modal';
 
 test('render open modal', () => {
@@ -255,4 +257,23 @@ test('renders destructive action button', () => {
   const button = getAllByRole('button')[1];
 
   expect(button).toMatchSnapshot();
+});
+
+test('unmounts appropriately', () => {
+  const onClick = jest.fn();
+  const { getByTestId, rerender, unmount } = render(<Modal isOpen={true} />);
+
+  unmount();
+
+  rerender(
+    <Button onClick={onClick} data-testid="button">
+      Test
+    </Button>,
+  );
+
+  const button = getByTestId('button');
+  button.click();
+
+  // Make sure events still work for other components
+  expect(onClick).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
This change will unmount the modal successfully by deactivating the focus trap allowing other components to listen for events.