### PR TITLE
feat(component): add mobileWidth prop to Button

### DIFF
--- a/packages/big-design/src/components/Button/Button.tsx
+++ b/packages/big-design/src/components/Button/Button.tsx
@@ -15,6 +15,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, Ma
   iconOnly?: React.ReactNode;
   iconRight?: React.ReactNode;
   isLoading?: boolean;
+  mobileWidth?: 'auto' | '100%';
   variant?: 'primary' | 'secondary' | 'subtle';
 }
 
@@ -57,9 +58,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(({ className, s
 ));
 
 const defaultProps = {
-  actionType: 'normal' as 'normal',
+  actionType: 'normal' as const,
   isLoading: false,
-  variant: 'primary' as 'primary',
+  mobileWidth: '100%' as const,
+  variant: 'primary' as const,
 };
 
 Button.displayName = 'Button';

--- a/packages/big-design/src/components/Button/styled.tsx
+++ b/packages/big-design/src/components/Button/styled.tsx
@@ -36,7 +36,7 @@ export const StyledButton = styled.button<ButtonProps & MarginProps>`
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: 100%;
+  width: ${({ mobileWidth }) => (mobileWidth === 'auto' ? 'auto' : '100%')};
 
   &:focus {
     outline: none;
@@ -48,7 +48,8 @@ export const StyledButton = styled.button<ButtonProps & MarginProps>`
   }
 
   & + .bd-button {
-    margin-top: ${({ theme }) => theme.spacing.xSmall};
+    margin-top: ${({ mobileWidth, theme }) => mobileWidth === '100%' && theme.spacing.xSmall};
+    margin-left: ${({ mobileWidth, theme }) => mobileWidth === 'auto' && theme.spacing.xSmall};
 
     ${({ theme }) => theme.breakpoints.tablet} {
       margin-top: ${({ theme }) => theme.spacing.none};

--- a/packages/docs/PropTables/ButtonPropTable.tsx
+++ b/packages/docs/PropTables/ButtonPropTable.tsx
@@ -67,6 +67,12 @@ const buttonProps: Prop[] = [
     description: 'Used to determine if component is in a loading state.',
   },
   {
+    name: 'mobileWidth',
+    types: ['auto', '100%'],
+    defaultValue: '100%',
+    description: 'Determines the width in mobile viewport.',
+  },
+  {
     name: 'variant',
     types: ['primary', 'secondary', 'subtle'],
     defaultValue: 'primary',


### PR DESCRIPTION
Currently, the `Button` component uses `width: 100%` on the mobile breakpoint, however, this is not always what developers/designers want. The current workaround is to wrap the button in a `Flex` component.

This PR adds a `mobileWidth` prop that can be set to either `auto` or `100%` (default). 

Related https://github.com/bigcommerce/big-design/issues/388