### PR TITLE
fix: lock downshift to 5.2.0 to fix behavior of onOptionChange

### DIFF
--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -36,7 +36,7 @@
     "@bigcommerce/big-design-icons": "^0.11.1",
     "@bigcommerce/big-design-theme": "^0.9.0",
     "@popperjs/core": "^2.2.1",
-    "downshift": "^5.2.2",
+    "downshift": "5.2.0",
     "focus-trap": "^5.1.0",
     "polished": "^3.0.3",
     "react-popper": "^2.1.0",

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -348,6 +348,7 @@ test('clicking on select options should trigger onOptionChange', () => {
   const options = getAllByRole('option');
   fireEvent.click(options[3]);
   expect(onChange).toHaveBeenCalledWith(mockOptions[3].value, mockOptions[3]);
+  expect(onChange).toHaveBeenCalledTimes(1);
 });
 
 test('clicking on disabled select options should not trigger onItemClick', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5754,10 +5754,10 @@ dotenv@^5.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
 
-downshift@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-5.2.2.tgz#284e2d66ba314b77617ceaabb8278ad8c812d9ec"
-  integrity sha512-MD1hmc2bBENBJgboAnZl27yJd/1YXjf7LV/EJ1NJ4lw0hOupVvAnXf80N9egJYKt3HQsc926r97qH0K/QeFsvQ==
+downshift@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-5.2.0.tgz#00b78531f5ba8518fd6adf5902ec9a2fe829ba95"
+  integrity sha512-gz0HTCkodUBkRs/HH1WsfNWDQcW8oYIQAvHyJKMfBHi+JHO0E6yO9IqzkV8Qm9CeNu+E2tL2KvoGyCPxNN3v7g==
   dependencies:
     "@babel/runtime" "^7.9.1"
     compute-scroll-into-view "^1.0.13"


### PR DESCRIPTION
This will fix the weird behavior of Selects until we can properly figure out why it breaks using the latest versions of Downshift.

The issue is that our `onOptionChange` is being called two times when you click an option, which trigger an infinite loop effect. By expecting a single call we know the code is working as expected.

Tested locally as well.

Fixes #396 