### PR TITLE
feat(component): add Popover component

### DIFF
--- a/packages/big-design/src/components/Popover/Popover.tsx
+++ b/packages/big-design/src/components/Popover/Popover.tsx
@@ -1,0 +1,176 @@
+import { Modifier, Placement } from '@popperjs/core';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { usePopper } from 'react-popper';
+
+import { useUniqueId } from '../../hooks';
+import { excludeMarginProps } from '../../mixins';
+import { Box, BoxProps } from '../Box';
+
+// Margin can't be used with popper elements
+type BoxPropsWithoutMargins = Omit<
+  BoxProps,
+  'margin' | 'marginBottom' | 'marginHorizontal' | 'marginLeft' | 'marginRight' | 'marginTop' | 'marginVertical'
+>;
+
+export interface PopoverProps extends BoxPropsWithoutMargins {
+  anchorElement: Element | null;
+  closeOnClickOutside?: boolean;
+  closeOnEscKey?: boolean;
+  isOpen: boolean;
+  label: string;
+  matchAnchorElementWidth?: boolean;
+  offsetX?: number;
+  offsetY?: number;
+  onClose?(): void;
+  placement?: Placement;
+}
+
+export const Popover: React.FC<PopoverProps> = ({ anchorElement, children, isOpen, role = 'dialog', ...props }) => {
+  const uniquePopoverId = useUniqueId('popover');
+  const rest = excludeMarginProps(props);
+
+  useEffect(() => {
+    if (!anchorElement) {
+      return;
+    }
+
+    anchorElement.setAttribute('aria-controls', uniquePopoverId);
+    anchorElement.setAttribute('aria-expanded', String(isOpen));
+    anchorElement.setAttribute('aria-haspopup', role);
+  }, [anchorElement, isOpen, role, uniquePopoverId]);
+
+  return isOpen ? (
+    <InternalPopover anchorElement={anchorElement} {...rest} id={uniquePopoverId}>
+      {children}
+    </InternalPopover>
+  ) : null;
+};
+
+type InternalPopoverProps = Omit<PopoverProps, 'isOpen'>;
+
+// We use an Internal component that mounts/unmounts on isOpen
+// This facilitates running cleanups on some effects.
+const InternalPopover: React.FC<InternalPopoverProps> = ({
+  anchorElement,
+  children,
+  closeOnClickOutside = true,
+  closeOnEscKey = true,
+  id,
+  label,
+  matchAnchorElementWidth = false,
+  offsetX = 0,
+  offsetY = 0,
+  onClose = () => null,
+  placement = 'auto',
+  role,
+  ...props
+}) => {
+  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const previousFocus = useRef(typeof document !== 'undefined' ? document.activeElement : null);
+
+  const popperModifiers = useMemo(
+    () => [
+      {
+        name: 'offset',
+        options: {
+          offset: [offsetX, offsetY],
+        },
+      },
+      {
+        name: 'sameWidth',
+        enabled: matchAnchorElementWidth,
+        phase: 'beforeWrite',
+        requires: ['computeStyles'],
+        fn({ state }) {
+          state.styles.popper.width = `${state.rects.reference.width}px`;
+        },
+        effect({ state }) {
+          const element = state.elements.reference;
+
+          if (element instanceof HTMLElement) {
+            state.elements.popper.style.width = `${element.offsetWidth}px`;
+          }
+        },
+      } as Modifier<unknown>,
+    ],
+    [offsetX, offsetY, matchAnchorElementWidth],
+  );
+
+  const { styles, attributes } = usePopper(anchorElement, popperElement, {
+    modifiers: popperModifiers,
+    placement,
+  });
+
+  useEffect(() => {
+    const prevFocus = previousFocus.current as HTMLElement;
+
+    return () => {
+      if (prevFocus && typeof prevFocus.focus === 'function') {
+        prevFocus.focus();
+      }
+    };
+  }, []);
+
+  // Setup close on click outside
+  useEffect(() => {
+    if (typeof document === 'undefined' || !closeOnClickOutside) {
+      return;
+    }
+
+    const clickHandler = (event: MouseEvent) => {
+      if (!(event.target instanceof Element)) {
+        return;
+      }
+
+      if (popperElement?.contains(event.target)) {
+        return;
+      }
+
+      onClose();
+    };
+
+    document.addEventListener('click', clickHandler);
+
+    return () => {
+      document.removeEventListener('click', clickHandler);
+    };
+  }, [closeOnClickOutside, onClose, popperElement]);
+
+  // Setup close on Esc key
+  useEffect(() => {
+    if (typeof document === 'undefined' || !closeOnEscKey) {
+      return;
+    }
+
+    const keydownHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', keydownHandler);
+
+    return () => {
+      document.removeEventListener('keydown', keydownHandler);
+    };
+  }, [closeOnEscKey, onClose]);
+
+  return (
+    <Box
+      aria-label={label}
+      backgroundColor="white"
+      padding="medium"
+      role={role}
+      shadow="floating"
+      tabIndex={-1}
+      zIndex="popover"
+      {...props}
+      {...attributes.popper}
+      id={id}
+      ref={setPopperElement}
+      style={styles.popper}
+    >
+      {children}
+    </Box>
+  );
+};

--- a/packages/big-design/src/components/Popover/index.ts
+++ b/packages/big-design/src/components/Popover/index.ts
@@ -1,0 +1,4 @@
+import { PopoverProps as _PopoverProps } from './Popover';
+
+export { Popover } from './Popover';
+export type PopoverProps = _PopoverProps;

--- a/packages/big-design/src/components/Popover/spec.tsx
+++ b/packages/big-design/src/components/Popover/spec.tsx
@@ -1,0 +1,161 @@
+import { theme } from '@bigcommerce/big-design-theme';
+import React, { useState } from 'react';
+
+import { fireEvent, render, screen, waitForElement } from '@test/utils';
+
+import { Popover } from './Popover';
+
+import { PopoverProps } from '.';
+
+const TestComponent: React.FC<Partial<PopoverProps>> = ({ isOpen = false, ...rest }) => {
+  const [open, setOpen] = useState(isOpen);
+  const [buttonRef, setButtonRef] = useState<HTMLButtonElement | null>(null);
+
+  return (
+    <>
+      <button ref={setButtonRef} onClick={() => setOpen((s) => !s)}>
+        Test Button
+      </button>
+      <Popover anchorElement={buttonRef} isOpen={open} label="Test Label" {...rest} onClose={() => setOpen(false)}>
+        Some Content
+      </Popover>
+    </>
+  );
+};
+
+test('it should not render popover content when not open', () => {
+  render(<TestComponent isOpen={false} />);
+
+  expect(screen.queryByText(/some content/i)).not.toBeInTheDocument();
+});
+
+test('it renders the popover content when open', async () => {
+  render(<TestComponent isOpen={true} />);
+
+  await waitForElement(() => screen.getByText(/some content/i));
+});
+
+test('toggles between open and closed', async () => {
+  render(<TestComponent isOpen={false} />);
+
+  expect(screen.queryByText(/some content/i)).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button'));
+
+  await waitForElement(() => screen.getByText(/some content/i));
+});
+
+test('accepts Box props', async () => {
+  render(<TestComponent isOpen={true} padding="medium" />);
+
+  const getPopover = () => screen.getByText(/some content/i);
+
+  await waitForElement(getPopover);
+
+  expect(getPopover()).toHaveStyle(`padding: ${theme.spacing.medium}`);
+});
+
+test('does not accept margin props', async () => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  render(<TestComponent isOpen={true} padding="medium" margin="medium" />);
+
+  const getPopover = () => screen.getByText(/some content/i);
+
+  await waitForElement(getPopover);
+
+  expect(getPopover()).toHaveStyle(`padding: ${theme.spacing.medium}`);
+  expect(getPopover()).not.toHaveStyle(`margin: ${theme.spacing.medium}`);
+});
+
+test('sets basic aria attributes', async () => {
+  render(<TestComponent isOpen={true} />);
+
+  const getPopover = () => screen.getByText(/some content/i);
+
+  await waitForElement(getPopover);
+
+  const popover = getPopover();
+  const popoverId = popover.id;
+  const anchorButton = screen.getByRole('button');
+
+  expect(anchorButton).toHaveAttribute('aria-controls', popoverId);
+  expect(anchorButton).toHaveAttribute('aria-expanded', 'true');
+  expect(anchorButton).toHaveAttribute('aria-haspopup', 'dialog');
+  expect(popover).toHaveAttribute('aria-label', 'Test Label');
+});
+
+test('close on Escape by default', async () => {
+  render(<TestComponent isOpen={true} />);
+
+  const getPopover = () => screen.queryByText(/some content/i);
+
+  await waitForElement(getPopover);
+
+  fireEvent.keyDown(screen.getByRole('button'), { key: 'Escape' });
+
+  expect(getPopover()).not.toBeInTheDocument();
+});
+
+test('does not close on Escape when closeOnEscKey is false', async () => {
+  render(<TestComponent isOpen={true} closeOnEscKey={false} />);
+
+  const getPopover = () => screen.queryByText(/some content/i);
+
+  await waitForElement(getPopover);
+
+  fireEvent.keyDown(screen.getByText(/some content/i), { key: 'Escape' });
+
+  expect(getPopover()).toBeInTheDocument();
+});
+
+test('close on click outisde by default', async () => {
+  render(
+    <>
+      <p>Outside Content</p>
+      <TestComponent isOpen={true} />
+    </>,
+  );
+
+  const getPopover = () => screen.queryByText(/some content/i);
+
+  await waitForElement(getPopover);
+
+  fireEvent.click(screen.getByText(/outside/i));
+
+  expect(getPopover()).not.toBeInTheDocument();
+});
+
+test('does not close when clicking inside the popover', async () => {
+  render(
+    <>
+      <p>Outside Content</p>
+      <TestComponent isOpen={true} />
+    </>,
+  );
+
+  const getPopover = () => screen.queryByText(/some content/i);
+
+  await waitForElement(getPopover);
+
+  fireEvent.click(screen.getByText(/some content/i));
+
+  expect(getPopover()).toBeInTheDocument();
+});
+
+test('does not close on click outisde when closeOnClickOutside is set to false', async () => {
+  render(
+    <>
+      <p>Outside Content</p>
+      <TestComponent isOpen={true} closeOnClickOutside={false} />
+    </>,
+  );
+
+  const getPopover = () => screen.queryByText(/some content/i);
+
+  await waitForElement(getPopover);
+
+  fireEvent.click(screen.getByText(/outside/i));
+
+  expect(getPopover()).toBeInTheDocument();
+});

--- a/packages/big-design/src/components/index.ts
+++ b/packages/big-design/src/components/index.ts
@@ -21,6 +21,7 @@ export * from './Modal';
 export * from './MultiSelect';
 export * from './Pagination';
 export * from './Panel';
+export * from './Popover';
 export * from './ProgressBar';
 export * from './ProgressCircle';
 export * from './Radio';

--- a/packages/docs/PropTables/PopoverPropTable.tsx
+++ b/packages/docs/PropTables/PopoverPropTable.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import { Code, Prop, PropTable, PropTableWrapper } from '../components';
+
+const popoverProps: Prop[] = [
+  {
+    name: 'anchorElement',
+    required: true,
+    types: ['Element', 'null'],
+    description: 'Element to be used as an anchor for the Popover.',
+  },
+  {
+    name: 'isOpen',
+    required: true,
+    types: 'boolean',
+    description: 'Specifies if the Popover is open or closed.',
+  },
+  {
+    name: 'label',
+    required: true,
+    types: 'string',
+    description: 'Label used for accessibility purposes, this label will be set as an aria-label on the popover.',
+  },
+  {
+    name: 'closeOnClickOutside',
+    types: 'boolean',
+    defaultValue: 'true',
+    description: (
+      <>
+        Determines if <Code>onClose</Code> gets called when clicking outside of the popover.
+      </>
+    ),
+  },
+  {
+    name: 'closeOnEscKey',
+    types: 'boolean',
+    defaultValue: 'true',
+    description: (
+      <>
+        Determines if <Code>onClose</Code> gets called when pressing the Esc key.
+      </>
+    ),
+  },
+  {
+    name: 'matchAnchorElementWidth',
+    types: 'boolean',
+    defaultValue: 'false',
+    description: 'If set to true, the Popover will have the same width as its anchor element.',
+  },
+  {
+    name: 'offsetX',
+    types: 'number',
+    defaultValue: '0',
+    description: 'Determines the popover offset on the X axis.',
+  },
+  {
+    name: 'offsetY',
+    types: 'number',
+    defaultValue: '0',
+    description: 'Determines the popover offset on the Y axis.',
+  },
+  {
+    name: 'onClose',
+    types: '() => void',
+    description: 'Callback that runs when the popover should close.',
+  },
+  {
+    name: 'placement',
+    defaultValue: 'auto',
+    types: [
+      'auto',
+      'auto-end',
+      'auto-start',
+      'bottom',
+      'bottom-end',
+      'bottom-start',
+      'left',
+      'left-end',
+      'left-start',
+      'right',
+      'right-end',
+      'right-start',
+      'top',
+      'top-end',
+      'top-start',
+    ],
+    description: 'Sets the position of the Popover.',
+  },
+];
+
+export const PopoverPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable title="Popover" propList={popoverProps} {...props} />
+);

--- a/packages/docs/PropTables/index.ts
+++ b/packages/docs/PropTables/index.ts
@@ -19,6 +19,7 @@ export * from './MultiSelectPropTable';
 export * from './PaddingPropTable';
 export * from './PaginationPropTable';
 export * from './PanelPropTable';
+export * from './PopoverPropTable';
 export * from './ProgressBarPropTable';
 export * from './ProgressCirclePropTable';
 export * from './RadioPropTable';

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -167,6 +167,9 @@ export const SideNav: React.FC = () => {
           <SideNavLink href="/Padding/PaddingPage" as="/padding">
             Padding
           </SideNavLink>
+          <SideNavLink href="/Popover/PopoverPage" as="/popover">
+            Popover
+          </SideNavLink>
         </SideNavGroup>
 
         <SideNavGroup title="Helpful Links">

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -49,6 +49,7 @@ module.exports = {
     '/padding': { page: '/Padding/PaddingPage' },
     '/pagination': { page: '/Pagination/PaginationPage' },
     '/panel': { page: '/Panel/PanelPage' },
+    '/popover': { page: '/Popover/PopoverPage' },
     '/progress-bar': { page: '/Progress/ProgressBarPage' },
     '/progress-circle': { page: '/Progress/ProgressCirclePage' },
     '/radio': { page: '/Radio/RadioPage' },

--- a/packages/docs/pages/Popover/PopoverPage.tsx
+++ b/packages/docs/pages/Popover/PopoverPage.tsx
@@ -1,0 +1,45 @@
+import { Button, H0, H1, H2, Popover, Text } from '@bigcommerce/big-design';
+import React, { useState } from 'react';
+
+import { CodePreview } from '../../components';
+import { BoxPropTable, PaddingPropTable, PopoverPropTable } from '../../PropTables';
+
+const PopoverPage = () => (
+  <>
+    <H0>Popover</H0>
+
+    <Text>
+      Popover is a component that floats around its anchor element. It's commonly used for building other components
+      such as dropdowns, tooltips, combobox, etc.
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      {function Example() {
+        const [isOpen, setIsOpen] = useState(false);
+        const [buttonRef, setButtonRef] = useState<HTMLButtonElement | null>(null);
+
+        return (
+          <>
+            <Button ref={setButtonRef} onClick={() => setIsOpen(true)}>
+              Open Popover
+            </Button>
+            <Popover anchorElement={buttonRef} isOpen={isOpen} label="Example Popover" onClose={() => setIsOpen(false)}>
+              <Text>This is the popover content!</Text>
+            </Popover>
+          </>
+        );
+      }}
+      {/* jsx-to-string:end */}
+    </CodePreview>
+
+    <H1>API</H1>
+    <PopoverPropTable />
+
+    <H2>Inherited Props</H2>
+    <BoxPropTable collapsible />
+    <PaddingPropTable collapsible />
+  </>
+);
+
+export default PopoverPage;


### PR DESCRIPTION
Adds `Popover` component. This is a util component that will help facilitate building other components such as the advanced table filters and search components.

![Screen 2020-08-25 at 10 16 01](https://user-images.githubusercontent.com/2752665/91192804-0035fe00-e6bc-11ea-831c-622e3d004c45.png)

