### PR TITLE
chore: set frontend team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,1 @@
-* @bigcommerce/channels-fe
-
-# Jorge's components:
-packages/big-design/src/components/Dropdown/ @jorgemoya
-packages/big-design/src/components/MultiSelect/ @jorgemoya
-packages/big-design/src/components/Select/ @jorgemoya
+* @bigcommerce/frontend


### PR DESCRIPTION
## What

Sets the @bigcommerce/frontend team as CODEOWNERS for `big-design`.

## Why

An ongoing effort to get BigCommerce employees insight and more involved with `big-design`. Also, the previous method of having SMEs as CODEOWNERS can restrict merging if someone is on PTO. 