### PR TITLE
fix(component): proper panel action button width

### DIFF
--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -4,9 +4,8 @@ import { MarginProps } from '../../mixins';
 import { excludePaddingProps } from '../../mixins/paddings/paddings';
 import { Button, ButtonProps } from '../Button';
 import { Flex } from '../Flex';
-import { H2 } from '../Typography';
 
-import { StyledPanel } from './styled';
+import { StyledH2, StyledPanel } from './styled';
 
 export interface PanelAction extends Omit<ButtonProps, 'children'> {
   text?: string;
@@ -31,8 +30,8 @@ export const RawPanel: React.FC<PanelProps> = memo(props => {
     }
 
     return (
-      <Flex justifyContent="space-between" flexDirection="row">
-        {header && <H2>{header}</H2>}
+      <Flex flexDirection="row">
+        {header && <StyledH2>{header}</StyledH2>}
         {action && <Button {...action}>{action.text}</Button>}
       </Flex>
     );

--- a/packages/big-design/src/components/Panel/spec.tsx
+++ b/packages/big-design/src/components/Panel/spec.tsx
@@ -88,3 +88,15 @@ test('ignores padding props', () => {
 
   expect(panel).not.toHaveStyle(`padding-right: ${theme.spacing.xxxLarge}`);
 });
+
+test("panel action doesn't go to full width", () => {
+  const { getByRole } = render(
+    <Panel header="Test Header" action={{ text: 'Test Action' }}>
+      Test
+    </Panel>,
+  );
+
+  const button = getByRole('button');
+
+  expect(button).toHaveStyle('width: auto');
+});

--- a/packages/big-design/src/components/Panel/styled.tsx
+++ b/packages/big-design/src/components/Panel/styled.tsx
@@ -2,6 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { Box } from '../Box';
+import { StyleableH2 } from '../Typography/private';
 
 export const StyledPanel = styled(Box)`
   ${({ theme }) => theme.breakpoints.tablet} {
@@ -9,7 +10,17 @@ export const StyledPanel = styled(Box)`
   }
 `;
 
+export const StyledH2 = styled(StyleableH2)`
+  flex-grow: 1;
+
+  & ~ .bd-button {
+    width: auto;
+    margin-top: 0;
+  }
+`;
+
 StyledPanel.defaultProps = {
   theme: defaultTheme,
   marginBottom: 'medium',
 };
+StyledH2.defaultProps = { theme: defaultTheme };


### PR DESCRIPTION
## What
Fixes this display issue on mobile with `Panels`:
<img width="614" alt="Screen Shot 2020-02-19 at 3 12 30 PM" src="https://user-images.githubusercontent.com/10539418/74877104-797a2000-532a-11ea-942d-e8746bcf510b.png">

## Screenshot
<img width="613" alt="Screen Shot 2020-02-19 at 3 14 32 PM" src="https://user-images.githubusercontent.com/10539418/74877140-8d258680-532a-11ea-8972-c5dfa00944c2.png">
