### PR TITLE
fix(component): fix links in Dropdown items and scroll bug

### DIFF
--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -5,12 +5,12 @@ import scrollIntoView from 'scroll-into-view-if-needed';
 import { uniqueId } from '../../utils';
 import { Flex } from '../Flex';
 import { FlexItem } from '../Flex/Item';
-import { Link } from '../Link';
 import { List } from '../List';
 import { ListGroupHeader } from '../List/GroupHeader';
 import { ListItem } from '../List/Item';
 import { Tooltip, TooltipProps } from '../Tooltip';
 
+import { StyledLink } from './styled';
 import { DropdownLinkItem, DropdownOption, DropdownOptionGroup, DropdownProps } from './types';
 
 interface DropdownState {
@@ -137,9 +137,9 @@ export class Dropdown<T extends any> extends React.PureComponent<DropdownProps<T
 
   private wrapInLink(option: DropdownLinkItem<T>, content: React.ReactChild) {
     return (
-      <Link href={option.url} target={option.target}>
+      <StyledLink href={option.url} target={option.target}>
         {content}
-      </Link>
+      </StyledLink>
     );
   }
 

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -5,6 +5,7 @@ import scrollIntoView from 'scroll-into-view-if-needed';
 import { uniqueId } from '../../utils';
 import { Flex } from '../Flex';
 import { FlexItem } from '../Flex/Item';
+import { Link } from '../Link';
 import { List } from '../List';
 import { ListGroupHeader } from '../List/GroupHeader';
 import { ListItem } from '../List/Item';
@@ -136,9 +137,9 @@ export class Dropdown<T extends any> extends React.PureComponent<DropdownProps<T
 
   private wrapInLink(option: DropdownLinkItem<T>, content: React.ReactChild) {
     return (
-      <a href={option.url} target={option.target}>
+      <Link href={option.url} target={option.target}>
         {content}
-      </a>
+      </Link>
     );
   }
 

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -5,7 +5,6 @@ import scrollIntoView from 'scroll-into-view-if-needed';
 import { uniqueId } from '../../utils';
 import { Flex } from '../Flex';
 import { FlexItem } from '../Flex/Item';
-import { Link } from '../Link';
 import { List } from '../List';
 import { ListGroupHeader } from '../List/GroupHeader';
 import { ListItem } from '../List/Item';
@@ -137,9 +136,9 @@ export class Dropdown<T extends any> extends React.PureComponent<DropdownProps<T
 
   private wrapInLink(option: DropdownLinkItem<T>, content: React.ReactChild) {
     return (
-      <Link href={option.url} target={option.target}>
+      <a href={option.url} target={option.target}>
         {content}
-      </Link>
+      </a>
     );
   }
 

--- a/packages/big-design/src/components/Dropdown/styled.ts
+++ b/packages/big-design/src/components/Dropdown/styled.ts
@@ -1,0 +1,21 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled from 'styled-components';
+
+import { withTransition } from '../../mixins/transitions';
+
+export const StyledLink = styled.a`
+  ${withTransition(['background-color', 'color'])}
+
+  align-items: center;
+  color: ${({ theme }) => theme.colors.secondary70};
+  display: flex;
+  height: 100%;
+  text-decoration: none;
+  width: 100%;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+StyledLink.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -18,6 +18,21 @@ export const StyledListItem = styled.li<ListItemProps>`
   outline: none;
   padding: 0 ${({ theme }) => theme.spacing.medium};
 
+  a {
+    ${withTransition(['background-color', 'color'])}
+
+    align-items: center;
+    color: ${({ theme }) => theme.colors.secondary70};
+    display: flex;
+    height: 100%;
+    text-decoration: none;
+    width: 100%;
+
+    &:focus {
+      outline: none;
+    }
+  }
+
   &[aria-selected='true'] {
     font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   }
@@ -43,10 +58,6 @@ export const StyledListItem = styled.li<ListItemProps>`
       color: ${theme.colors.secondary40};
       cursor: not-allowed;
     `}
-
-  a {
-    color: ${({ theme }) => theme.colors.secondary70};
-  }
 
   label {
     cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -18,21 +18,6 @@ export const StyledListItem = styled.li<ListItemProps>`
   outline: none;
   padding: 0 ${({ theme }) => theme.spacing.medium};
 
-  a {
-    ${withTransition(['background-color', 'color'])}
-
-    align-items: center;
-    color: ${({ theme }) => theme.colors.secondary70};
-    display: flex;
-    height: 100%;
-    text-decoration: none;
-    width: 100%;
-
-    &:focus {
-      outline: none;
-    }
-  }
-
   &[aria-selected='true'] {
     font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   }

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -1,5 +1,5 @@
 import { Placement } from 'popper.js';
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { Popper } from 'react-popper';
 
 import { StyledList } from './styled';
@@ -26,31 +26,35 @@ export const List: React.FC<ListProps> = memo(
     positionFixed,
     style,
     ...rest
-  }) => (
-    <Popper
-      innerRef={handleListRef}
-      placement={selectedPlacement}
-      positionFixed={positionFixed}
-      modifiers={{ offset: { offset: '0, 10' } }}
-      eventsEnabled={isOpen}
-    >
-      {({ placement, ref, scheduleUpdate, style: popperStyle }) => (
-        <StyledList
-          data-placement={placement}
-          isOpen={isOpen}
-          maxHeight={maxHeight}
-          ref={ref}
-          style={popperStyle}
-          tabIndex={-1}
-          {...rest}
-        >
-          <ListPopperElement isOpen={isOpen} scheduleUpdate={scheduleUpdate}>
-            {children}
-          </ListPopperElement>
-        </StyledList>
-      )}
-    </Popper>
-  ),
+  }) => {
+    const modifiers = useMemo(() => ({ offset: { offset: '0, 10' } }), []);
+
+    return (
+      <Popper
+        innerRef={handleListRef}
+        placement={selectedPlacement}
+        positionFixed={positionFixed}
+        modifiers={modifiers}
+        eventsEnabled={isOpen}
+      >
+        {({ placement, ref, scheduleUpdate, style: popperStyle }) => (
+          <StyledList
+            data-placement={placement}
+            isOpen={isOpen}
+            maxHeight={maxHeight}
+            ref={ref}
+            style={popperStyle}
+            tabIndex={-1}
+            {...rest}
+          >
+            <ListPopperElement isOpen={isOpen} scheduleUpdate={scheduleUpdate}>
+              {children}
+            </ListPopperElement>
+          </StyledList>
+        )}
+      </Popper>
+    );
+  },
 );
 
 List.displayName = 'List';

--- a/packages/big-design/src/components/List/ListPopperElement.tsx
+++ b/packages/big-design/src/components/List/ListPopperElement.tsx
@@ -1,22 +1,16 @@
-import React, { ReactNode } from 'react';
+import React, { memo } from 'react';
+
+import { useIsomorphicLayoutEffect, useWindowSize } from '../../hooks/';
 
 interface ListPopperElementProps {
-  children: ReactNode;
   isOpen: boolean;
   scheduleUpdate(): void;
 }
 
-export class ListPopperElement extends React.PureComponent<ListPopperElementProps> {
-  componentDidUpdate(prevProps: ListPopperElementProps) {
-    if (
-      this.props.isOpen !== prevProps.isOpen ||
-      React.Children.count(this.props.children) !== React.Children.count(prevProps.children)
-    ) {
-      this.props.scheduleUpdate();
-    }
-  }
+export const ListPopperElement: React.FC<ListPopperElementProps> = memo(({ children, isOpen, scheduleUpdate }) => {
+  const { height, width } = useWindowSize();
 
-  render() {
-    return this.props.children;
-  }
-}
+  useIsomorphicLayoutEffect(scheduleUpdate, [children, isOpen, height, width]);
+
+  return <>{children}</>;
+});

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -135,30 +135,6 @@ exports[`render pagination component 1`] = `
   padding: 0 1rem;
 }
 
-.c8 a {
-  -webkit-transition: all 150ms ease-out;
-  transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,color;
-  transition-property: background-color,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #313440;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 100%;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  width: 100%;
-}
-
-.c8 a:focus {
-  outline: none;
-}
-
 .c8[aria-selected='true'] {
   font-weight: 600;
 }
@@ -675,30 +651,6 @@ exports[`render pagination component with invalid page info 1`] = `
   min-width: 16rem;
   outline: none;
   padding: 0 1rem;
-}
-
-.c8 a {
-  -webkit-transition: all 150ms ease-out;
-  transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,color;
-  transition-property: background-color,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #313440;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 100%;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  width: 100%;
-}
-
-.c8 a:focus {
-  outline: none;
 }
 
 .c8[aria-selected='true'] {
@@ -1219,30 +1171,6 @@ exports[`render pagination component with invalid range info 1`] = `
   padding: 0 1rem;
 }
 
-.c8 a {
-  -webkit-transition: all 150ms ease-out;
-  transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,color;
-  transition-property: background-color,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #313440;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 100%;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  width: 100%;
-}
-
-.c8 a:focus {
-  outline: none;
-}
-
 .c8[aria-selected='true'] {
   font-weight: 600;
 }
@@ -1760,30 +1688,6 @@ exports[`render pagination component with no items 1`] = `
   min-width: 16rem;
   outline: none;
   padding: 0 1rem;
-}
-
-.c8 a {
-  -webkit-transition: all 150ms ease-out;
-  transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,color;
-  transition-property: background-color,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #313440;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 100%;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  width: 100%;
-}
-
-.c8 a:focus {
-  outline: none;
 }
 
 .c8[aria-selected='true'] {

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -135,6 +135,30 @@ exports[`render pagination component 1`] = `
   padding: 0 1rem;
 }
 
+.c8 a {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,color;
+  transition-property: background-color,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #313440;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 100%;
+}
+
+.c8 a:focus {
+  outline: none;
+}
+
 .c8[aria-selected='true'] {
   font-weight: 600;
 }
@@ -143,10 +167,6 @@ exports[`render pagination component 1`] = `
 .c8[data-highlighted='true'] a {
   background-color: #F0F3FF;
   color: #3C64F4;
-}
-
-.c8 a {
-  color: #313440;
 }
 
 .c8 label {
@@ -657,6 +677,30 @@ exports[`render pagination component with invalid page info 1`] = `
   padding: 0 1rem;
 }
 
+.c8 a {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,color;
+  transition-property: background-color,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #313440;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 100%;
+}
+
+.c8 a:focus {
+  outline: none;
+}
+
 .c8[aria-selected='true'] {
   font-weight: 600;
 }
@@ -665,10 +709,6 @@ exports[`render pagination component with invalid page info 1`] = `
 .c8[data-highlighted='true'] a {
   background-color: #F0F3FF;
   color: #3C64F4;
-}
-
-.c8 a {
-  color: #313440;
 }
 
 .c8 label {
@@ -1179,6 +1219,30 @@ exports[`render pagination component with invalid range info 1`] = `
   padding: 0 1rem;
 }
 
+.c8 a {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,color;
+  transition-property: background-color,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #313440;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 100%;
+}
+
+.c8 a:focus {
+  outline: none;
+}
+
 .c8[aria-selected='true'] {
   font-weight: 600;
 }
@@ -1187,10 +1251,6 @@ exports[`render pagination component with invalid range info 1`] = `
 .c8[data-highlighted='true'] a {
   background-color: #F0F3FF;
   color: #3C64F4;
-}
-
-.c8 a {
-  color: #313440;
 }
 
 .c8 label {
@@ -1702,6 +1762,30 @@ exports[`render pagination component with no items 1`] = `
   padding: 0 1rem;
 }
 
+.c8 a {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,color;
+  transition-property: background-color,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #313440;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 100%;
+}
+
+.c8 a:focus {
+  outline: none;
+}
+
 .c8[aria-selected='true'] {
   font-weight: 600;
 }
@@ -1710,10 +1794,6 @@ exports[`render pagination component with no items 1`] = `
 .c8[data-highlighted='true'] a {
   background-color: #F0F3FF;
   color: #3C64F4;
-}
-
-.c8 a {
-  color: #313440;
 }
 
 .c8 label {

--- a/packages/big-design/src/components/Select/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Select/__snapshots__/spec.tsx.snap
@@ -182,30 +182,6 @@ exports[`select action supports icons 1`] = `
   padding: 0 1rem;
 }
 
-.c1 a {
-  -webkit-transition: all 150ms ease-out;
-  transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,color;
-  transition-property: background-color,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #313440;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 100%;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  width: 100%;
-}
-
-.c1 a:focus {
-  outline: none;
-}
-
 .c1[aria-selected='true'] {
   font-weight: 600;
 }

--- a/packages/big-design/src/components/Select/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Select/__snapshots__/spec.tsx.snap
@@ -182,6 +182,30 @@ exports[`select action supports icons 1`] = `
   padding: 0 1rem;
 }
 
+.c1 a {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,color;
+  transition-property: background-color,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #313440;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 100%;
+}
+
+.c1 a:focus {
+  outline: none;
+}
+
 .c1[aria-selected='true'] {
   font-weight: 600;
 }
@@ -190,10 +214,6 @@ exports[`select action supports icons 1`] = `
 .c1[data-highlighted='true'] a {
   background-color: #FFF0F1;
   color: #CC1F1F;
-}
-
-.c1 a {
-  color: #313440;
 }
 
 .c1 label {

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -154,6 +154,30 @@ exports[`renders a pagination component 1`] = `
   padding: 0 1rem;
 }
 
+.c11 a {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,color;
+  transition-property: background-color,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #313440;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 100%;
+}
+
+.c11 a:focus {
+  outline: none;
+}
+
 .c11[aria-selected='true'] {
   font-weight: 600;
 }
@@ -162,10 +186,6 @@ exports[`renders a pagination component 1`] = `
 .c11[data-highlighted='true'] a {
   background-color: #F0F3FF;
   color: #3C64F4;
-}
-
-.c11 a {
-  color: #313440;
 }
 
 .c11 label {

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -154,30 +154,6 @@ exports[`renders a pagination component 1`] = `
   padding: 0 1rem;
 }
 
-.c11 a {
-  -webkit-transition: all 150ms ease-out;
-  transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,color;
-  transition-property: background-color,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #313440;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 100%;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  width: 100%;
-}
-
-.c11 a:focus {
-  outline: none;
-}
-
 .c11[aria-selected='true'] {
   font-weight: 600;
 }

--- a/packages/big-design/src/components/Tooltip/Tooltip.tsx
+++ b/packages/big-design/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useState } from 'react';
+import React, { memo, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Manager, Popper, PopperProps, Reference } from 'react-popper';
 
@@ -16,6 +16,7 @@ export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
 export const Tooltip: React.FC<TooltipProps> = memo(({ children, inline = true, modifiers, trigger, ...props }) => {
   const [isVisible, setIsVisible] = useState(false);
   const [tooltipContainer, setTooltipContainer] = useState<HTMLDivElement | null>(null);
+  const tooltipModifiers = useMemo(() => ({ offset: { offset: '0, 8' }, ...modifiers }), [modifiers]);
 
   useEffect(() => {
     const container = document.createElement('div');
@@ -69,11 +70,7 @@ export const Tooltip: React.FC<TooltipProps> = memo(({ children, inline = true, 
       </Reference>
       {tooltipContainer
         ? createPortal(
-            <Popper
-              placement={props.placement || 'top'}
-              modifiers={{ offset: { offset: '0, 8' }, ...modifiers }}
-              eventsEnabled={isVisible}
-            >
+            <Popper placement={props.placement || 'top'} modifiers={tooltipModifiers} eventsEnabled={isVisible}>
               {({ placement, ref, style }) =>
                 isVisible && (
                   <StyledTooltip ref={ref} style={style} data-placement={placement}>

--- a/packages/big-design/src/hooks/index.ts
+++ b/packages/big-design/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './useComponentSize';
 export * from './useDidUpdate';
 export * from './useEventCallback';
+export * from './useIsomorphicLayoutEffect';
 export * from './useRafState';
 export * from './useUniqueId';
 export * from './useWindowSize';

--- a/packages/big-design/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/big-design/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,5 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+import { isClient } from '../utils';
+
+export const useIsomorphicLayoutEffect = isClient ? useLayoutEffect : useEffect;


### PR DESCRIPTION
Fixes `DropdownLinkItems` `a` tag not spanning the width of the element, thus clicks wouldn't work unless clicking the link.

Links now also matches background transitions of `DropdownItems`.

Fix scroll bug by scheduling Popper to update when user resizes window.