### PR TITLE
fix(component): table column prop  incorrect value for middle alignment

### DIFF
--- a/packages/big-design/src/components/Table/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/Table/DataCell/DataCell.tsx
@@ -5,7 +5,7 @@ import { StyledTableDataCell, StyledTableDataCheckbox } from './styled';
 export interface DataCellProps extends TableHTMLAttributes<HTMLTableCellElement> {
   align?: 'left' | 'center' | 'right';
   isCheckbox?: boolean;
-  verticalAlign?: 'top' | 'center';
+  verticalAlign?: 'top' | 'middle';
   width?: number | string;
   withBorder?: boolean;
   withPadding?: boolean;

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -102,7 +102,7 @@ test('tweaks column styles with props', () => {
           header: 'Sku',
           render: ({ sku }: any) => sku,
           align: 'right',
-          verticalAlign: 'center',
+          verticalAlign: 'middle',
         },
         {
           header: 'Name',
@@ -130,7 +130,7 @@ test('tweaks column styles with props', () => {
 
   expect(skuTd).toHaveStyle(`
     text-align: right;
-    vertical-align: center;
+    vertical-align: middle;
   `);
 
   expect(nameTd).toHaveStyle(`

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -28,7 +28,7 @@ export interface TableColumn<T> {
   hideHeader?: boolean;
   isSortable?: boolean;
   render: React.ComponentType<T> | ((props: T & { children?: ReactNode }, context?: any) => string | number);
-  verticalAlign?: 'top' | 'center';
+  verticalAlign?: 'top' | 'middle';
   width?: number | string;
   withPadding?: boolean;
 }

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -115,7 +115,7 @@ const tableColumnsProps: Prop[] = [
   },
   {
     name: 'verticalAlign',
-    types: ['top', 'center'],
+    types: ['top', 'middle'],
     defaultValue: 'top',
     description: 'Sets vertical alignment for column (td only).',
   },

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -116,7 +116,7 @@ const tableColumnsProps: Prop[] = [
   },
   {
     name: 'verticalAlign',
-    types: ['top', 'center'],
+    types: ['top', 'middle'],
     defaultValue: 'top',
     description: 'Sets vertical alignment for column (td only).',
   },


### PR DESCRIPTION
## What

Change `verticalAlign: 'center'` to `verticalAlign: 'middle'`.

## Why

`vertical-align: center;` isn't valid CSS.