### PR TITLE
fix(component): allow Dropdown groups to have optional `label`

### DIFF
--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -146,7 +146,7 @@ export const Dropdown = memo(
       (group: DropdownItemGroup) => {
         return (
           <>
-            <ListGroupHeader>{group.label}</ListGroupHeader>
+            {group.label && <ListGroupHeader>{group.label}</ListGroupHeader>}
             {renderItems(group.items)}
           </>
         );

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -505,3 +505,26 @@ test('clicking label does not call onItemClick', async () => {
 
   await waitForElement(() => screen.getByRole('option', { name: /option 1/i }));
 });
+
+test('renders appropriate amount of list items', async () => {
+  const { getByRole, container } = render(
+    <Dropdown
+      items={[
+        {
+          label: 'Label 1',
+          items: [{ content: 'Option 1', onItemClick }],
+        },
+        {
+          items: [{ content: 'Option 2', onItemClick }],
+        },
+      ]}
+      toggle={<Button>Button</Button>}
+    />,
+  );
+  const toggle = getByRole('button');
+  fireEvent.click(toggle);
+
+  const listItems = await waitForElement(() => container.querySelectorAll('li'));
+
+  expect(listItems.length).toBe(3);
+});

--- a/packages/big-design/src/components/Dropdown/types.ts
+++ b/packages/big-design/src/components/Dropdown/types.ts
@@ -29,6 +29,6 @@ export interface DropdownLinkItem extends BaseItem {
 }
 
 export interface DropdownItemGroup {
-  label: string;
+  label?: string;
   items: Array<DropdownItem | DropdownLinkItem>;
 }

--- a/packages/docs/PropTables/DropdownPropTable.tsx
+++ b/packages/docs/PropTables/DropdownPropTable.tsx
@@ -190,7 +190,6 @@ const dropdownItemGroupProps: Prop[] = [
   {
     name: 'label',
     types: 'string',
-    required: true,
     description: 'Sets the label for the group.',
   },
   {


### PR DESCRIPTION
Allows `DropdownItemGroup`'s to have optional `label` key/vals.

#### Without `label`:
<img width="496" alt="Screen Shot 2020-08-25 at 14 55 06" src="https://user-images.githubusercontent.com/10539418/91229316-3fca0d80-e6ef-11ea-8646-966eb1442767.png">
