### PR TITLE
feat(component): add id support for Tree component

### DIFF
--- a/packages/big-design/src/components/Tree/Tree.tsx
+++ b/packages/big-design/src/components/Tree/Tree.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useReducer, useState } from 'react';
 
+import { useUniqueId } from '../../hooks';
 import { typedMemo } from '../../utils';
 
 import { createReducer, createReducerInit } from './reducer';
@@ -9,6 +10,7 @@ import { TreeProps } from './types';
 
 const InternalTree = <T extends unknown>({
   iconless,
+  id,
   initialNodes,
   onCollapse,
   onExpand,
@@ -16,6 +18,8 @@ const InternalTree = <T extends unknown>({
   selectable,
 }: TreeProps<T>): React.ReactElement<TreeProps<T>> => {
   const [nodes] = useState(initialNodes);
+  const uniqueTreeId = useUniqueId('tree');
+  const treeId = id ?? uniqueTreeId;
   const reducer = useMemo(() => createReducer<T>(), []);
   const reducerInit = useMemo(() => createReducerInit<T>(), []);
   const [state, dispatch] = useReducer(reducer, { nodes, selectable }, reducerInit);
@@ -33,13 +37,14 @@ const InternalTree = <T extends unknown>({
           onSelect={onSelect}
           selectable={selectable}
           state={state}
+          treeId={treeId}
         />
       )),
-    [iconless, nodes, onCollapse, onExpand, onSelect, selectable, state],
+    [iconless, nodes, onCollapse, onExpand, onSelect, selectable, state, treeId],
   );
 
   return (
-    <StyledUl role="tree" aria-multiselectable={selectable === 'multi'} style={{ overflow: 'hidden' }}>
+    <StyledUl id={treeId} role="tree" aria-multiselectable={selectable === 'multi'} style={{ overflow: 'hidden' }}>
       {renderedItems}
     </StyledUl>
   );

--- a/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
@@ -25,6 +25,7 @@ interface PrivateTreeItemProps<T> {
   state: TreeState<T>;
   dispatch: Dispatch<Action<T>>;
   iconless?: boolean;
+  treeId?: string;
   selectable: TreeProps<T>['selectable'];
   onExpand?: TreeProps<T>['onExpand'];
   onCollapse?: TreeProps<T>['onCollapse'];
@@ -46,11 +47,13 @@ const InternalTreeNode = <T extends unknown>({
   onSelect,
   selectable,
   state,
+  treeId,
   value,
 }: TreeNodeProps<T> & PrivateTreeItemProps<T>): React.ReactElement<TreeNodeProps<T>> => {
   const thisRef = useRef<TreeNodeRef<T>>({ children });
   const nodeRef = useRef<HTMLLIElement | null>(null);
   const selectableRef = useRef<HTMLLabelElement | null>(null);
+  const treeNodeId = `${treeId}-treenode-${id}`;
   const [isLoading, setIsLoading] = useState(false);
   const expanded = useIsExpanded(state, id);
   const selected = useIsSelected(state, value);
@@ -259,6 +262,7 @@ const InternalTreeNode = <T extends unknown>({
               dispatch={dispatch}
               selectable={selectable}
               state={state}
+              treeId={treeId}
             />
           ) : (
             thisRef.current.children?.map((child, index) => (
@@ -272,12 +276,13 @@ const InternalTreeNode = <T extends unknown>({
                 onSelect={onSelect}
                 selectable={selectable}
                 state={state}
+                treeId={treeId}
               />
             ))
           )}
         </StyledUl>
       ),
-    [dispatch, expanded, iconless, isLoading, onCollapse, onExpand, onSelect, selectable, state],
+    [dispatch, expanded, iconless, isLoading, onCollapse, onExpand, onSelect, selectable, state, treeId],
   );
 
   const renderedIcon = useMemo(() => {
@@ -339,6 +344,7 @@ const InternalTreeNode = <T extends unknown>({
   return (
     <StyledLi
       aria-expanded={expanded}
+      id={treeNodeId}
       onKeyDown={handleKeyEvent}
       ref={nodeRef}
       role="treeitem"

--- a/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
@@ -4,12 +4,14 @@ exports[`renders Tree component base 1`] = `
 <ul
   aria-multiselectable="false"
   class="styled__StyledUl-sc-7vo4ly-0 iuWuiq"
+  id="bd-tree-1"
   role="tree"
   style="overflow: hidden;"
 >
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-1-treenode-0"
     role="treeitem"
     tabindex="0"
   >
@@ -72,6 +74,7 @@ exports[`renders Tree component base 1`] = `
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-1-treenode-1"
     role="treeitem"
     tabindex="-1"
   >
@@ -114,6 +117,7 @@ exports[`renders Tree component base 1`] = `
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-1-treenode-2"
     role="treeitem"
     tabindex="-1"
   >
@@ -176,6 +180,7 @@ exports[`renders Tree component base 1`] = `
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-1-treenode-3"
     role="treeitem"
     tabindex="-1"
   >
@@ -218,6 +223,7 @@ exports[`renders Tree component base 1`] = `
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-1-treenode-4"
     role="treeitem"
     tabindex="-1"
   >
@@ -284,12 +290,14 @@ exports[`renders Tree component iconless 1`] = `
 <ul
   aria-multiselectable="false"
   class="styled__StyledUl-sc-7vo4ly-0 iuWuiq"
+  id="bd-tree-29"
   role="tree"
   style="overflow: hidden;"
 >
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-29-treenode-0"
     role="treeitem"
     tabindex="0"
   >
@@ -330,6 +338,7 @@ exports[`renders Tree component iconless 1`] = `
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-29-treenode-1"
     role="treeitem"
     tabindex="-1"
   >
@@ -350,6 +359,7 @@ exports[`renders Tree component iconless 1`] = `
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-29-treenode-2"
     role="treeitem"
     tabindex="-1"
   >
@@ -390,6 +400,7 @@ exports[`renders Tree component iconless 1`] = `
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-29-treenode-3"
     role="treeitem"
     tabindex="-1"
   >
@@ -410,6 +421,7 @@ exports[`renders Tree component iconless 1`] = `
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-29-treenode-4"
     role="treeitem"
     tabindex="-1"
   >
@@ -454,6 +466,7 @@ exports[`renders Tree component multi-select 1`] = `
 <ul
   aria-multiselectable="true"
   class="styled__StyledUl-sc-7vo4ly-0 iuWuiq"
+  id="bd-tree-10"
   role="tree"
   style="overflow: hidden;"
 >
@@ -461,6 +474,7 @@ exports[`renders Tree component multi-select 1`] = `
     aria-expanded="false"
     aria-selected="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-10-treenode-0"
     role="treeitem"
     tabindex="-1"
   >
@@ -541,6 +555,7 @@ exports[`renders Tree component multi-select 1`] = `
     aria-expanded="false"
     aria-selected="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-10-treenode-1"
     role="treeitem"
     tabindex="-1"
   >
@@ -592,6 +607,7 @@ exports[`renders Tree component multi-select 1`] = `
     aria-expanded="false"
     aria-selected="true"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-10-treenode-2"
     role="treeitem"
     tabindex="-1"
   >
@@ -690,6 +706,7 @@ exports[`renders Tree component multi-select 1`] = `
     aria-expanded="false"
     aria-selected="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-10-treenode-3"
     role="treeitem"
     tabindex="-1"
   >
@@ -742,6 +759,7 @@ exports[`renders Tree component multi-select 1`] = `
     aria-expanded="false"
     aria-selected="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-10-treenode-4"
     role="treeitem"
     tabindex="-1"
   >
@@ -816,6 +834,7 @@ exports[`renders Tree component radio-select 1`] = `
 <ul
   aria-multiselectable="false"
   class="styled__StyledUl-sc-7vo4ly-0 iuWuiq"
+  id="bd-tree-20"
   role="tree"
   style="overflow: hidden;"
 >
@@ -823,6 +842,7 @@ exports[`renders Tree component radio-select 1`] = `
     aria-expanded="false"
     aria-selected="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-20-treenode-0"
     role="treeitem"
     tabindex="-1"
   >
@@ -903,6 +923,7 @@ exports[`renders Tree component radio-select 1`] = `
     aria-expanded="false"
     aria-selected="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-20-treenode-1"
     role="treeitem"
     tabindex="-1"
   >
@@ -954,6 +975,7 @@ exports[`renders Tree component radio-select 1`] = `
     aria-expanded="false"
     aria-selected="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-20-treenode-2"
     role="treeitem"
     tabindex="-1"
   >
@@ -1025,6 +1047,7 @@ exports[`renders Tree component radio-select 1`] = `
     aria-expanded="false"
     aria-selected="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-20-treenode-3"
     role="treeitem"
     tabindex="-1"
   >
@@ -1077,6 +1100,7 @@ exports[`renders Tree component radio-select 1`] = `
     aria-expanded="false"
     aria-selected="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-20-treenode-4"
     role="treeitem"
     tabindex="-1"
   >
@@ -1151,12 +1175,14 @@ exports[`renders Tree component renders with string ids 1`] = `
 <ul
   aria-multiselectable="false"
   class="styled__StyledUl-sc-7vo4ly-0 iuWuiq"
+  id="bd-tree-33"
   role="tree"
   style="overflow: hidden;"
 >
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-33-treenode-test-id"
     role="treeitem"
     tabindex="0"
   >
@@ -1199,6 +1225,7 @@ exports[`renders Tree component renders with string ids 1`] = `
   <li
     aria-expanded="false"
     class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    id="bd-tree-33-treenode-test-id-2"
     role="treeitem"
     tabindex="-1"
   >

--- a/packages/big-design/src/components/Tree/spec.tsx
+++ b/packages/big-design/src/components/Tree/spec.tsx
@@ -84,6 +84,45 @@ describe('renders Tree component', () => {
   });
 });
 
+test('create unique ids if not provided', () => {
+  const { container } = render(
+    <Tree
+      initialNodes={[
+        { id: 1, label: 'Category' },
+        { id: 2, label: 'Category' },
+      ]}
+    />,
+  );
+
+  const nodes = container.querySelectorAll('li');
+
+  const node1 = nodes[0] as HTMLLIElement;
+  const node2 = nodes[1] as HTMLLIElement;
+
+  expect(node1).toBeDefined();
+  expect(node2).toBeDefined();
+  expect(node1.id).not.toBe(node2.id);
+});
+
+test('respects provided id', () => {
+  const { container } = render(
+    <Tree
+      initialNodes={[
+        { id: 1, label: 'Category' },
+        { id: 2, label: 'Category' },
+      ]}
+      id="test"
+    />,
+  );
+  const input = container.querySelector('#test') as HTMLLIElement;
+
+  expect(input.id).toBe('test');
+
+  const node1 = container.querySelector('#test-treenode-1');
+
+  expect(node1).toBeDefined();
+});
+
 test('does not rerender when props change', () => {
   const text = 'Category';
   const { queryAllByText, rerender } = render(<Tree initialNodes={[]} />);

--- a/packages/big-design/src/components/Tree/types.ts
+++ b/packages/big-design/src/components/Tree/types.ts
@@ -1,5 +1,6 @@
 export interface TreeProps<T> {
   iconless?: boolean;
+  id?: string;
   initialNodes: TreeNodeProps<T>[];
   selectable?: 'radio' | 'multi';
   onExpand?(node: TreeNodeProps<T>): Promise<TreeNodeRef<T>> | TreeNodeRef<T> | void;


### PR DESCRIPTION
## What

Adds id support to the `Tree` component.

ID schema:
```
// TreeId
id || `bd-tree-{uniqueId}`


// TreeNodeId
`{treeId}-treenode-{nodeId}`
```