### PR TITLE
fix(component): SHIPPING-1526 adds description to Select & MultiSelect

### DIFF
--- a/packages/big-design/src/components/MultiSelect/types.ts
+++ b/packages/big-design/src/components/MultiSelect/types.ts
@@ -1,11 +1,12 @@
 import { Placement } from '@popperjs/core';
-import { RefObject } from 'react';
+import React, { RefObject } from 'react';
 
 import { InputProps } from '../Input';
 import { SelectAction, SelectOption } from '../Select';
 
 interface BaseSelect extends Omit<React.HTMLAttributes<HTMLInputElement>, 'children'> {
   action?: SelectAction;
+  description?: React.ReactChild;
   disabled?: boolean;
   error?: InputProps['error'];
   filterable?: boolean;

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -1,11 +1,12 @@
 import { Placement } from '@popperjs/core';
-import { RefObject } from 'react';
+import React, { RefObject } from 'react';
 
 import { InputProps } from '../Input';
 import { ListItemProps } from '../List/Item';
 
 interface BaseSelect extends Omit<React.HTMLAttributes<HTMLInputElement>, 'children'> {
   action?: SelectAction;
+  description?: React.ReactChild;
   disabled?: boolean;
   error?: InputProps['error'];
   filterable?: boolean;

--- a/packages/docs/PropTables/MultiSelectPropTable.tsx
+++ b/packages/docs/PropTables/MultiSelectPropTable.tsx
@@ -3,7 +3,16 @@ import React from 'react';
 import { Code, NextLink, Prop, PropTable, PropTableWrapper } from '../components';
 
 const selectProps: Prop[] = [
-  { name: 'action', types: 'SelectAction', description: 'Action option displayed at the end of the list.' },
+  {
+    name: 'action',
+    types: 'SelectAction',
+    description: 'Action option displayed at the end of the list.',
+  },
+  {
+    name: 'description',
+    types: 'string | FormControlDescription',
+    description: 'Append a description to the select field.',
+  },
   {
     name: 'disabled',
     defaultValue: 'false',

--- a/packages/docs/PropTables/SelectPropTable.tsx
+++ b/packages/docs/PropTables/SelectPropTable.tsx
@@ -3,7 +3,16 @@ import React from 'react';
 import { Code, NextLink, Prop, PropTable, PropTableWrapper } from '../components';
 
 const selectProps: Prop[] = [
-  { name: 'action', types: 'SelectAction', description: 'Action option displayed at the end of the list.' },
+  {
+    name: 'action',
+    types: 'SelectAction',
+    description: 'Action option displayed at the end of the list.',
+  },
+  {
+    name: 'description',
+    types: 'string | FormControlDescription',
+    description: 'Append a description to the select field.',
+  },
   {
     name: 'disabled',
     defaultValue: 'false',


### PR DESCRIPTION
## What?

Add description prop to Select dropdown

## Why?

We support the description prop, but typescript doesn't recognise it as a prop

## Testing/Proof
Select
![Screen Shot 2020-04-24 at 2 50 54 pm](https://user-images.githubusercontent.com/12403409/80176201-2595fb00-863b-11ea-9232-50bac338a5b4.png)


MultiSelect
![Screen Shot 2020-04-24 at 2 51 05 pm](https://user-images.githubusercontent.com/12403409/80176178-14e58500-863b-11ea-9d19-1dc79ec61dbb.png)


ping @deini @animesh1987 @chanceaclark 