### PR TITLE
fix(component): modal overflowY cleanup on unmount

### DIFF
--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -269,7 +269,7 @@ exports[`render open modal 1`] = `
               class="c7"
             >
               <svg
-                aria-labelledby="bd-icon-3"
+                aria-labelledby="bd-icon-2"
                 class="c8"
                 fill="currentColor"
                 height="24"
@@ -279,7 +279,7 @@ exports[`render open modal 1`] = `
                 width="24"
               >
                 <title
-                  id="bd-icon-3"
+                  id="bd-icon-2"
                 >
                   Close
                 </title>
@@ -564,7 +564,7 @@ exports[`render open modal without backdrop 1`] = `
               class="c7"
             >
               <svg
-                aria-labelledby="bd-icon-3"
+                aria-labelledby="bd-icon-2"
                 class="c8"
                 fill="currentColor"
                 height="24"
@@ -574,7 +574,7 @@ exports[`render open modal without backdrop 1`] = `
                 width="24"
               >
                 <title
-                  id="bd-icon-3"
+                  id="bd-icon-2"
                 >
                   Close
                 </title>

--- a/packages/big-design/src/components/Modal/spec.tsx
+++ b/packages/big-design/src/components/Modal/spec.tsx
@@ -280,3 +280,11 @@ test('unmounts appropriately', () => {
   // Make sure mouse events still work for other components
   expect(onClick).toHaveBeenCalledTimes(1);
 });
+
+test('body overflowY should reset on unmount', () => {
+  const { unmount } = render(<Modal isOpen={true} />);
+
+  expect(document.body.style.overflowY).toEqual('hidden');
+  unmount();
+  expect(document.body.style.overflowY).toEqual('');
+});


### PR DESCRIPTION
Fixes a corner case of `overflowY` not being set back to its initial value when unmounting the modal.

Eg:
```jsx
{isOpen && <Modal isOpen={true} />}
```

In this scenario, setting `isOpen` to false won't run the expected cleanups.

Did a bit of refactoring by creating an `InternalModal` which we mount/unmount on `isOpen`, this simplifies our effects as we don't need to check for `isOpen` in our cleanup effects.