### PR TITLE
feat(component): rename popover offset props and defaults

### DIFF
--- a/packages/big-design/src/components/Popover/Popover.tsx
+++ b/packages/big-design/src/components/Popover/Popover.tsx
@@ -19,8 +19,8 @@ export interface PopoverProps extends BoxPropsWithoutMargins {
   isOpen: boolean;
   label: string;
   matchAnchorElementWidth?: boolean;
-  offsetX?: number;
-  offsetY?: number;
+  skidding?: number;
+  distance?: number;
   onClose?(): void;
   placement?: Placement;
 }
@@ -58,8 +58,8 @@ const InternalPopover: React.FC<InternalPopoverProps> = ({
   id,
   label,
   matchAnchorElementWidth = false,
-  offsetX = 0,
-  offsetY = 0,
+  skidding = 0,
+  distance = 4,
   onClose = () => null,
   placement = 'auto',
   role,
@@ -73,7 +73,7 @@ const InternalPopover: React.FC<InternalPopoverProps> = ({
       {
         name: 'offset',
         options: {
-          offset: [offsetX, offsetY],
+          offset: [skidding, distance],
         },
       },
       {
@@ -93,7 +93,7 @@ const InternalPopover: React.FC<InternalPopoverProps> = ({
         },
       } as Modifier<unknown, unknown>,
     ],
-    [offsetX, offsetY, matchAnchorElementWidth],
+    [skidding, distance, matchAnchorElementWidth],
   );
 
   const { styles, attributes } = usePopper(anchorElement, popperElement, {

--- a/packages/big-design/src/components/Tooltip/Tooltip.tsx
+++ b/packages/big-design/src/components/Tooltip/Tooltip.tsx
@@ -22,7 +22,7 @@ export const Tooltip: React.FC<TooltipProps> = memo(({ children, inline = true, 
 
     return [
       { name: 'eventListeners', options: { scroll: isVisible, resize: isVisible } },
-      { name: 'offset', options: { offset: [0, 8] } },
+      { name: 'offset', options: { offset: [0, 4] } },
       ...mods,
     ];
   }, [isVisible, modifiers]);

--- a/packages/docs/PropTables/PopoverPropTable.tsx
+++ b/packages/docs/PropTables/PopoverPropTable.tsx
@@ -54,7 +54,7 @@ const popoverProps: Prop[] = [
     description: 'Determines the offset along the anchorElement.',
   },
   {
-    name: 'offsetY',
+    name: 'distance',
     types: 'number',
     defaultValue: '4',
     description: 'Determines the offset away from the anchorElement.',

--- a/packages/docs/PropTables/PopoverPropTable.tsx
+++ b/packages/docs/PropTables/PopoverPropTable.tsx
@@ -48,16 +48,16 @@ const popoverProps: Prop[] = [
     description: 'If set to true, the Popover will have the same width as its anchor element.',
   },
   {
-    name: 'offsetX',
+    name: 'skidding',
     types: 'number',
     defaultValue: '0',
-    description: 'Determines the popover offset on the X axis.',
+    description: 'Determines the offset along the anchorElement.',
   },
   {
     name: 'offsetY',
     types: 'number',
-    defaultValue: '0',
-    description: 'Determines the popover offset on the Y axis.',
+    defaultValue: '4',
+    description: 'Determines the offset away from the anchorElement.',
   },
   {
     name: 'onClose',


### PR DESCRIPTION
- Make Popover and Tooltips have the same default offset as dropdowns. 
- Rename offset props for Popover