### PR TITLE
feat(component): add description to select option and select action

### DIFF
--- a/packages/big-design/src/components/List/Item/CheckboxItem.tsx
+++ b/packages/big-design/src/components/List/Item/CheckboxItem.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, LiHTMLAttributes, memo, Ref } from 'react';
 
-import { Checkbox } from '../../Checkbox';
+import { Checkbox, CheckboxProps } from '../../Checkbox';
 
 import { StyledListItem } from './styled';
 
@@ -20,19 +20,16 @@ export interface ListItemCheckboxProps extends LiHTMLAttributes<HTMLLIElement> {
   isHighlighted: boolean;
 }
 
-const StyleableListCheckboxItem: React.FC<ListItemCheckboxProps & PrivateProps> = ({
-  checked,
-  children,
-  disabled,
-  forwardedRef,
-  ...props
-}) => {
+const StyleableListCheckboxItem: React.FC<
+  ListItemCheckboxProps & Pick<CheckboxProps, 'label' | 'description'> & PrivateProps
+> = ({ checked, disabled, description, forwardedRef, label, ...props }) => {
   return (
     <StyledListItem {...props} actionType="normal" isSelected={false} disabled={disabled} ref={forwardedRef}>
       <Checkbox
         checked={checked}
         disabled={disabled}
-        label={typeof children === 'string' ? children : ''}
+        description={description}
+        label={label}
         onChange={() => null}
         onClick={(event) => {
           event.preventDefault();
@@ -45,7 +42,7 @@ const StyleableListCheckboxItem: React.FC<ListItemCheckboxProps & PrivateProps> 
 };
 
 export const ListItemCheckbox = memo(
-  forwardRef<HTMLLIElement, ListCheckboxItemProps>((props, ref) => (
+  forwardRef<HTMLLIElement, ListCheckboxItemProps & Pick<CheckboxProps, 'label' | 'description'>>((props, ref) => (
     <StyleableListCheckboxItem {...props} forwardedRef={ref} />
   )),
 );

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -14,8 +14,8 @@ export const StyledListItem = styled.li<ListItemProps>`
   display: flex;
   font-weight: ${({ theme, isSelected }) =>
     isSelected ? theme.typography.fontWeight.semiBold : theme.typography.fontWeight.regular};
-  height: ${({ theme }) => theme.helpers.remCalc(36)};
   justify-content: space-between;
+  min-height: ${({ theme }) => theme.helpers.remCalc(36)};
   min-width: ${({ theme }) => theme.helpers.remCalc(256)};
   outline: none;
   padding: 0 ${({ theme }) => theme.spacing.medium};

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -18,7 +18,7 @@ export const StyledListItem = styled.li<ListItemProps>`
   min-height: ${({ theme }) => theme.helpers.remCalc(36)};
   min-width: ${({ theme }) => theme.helpers.remCalc(256)};
   outline: none;
-  padding: 0 ${({ theme }) => theme.spacing.medium};
+  padding: ${({ theme }) => `${theme.spacing.xxSmall} ${theme.spacing.medium}`};
 
   a {
     align-items: center;

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -23,6 +23,7 @@ import { ListItem } from '../List/Item';
 import { ListItemCheckbox } from '../List/Item/CheckboxItem';
 import { SelectAction, SelectOption } from '../Select';
 import { DropdownButton, StyledDropdownIcon, StyledInputContainer } from '../Select/styled';
+import { Small } from '../Typography';
 
 import { MultiSelectProps } from './types';
 
@@ -370,8 +371,10 @@ export const MultiSelect = typedMemo(
               index,
             })}
             checked={isChecked}
+            description={item.description}
             isHighlighted={isHighlighted}
             key={`${content}-${index}`}
+            label={item.content}
             onClick={() => {
               if (itemDisabled) {
                 return;
@@ -379,9 +382,7 @@ export const MultiSelect = typedMemo(
 
               isChecked ? removeItem(item as SelectOption<T>) : addSelectedItem(item as SelectOption<T>);
             }}
-          >
-            {content}
-          </ListItemCheckbox>
+          />
         );
       });
     }, [action, addSelectedItem, getItemProps, highlightedIndex, items, removeItem, renderAction, selectedOptions]);
@@ -421,12 +422,27 @@ export const MultiSelect = typedMemo(
 );
 
 const getContent = <T extends any>(item: SelectOption<T> | SelectAction, isHighlighted: boolean) => {
-  const { icon } = item;
+  const { content, disabled, description, icon } = item;
 
   return (
     <Flex alignItems="center" flexDirection="row">
-      {icon && <FlexItem paddingRight="xSmall">{renderIcon(item, isHighlighted)}</FlexItem>}
-      {item.content}
+      {icon && (
+        <FlexItem
+          alignSelf={description ? 'flex-start' : undefined}
+          paddingRight="xSmall"
+          paddingTop={description ? 'xSmall' : undefined}
+        >
+          {renderIcon(item, isHighlighted)}
+        </FlexItem>
+      )}
+      {description ? (
+        <FlexItem paddingVertical="xSmall">
+          {content}
+          <Small color={descriptionColor(disabled)}>{description}</Small>
+        </FlexItem>
+      ) : (
+        content
+      )}
     </Flex>
   );
 };
@@ -452,3 +468,5 @@ const iconColor = <T extends any>(item: SelectOption<T> | SelectAction, isHighli
 
   return 'actionType' in item ? (item.actionType === 'destructive' ? 'danger50' : 'primary') : 'primary';
 };
+
+const descriptionColor = (isDisabled: boolean | undefined) => (isDisabled ? 'secondary40' : 'secondary60');

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -19,6 +19,12 @@ const mockOptions = [
   { value: 'fr', content: 'France', disabled: true },
 ];
 
+const mockOptionsWithDescription = [
+  { value: 'us', content: 'United States', description: 'US Description' },
+  { value: 'mx', content: 'Mexico', description: 'MX Description' },
+  { value: 'fr', content: 'France', disabled: true, description: 'FR Description' },
+];
+
 const MultiSelectMock = (
   <MultiSelect
     action={{
@@ -35,6 +41,26 @@ const MultiSelectMock = (
     placeholder="Choose country"
     required
     value={['us', 'mx']}
+  />
+);
+
+const MultiSelectWithOptionsDescriptions = (
+  <MultiSelect
+    action={{
+      actionType: 'destructive',
+      content: 'Remove Country',
+      description: 'Action Description',
+      icon: <DeleteIcon />,
+      onActionClick,
+    }}
+    data-testid="select"
+    error="Required"
+    label="Countries"
+    onOptionsChange={onChange}
+    options={mockOptionsWithDescription}
+    placeholder="Choose country"
+    required
+    value={['mx']}
   />
 );
 
@@ -654,4 +680,20 @@ test('options should allow icons', () => {
 
   const svg = container.querySelectorAll('svg');
   expect(svg.length).toBe(3);
+});
+
+test('select option should supports description', () => {
+  const { getByText, getByTestId } = render(MultiSelectWithOptionsDescriptions);
+  const input = getByTestId('select');
+  fireEvent.focus(input);
+
+  expect(getByText('US Description')).toBeInTheDocument();
+});
+
+test('select action should supports description', () => {
+  const { getByText, getByTestId } = render(MultiSelectWithOptionsDescriptions);
+  const input = getByTestId('select');
+  fireEvent.focus(input);
+
+  expect(getByText('Action Description')).toBeInTheDocument();
 });

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -494,8 +494,12 @@ const iconColor = <T extends any>(item: SelectOption<T> | SelectAction, isHighli
 };
 
 const descriptionColor = <T extends any>(item: SelectOption<T> | SelectAction, isHighlighted: boolean) => {
-  if (!isHighlighted || !('onActionClick' in item)) {
+  if (item.disabled) {
     return 'secondary40';
+  }
+
+  if (!isHighlighted || !('onActionClick' in item)) {
+    return 'secondary60';
   }
 
   return 'actionType' in item ? (item.actionType === 'destructive' ? 'danger30' : 'primary30') : 'primary30';

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -24,6 +24,7 @@ import { Input } from '../Input';
 import { List } from '../List';
 import { ListGroupHeader } from '../List/GroupHeader';
 import { ListItem } from '../List/Item';
+import { Small } from '../Typography';
 
 import { DropdownButton, StyledDropdownIcon, StyledInputContainer } from './styled';
 import { SelectAction, SelectOption, SelectOptionGroup, SelectProps } from './types';
@@ -317,8 +318,8 @@ export const Select = typedMemo(
     );
 
     const renderOptions = useCallback(
-      (items: Array<SelectOption<T>>) => {
-        return items.map((item) => {
+      (items: Array<SelectOption<T>>) =>
+        items.map((item) => {
           if (
             !selectOptions.find(
               (option: SelectOption<T> | SelectAction) => 'value' in option && option.value === item.value,
@@ -351,8 +352,7 @@ export const Select = typedMemo(
               {isSelected && <CheckIcon color="primary" size="large" />}
             </ListItem>
           );
-        });
-      },
+        }),
       [getItemProps, highlightedIndex, selectedOption, selectOptions],
     );
 
@@ -446,12 +446,27 @@ const isGroup = <T extends any>(item: SelectOption<T> | SelectOptionGroup<T>) =>
 };
 
 const getContent = <T extends any>(item: SelectOption<T> | SelectAction, isHighlighted: boolean) => {
-  const { icon } = item;
+  const { content, description, icon } = item;
 
   return (
     <Flex alignItems="center" flexDirection="row">
-      {icon && <FlexItem paddingRight="xSmall">{renderIcon(item, isHighlighted)}</FlexItem>}
-      {item.content}
+      {icon && (
+        <FlexItem
+          alignSelf={description ? 'flex-start' : undefined}
+          paddingRight="xSmall"
+          paddingTop={description ? 'xSmall' : undefined}
+        >
+          {renderIcon(item, isHighlighted)}
+        </FlexItem>
+      )}
+      {description ? (
+        <FlexItem paddingVertical="xSmall">
+          {content}
+          <Small color={descriptionColor(item, isHighlighted)}>{description}</Small>
+        </FlexItem>
+      ) : (
+        content
+      )}
     </Flex>
   );
 };
@@ -476,4 +491,12 @@ const iconColor = <T extends any>(item: SelectOption<T> | SelectAction, isHighli
   }
 
   return 'actionType' in item ? (item.actionType === 'destructive' ? 'danger50' : 'primary') : 'primary';
+};
+
+const descriptionColor = <T extends any>(item: SelectOption<T> | SelectAction, isHighlighted: boolean) => {
+  if (!isHighlighted || !('onActionClick' in item)) {
+    return 'secondary40';
+  }
+
+  return 'actionType' in item ? (item.actionType === 'destructive' ? 'danger30' : 'primary30') : 'primary30';
 };

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -446,7 +446,7 @@ const isGroup = <T extends any>(item: SelectOption<T> | SelectOptionGroup<T>) =>
 };
 
 const getContent = <T extends any>(item: SelectOption<T> | SelectAction, isHighlighted: boolean) => {
-  const { content, description, icon } = item;
+  const { content, disabled, description, icon } = item;
 
   return (
     <Flex alignItems="center" flexDirection="row">
@@ -462,7 +462,7 @@ const getContent = <T extends any>(item: SelectOption<T> | SelectAction, isHighl
       {description ? (
         <FlexItem paddingVertical="xSmall">
           {content}
-          <Small color={descriptionColor(item, isHighlighted)}>{description}</Small>
+          <Small color={descriptionColor(disabled)}>{description}</Small>
         </FlexItem>
       ) : (
         content
@@ -493,14 +493,4 @@ const iconColor = <T extends any>(item: SelectOption<T> | SelectAction, isHighli
   return 'actionType' in item ? (item.actionType === 'destructive' ? 'danger50' : 'primary') : 'primary';
 };
 
-const descriptionColor = <T extends any>(item: SelectOption<T> | SelectAction, isHighlighted: boolean) => {
-  if (item.disabled) {
-    return 'secondary40';
-  }
-
-  if (!isHighlighted || !('onActionClick' in item)) {
-    return 'secondary60';
-  }
-
-  return 'actionType' in item ? (item.actionType === 'destructive' ? 'danger30' : 'primary30') : 'primary30';
-};
+const descriptionColor = (isDisabled: boolean | undefined) => (isDisabled ? 'secondary40' : 'secondary60');

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -37,6 +37,12 @@ const groupMockOptions = [
   },
 ];
 
+const mockOptionsWithDescription = [
+  { value: 'us', content: 'United States', description: 'US Description' },
+  { value: 'mx', content: 'Mexico', description: 'MX Description' },
+  { value: 'fr', content: 'France', disabled: true, description: 'FR Description' },
+];
+
 const SelectMock = (
   <Select
     action={{
@@ -69,6 +75,26 @@ const GroupedSelectMock = (
     label="Countries"
     onOptionChange={onChange}
     options={groupMockOptions}
+    placeholder="Choose country"
+    required
+    value="mx"
+  />
+);
+
+const SelectWithOptionsDescriptions = (
+  <Select
+    action={{
+      actionType: 'destructive',
+      content: 'Remove Country',
+      description: 'Action Description',
+      icon: <DeleteIcon />,
+      onActionClick,
+    }}
+    data-testid="select"
+    error="Required"
+    label="Countries"
+    onOptionChange={onChange}
+    options={mockOptionsWithDescription}
     placeholder="Choose country"
     required
     value="mx"
@@ -711,4 +737,20 @@ test('group labels should still render when filtering options', () => {
   expect(options.length).toBe(2);
   expect(label1).toBeInTheDocument();
   expect(label2).toBeInTheDocument();
+});
+
+test('select option should supports description', () => {
+  const { getByText, getByTestId } = render(SelectWithOptionsDescriptions);
+  const input = getByTestId('select');
+  fireEvent.focus(input);
+
+  expect(getByText('US Description')).toBeInTheDocument();
+});
+
+test('select action should supports description', () => {
+  const { getByText, getByTestId } = render(SelectWithOptionsDescriptions);
+  const input = getByTestId('select');
+  fireEvent.focus(input);
+
+  expect(getByText('Action Description')).toBeInTheDocument();
 });

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -29,6 +29,7 @@ export interface SelectProps<T> extends BaseSelect {
 interface BaseItem
   extends Omit<ListItemProps, 'children' | 'content' | 'isAction' | 'isHighlighted' | 'isSelected' | 'value'> {
   content: string;
+  description?: string;
   icon?: React.ReactElement;
 }
 

--- a/packages/docs/PropTables/SelectPropTable.tsx
+++ b/packages/docs/PropTables/SelectPropTable.tsx
@@ -150,6 +150,15 @@ const selectOptionProps: Prop[] = [
     ),
   },
   {
+    name: 'description',
+    types: 'string',
+    description: (
+      <>
+        Sets the content description of the <Code>SelectOption</Code>
+      </>
+    ),
+  },
+  {
     name: 'icon',
     types: (
       <NextLink href="/Icons/IconsPage" as="/icons">
@@ -206,6 +215,15 @@ const selectActionProps: Prop[] = [
     description: (
       <>
         'Sets the text content of the <Code>SelectAction</Code> .'
+      </>
+    ),
+  },
+  {
+    name: 'description',
+    types: 'string',
+    description: (
+      <>
+        Sets the content description of the <Code>SelectAction</Code>
       </>
     ),
   },

--- a/packages/docs/pages/MultiSelect/MultiSelectPage.tsx
+++ b/packages/docs/pages/MultiSelect/MultiSelectPage.tsx
@@ -303,7 +303,7 @@ const MultiSelectPage = () => (
 
     <H2>Option & Action Description</H2>
 
-    <Text>It is possible to add a description for select options and select action</Text>
+    <Text>It is possible to add a description for select options and actions.</Text>
 
     <CodePreview>
       {/* jsx-to-string:start */}

--- a/packages/docs/pages/MultiSelect/MultiSelectPage.tsx
+++ b/packages/docs/pages/MultiSelect/MultiSelectPage.tsx
@@ -300,6 +300,53 @@ const MultiSelectPage = () => (
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>
+
+    <H2>Option & Action Description</H2>
+
+    <Text>It is possible to add a description for select options and select action</Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      {function Example() {
+        const [value, setValue] = useState([1]);
+        const handleChange = (val) => setValue(val);
+
+        return (
+          <Form>
+            <FormGroup>
+              <MultiSelect
+                action={{
+                  actionType: 'destructive',
+                  content: 'Remove',
+                  description: 'Description for remove action',
+                  icon: <DeleteIcon />,
+                  onActionClick: () => null,
+                }}
+                label="Select"
+                onOptionsChange={() => null}
+                options={[
+                  { value: 1, content: 'Option #1', description: 'Description for option #1' },
+                  {
+                    value: 2,
+                    content: 'Option #2',
+                    description: 'Description for option #2',
+                    disabled: true,
+                  },
+                  { value: 3, content: 'Option #3' },
+                  { value: 4, content: 'Option #4' },
+                  { value: 5, content: 'Option #5' },
+                ]}
+                onChange={handleChange}
+                placeholder="Choose option"
+                required
+                value={value}
+              />
+            </FormGroup>
+          </Form>
+        );
+      }}
+      {/* jsx-to-string:end */}
+    </CodePreview>
   </>
 );
 

--- a/packages/docs/pages/Select/SelectPage.tsx
+++ b/packages/docs/pages/Select/SelectPage.tsx
@@ -345,7 +345,7 @@ const SelectPage = () => (
 
     <H2>Option & Action Description</H2>
 
-    <Text>It is possible to add a description for select options and select action</Text>
+    <Text>It is possible to add a description for select options and actions</Text>
 
     <CodePreview>
       {/* jsx-to-string:start */}

--- a/packages/docs/pages/Select/SelectPage.tsx
+++ b/packages/docs/pages/Select/SelectPage.tsx
@@ -342,6 +342,53 @@ const SelectPage = () => (
       </Form>
       {/* jsx-to-string:end */}
     </CodePreview>
+
+    <H2>Option & Action Description</H2>
+
+    <Text>It is possible to add a description for select options and select action</Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      {function Example() {
+        const [value, setValue] = useState(1);
+        const handleChange = (val) => setValue(val);
+
+        return (
+          <Form>
+            <FormGroup>
+              <Select
+                action={{
+                  actionType: 'destructive',
+                  content: 'Remove',
+                  description: 'Description for remove action',
+                  icon: <DeleteIcon />,
+                  onActionClick: () => null,
+                }}
+                label="Select"
+                onOptionChange={() => null}
+                options={[
+                  { value: 1, content: 'Option #1', description: 'Description for option #1' },
+                  {
+                    value: 2,
+                    content: 'Option #2',
+                    description: 'Description for option #2',
+                    disabled: true,
+                  },
+                  { value: 3, content: 'Option #3' },
+                  { value: 4, content: 'Option #4' },
+                  { value: 5, content: 'Option #5' },
+                ]}
+                onChange={handleChange}
+                placeholder="Larger"
+                required
+                value={value}
+              />
+            </FormGroup>
+          </Form>
+        );
+      }}
+      {/* jsx-to-string:end */}
+    </CodePreview>
   </>
 );
 

--- a/packages/docs/pages/Select/SelectPage.tsx
+++ b/packages/docs/pages/Select/SelectPage.tsx
@@ -345,7 +345,7 @@ const SelectPage = () => (
 
     <H2>Option & Action Description</H2>
 
-    <Text>It is possible to add a description for select options and actions</Text>
+    <Text>It is possible to add a description for select options and actions.</Text>
 
     <CodePreview>
       {/* jsx-to-string:start */}


### PR DESCRIPTION
## What?
Adding a description to the `select option` and `select action`.

## Screenshots
<img width="453" alt="Screenshot 2020-07-28 at 11 15 05" src="https://user-images.githubusercontent.com/9980803/88638053-a2fe5b00-d0c3-11ea-8131-aad6bec6aed0.png">
<img width="453" alt="Screenshot 2020-07-30 at 09 45 23" src="https://user-images.githubusercontent.com/9980803/88890114-d10da780-d249-11ea-86b7-03d57c163e53.png">
<img width="431" alt="Screenshot 2020-07-30 at 09 45 38" src="https://user-images.githubusercontent.com/9980803/88890118-d2d76b00-d249-11ea-81da-13c749a5105a.png">
<img width="967" alt="Screenshot 2020-07-28 at 09 38 44" src="https://user-images.githubusercontent.com/9980803/88629491-ff5b7d80-d0b7-11ea-80cf-fe3c56f0929c.png">
<img width="969" alt="Screenshot 2020-07-28 at 09 39 01" src="https://user-images.githubusercontent.com/9980803/88629495-008caa80-d0b8-11ea-80e3-ce98e0d9b9e9.png">

## Testing
Unit tests.