### PR TITLE
feat(component): add additional size to ProgressCircle component

### DIFF
--- a/packages/big-design/src/components/Button/Button.tsx
+++ b/packages/big-design/src/components/Button/Button.tsx
@@ -30,7 +30,7 @@ const RawButton: React.FC<ButtonProps & PrivateProps> = memo(({ forwardedRef, ..
   const renderLoadingSpinner = () => {
     return (
       <LoadingSpinnerWrapper alignItems="center">
-        <ProgressCircle size="xSmall" />
+        <ProgressCircle size="xxSmall" />
       </LoadingSpinnerWrapper>
     );
   };

--- a/packages/big-design/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/big-design/src/components/ProgressCircle/ProgressCircle.tsx
@@ -9,7 +9,7 @@ import { StyledCircle, StyledCircleFiller, StyledProgressCircle, StyledText } fr
 export interface ProgressCircleProps {
   error?: boolean;
   percent?: number;
-  size?: 'xSmall' | 'small' | 'medium' | 'large';
+  size?: 'xxSmall' | 'xSmall' | 'small' | 'medium' | 'large';
 }
 
 export const ProgressCircle: React.FC<ProgressCircleProps> = typedMemo(({ error, percent, size = 'medium' }) => {

--- a/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
@@ -345,6 +345,58 @@ exports[`render small progress circle 1`] = `
 
 exports[`render xSmall progress circle 1`] = `
 .c0 {
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  fill: transparent;
+  stroke-width: 0.1875rem;
+  stroke: #ECEEF5;
+}
+
+.c2 {
+  fill: transparent;
+  stroke-width: 0.1875rem;
+  stroke: #ECEEF5;
+  stroke-dasharray: 65.97344572538566 65.97344572538566;
+  stroke: #3C64F4;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+  -webkit-animation: ceJQKV 1s ease-out infinite;
+  animation: ceJQKV 1s ease-out infinite;
+  stroke-dashoffset: 65.97344572538566;
+  -webkit-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+  -webkit-transition: stroke-dashoffset 0.35s;
+  transition: stroke-dashoffset 0.35s;
+}
+
+<div>
+  <svg
+    class="c0"
+    role="progressbar"
+  >
+    <circle
+      class="c1"
+      cx="0.75rem"
+      cy="0.75rem"
+      r="0.65625rem"
+    />
+    <circle
+      class="c2"
+      cx="0.75rem"
+      cy="0.75rem"
+      r="0.65625rem"
+    />
+  </svg>
+</div>
+`;
+
+exports[`render xSmall progress circle 2`] = `
+.c0 {
   height: 1rem;
   width: 1rem;
 }

--- a/packages/big-design/src/components/ProgressCircle/constants.ts
+++ b/packages/big-design/src/components/ProgressCircle/constants.ts
@@ -2,14 +2,16 @@ export const CIRCLE_DIMENSIONS = {
   large: 80,
   medium: 48,
   small: 32,
-  xSmall: 16,
+  xSmall: 24,
+  xxSmall: 16,
 };
 
 export const CIRCLE_STROKE_WIDTHS = {
   large: 8,
   medium: 4,
   small: 4,
-  xSmall: 2,
+  xSmall: 3,
+  xxSmall: 2,
 };
 
 export const CIRCLE_CIRCUMFERENCES = {
@@ -17,4 +19,5 @@ export const CIRCLE_CIRCUMFERENCES = {
   medium: (CIRCLE_DIMENSIONS.medium / 2 - CIRCLE_STROKE_WIDTHS.medium / 2) * 2 * Math.PI,
   small: (CIRCLE_DIMENSIONS.small / 2 - CIRCLE_STROKE_WIDTHS.small / 2) * 2 * Math.PI,
   xSmall: (CIRCLE_DIMENSIONS.xSmall / 2 - CIRCLE_STROKE_WIDTHS.xSmall / 2) * 2 * Math.PI,
+  xxSmall: (CIRCLE_DIMENSIONS.xxSmall / 2 - CIRCLE_STROKE_WIDTHS.xxSmall / 2) * 2 * Math.PI,
 };

--- a/packages/big-design/src/components/ProgressCircle/spec.tsx
+++ b/packages/big-design/src/components/ProgressCircle/spec.tsx
@@ -53,3 +53,9 @@ test('render xSmall progress circle', () => {
 
   expect(container).toMatchSnapshot();
 });
+
+test('render xSmall progress circle', () => {
+  const { container } = render(<ProgressCircle size="xxSmall" />);
+
+  expect(container).toMatchSnapshot();
+});

--- a/packages/docs/PropTables/ProgressCirclePropTable.tsx
+++ b/packages/docs/PropTables/ProgressCirclePropTable.tsx
@@ -15,7 +15,7 @@ const progressCircleProps: Prop[] = [
   },
   {
     name: 'size',
-    types: ['xSmall', 'small', 'medium', 'large'],
+    types: ['xxSmall', 'xSmall', 'small', 'medium', 'large'],
     defaultValue: 'medium',
     description: 'Size of the component.',
   },


### PR DESCRIPTION
## What

Adds a new size for the `ProgressCircle` component. New size is 24px x 24px which we needed to shift the `xSmall` size down to `xxSmall`.

This is in order to have a loading icon for the `Tree` component in #406.

## Screenshot
<img width="283" alt="Screen Shot 2020-05-29 at 2 56 25 PM" src="https://user-images.githubusercontent.com/10539418/83299885-a311d580-a1bc-11ea-8630-7bac9b8f94c1.png">


```
BREAKING CHANGE:
`xSmall` `ProgressCircle` size changed to `xxSmall`.
```