### PR TITLE
fix: render new options for Selects when option prop changes

### DIFF
--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -119,6 +119,28 @@ test('dropdown menu should have 4 dropdown items', () => {
   expect(options.length).toBe(4);
 });
 
+test('dropdown items should immediately rerender when prop changes', () => {
+  const { getAllByRole, getByRole, rerender } = render(DropdownMock);
+  const toggle = getByRole('button');
+  fireEvent.click(toggle);
+
+  let options = getAllByRole('option');
+  expect(options.length).toBe(4);
+
+  rerender(
+    <Dropdown
+      items={[
+        { content: 'Foo', onItemClick },
+        { content: 'Bar', onItemClick },
+      ]}
+      toggle={<Button>Button</Button>}
+    />,
+  );
+
+  options = getAllByRole('option');
+  expect(options.length).toBe(2);
+});
+
 test('first dropdown item should be selected when dropdown is opened', () => {
   const { getByRole, getAllByRole } = render(DropdownMock);
   const toggle = getByRole('button');

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -54,6 +54,9 @@ export const MultiSelect = typedMemo(
     const defaultRef: RefObject<HTMLInputElement> = createRef();
     const multiSelectUniqueId = useUniqueId('multi-select');
 
+    // Need to set items if options prop changes
+    useEffect(() => setItems(initialOptions), [initialOptions]);
+
     useEffect(() => {
       setInputValue('');
     }, [selectedOptions]);

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -546,6 +546,30 @@ test('multiselect should be able to deselect options', () => {
   expect(onChange).toHaveBeenCalledWith([mockOptions[1].value], [mockOptions[1]]);
 });
 
+test('multiselect options should immediately rerender when prop changes', () => {
+  const { getAllByRole, getByRole, rerender } = render(
+    <MultiSelect onOptionsChange={onChange} options={mockOptions} />,
+  );
+  const button = getByRole('button');
+  fireEvent.click(button);
+
+  let options = getAllByRole('option');
+  expect(options.length).toBe(5);
+
+  rerender(
+    <MultiSelect
+      onOptionsChange={onChange}
+      options={[
+        { content: 'foo', value: 'foo' },
+        { content: 'bar', value: 'bar' },
+      ]}
+    />,
+  );
+
+  options = getAllByRole('option');
+  expect(options.length).toBe(2);
+});
+
 test('chips should be rendered', () => {
   const { getAllByText } = render(MultiSelectMock);
 

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -60,6 +60,9 @@ export const Select = typedMemo(
     const defaultRef: RefObject<HTMLInputElement> = createRef();
     const selectUniqueId = useUniqueId('select');
 
+    // Need to set select options if options prop changes
+    useEffect(() => setSelectOptions(flattenedOptions), [flattenedOptions]);
+
     // Set the input's value to match the selected item
     useEffect(() => {
       setInputValue(selectedOption ? selectedOption.content : '');

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -256,6 +256,28 @@ test('select items should be filterable', () => {
   expect(options.length).toBe(2);
 });
 
+test('select options should immediately rerender when prop changes', () => {
+  const { getAllByRole, getByRole, rerender } = render(<Select onOptionChange={onChange} options={mockOptions} />);
+  const button = getByRole('button');
+  fireEvent.click(button);
+
+  let options = getAllByRole('option');
+  expect(options.length).toBe(5);
+
+  rerender(
+    <Select
+      onOptionChange={onChange}
+      options={[
+        { content: 'foo', value: 'foo' },
+        { content: 'bar', value: 'bar' },
+      ]}
+    />,
+  );
+
+  options = getAllByRole('option');
+  expect(options.length).toBe(2);
+});
+
 test('up/down arrows should change select item selection', () => {
   const { getAllByRole, getByTestId } = render(SelectMock);
   const input = getByTestId('select');


### PR DESCRIPTION
Sets `selectOptions` when `options` prop updates. Added tests.

Closes #363.