### PR TITLE
feat(component): add emptyComponent prop to Table

### DIFF
--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -18,6 +18,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     className,
     columns,
     actions,
+    emptyComponent,
     headerless = false,
     id,
     itemName,
@@ -137,6 +138,14 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     </Body>
   );
 
+  const renderEmptyState = () => {
+    if (items.length === 0 || emptyComponent) {
+      return emptyComponent;
+    }
+
+    return null;
+  };
+
   return (
     <>
       {shouldRenderActions() && (
@@ -156,6 +165,8 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
         {renderHeaders()}
         {renderItems()}
       </StyledTable>
+
+      {renderEmptyState()}
     </>
   );
 };

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { Table, TableFigure } from './Table';
 
@@ -9,6 +9,7 @@ interface SimpleTableOptions {
   className?: string;
   columns?: any[];
   dataTestId?: string;
+  emptyComponent?: React.ReactElement;
   headerless?: boolean;
   id?: string;
   itemName?: string;
@@ -19,6 +20,7 @@ const getSimpleTable = ({
   className,
   columns,
   dataTestId,
+  emptyComponent,
   headerless,
   id,
   itemName,
@@ -30,6 +32,7 @@ const getSimpleTable = ({
     id={id}
     headerless={headerless}
     itemName={itemName}
+    emptyComponent={emptyComponent}
     style={style}
     columns={
       columns || [
@@ -443,5 +446,13 @@ describe('sortable', () => {
 
     expect(container.querySelector('th')).toBeInTheDocument();
     expect(container.querySelector('th')).not.toBeVisible();
+  });
+
+  test('renders the emptyComponent when there are no items', () => {
+    const emptyComponent = <p>There are no items!</p>;
+
+    render(getSimpleTable({ columns: [], emptyComponent }));
+
+    expect(screen.getByText(/no items/i)).toBeInTheDocument();
   });
 });

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -38,6 +38,7 @@ export type TablePaginationProps = Omit<PaginationProps, keyof MarginProps>;
 export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElement> {
   actions?: React.ComponentType<T>;
   columns: Array<TableColumn<T>>;
+  emptyComponent?: React.ReactElement;
   headerless?: boolean;
   itemName?: string;
   items: T[];

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -69,6 +69,11 @@ const statefulTableProps: Prop[] = [
     types: 'React.ComponentType<any>',
     description: 'Component to render custom actions.',
   },
+  {
+    name: 'emptyComponent',
+    types: 'React.ReactElement',
+    description: 'Component to render when there are no items.',
+  },
 ];
 
 const tableColumnsProps: Prop[] = [

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -74,6 +74,11 @@ const tableProps: Prop[] = [
     types: 'React.ComponentType<any>',
     description: 'Component to render custom actions.',
   },
+  {
+    name: 'emptyComponent',
+    types: 'React.ReactElement',
+    description: 'Component to render when there are no items.',
+  },
 ];
 
 const tableColumnsProps: Prop[] = [


### PR DESCRIPTION
Adds `emptyComponent` to `Table` and `StatefulTable`. Renders the component when there are no items.