### PR TITLE
fix: typo in description text

### DIFF
--- a/packages/docs/PropTables/FlexPropTable.tsx
+++ b/packages/docs/PropTables/FlexPropTable.tsx
@@ -102,7 +102,7 @@ const flexItemProps: Prop[] = [
     defaultValue: '0',
     description: (
       <>
-        Determines how much a flex item can grow relitive to the rest of the flex items. Same as the{' '}
+        Determines how much a flex item can grow relative to the rest of the flex items. Same as the{' '}
         <Code highlight={false}>flex-grow</Code> CSS property.
       </>
     ),
@@ -124,7 +124,7 @@ const flexItemProps: Prop[] = [
     defaultValue: '1',
     description: (
       <>
-        Determines how much a flex item can shrink relitive to the rest of the flex items. Same as the{' '}
+        Determines how much a flex item can shrink relative to the rest of the flex items. Same as the{' '}
         <Code highlight={false}>flex-shrink</Code> CSS property.
       </>
     ),

--- a/packages/docs/pages/Message/MessagePage.tsx
+++ b/packages/docs/pages/Message/MessagePage.tsx
@@ -10,7 +10,7 @@ const MessagePage = () => (
   <>
     <H0>Messages</H0>
     <Text>
-      A message primarily used for displaying page/table messaging, feature/discover/system level mesaages, or even
+      A message primarily used for displaying page/table messaging, feature/discover/system level messages, or even
       non-critical messaging.
     </Text>
 


### PR DESCRIPTION
Found this typo while browsing BigDesign site.