### PR TITLE
fix(examples): remove danling comma

### DIFF
--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -4,6 +4,6 @@
     "lib": ["dom", "es2015"],
     "jsx": "react",
     "esModuleInterop": true,
-    "skipLibCheck": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
`tsc` can parse json5 but not CodeSandbox.