### PR TITLE
feat(component): add clear method to alerts manager

### DIFF
--- a/packages/big-design/src/managers/alerts/manager.ts
+++ b/packages/big-design/src/managers/alerts/manager.ts
@@ -41,6 +41,15 @@ class AlertsManager {
     return key;
   }
 
+  clear() {
+    const removed = this.alerts;
+
+    this.alerts = [];
+    this.notifySubscribers();
+
+    return removed;
+  }
+
   remove(key: string) {
     let removed: AlertProps | undefined;
 

--- a/packages/big-design/src/managers/alerts/spec.tsx
+++ b/packages/big-design/src/managers/alerts/spec.tsx
@@ -75,6 +75,28 @@ describe('alertsManager functionality', () => {
     }
   });
 
+  test('removes all alerts', () => {
+    const testAlertA = { messages: [{ text: 'Text A' }] };
+    const testAlertB = { messages: [{ text: 'Text B' }] };
+    const mockSubscriber = jest.fn();
+
+    alertsManager.subscribe(mockSubscriber);
+    alertsManager.add(testAlertA);
+    alertsManager.add(testAlertB);
+
+    const removed = alertsManager.clear();
+
+    expect(removed).toEqual([
+      expect.objectContaining({ messages: testAlertA.messages }),
+      expect.objectContaining({ messages: testAlertB.messages }),
+    ]);
+
+    expect(mockSubscriber).toHaveBeenCalledTimes(3);
+    expect(mockSubscriber).toHaveBeenNthCalledWith(1, expect.objectContaining({ messages: testAlertA.messages }));
+    expect(mockSubscriber).toHaveBeenNthCalledWith(2, expect.objectContaining({ messages: testAlertA.messages }));
+    expect(mockSubscriber).toHaveBeenNthCalledWith(3, null);
+  });
+
   test("doesn't remove existing alert with invalid key", () => {
     const alertKey = alertsManager.add(alert);
 

--- a/packages/docs/MethodLists/AlertsManagerMethodLists.tsx
+++ b/packages/docs/MethodLists/AlertsManagerMethodLists.tsx
@@ -43,6 +43,16 @@ export const AlertsManagerRemoveMethodList: React.FC = () => (
   />
 );
 
+export const AlertsManagerClearMethodList: React.FC = () => (
+  <MethodList
+    name="clear"
+    intro="Removes all alerts."
+    usage="alertsManager.clear()"
+    parameterList={[]}
+    returnDescription="Contains the alerts removed."
+  />
+);
+
 export const AlertsManagerSubscribeMethodList: React.FC = () => (
   <MethodList
     name="subscribe"

--- a/packages/docs/pages/Alert/AlertPage.tsx
+++ b/packages/docs/pages/Alert/AlertPage.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Code, CodePreview, CodeSnippet } from '../../components';
 import {
   AlertsManagerAddMethodList,
+  AlertsManagerClearMethodList,
   AlertsManagerRemoveMethodList,
   AlertsManagerSubscribeMethodList,
 } from '../../MethodLists';
@@ -104,6 +105,8 @@ const AlertPage = () => (
     <AlertsManagerAddMethodList />
 
     <AlertsManagerRemoveMethodList />
+
+    <AlertsManagerClearMethodList />
 
     <AlertsManagerSubscribeMethodList />
   </>


### PR DESCRIPTION
Currently, there is no easy way to clear all alerts. This PR adds a `clear` method to the alert manager. An example usage would be calling this method from a router's `change` event.