### PR TITLE
fix(component): remove bottom margin on the TableFigure component

### DIFF
--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -680,6 +680,25 @@ exports[`renders a simple table 1`] = `
 </table>
 `;
 
+exports[`renders a table figure 1`] = `
+.c0 {
+  margin: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+@media (min-width:720px) {
+  .c0 {
+    white-space: normal;
+  }
+}
+
+<figure
+  class="c0"
+/>
+`;
+
 exports[`selectable renders selectable actions and checkboxes 1`] = `
 .c9 {
   vertical-align: middle;

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -3,7 +3,7 @@ import 'jest-styled-components';
 
 import { fireEvent, render } from '@test/utils';
 
-import { Table } from './Table';
+import { Table, TableFigure } from './Table';
 
 interface SimpleTableOptions {
   className?: string;
@@ -50,6 +50,12 @@ const getSimpleTable = ({
 
 test('renders a simple table', () => {
   const { container } = render(getSimpleTable());
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('renders a table figure', () => {
+  const { container } = render(<TableFigure />);
 
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/packages/big-design/src/components/Table/styled.tsx
+++ b/packages/big-design/src/components/Table/styled.tsx
@@ -5,7 +5,6 @@ import { MarginProps, withMargins } from '../../mixins';
 
 export const StyledTableFigure = styled.figure<MarginProps>`
   margin: 0;
-  margin-bottom: ${({ theme }) => `${theme.spacing.xLarge}`};
   max-width: 100%;
   overflow-x: auto;
   white-space: nowrap;

--- a/packages/docs/components/PropTable/PropTable.tsx
+++ b/packages/docs/components/PropTable/PropTable.tsx
@@ -29,7 +29,7 @@ export const PropTable: FC<PropTableProps> = (props) => {
   const { collapsible, id, propList: items, title } = props;
 
   const renderTable = () => (
-    <TableFigure>
+    <TableFigure marginBottom="xLarge">
       <Table
         columns={[
           {


### PR DESCRIPTION
## What

Remove `margin-bottom` on `TableFigure` components. See breaking change snippet below if margin is needed:

```
BREAKING CHANGE:
Visual breaking change; removes the bottom margin on `TableFigure` components.
Use the built in `margin` props if margin is needed.
```