### PR TITLE
fix(docs): rename public asset paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://design.bigcommerce.com/components">
-    <img alt="BigDesign" src="https://bigcommerce.github.io/big-design/public/logo-with-text.svg" width="546">
+    <img alt="BigDesign" src="https://bigcommerce.github.io/big-design/logo-with-text.svg" width="546">
   </a>
 </div>
 

--- a/packages/docs/components/SideNav/SideNavLogo/SideNavLogo.tsx
+++ b/packages/docs/components/SideNav/SideNavLogo/SideNavLogo.tsx
@@ -7,7 +7,7 @@ import { StyledLogo } from './styled';
 export const SideNavLogo: React.FC = () => (
   <Link href="/GettingStarted/GettingStartedPage" as="/">
     <StyledLogo>
-      <img src={`${process.env.URL_PREFIX}/public/logo-with-text.svg`} alt="BigDesign Logo" />
+      <img src={`${process.env.URL_PREFIX}/logo-with-text.svg`} alt="BigDesign Logo" />
     </StyledLogo>
   </Link>
 );

--- a/packages/docs/pages/GettingStarted/GettingStartedPage.tsx
+++ b/packages/docs/pages/GettingStarted/GettingStartedPage.tsx
@@ -12,7 +12,7 @@ export default () => {
   return (
     <Flex flexDirection="column">
       <figure style={{ textAlign: 'center' }}>
-        <img src={`${process.env.URL_PREFIX}/public/logo.svg`} alt="BigDesign Logo" style={{ width: 200 }} />
+        <img src={`${process.env.URL_PREFIX}/logo.svg`} alt="BigDesign Logo" style={{ width: 200 }} />
       </figure>
 
       <FlexItem alignSelf="center">

--- a/packages/docs/pages/_app.tsx
+++ b/packages/docs/pages/_app.tsx
@@ -33,7 +33,7 @@ export default class MyApp extends App {
     return (
       <>
         <Head>
-          <link rel="icon" type="image/png" href={`${process.env.URL_PREFIX}/public/favicon.png`}></link>
+          <link rel="icon" type="image/png" href={`${process.env.URL_PREFIX}/favicon.png`}></link>
           <title>BigDesign</title>
         </Head>
         <style jsx global>


### PR DESCRIPTION
## What
Rename public asset paths.

## What
Documentation says you can now access `public/` files via root path: https://nextjs.org/docs/basic-features/static-file-serving