### PR TITLE
feat(docs): add BigDesign version on the documentation site

### DIFF
--- a/packages/docs/components/SideNav/SideNavLogo/SideNavLogo.tsx
+++ b/packages/docs/components/SideNav/SideNavLogo/SideNavLogo.tsx
@@ -1,3 +1,4 @@
+import { Small } from '@bigcommerce/big-design';
 import Link from 'next/link';
 import React from 'react';
 
@@ -7,6 +8,7 @@ export const SideNavLogo: React.FC = () => (
   <Link href="/GettingStarted/GettingStartedPage" as="/">
     <StyledLogo>
       <img src={`${process.env.URL_PREFIX}/logo-with-text.svg`} alt="BigDesign Logo" />
+      <Small>v{process.env.BD_VERSION}</Small>
     </StyledLogo>
   </Link>
 );

--- a/packages/docs/components/SideNav/SideNavLogo/styled.tsx
+++ b/packages/docs/components/SideNav/SideNavLogo/styled.tsx
@@ -7,4 +7,8 @@ export const StyledLogo = styled.div`
     margin: 0 auto;
     max-width: 100%;
   }
+
+  p {
+    text-align: right;
+  }
 `;

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -1,3 +1,5 @@
+const bdPkg = require('../big-design/package.json');
+
 const pkg = require('./package.json');
 const isProduction = process.env.NODE_ENV === 'production';
 const isDev = !isProduction;
@@ -9,6 +11,7 @@ module.exports = {
   env: {
     CODE_SANDBOX_URL: `https://codesandbox.io/s/github/bigcommerce/big-design/tree/%40bigcommerce/examples%40${examplesVersion}/packages/examples`,
     URL_PREFIX: isProduction ? URL_PREFIX : '',
+    BD_VERSION: bdPkg.version,
   },
   webpack: (config) => {
     config.module.rules.push({


### PR DESCRIPTION
## What

Adds the current BigDesign version in the docs.

## Screenshot

<img width="1244" alt="Screen Shot 2020-07-31 at 13 17 18" src="https://user-images.githubusercontent.com/10539418/89065015-9b8fb980-d330-11ea-9fb4-f04dea656c2a.png">

Closes #394.