### PR TITLE
fix(component): pagination avoid page 0

### DIFF
--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -18,7 +18,7 @@ export interface PaginationProps extends MarginProps {
 
 export const Pagination: React.FC<PaginationProps> = memo(
   ({ itemsPerPage, currentPage, totalItems, itemsPerPageOptions = [], onPageChange, onItemsPerPageChange }) => {
-    const [maxPages, setMaxPages] = useState(Math.ceil(totalItems / itemsPerPage));
+    const [maxPages, setMaxPages] = useState(Math.max(1, Math.ceil(totalItems / itemsPerPage)));
     const [itemRange, setItemRange] = useState({ start: 0, end: 0 });
 
     const handlePageOutOfBounds = useCallback(() => {
@@ -57,7 +57,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
 
       calculateRange();
 
-      setMaxPages(Math.ceil(totalItems / itemsPerPage));
+      setMaxPages(Math.max(1, Math.ceil(totalItems / itemsPerPage)));
     }, [calculateRange, currentPage, handlePageOutOfBounds, handlePerPageOutOfBounds, itemsPerPage, totalItems]);
 
     const handlePageIncrease = () => {


### PR DESCRIPTION
There was a scenario (totalItems = 0) when `currentPage` was set to `0` instead of `1`.