### PR TITLE
fix(docs): fix hash routes

### DIFF
--- a/packages/docs/components/NextLink/NextLink.tsx
+++ b/packages/docs/components/NextLink/NextLink.tsx
@@ -3,6 +3,10 @@ import { default as NLink } from 'next/link';
 import React from 'react';
 
 function getLinkAs(as = '') {
+  if (!as) {
+    return undefined;
+  }
+
   const prefix = process.env.URL_PREFIX || '';
 
   return prefix + as;


### PR DESCRIPTION
Links to `ids` were getting overridden by production's `URL_PREFIX`