### PR TITLE
feat(component): CHP-6225 adds ability to hide individual table headers

### DIFF
--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -65,8 +65,9 @@ const InternalHeaderCell = <T extends TableItem>({
     >
       <StyledFlex alignItems="center" flexDirection="row" hide={hide} align={align}>
         {children}
-        {renderSortIcon()}
+        {!hide && renderSortIcon()}
       </StyledFlex>
+      {hide && renderSortIcon()}
     </StyledTableHeaderCell>
   );
 };

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -10,6 +10,7 @@ import { StyledFlex, StyledTableHeaderCell, StyledTableHeaderCheckbox } from './
 export interface HeaderCellProps<T> extends React.TableHTMLAttributes<HTMLTableCellElement> {
   actionsRef: RefObject<HTMLDivElement>;
   column: TableColumn<T>;
+  hide?: boolean;
   isSorted?: boolean;
   sortDirection?: 'ASC' | 'DESC';
   stickyHeader?: boolean;
@@ -24,6 +25,7 @@ export interface HeaderCheckboxCellProps {
 const InternalHeaderCell = <T extends TableItem>({
   children,
   column,
+  hide = false,
   isSorted,
   onSortClick,
   sortDirection,
@@ -61,7 +63,7 @@ const InternalHeaderCell = <T extends TableItem>({
       width={width}
       stickyHeight={actionsSize.height}
     >
-      <StyledFlex alignItems="center" flexDirection="row" align={align}>
+      <StyledFlex alignItems="center" flexDirection="row" hide={hide} align={align}>
         {children}
         {renderSortIcon()}
       </StyledFlex>

--- a/packages/big-design/src/components/Table/HeaderCell/styled.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/styled.tsx
@@ -1,4 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { hideVisually } from 'polished';
 import styled, { css } from 'styled-components';
 
 import { Flex } from '../../Flex';
@@ -12,6 +13,7 @@ interface StyledTableHeaderCellProps {
 
 interface StyledFlexProps {
   align?: 'left' | 'center' | 'right';
+  hide: boolean;
 }
 
 export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
@@ -69,7 +71,8 @@ export const StyledFlex = styled(Flex)<StyledFlexProps>`
           justify-content: flex-start;
         `;
     }
-  }}
+  }};
+  ${({ hide }) => hide && hideVisually()};
 `;
 
 StyledFlex.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -94,13 +94,14 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
         {isSelectable && <HeaderCheckboxCell stickyHeader={stickyHeader} actionsRef={actionsRef} />}
 
         {columns.map((column, index) => {
-          const { hash, header, isSortable } = column;
+          const { hash, header, isSortable, hideHeader } = column;
           const isSorted = isSortable && sortable && hash === sortable.columnHash;
           const sortDirection = sortable && sortable.direction;
 
           return (
             <HeaderCell
               column={column}
+              hide={hideHeader}
               isSorted={isSorted}
               key={index}
               onSortClick={onSortClick}

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -25,6 +25,7 @@ export interface TableColumn<T> {
   align?: 'left' | 'center' | 'right';
   hash: string;
   header: string;
+  hideHeader?: boolean;
   isSortable?: boolean;
   render: React.ComponentType<T> | ((props: T & { children?: ReactNode }, context?: any) => string | number);
   verticalAlign?: 'top' | 'center';

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -50,7 +50,7 @@ const statefulTableProps: Prop[] = [
     types: 'boolean',
     defaultValue: 'false',
     description:
-      "Hides the current tables's headers. Headers are only visually hidden to keep with accessibility best practices.",
+      'Hides header row with all table headers. Headers are only visually hidden to keep with accessibility best practices.',
   },
   {
     name: 'defaultSelected',
@@ -81,6 +81,13 @@ const tableColumnsProps: Prop[] = [
     types: 'string',
     required: true,
     description: 'Header title.',
+  },
+  {
+    name: 'hideHeader',
+    types: 'boolean',
+    defaultValue: 'false',
+    description:
+      'Hides individual header values in the header row. Header is only visually hidden to keep with accessibility best practices.',
   },
   {
     name: 'align',

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -65,7 +65,7 @@ const tableProps: Prop[] = [
     types: 'boolean',
     defaultValue: 'false',
     description:
-      "Hides the current tables's headers. Headers are only visually hidden to keep with accessibility best practices.",
+      'Hides header row with all table headers. Headers are only visually hidden to keep with accessibility best practices.',
   },
   {
     name: 'actions',
@@ -86,6 +86,13 @@ const tableColumnsProps: Prop[] = [
     types: 'string',
     required: true,
     description: 'Header title.',
+  },
+  {
+    name: 'hideHeader',
+    types: 'boolean',
+    defaultValue: 'false',
+    description:
+      'Hides individual header values in the header row. Header is only visually hidden to keep with accessibility best practices.',
   },
   {
     name: 'align',


### PR DESCRIPTION
### WHAT
Adds ability to hide individual headers on the `Table` and `Stateful Table` components without hiding all of them.

### Testing
Manual testing, see screenshot below 

<img width="830" alt="Screen Shot 2020-04-02 at 10 41 46 AM" src="https://user-images.githubusercontent.com/37593557/78268950-916ac500-74ce-11ea-842f-f768c4c3581f.png">
