### PR TITLE
feat(component): stateful table sortFn

### DIFF
--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -225,6 +225,46 @@ test('sorts numerically', () => {
   expect(lastItemContent).toBe('104');
 });
 
+test('sorts using a custom sorting function', () => {
+  const { getAllByTestId, getByText } = render(
+    getSimpleTable({
+      columns: [
+        { header: 'Name', hash: 'name', render: ({ name }) => <span data-testid="name">{name}</span>, sortKey: 'name' },
+        {
+          header: 'Stock',
+          hash: 'stock',
+          render: ({ stock }) => <span data-testid="stock">{stock}</span>,
+          sortFn: (a, b, dir) => (dir === 'ASC' ? a.stock - b.stock : b.stock - a.stock),
+        },
+      ],
+      pagination: false,
+    }),
+  );
+
+  let items = getAllByTestId('stock');
+  let firstItemContent = items[0].textContent;
+  let lastItemContent = items[items.length - 1].textContent;
+
+  // Descending order
+  fireEvent.click(getByText('Stock'));
+
+  items = getAllByTestId('stock');
+  firstItemContent = items[0].textContent;
+  lastItemContent = items[items.length - 1].textContent;
+
+  expect(firstItemContent).toBe('104');
+  expect(lastItemContent).toBe('1');
+
+  // Ascending order
+  fireEvent.click(getByText('Stock'));
+  items = getAllByTestId('stock');
+  firstItemContent = items[0].textContent;
+  lastItemContent = items[items.length - 1].textContent;
+
+  expect(firstItemContent).toBe('1');
+  expect(lastItemContent).toBe('104');
+});
+
 test('renders custom actions', () => {
   const { getByTestId } = render(getSimpleTable({ actions: () => <div data-testid="customAction">Test Action</div> }));
 

--- a/packages/configs/tslint/tslint.json
+++ b/packages/configs/tslint/tslint.json
@@ -4,6 +4,7 @@
     "tslint-config-prettier"
   ],
   "rules": {
-    "object-literal-sort-keys": false
+    "object-literal-sort-keys": false,
+    "unified-signatures": false
   }
 }

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -95,6 +95,11 @@ const tableColumnsProps: Prop[] = [
     description: 'Unique identifier for column.',
   },
   {
+    name: 'sortFn',
+    types: `(a: Item, b: Item, dir: 'ASC' | 'DESC') => number`,
+    description: 'Enables sorting on the column using a custom sort function.',
+  },
+  {
     name: 'sortKey',
     types: 'string',
     description: 'Enables sorting on the column using item[sortKey].',


### PR DESCRIPTION
`StatefulTable` column can now be sorted via `sortKey` or a custom `sortFn`.