### PR TITLE
fix: type regression for ts < 3.8

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     },
     'import/resolver': {
       typescript: {
+        alwaysTryTypes: true,
         directory: 'packages/*/tsconfig.json',
       },
     },
@@ -49,6 +50,7 @@ module.exports = {
         ignoreDeclarationSort: true,
       },
     ],
+    'import/named': 'off',
     // Remove this when https://github.com/benmosher/eslint-plugin-import/pull/1528 gets released
     'import/default': 'off',
     'import/order': [

--- a/packages/big-design-icons/src/index.ts
+++ b/packages/big-design-icons/src/index.ts
@@ -1,4 +1,6 @@
+import { IconProps as _IconProps } from './base';
+
 export * from './components';
 export * from './utils';
 export { createStyledIcon } from './base';
-export type { IconProps } from './base';
+export type IconProps = _IconProps;

--- a/packages/big-design/src/components/Alert/index.ts
+++ b/packages/big-design/src/components/Alert/index.ts
@@ -1,2 +1,4 @@
+import { AlertProps as _AlertProps } from './Alert';
+
 export { Alert } from './Alert';
-export type { AlertProps } from './Alert';
+export type AlertProps = _AlertProps;

--- a/packages/big-design/src/components/Badge/index.ts
+++ b/packages/big-design/src/components/Badge/index.ts
@@ -1,2 +1,4 @@
+import { BadgeProps as _BadgeProps } from './Badge';
+
 export { Badge } from './Badge';
-export type { BadgeProps } from './Badge';
+export type BadgeProps = _BadgeProps;

--- a/packages/big-design/src/components/Box/index.ts
+++ b/packages/big-design/src/components/Box/index.ts
@@ -1,2 +1,4 @@
+import { BoxProps as _BoxProps } from './Box';
+
 export { Box } from './Box';
-export type { BoxProps } from './Box';
+export type BoxProps = _BoxProps;

--- a/packages/big-design/src/components/Button/index.ts
+++ b/packages/big-design/src/components/Button/index.ts
@@ -1,2 +1,4 @@
+import { ButtonProps as _ButtonProps } from './Button';
+
 export { Button } from './Button';
-export type { ButtonProps } from './Button';
+export type ButtonProps = _ButtonProps;

--- a/packages/big-design/src/components/Checkbox/index.ts
+++ b/packages/big-design/src/components/Checkbox/index.ts
@@ -1,3 +1,5 @@
+import { CheckboxProps as _CheckboxProps } from './Checkbox';
+
 export { Checkbox } from './Checkbox';
-export type { CheckboxProps } from './Checkbox';
 export * from './Label';
+export type CheckboxProps = _CheckboxProps;

--- a/packages/big-design/src/components/Chip/index.ts
+++ b/packages/big-design/src/components/Chip/index.ts
@@ -1,2 +1,4 @@
+import { ChipProps as _ChipProps } from './Chip';
+
 export { Chip } from './Chip';
-export type { ChipProps } from './Chip';
+export type ChipProps = _ChipProps;

--- a/packages/big-design/src/components/Collapse/index.ts
+++ b/packages/big-design/src/components/Collapse/index.ts
@@ -1,2 +1,4 @@
+import { CollapseProps as _CollapseProps } from './Collapse';
+
 export { Collapse } from './Collapse';
-export type { CollapseProps } from './Collapse';
+export type CollapseProps = _CollapseProps;

--- a/packages/big-design/src/components/Counter/index.ts
+++ b/packages/big-design/src/components/Counter/index.ts
@@ -1,2 +1,4 @@
+import { CounterProps as _CounterProps } from './Counter';
+
 export { Counter } from './Counter';
-export type { CounterProps } from './Counter';
+export type CounterProps = _CounterProps;

--- a/packages/big-design/src/components/Dropdown/index.ts
+++ b/packages/big-design/src/components/Dropdown/index.ts
@@ -1,2 +1,12 @@
+import {
+  DropdownItem as _DropdownItem,
+  DropdownItemGroup as _DropdownItemGroup,
+  DropdownLinkItem as _DropdownLinkItem,
+  DropdownProps as _DropdownProps,
+} from './types';
+
 export { Dropdown } from './Dropdown';
-export type { DropdownItem, DropdownItemGroup, DropdownLinkItem, DropdownProps } from './types';
+export type DropdownItem = _DropdownItem;
+export type DropdownItemGroup = _DropdownItemGroup;
+export type DropdownLinkItem = _DropdownLinkItem;
+export type DropdownProps = _DropdownProps;

--- a/packages/big-design/src/components/Dropdown/types.ts
+++ b/packages/big-design/src/components/Dropdown/types.ts
@@ -1,4 +1,4 @@
-import type { Placement } from '@popperjs/core';
+import { Placement } from '@popperjs/core';
 
 import { ListItemProps } from '../List/Item';
 

--- a/packages/big-design/src/components/Fieldset/index.ts
+++ b/packages/big-design/src/components/Fieldset/index.ts
@@ -1,4 +1,6 @@
+import { FieldsetProps as _FieldsetProps } from './Fieldset';
+
 export { FieldsetDescription } from './Description';
 export { Fieldset } from './Fieldset';
 export { FieldsetLegend } from './Legend';
-export type { FieldsetProps } from './Fieldset';
+export type FieldsetProps = _FieldsetProps;

--- a/packages/big-design/src/components/Flex/Item/index.ts
+++ b/packages/big-design/src/components/Flex/Item/index.ts
@@ -1,2 +1,4 @@
+import { FlexItemProps as _FlexItemProps } from './Item';
+
 export { FlexItem } from './Item';
-export type { FlexItemProps } from './Item';
+export type FlexItemProps = _FlexItemProps;

--- a/packages/big-design/src/components/Flex/index.ts
+++ b/packages/big-design/src/components/Flex/index.ts
@@ -1,3 +1,5 @@
+import { FlexProps as _FlexProps } from './Flex';
+
 export { Flex } from './Flex';
-export type { FlexProps } from './Flex';
 export * from './Item';
+export type FlexProps = _FlexProps;

--- a/packages/big-design/src/components/Form/Description/index.ts
+++ b/packages/big-design/src/components/Form/Description/index.ts
@@ -1,2 +1,4 @@
+import { FormControlDescriptionLinkProps as _FormControlDescriptionLinkProps } from './Description';
+
 export { FormControlDescription } from './Description';
-export type { FormControlDescriptionLinkProps } from './Description';
+export type FormControlDescriptionLinkProps = _FormControlDescriptionLinkProps;

--- a/packages/big-design/src/components/Form/index.ts
+++ b/packages/big-design/src/components/Form/index.ts
@@ -1,7 +1,10 @@
+import { FormControlDescriptionLinkProps as _FormControlDescriptionLinkProps } from './Description';
+import { FormProps as _FormProps } from './Form';
+
 export { Form } from './Form';
 export { FormControlDescription } from './Description';
 export { FormControlError } from './Error';
 export { FormGroup } from './Group';
 export { FormControlLabel } from './Label';
-export type { FormControlDescriptionLinkProps } from './Description';
-export type { FormProps } from './Form';
+export type FormProps = _FormProps;
+export type FormControlDescriptionLinkProps = _FormControlDescriptionLinkProps;

--- a/packages/big-design/src/components/Grid/Item/index.ts
+++ b/packages/big-design/src/components/Grid/Item/index.ts
@@ -1,2 +1,4 @@
+import { GridItemProps as _GridItemProps } from './Item';
+
 export { GridItem } from './Item';
-export type { GridItemProps } from './Item';
+export type GridItemProps = _GridItemProps;

--- a/packages/big-design/src/components/Grid/index.ts
+++ b/packages/big-design/src/components/Grid/index.ts
@@ -1,3 +1,5 @@
+import { GridProps as _GridProps } from './Grid';
+
 export { Grid } from './Grid';
-export type { GridProps } from './Grid';
 export * from './Item';
+export type GridProps = _GridProps;

--- a/packages/big-design/src/components/InlineAlert/index.ts
+++ b/packages/big-design/src/components/InlineAlert/index.ts
@@ -1,2 +1,4 @@
+import { InlineAlertProps as _InlineAlertProps } from './InlineAlert';
+
 export { InlineAlert } from './InlineAlert';
-export type { InlineAlertProps } from './InlineAlert';
+export type InlineAlertProps = _InlineAlertProps;

--- a/packages/big-design/src/components/Input/index.ts
+++ b/packages/big-design/src/components/Input/index.ts
@@ -1,2 +1,4 @@
+import { InputProps as _InputProps } from './Input';
+
 export { Input } from './Input';
-export type { InputProps } from './Input';
+export type InputProps = _InputProps;

--- a/packages/big-design/src/components/Input/private.ts
+++ b/packages/big-design/src/components/Input/private.ts
@@ -1,4 +1,4 @@
 import { StyledInputWrapperProps as _StyledInputWrapperProps } from './styled';
 
-export type StyledInputWrapperProps = _StyledInputWrapperProps;
 export { StyledInput, StyledInputWrapper } from './styled';
+export type StyledInputWrapperProps = _StyledInputWrapperProps;

--- a/packages/big-design/src/components/Input/private.ts
+++ b/packages/big-design/src/components/Input/private.ts
@@ -1,2 +1,4 @@
+import { StyledInputWrapperProps as _StyledInputWrapperProps } from './styled';
+
+export type StyledInputWrapperProps = _StyledInputWrapperProps;
 export { StyledInput, StyledInputWrapper } from './styled';
-export type { StyledInputWrapperProps } from './styled';

--- a/packages/big-design/src/components/Link/index.ts
+++ b/packages/big-design/src/components/Link/index.ts
@@ -1,2 +1,4 @@
+import { LinkProps as _LinkProps } from './Link';
+
 export { Link } from './Link';
-export type { LinkProps } from './Link';
+export type LinkProps = _LinkProps;

--- a/packages/big-design/src/components/List/Item/index.ts
+++ b/packages/big-design/src/components/List/Item/index.ts
@@ -1,2 +1,4 @@
+import { ListItemProps as _ListItemProps } from './Item';
+
 export { ListItem } from './Item';
-export type { ListItemProps } from './Item';
+export type ListItemProps = _ListItemProps;

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -1,4 +1,4 @@
-import type { State } from '@popperjs/core';
+import { State } from '@popperjs/core';
 import React, { forwardRef, HTMLAttributes, memo, Ref } from 'react';
 
 import { useIsomorphicLayoutEffect, useWindowSize } from '../../hooks';

--- a/packages/big-design/src/components/Message/index.ts
+++ b/packages/big-design/src/components/Message/index.ts
@@ -1,2 +1,4 @@
+import { MessageProps as _MessageProps } from './Message';
+
 export { Message } from './Message';
-export type { MessageProps } from './Message';
+export type MessageProps = _MessageProps;

--- a/packages/big-design/src/components/Modal/index.ts
+++ b/packages/big-design/src/components/Modal/index.ts
@@ -1,2 +1,5 @@
+import { ModalAction as _ModalAction, ModalProps as _ModalProps } from './Modal';
+
 export { Modal } from './Modal';
-export type { ModalAction, ModalProps } from './Modal';
+export type ModalProps = _ModalProps;
+export type ModalAction = _ModalAction;

--- a/packages/big-design/src/components/MultiSelect/index.ts
+++ b/packages/big-design/src/components/MultiSelect/index.ts
@@ -1,2 +1,5 @@
+import { MultiSelectProps as _MultiSelectProps } from './types';
+
 export { MultiSelect } from './MultiSelect';
-export type { MultiSelectProps } from './types';
+
+export type MultiSelectProps<T> = _MultiSelectProps<T>;

--- a/packages/big-design/src/components/MultiSelect/types.ts
+++ b/packages/big-design/src/components/MultiSelect/types.ts
@@ -1,4 +1,4 @@
-import type { Placement } from '@popperjs/core';
+import { Placement } from '@popperjs/core';
 import React, { RefObject } from 'react';
 
 import { InputProps } from '../Input';

--- a/packages/big-design/src/components/Pagination/index.ts
+++ b/packages/big-design/src/components/Pagination/index.ts
@@ -1,2 +1,4 @@
+import { PaginationProps as _PaginationProps } from './Pagination';
+
 export { Pagination } from './Pagination';
-export type { PaginationProps } from './Pagination';
+export type PaginationProps = _PaginationProps;

--- a/packages/big-design/src/components/Panel/index.ts
+++ b/packages/big-design/src/components/Panel/index.ts
@@ -1,2 +1,4 @@
+import { PanelProps as _PanelProps } from './Panel';
+
 export { Panel } from './Panel';
-export type { PanelProps } from './Panel';
+export type PanelProps = _PanelProps;

--- a/packages/big-design/src/components/ProgressBar/index.ts
+++ b/packages/big-design/src/components/ProgressBar/index.ts
@@ -1,2 +1,4 @@
+import { ProgressBarProps as _ProgressBarProps } from './ProgressBar';
+
 export { ProgressBar } from './ProgressBar';
-export type { ProgressBarProps } from './ProgressBar';
+export type ProgressBarProps = _ProgressBarProps;

--- a/packages/big-design/src/components/ProgressCircle/index.ts
+++ b/packages/big-design/src/components/ProgressCircle/index.ts
@@ -1,2 +1,4 @@
+import { ProgressCircleProps as _ProgressCircleProps } from './ProgressCircle';
+
 export { ProgressCircle } from './ProgressCircle';
-export type { ProgressCircleProps } from './ProgressCircle';
+export type ProgressCircleProps = _ProgressCircleProps;

--- a/packages/big-design/src/components/Radio/index.ts
+++ b/packages/big-design/src/components/Radio/index.ts
@@ -1,3 +1,5 @@
+import { RadioProps as _RadioProps } from './Radio';
+
 export { Radio } from './Radio';
-export type { RadioProps } from './Radio';
 export * from './Label';
+export type RadioProps = _RadioProps;

--- a/packages/big-design/src/components/Select/index.ts
+++ b/packages/big-design/src/components/Select/index.ts
@@ -1,2 +1,13 @@
+import {
+  SelectAction as _SelectAction,
+  SelectOption as _SelectOption,
+  SelectOptionGroup as _SelectOptionGroup,
+  SelectProps as _SelectProps,
+} from './types';
+
 export { Select } from './Select';
-export type { SelectAction, SelectOption, SelectOptionGroup, SelectProps } from './types';
+
+export type SelectAction = _SelectAction;
+export type SelectOptionGroup<T> = _SelectOptionGroup<T>;
+export type SelectOption<T> = _SelectOption<T>;
+export type SelectProps<T> = _SelectProps<T>;

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -1,4 +1,4 @@
-import type { Placement } from '@popperjs/core';
+import { Placement } from '@popperjs/core';
 import React, { RefObject } from 'react';
 
 import { InputProps } from '../Input';

--- a/packages/big-design/src/components/StatefulTable/index.ts
+++ b/packages/big-design/src/components/StatefulTable/index.ts
@@ -1,2 +1,9 @@
+import {
+  StatefulTableColumn as _StatefulTableColumn,
+  StatefulTableProps as _StatefulTableProps,
+} from './StatefulTable';
+
 export { StatefulTable } from './StatefulTable';
-export type { StatefulTableColumn, StatefulTableProps } from './StatefulTable';
+
+export type StatefulTableProps<T> = _StatefulTableProps<T>;
+export type StatefulTableColumn<T> = _StatefulTableColumn<T>;

--- a/packages/big-design/src/components/Table/Actions/index.ts
+++ b/packages/big-design/src/components/Table/Actions/index.ts
@@ -1,2 +1,5 @@
+import { ActionsProps as _ActionsProps } from './Actions';
+
 export { Actions } from './Actions';
-export type { ActionsProps } from './Actions';
+
+export type ActionsProps<T> = _ActionsProps<T>;

--- a/packages/big-design/src/components/Table/Body/index.ts
+++ b/packages/big-design/src/components/Table/Body/index.ts
@@ -1,2 +1,5 @@
+import { BodyProps as _BodyProps } from './Body';
+
 export { Body } from './Body';
-export type { BodyProps } from './Body';
+
+export type BodyProps = _BodyProps;

--- a/packages/big-design/src/components/Table/DataCell/index.ts
+++ b/packages/big-design/src/components/Table/DataCell/index.ts
@@ -1,2 +1,5 @@
+import { DataCellProps as _DataCellProps } from './DataCell';
+
 export { DataCell } from './DataCell';
-export type { DataCellProps } from './DataCell';
+
+export type DataCellProps = _DataCellProps;

--- a/packages/big-design/src/components/Table/Head/index.ts
+++ b/packages/big-design/src/components/Table/Head/index.ts
@@ -1,2 +1,5 @@
+import { HeadProps as _HeadProps } from './Head';
+
 export { Head } from './Head';
-export type { HeadProps } from './Head';
+
+export type HeadProps = _HeadProps;

--- a/packages/big-design/src/components/Table/HeaderCell/index.ts
+++ b/packages/big-design/src/components/Table/HeaderCell/index.ts
@@ -1,2 +1,5 @@
+import { HeaderCellProps as _HeaderCellProps } from './HeaderCell';
+
 export { HeaderCell } from './HeaderCell';
-export type { HeaderCellProps } from './HeaderCell';
+
+export type HeaderCellProps<T> = _HeaderCellProps<T>;

--- a/packages/big-design/src/components/Table/Row/index.ts
+++ b/packages/big-design/src/components/Table/Row/index.ts
@@ -1,2 +1,5 @@
+import { RowProps as _RowProps } from './Row';
+
 export { Row } from './Row';
-export type { RowProps } from './Row';
+
+export type RowProps<T> = _RowProps<T>;

--- a/packages/big-design/src/components/Tabs/index.ts
+++ b/packages/big-design/src/components/Tabs/index.ts
@@ -1,2 +1,6 @@
+import { TabItem as _TabItem, TabsProps as _TabsProps } from './Tabs';
+
 export { Tabs } from './Tabs';
-export type { TabItem, TabsProps } from './Tabs';
+
+export type TabItem = _TabItem;
+export type TabsProps = _TabsProps;

--- a/packages/big-design/src/components/Textarea/index.ts
+++ b/packages/big-design/src/components/Textarea/index.ts
@@ -1,2 +1,5 @@
+import { TextareaProps as _TextareaProps } from './Textarea';
+
 export { Textarea } from './Textarea';
-export type { TextareaProps } from './Textarea';
+
+export type TextareaProps = _TextareaProps;

--- a/packages/big-design/src/components/Tooltip/index.ts
+++ b/packages/big-design/src/components/Tooltip/index.ts
@@ -1,2 +1,5 @@
+import { TooltipProps as _TooltipProps } from './Tooltip';
+
 export { Tooltip } from './Tooltip';
-export type { TooltipProps } from './Tooltip';
+
+export type TooltipProps = _TooltipProps;

--- a/packages/big-design/src/components/Typography/index.ts
+++ b/packages/big-design/src/components/Typography/index.ts
@@ -1,2 +1,6 @@
+import { HeadingProps as _HeadingProps, TextProps as _TextProps } from './types';
+
 export { Text, Small, H0, H1, H2, H3, H4 } from './Typography';
-export type { HeadingProps, TextProps } from './types';
+
+export type TextProps = _TextProps;
+export type HeadingProps = _HeadingProps;

--- a/packages/big-design/src/mixins/display/index.ts
+++ b/packages/big-design/src/mixins/display/index.ts
@@ -1,2 +1,5 @@
+import { DisplayProps as _DisplayProps } from './types';
+
 export { withDisplay } from './display';
-export type { DisplayProps } from './types';
+
+export type DisplayProps = _DisplayProps;

--- a/packages/big-design/src/mixins/margins/index.ts
+++ b/packages/big-design/src/mixins/margins/index.ts
@@ -1,2 +1,5 @@
+import { MarginProps as _MarginProps } from './margins';
+
 export { excludeMarginProps, withMargins } from './margins';
-export type { MarginProps } from './margins';
+
+export type MarginProps = _MarginProps;

--- a/packages/big-design/src/mixins/paddings/index.ts
+++ b/packages/big-design/src/mixins/paddings/index.ts
@@ -1,2 +1,5 @@
+import { PaddingProps as _PaddingProps } from './paddings';
+
 export { excludePaddingProps, withPaddings } from './paddings';
-export type { PaddingProps } from './paddings';
+
+export type PaddingProps = _PaddingProps;


### PR DESCRIPTION
No longer relying on import/export type only to support ts < 3.8