### PR TITLE
feat(component): add toggle button component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages/docs/.next
 packages/docs/out
 packages/docs/pages/Dev
 .idea
+.DS_Store

--- a/packages/big-design/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/big-design/src/components/ToggleButton/ToggleButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { StyledToggleButton } from './styled';
+
+export interface ToggleButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  selected: boolean;
+}
+
+export const ToggleButton: React.FC<ToggleButtonProps> = React.memo(({ className, style, ...props }) => {
+  const { selected } = props;
+
+  return (
+    <StyledToggleButton aria-pressed={selected} selected={selected} {...props}>
+      {props.children}
+    </StyledToggleButton>
+  );
+});

--- a/packages/big-design/src/components/ToggleButton/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/ToggleButton/__snapshots__/spec.tsx.snap
@@ -1,0 +1,155 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render selected and disabled 1`] = `
+.c0 {
+  background: #DBE3FE;
+  border: 1px solid #9EB3FC;
+  border-radius: 0.25rem;
+  color: #0B38D9;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 2rem;
+  margin: 0;
+  outline: none;
+  padding: 0 1rem;
+  position: relative;
+}
+
+.c0[disabled] {
+  background: #F6F7FC;
+  border: 1px solid #D9DCE9;
+  color: #B4BAD1;
+  cursor: not-allowed;
+}
+
+.c0:not([disabled]):hover,
+.c0:not([disabled]):active {
+  background: #DBE3FE;
+  color: #0B38D9;
+}
+
+.c0:not([disabled]):focus {
+  box-shadow: 0 0 0 4px #DBE3FE;
+}
+
+<button
+  aria-pressed="true"
+  class="c0"
+  disabled=""
+/>
+`;
+
+exports[`render selected and enabled 1`] = `
+.c0 {
+  background: #DBE3FE;
+  border: 1px solid #9EB3FC;
+  border-radius: 0.25rem;
+  color: #0B38D9;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 2rem;
+  margin: 0;
+  outline: none;
+  padding: 0 1rem;
+  position: relative;
+}
+
+.c0[disabled] {
+  background: #F6F7FC;
+  border: 1px solid #D9DCE9;
+  color: #B4BAD1;
+  cursor: not-allowed;
+}
+
+.c0:not([disabled]):hover,
+.c0:not([disabled]):active {
+  background: #DBE3FE;
+  color: #0B38D9;
+}
+
+.c0:not([disabled]):focus {
+  box-shadow: 0 0 0 4px #DBE3FE;
+}
+
+<button
+  aria-pressed="true"
+  class="c0"
+/>
+`;
+
+exports[`render unselected and disabled 1`] = `
+.c0 {
+  background: #FFFFFF;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #5E637A;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 2rem;
+  margin: 0;
+  outline: none;
+  padding: 0 1rem;
+  position: relative;
+}
+
+.c0[disabled] {
+  background: #FFFFFF;
+  border: 1px solid #D9DCE9;
+  color: #B4BAD1;
+  cursor: not-allowed;
+}
+
+.c0:not([disabled]):hover,
+.c0:not([disabled]):active {
+  background: #F0F3FF;
+  color: #2852EB;
+}
+
+.c0:not([disabled]):focus {
+  box-shadow: 0 0 0 4px #DBE3FE;
+}
+
+<button
+  aria-pressed="false"
+  class="c0"
+  disabled=""
+/>
+`;
+
+exports[`render unselected and enabled 1`] = `
+.c0 {
+  background: #FFFFFF;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #5E637A;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 2rem;
+  margin: 0;
+  outline: none;
+  padding: 0 1rem;
+  position: relative;
+}
+
+.c0[disabled] {
+  background: #FFFFFF;
+  border: 1px solid #D9DCE9;
+  color: #B4BAD1;
+  cursor: not-allowed;
+}
+
+.c0:not([disabled]):hover,
+.c0:not([disabled]):active {
+  background: #F0F3FF;
+  color: #2852EB;
+}
+
+.c0:not([disabled]):focus {
+  box-shadow: 0 0 0 4px #DBE3FE;
+}
+
+<button
+  aria-pressed="false"
+  class="c0"
+/>
+`;

--- a/packages/big-design/src/components/ToggleButton/private.ts
+++ b/packages/big-design/src/components/ToggleButton/private.ts
@@ -1,0 +1,3 @@
+import { ToggleButtonProps as _ToggleButtonProps } from './ToggleButton';
+export { ToggleButton } from './ToggleButton';
+export type ToggleButtonProps = _ToggleButtonProps;

--- a/packages/big-design/src/components/ToggleButton/spec.tsx
+++ b/packages/big-design/src/components/ToggleButton/spec.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render } from '@test/utils';
+import 'jest-styled-components';
+import React from 'react';
+
+import { ToggleButton } from './ToggleButton';
+
+test('render selected and enabled', () => {
+  const { container } = render(<ToggleButton selected={true}></ToggleButton>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render unselected and enabled', () => {
+  const { container } = render(<ToggleButton selected={false}></ToggleButton>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render selected and disabled', () => {
+  const { container } = render(<ToggleButton selected={true} disabled></ToggleButton>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('render unselected and disabled', () => {
+  const { container } = render(<ToggleButton selected={false} disabled></ToggleButton>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('does not forward styles', () => {
+  const { container } = render(<ToggleButton className="test" selected={true} style={{ backgroundColor: 'orange' }} />);
+
+  expect(container.getElementsByClassName('test').length).toBe(0);
+  expect(container.style.backgroundColor).toBe('');
+});
+
+test('triggers onClick', () => {
+  const onClick = jest.fn();
+
+  const { container } = render(<ToggleButton selected={true} onClick={onClick}></ToggleButton>);
+  const button = container.firstChild as HTMLElement;
+
+  fireEvent.click(button);
+
+  expect(onClick).toHaveBeenCalled();
+});

--- a/packages/big-design/src/components/ToggleButton/styled.tsx
+++ b/packages/big-design/src/components/ToggleButton/styled.tsx
@@ -1,0 +1,39 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled from 'styled-components';
+
+interface StyledToggleButtonProps {
+  selected: boolean;
+}
+
+export const StyledToggleButton = styled('button')<StyledToggleButtonProps>`
+  background: ${({ selected, theme }) => (selected ? theme.colors.primary20 : theme.colors.white)};
+  border: 1px solid ${({ selected, theme }) => (selected ? theme.colors.primary30 : theme.colors.secondary30)};
+  border-radius: ${({ theme }) => theme.borderRadius.normal};
+  color: ${({ selected, theme }) => (selected ? theme.colors.primary60 : theme.colors.secondary60)};
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.typography.fontSize.medium};
+  line-height: ${({ theme }) => theme.lineHeight.xLarge};
+  margin: 0;
+  outline: none;
+  padding: 0 ${({ theme }) => theme.spacing.medium};
+  position: relative;
+
+  &[disabled] {
+    background: ${({ selected, theme }) => (selected ? theme.colors.secondary10 : theme.colors.white)};
+    border: 1px solid ${({ theme }) => theme.colors.secondary30};
+    color: ${({ theme }) => theme.colors.secondary40};
+    cursor: not-allowed;
+  }
+
+  &:not([disabled]):hover,
+  &:not([disabled]):active {
+    background: ${({ selected, theme }) => (selected ? theme.colors.primary20 : theme.colors.primary10)};
+    color: ${({ selected, theme }) => (selected ? theme.colors.primary60 : theme.colors.primary50)};
+  }
+
+  &:not([disabled]):focus {
+    box-shadow: 0 0 0 4px ${({ theme }) => theme.colors.primary20};
+  }
+`;
+
+StyledToggleButton.defaultProps = { theme: defaultTheme };


### PR DESCRIPTION
Adds new Toggle Button component. This just a step towards implementing Toggle Buttons component and is intentionally not exposed to external users of big-design. I had a quick sync up with @deini and @chanceaclark and this was the recommended first step.

Example of different states:
![Apr-12-2020 16-58-10](https://user-images.githubusercontent.com/955777/79082848-dcf74d00-7cde-11ea-84e4-e7ae7155c0ce.gif)


This is my first component in big-design, so I am very interested to learn from the team on any best practices or improvements that can be made!