### PR TITLE
fix(component): compute selectedItems on StatefulTable when items change

### DIFF
--- a/packages/big-design/src/components/StatefulTable/reducer.ts
+++ b/packages/big-design/src/components/StatefulTable/reducer.ts
@@ -81,11 +81,14 @@ export const createReducer = <T>(): Reducer<State<T>, Action<T>> => (state, acti
         itemsPerPage: state.pagination.itemsPerPage,
       });
 
+      const selectedItems = state.selectedItems.filter(item => items.includes(item));
+
       return {
         ...state,
         currentItems,
         isPaginationEnabled,
         items,
+        selectedItems,
         pagination: {
           ...state.pagination,
           currentPage,


### PR DESCRIPTION
`selectedItems` were not being re-computed when items changed, a bit of a corner-case scenario since items shouldn't be changing that much.

If an item is selected and removed from `items`, `selectedItems` would still have a reference to it.

Contrived example:

```tsx
export default () => {
  const [items, setItems] = React.useState([
    { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
    { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
    { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
  ]);

  const [selectedItems, setSelectedItems] = React.useState([]);

  const deleteItem = () => {
    const [_first, ...rest] = items; 

    setItems(rest);
  };

  return (
    <StatefulTable
      selectable
      columns={[
        { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
        { header: 'Name', hash: 'name', render: ({ name }) => name },
        { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
      ]}
      items={items}
      onSelectionChange={setSelectedItems}
      actions={() => <Button onClick={deleteItem}>Delete</Button>}
    />
  );
};
```