### PR TITLE
feat(component): add separator to dropdown item groups

### DIFF
--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -7,6 +7,7 @@ import { Flex } from '../Flex';
 import { FlexItem } from '../Flex/Item';
 import { List } from '../List';
 import { ListGroupHeader } from '../List/GroupHeader';
+import { ListGroupSeparator } from '../List/GroupSeparator';
 import { ListItem } from '../List/Item';
 import { Tooltip } from '../Tooltip';
 
@@ -146,6 +147,7 @@ export const Dropdown = memo(
       (group: DropdownItemGroup) => {
         return (
           <>
+            {group.separated && <ListGroupSeparator />}
             {group.label && <ListGroupHeader>{group.label}</ListGroupHeader>}
             {renderItems(group.items)}
           </>

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -47,6 +47,22 @@ const GroupedDropdownMock = (
   />
 );
 
+const LineSeparatedGroupedDropdownMock = (
+  <Dropdown
+    items={[
+      {
+        label: 'Label 1',
+        items: [{ content: 'Option 1', onItemClick }],
+      },
+      {
+        separated: true,
+        items: [{ content: 'Option 2', onItemClick }],
+      },
+    ]}
+    toggle={<Button>Button</Button>}
+  />
+);
+
 test('renders dropdown toggle', () => {
   const { getByRole } = render(DropdownMock);
   const toggle = getByRole('button');
@@ -527,4 +543,24 @@ test('renders appropriate amount of list items', async () => {
   const listItems = await waitForElement(() => container.querySelectorAll('li'));
 
   expect(listItems.length).toBe(3);
+});
+
+test('rendered line separators have correct accessibility properties', async () => {
+  const { getByRole, container } = render(LineSeparatedGroupedDropdownMock);
+  const toggle = getByRole('button');
+  fireEvent.click(toggle);
+
+  const hrListItem = await waitForElement(() => container.querySelectorAll('hr')[0].parentElement as HTMLElement);
+  expect(hrListItem.getAttribute('aria-hidden')).toBe('true');
+  expect(hrListItem.getAttribute('tabindex')).toBe('-1');
+});
+
+test('rendered line separators cannot be focused on', async () => {
+  const { getByRole, container } = render(LineSeparatedGroupedDropdownMock);
+  const toggle = getByRole('button');
+  fireEvent.click(toggle);
+
+  const hrListItem = await waitForElement(() => container.querySelectorAll('hr')[0].parentElement as HTMLElement);
+  fireEvent.mouseOver(hrListItem);
+  expect(document.activeElement).not.toEqual(hrListItem);
 });

--- a/packages/big-design/src/components/Dropdown/types.ts
+++ b/packages/big-design/src/components/Dropdown/types.ts
@@ -30,5 +30,6 @@ export interface DropdownLinkItem extends BaseItem {
 
 export interface DropdownItemGroup {
   label?: string;
+  separated?: boolean;
   items: Array<DropdownItem | DropdownLinkItem>;
 }

--- a/packages/big-design/src/components/List/GroupSeparator/ListGroupSeparator.tsx
+++ b/packages/big-design/src/components/List/GroupSeparator/ListGroupSeparator.tsx
@@ -1,0 +1,15 @@
+import React, { memo } from 'react';
+
+import { HR } from '../../Typography';
+
+export const ListGroupSeparator: React.FC<React.LiHTMLAttributes<HTMLLIElement>> = memo(() => (
+  <li tabIndex={-1} onMouseDown={preventFocus} aria-hidden={true}>
+    <HR />
+  </li>
+));
+
+function preventFocus(event: React.MouseEvent<HTMLLIElement, MouseEvent>) {
+  event.preventDefault();
+}
+
+ListGroupSeparator.displayName = 'ListGroupSeparator';

--- a/packages/big-design/src/components/List/GroupSeparator/index.ts
+++ b/packages/big-design/src/components/List/GroupSeparator/index.ts
@@ -1,0 +1,1 @@
+export { ListGroupSeparator } from './ListGroupSeparator';

--- a/packages/docs/PropTables/DropdownPropTable.tsx
+++ b/packages/docs/PropTables/DropdownPropTable.tsx
@@ -193,6 +193,11 @@ const dropdownItemGroupProps: Prop[] = [
     description: 'Sets the label for the group.',
   },
   {
+    name: 'separated',
+    types: 'boolean',
+    description: 'If true, adds a line separator above the group.',
+  },
+  {
     name: 'options',
     types: 'Array<DropdownItem | DropdownLinkItem>',
     required: true,


### PR DESCRIPTION
Add hr to dropdown when separated flag is true for dropdown groups

![image](https://user-images.githubusercontent.com/50118040/91623110-f972e980-e94e-11ea-8b4d-b04298f69b49.png)
![image](https://user-images.githubusercontent.com/50118040/91623116-fed03400-e94e-11ea-8e80-c66addace993.png)