### PR TITLE
feat(component): add fadeAway option to alertsManager

### DIFF
--- a/packages/big-design/src/managers/alerts/manager.ts
+++ b/packages/big-design/src/managers/alerts/manager.ts
@@ -6,6 +6,10 @@ interface PrivateAlert extends AlertProps {
   onClose(): void;
 }
 
+interface AddAlertConfig extends AlertProps {
+  fadeAway?: boolean;
+}
+
 class AlertsManager {
   private alerts: PrivateAlert[] = [];
   private counter = 0;
@@ -17,7 +21,7 @@ class AlertsManager {
     info: 3,
   };
 
-  add(alert: AlertProps): string {
+  add = (alert: AddAlertConfig): string => {
     if (alert.key && this.containsKey(alert.key)) {
       this.remove(alert.key);
     }
@@ -38,19 +42,23 @@ class AlertsManager {
 
     this.notifySubscribers();
 
-    return key;
-  }
+    if (alert.fadeAway) {
+      setTimeout(onClose, 5000);
+    }
 
-  clear() {
+    return key;
+  };
+
+  clear = () => {
     const removed = this.alerts;
 
     this.alerts = [];
     this.notifySubscribers();
 
     return removed;
-  }
+  };
 
-  remove(key: string) {
+  remove = (key: string) => {
     let removed: AlertProps | undefined;
 
     this.alerts = this.alerts.reduce((acc, alert) => {
@@ -66,15 +74,15 @@ class AlertsManager {
     this.notifySubscribers();
 
     return removed;
-  }
+  };
 
-  subscribe(subscriber: Subscriber) {
+  subscribe = (subscriber: Subscriber) => {
     this.subscribers.push(subscriber);
 
     return () => {
       this.subscribers = this.subscribers.filter((sub) => sub !== subscriber);
     };
-  }
+  };
 
   private notifySubscribers() {
     this.subscribers.forEach((subscriber) => subscriber(this.alerts[0] || null));

--- a/packages/big-design/src/managers/alerts/spec.tsx
+++ b/packages/big-design/src/managers/alerts/spec.tsx
@@ -75,6 +75,24 @@ describe('alertsManager functionality', () => {
     }
   });
 
+  test('removes an alert with fadeAway', (done) => {
+    jest.useFakeTimers();
+
+    const mockSubscriber = jest.fn();
+    const testAlert = { ...alert, fadeAway: true, onClose: done, key: 'test-key' };
+
+    alertsManager.subscribe(mockSubscriber);
+
+    const alertKey = alertsManager.add(testAlert);
+
+    jest.runAllTimers();
+
+    expect(alertKey).not.toBeUndefined();
+    expect(mockSubscriber).toHaveBeenCalledTimes(2);
+    expect(mockSubscriber).toHaveBeenCalledWith(expect.objectContaining({ key: 'test-key' }));
+    expect(mockSubscriber).toHaveBeenCalledWith(null);
+  });
+
   test('removes all alerts', () => {
     const testAlertA = { messages: [{ text: 'Text A' }] };
     const testAlertB = { messages: [{ text: 'Text B' }] };

--- a/packages/docs/MethodLists/AlertsManagerMethodLists.tsx
+++ b/packages/docs/MethodLists/AlertsManagerMethodLists.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Code, MethodList } from '../components';
+import { MethodList } from '../components';
 
 export const AlertsManagerAddMethodList: React.FC = () => (
   <MethodList
@@ -12,15 +12,6 @@ export const AlertsManagerAddMethodList: React.FC = () => (
         param: 'alert',
         description: 'An object with the same key/values as the alert props.',
         required: true,
-      },
-      {
-        param: 'dismissCallback',
-        description: (
-          <>
-            Callback function to run when the alert is dismissed. Runs before the <Code>onClose</Code> function in the
-            passed in alert.
-          </>
-        ),
       },
     ]}
     returnDescription="The value of the alert key. If no key is provided, then an auto-generated one will be provided."

--- a/packages/docs/PropTables/AlertPropTable.tsx
+++ b/packages/docs/PropTables/AlertPropTable.tsx
@@ -1,3 +1,4 @@
+import { Small, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { Prop, PropTable, PropTableWrapper } from '../components';
@@ -10,6 +11,17 @@ const alertProps: Prop[] = [
     name: 'key',
     types: 'string',
     description: 'Key used to identify alert.',
+  },
+  {
+    name: 'fadeAway',
+    types: 'boolean',
+    defaultValue: 'false',
+    description: (
+      <>
+        <Text>Autoclose after 5 seconds.</Text>
+        <Small>Note: Only valid when used with AlertManager.</Small>
+      </>
+    ),
   },
 ];
 


### PR DESCRIPTION
Auto-dismiss an alert using AlertManager after 5s

Eg usage:
```js
alertsManager.add({ title: 'Hello', fadeAway: true });
```