### PR TITLE
feat(component): create mobileFriendly prop

### DIFF
--- a/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
@@ -466,7 +466,7 @@ exports[`renders close button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: #3C64F4;
   border-color: #3C64F4;

--- a/packages/big-design/src/components/Button/Button.tsx
+++ b/packages/big-design/src/components/Button/Button.tsx
@@ -15,6 +15,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, Ma
   iconOnly?: React.ReactNode;
   iconRight?: React.ReactNode;
   isLoading?: boolean;
+  mobileFriendly?: boolean;
   variant?: 'primary' | 'secondary' | 'subtle';
 }
 

--- a/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
@@ -45,7 +45,7 @@ exports[`render default button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: #3C64F4;
   border-color: #3C64F4;
   font-weight: 600;
@@ -165,7 +165,7 @@ exports[`render destructive button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: #DB3643;
   border-color: #DB3643;
   font-weight: 600;
@@ -285,7 +285,7 @@ exports[`render destructive disabled button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: #DB3643;
   border-color: #DB3643;
   font-weight: 600;
@@ -406,7 +406,7 @@ exports[`render disabled button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: #3C64F4;
   border-color: #3C64F4;
   font-weight: 600;
@@ -533,7 +533,7 @@ exports[`render icon left and right button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   background-color: #3C64F4;
@@ -695,7 +695,7 @@ exports[`render icon left button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding-left: 0.5rem;
   background-color: #3C64F4;
   border-color: #3C64F4;
@@ -839,7 +839,7 @@ exports[`render icon only button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: #3C64F4;
   border-color: #3C64F4;
@@ -982,7 +982,7 @@ exports[`render icon right button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding-right: 0.5rem;
   background-color: #3C64F4;
   border-color: #3C64F4;
@@ -1175,7 +1175,7 @@ exports[`render loading button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: #3C64F4;
   border-color: #3C64F4;
   font-weight: 600;
@@ -1291,7 +1291,7 @@ exports[`render loading button 1`] = `
 </button>
 `;
 
-exports[`render secondary button 1`] = `
+exports[`render mobileFriendly button 1`] = `
 .c0 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
@@ -1337,6 +1337,126 @@ exports[`render secondary button 1`] = `
   vertical-align: middle;
   white-space: nowrap;
   width: 100%;
+  background-color: #3C64F4;
+  border-color: #3C64F4;
+  font-weight: 600;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c0 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c0:active {
+  background-color: #0B38D9;
+}
+
+.c0:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c0:hover:not(:active) {
+  background-color: #2852EB;
+}
+
+.c0[disabled] {
+  background-color: #D9DCE9;
+}
+
+.c1 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+  visibility: visible;
+}
+
+@media (min-width:720px) {
+  .c0 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    width: auto;
+  }
+}
+
+<button
+  class="c0 bd-button"
+  role="button"
+  tabindex="0"
+>
+  <span
+    class="c1"
+  >
+    Button
+  </span>
+</button>
+`;
+
+exports[`render secondary button 1`] = `
+.c0 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
   background-color: transparent;
   border-color: #3C64F4;
   color: #3C64F4;
@@ -1456,7 +1576,7 @@ exports[`render secondary destructive button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: transparent;
   border-color: #DB3643;
   color: #DB3643;
@@ -1576,7 +1696,7 @@ exports[`render secondary destructive disabled button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: transparent;
   border-color: #DB3643;
   color: #DB3643;
@@ -1697,7 +1817,7 @@ exports[`render secondary disabled button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: transparent;
   border-color: #3C64F4;
   color: #3C64F4;
@@ -1818,7 +1938,7 @@ exports[`render subtle button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: transparent;
   border-color: transparent;
   color: #3C64F4;
@@ -1939,7 +2059,7 @@ exports[`render subtle destructive button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: transparent;
   border-color: transparent;
   color: #DB3643;
@@ -2060,7 +2180,7 @@ exports[`render subtle destructive disabled button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: transparent;
   border-color: transparent;
   color: #DB3643;
@@ -2182,7 +2302,7 @@ exports[`render subtle disabled button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: transparent;
   border-color: transparent;
   color: #3C64F4;

--- a/packages/big-design/src/components/Button/spec.tsx
+++ b/packages/big-design/src/components/Button/spec.tsx
@@ -142,6 +142,12 @@ test('render icon left and right button', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
+test('render mobileFriendly button', () => {
+  const { container } = render(<Button mobileFriendly={true}>Button</Button>);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
 test('forwards ref', () => {
   const ref = createRef<HTMLButtonElement>();
 

--- a/packages/big-design/src/components/Button/styled.tsx
+++ b/packages/big-design/src/components/Button/styled.tsx
@@ -36,7 +36,7 @@ export const StyledButton = styled.button<ButtonProps & MarginProps>`
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: ${({ mobileFriendly }) => (mobileFriendly ? '100%' : 'auto')};
 
   &:focus {
     outline: none;

--- a/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
@@ -74,7 +74,7 @@ exports[`renders with close button if onRemove is present 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: transparent;
   border-color: transparent;

--- a/packages/big-design/src/components/InlineAlert/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineAlert/__snapshots__/spec.tsx.snap
@@ -438,7 +438,7 @@ exports[`renders close button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: #3C64F4;
   border-color: #3C64F4;

--- a/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
@@ -434,7 +434,7 @@ exports[`renders close button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: #3C64F4;
   border-color: #3C64F4;

--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -88,7 +88,7 @@ exports[`render open modal 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: #3C64F4;
   border-color: #3C64F4;
@@ -388,7 +388,7 @@ exports[`render open modal without backdrop 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: #3C64F4;
   border-color: #3C64F4;
@@ -645,7 +645,7 @@ exports[`renders destructive action button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: #DB3643;
   border-color: #DB3643;
   font-weight: 600;
@@ -765,7 +765,7 @@ exports[`renders secondary action button 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: transparent;
   border-color: #3C64F4;
   color: #3C64F4;

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -108,7 +108,7 @@ exports[`render pagination component 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding-right: 0.5rem;
   background-color: transparent;
   border-color: transparent;
@@ -189,7 +189,7 @@ exports[`render pagination component 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: transparent;
   border-color: transparent;
@@ -498,7 +498,7 @@ exports[`render pagination component with invalid page info 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding-right: 0.5rem;
   background-color: transparent;
   border-color: transparent;
@@ -579,7 +579,7 @@ exports[`render pagination component with invalid page info 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: transparent;
   border-color: transparent;
@@ -888,7 +888,7 @@ exports[`render pagination component with invalid range info 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding-right: 0.5rem;
   background-color: transparent;
   border-color: transparent;
@@ -969,7 +969,7 @@ exports[`render pagination component with invalid range info 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: transparent;
   border-color: transparent;
@@ -1279,7 +1279,7 @@ exports[`render pagination component with no items 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding-right: 0.5rem;
   background-color: transparent;
   border-color: transparent;
@@ -1360,7 +1360,7 @@ exports[`render pagination component with no items 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: transparent;
   border-color: transparent;

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -127,7 +127,7 @@ exports[`renders a pagination component 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding-right: 0.5rem;
   background-color: transparent;
   border-color: transparent;
@@ -208,7 +208,7 @@ exports[`renders a pagination component 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   padding: 0 0.5rem;
   background-color: transparent;
   border-color: transparent;

--- a/packages/big-design/src/components/Tabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tabs/__snapshots__/spec.tsx.snap
@@ -73,7 +73,7 @@ exports[`render Tabs 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: transparent;
   border-color: transparent;
   color: #3C64F4;
@@ -254,7 +254,7 @@ exports[`render Tabs with disabled item 1`] = `
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: auto;
   background-color: transparent;
   border-color: transparent;
   color: #3C64F4;


### PR DESCRIPTION
# What
Create mobileFriendly prop. 

## Screenshot

Default button (mobileFriendly not set)
<img width="961" alt="Screen Shot 2020-06-23 at 9 55 55 AM" src="https://user-images.githubusercontent.com/33278039/85432510-ebac7c80-b537-11ea-915e-d2286ff0acf5.png">

**With mobileFriendly Prop true**
<img width="1915" alt="Screen Shot 2020-06-23 at 9 55 05 AM" src="https://user-images.githubusercontent.com/33278039/85432354-b30ca300-b537-11ea-9acc-4f6a2f83126e.png">


Fixes #388 
