### PR TITLE
fix(component): modal focus first focusable element

### DIFF
--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -93,7 +93,7 @@ export const Modal: React.FC<ModalProps> = typedMemo(
 
     useEffect(() => {
       if (modalRef.current && !internalTrap) {
-        setInternalTrap(focusTrap(modalRef.current as HTMLElement, { initialFocus: modalRef.current }));
+        setInternalTrap(focusTrap(modalRef.current as HTMLElement, { fallbackFocus: modalRef.current }));
       }
 
       if (isOpen) {


### PR DESCRIPTION
Currently, when opening a Modal the modal ref will be focused, changed that so that it will fall back to the modal ref if no other focusable element is present.