### PR TITLE
feat(theme): add DefaultTheme extension types

### DIFF
--- a/packages/big-design-theme/README.md
+++ b/packages/big-design-theme/README.md
@@ -29,6 +29,22 @@ or with `yarn`:
 yarn add @bigcommerce/big-design-theme styled-components
 ```
 
+```tsx
+// index.tsx
+
+import { theme } from '@bigcommerce/big-design-theme';
+import { ThemeProvider } from 'styled-components';
+
+// ...
+
+ReactDOM.render(
+  <ThemeProvider theme={theme}>
+      <App />
+  </ThemeProvider>,
+  document.getElementById('root'),
+);
+```
+
 #### Using a different html font size
 
 When your app uses an html font size different than `16px` you will need to create a new theme that uses

--- a/packages/big-design-theme/src/index.ts
+++ b/packages/big-design-theme/src/index.ts
@@ -48,3 +48,7 @@ export const createTheme = (customOptions: Partial<ThemeOptions> = {}): ThemeInt
 };
 
 export const theme: ThemeInterface = createTheme();
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends ThemeInterface {} // eslint-disable-line
+}


### PR DESCRIPTION
Adds the `ThemeInterface` to `styled-components` `DefaultTheme` type so repositories don't have to manually include them.

Assumes you wrap your app in a `ThemeProvider` and added documentation on how to add that.