### PR TITLE
fix: add extra options for maxHeight examples and set up tests

### DIFF
--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -1,4 +1,5 @@
 import { CheckCircleIcon } from '@bigcommerce/big-design-icons';
+import { remCalc } from '@bigcommerce/big-design-theme';
 import { fireEvent, render } from '@test/utils';
 import 'jest-styled-components';
 import React, { Fragment } from 'react';
@@ -117,6 +118,35 @@ test('dropdown menu should have 4 dropdown items', () => {
 
   const options = getAllByRole('option');
   expect(options.length).toBe(4);
+});
+
+test('should accept a maxHeight prop', () => {
+  const { getByRole } = render(
+    <Dropdown
+      items={[
+        { content: 'Foo', onItemClick },
+        { content: 'Bar', onItemClick },
+      ]}
+      maxHeight={350}
+      toggle={<Button>Button</Button>}
+    />,
+  );
+
+  const toggle = getByRole('button');
+  fireEvent.click(toggle);
+
+  const list = getByRole('listbox');
+  expect(list).toHaveStyleRule('max-height', remCalc(350));
+});
+
+test('should default max-height to 250', () => {
+  const { getByRole } = render(DropdownMock);
+
+  const toggle = getByRole('button');
+  fireEvent.click(toggle);
+
+  const list = getByRole('listbox');
+  expect(list).toHaveStyleRule('max-height', remCalc(250));
 });
 
 test('dropdown items should immediately rerender when prop changes', () => {

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -1,4 +1,5 @@
 import { ArrowBackIcon, ArrowForwardIcon, DeleteIcon } from '@bigcommerce/big-design-icons';
+import { remCalc } from '@bigcommerce/big-design-theme';
 import { fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 import React from 'react';
@@ -444,6 +445,40 @@ test('should render a non filterable select', () => {
 
   const input = getAllByLabelText('Countries')[0];
   expect(input.getAttribute('readonly')).toBe('');
+});
+
+test('should accept a maxHeight prop', () => {
+  const { getAllByLabelText, getByRole } = render(
+    <MultiSelect
+      label="Countries"
+      maxHeight={350}
+      onOptionsChange={onChange}
+      options={[
+        { value: 'us', content: 'United States' },
+        { value: 'mx', content: 'Mexico' },
+        { value: 'ca', content: 'Canada' },
+        { value: 'en', content: 'England' },
+        { value: 'fr', content: 'France', disabled: true },
+      ]}
+      placeholder="Choose country"
+    />,
+  );
+
+  const input = getAllByLabelText('Countries')[0];
+  fireEvent.focus(input);
+
+  const list = getByRole('listbox');
+  expect(list).toHaveStyleRule('max-height', remCalc(350));
+});
+
+test('should default max-height to 250', () => {
+  const { getAllByLabelText, getByRole } = render(MultiSelectMock);
+
+  const input = getAllByLabelText('Countries')[0];
+  fireEvent.focus(input);
+
+  const list = getByRole('listbox');
+  expect(list).toHaveStyleRule('max-height', remCalc(250));
 });
 
 test('should use the passed in ref object if provided', () => {

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -1,4 +1,5 @@
 import { ArrowBackIcon, ArrowForwardIcon, DeleteIcon } from '@bigcommerce/big-design-icons';
+import { remCalc } from '@bigcommerce/big-design-theme';
 import { fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 import React from 'react';
@@ -529,6 +530,40 @@ test('should render a non filterable select', () => {
 
   const input = getAllByLabelText('Countries')[0];
   expect(input.getAttribute('readonly')).toBe('');
+});
+
+test('should accept a maxHeight prop', () => {
+  const { getAllByLabelText, getByRole } = render(
+    <Select
+      label="Countries"
+      maxHeight={350}
+      onOptionChange={onChange}
+      options={[
+        { value: 'us', content: 'United States' },
+        { value: 'mx', content: 'Mexico' },
+        { value: 'ca', content: 'Canada' },
+        { value: 'en', content: 'England' },
+        { value: 'fr', content: 'France', disabled: true },
+      ]}
+      placeholder="Choose country"
+    />,
+  );
+
+  const input = getAllByLabelText('Countries')[0];
+  fireEvent.focus(input);
+
+  const list = getByRole('listbox');
+  expect(list).toHaveStyleRule('max-height', remCalc(350));
+});
+
+test('should default max-height to 250', () => {
+  const { getAllByLabelText, getByRole } = render(SelectMock);
+
+  const input = getAllByLabelText('Countries')[0];
+  fireEvent.focus(input);
+
+  const list = getByRole('listbox');
+  expect(list).toHaveStyleRule('max-height', remCalc(250));
 });
 
 test('should use the passed in ref object if provided', () => {

--- a/packages/docs/pages/Dropdown/DropdownPage.tsx
+++ b/packages/docs/pages/Dropdown/DropdownPage.tsx
@@ -248,13 +248,11 @@ export default () => (
             { content: 'Item', onItemClick: item => item },
             { content: 'Item', onItemClick: item => item },
             { content: 'Item', onItemClick: item => item },
-            { content: 'Item', onItemClick: item => item },
           ]}
           toggle={<Button>Default</Button>}
         />
         <Dropdown
           items={[
-            { content: 'Item', onItemClick: item => item },
             { content: 'Item', onItemClick: item => item },
             { content: 'Item', onItemClick: item => item },
             { content: 'Item', onItemClick: item => item },
@@ -269,6 +267,9 @@ export default () => (
         />
         <Dropdown
           items={[
+            { content: 'Item', onItemClick: item => item },
+            { content: 'Item', onItemClick: item => item },
+            { content: 'Item', onItemClick: item => item },
             { content: 'Item', onItemClick: item => item },
             { content: 'Item', onItemClick: item => item },
             { content: 'Item', onItemClick: item => item },

--- a/packages/docs/pages/MultiSelect/MultiSelectPage.tsx
+++ b/packages/docs/pages/MultiSelect/MultiSelectPage.tsx
@@ -157,6 +157,10 @@ export default () => (
             { value: 2, content: 'Option' },
             { value: 3, content: 'Option' },
             { value: 4, content: 'Option' },
+            { value: 5, content: 'Option' },
+            { value: 6, content: 'Option' },
+            { value: 7, content: 'Option' },
+            { value: 8, content: 'Option' },
           ]}
           placeholder="Default"
           required
@@ -170,6 +174,10 @@ export default () => (
             { value: 2, content: 'Option' },
             { value: 3, content: 'Option' },
             { value: 4, content: 'Option' },
+            { value: 5, content: 'Option' },
+            { value: 6, content: 'Option' },
+            { value: 7, content: 'Option' },
+            { value: 8, content: 'Option' },
           ]}
           placeholder="Smaller"
           required
@@ -183,6 +191,14 @@ export default () => (
             { value: 2, content: 'Option' },
             { value: 3, content: 'Option' },
             { value: 4, content: 'Option' },
+            { value: 5, content: 'Option' },
+            { value: 6, content: 'Option' },
+            { value: 7, content: 'Option' },
+            { value: 8, content: 'Option' },
+            { value: 9, content: 'Option' },
+            { value: 10, content: 'Option' },
+            { value: 11, content: 'Option' },
+            { value: 12, content: 'Option' },
           ]}
           placeholder="Larger"
           required

--- a/packages/docs/pages/Select/SelectPage.tsx
+++ b/packages/docs/pages/Select/SelectPage.tsx
@@ -158,6 +158,10 @@ export default () => (
             { value: 2, content: 'Option' },
             { value: 3, content: 'Option' },
             { value: 4, content: 'Option' },
+            { value: 5, content: 'Option' },
+            { value: 6, content: 'Option' },
+            { value: 7, content: 'Option' },
+            { value: 8, content: 'Option' },
           ]}
           placeholder="Default"
           required
@@ -171,6 +175,10 @@ export default () => (
             { value: 2, content: 'Option' },
             { value: 3, content: 'Option' },
             { value: 4, content: 'Option' },
+            { value: 5, content: 'Option' },
+            { value: 6, content: 'Option' },
+            { value: 7, content: 'Option' },
+            { value: 8, content: 'Option' },
           ]}
           placeholder="Smaller"
           required
@@ -184,6 +192,14 @@ export default () => (
             { value: 2, content: 'Option' },
             { value: 3, content: 'Option' },
             { value: 4, content: 'Option' },
+            { value: 5, content: 'Option' },
+            { value: 6, content: 'Option' },
+            { value: 7, content: 'Option' },
+            { value: 8, content: 'Option' },
+            { value: 9, content: 'Option' },
+            { value: 10, content: 'Option' },
+            { value: 11, content: 'Option' },
+            { value: 12, content: 'Option' },
           ]}
           placeholder="Larger"
           required


### PR DESCRIPTION
Add extra options to examples since the ones provided were not enough to showcase the `maxHeight` property. I thought it was broken.

Added tests.