### PR TITLE
feat(component): rename alertManager's fadeAway to autoDismiss

### DIFF
--- a/packages/big-design/src/managers/alerts/manager.ts
+++ b/packages/big-design/src/managers/alerts/manager.ts
@@ -7,7 +7,7 @@ interface PrivateAlert extends AlertProps {
 }
 
 interface AddAlertConfig extends AlertProps {
-  fadeAway?: boolean;
+  autoDismiss?: boolean;
 }
 
 class AlertsManager {
@@ -42,7 +42,7 @@ class AlertsManager {
 
     this.notifySubscribers();
 
-    if (alert.fadeAway) {
+    if (alert.autoDismiss) {
       setTimeout(onClose, 5000);
     }
 

--- a/packages/big-design/src/managers/alerts/spec.tsx
+++ b/packages/big-design/src/managers/alerts/spec.tsx
@@ -75,11 +75,11 @@ describe('alertsManager functionality', () => {
     }
   });
 
-  test('removes an alert with fadeAway', (done) => {
+  test('removes an alert with autoDismiss', (done) => {
     jest.useFakeTimers();
 
     const mockSubscriber = jest.fn();
-    const testAlert = { ...alert, fadeAway: true, onClose: done, key: 'test-key' };
+    const testAlert = { ...alert, autoDismiss: true, onClose: done, key: 'test-key' };
 
     alertsManager.subscribe(mockSubscriber);
 

--- a/packages/docs/PropTables/AlertPropTable.tsx
+++ b/packages/docs/PropTables/AlertPropTable.tsx
@@ -13,12 +13,12 @@ const alertProps: Prop[] = [
     description: 'Key used to identify alert.',
   },
   {
-    name: 'fadeAway',
+    name: 'autoDismiss',
     types: 'boolean',
     defaultValue: 'false',
     description: (
       <>
-        <Text>Autoclose after 5 seconds.</Text>
+        <Text>Auto dismiss after 5 seconds.</Text>
         <Small>Note: Only valid when used with AlertManager.</Small>
       </>
     ),


### PR DESCRIPTION
BREAKING CHANGE:

If you are using alertManager's `fadeAway` option you will need to change it to `autoDismiss`.