### PR TITLE
fix(component): form controls error states

### DIFF
--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -143,7 +143,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
     if (Array.isArray(error)) {
       error.forEach(validateError);
 
-      return error;
+      return error.length > 0 ? error : null;
     }
 
     return validateError(error);

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -141,9 +141,13 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
     };
 
     if (Array.isArray(error)) {
-      error.forEach(validateError);
+      const nextError = error.reduce<Array<Props['error']>>((acc, errorItem) => {
+        const nextErrorItem = validateError(errorItem);
 
-      return error.length > 0 ? error : null;
+        return nextErrorItem ? [...acc, nextErrorItem] : acc;
+      }, []);
+
+      return nextError.length > 0 ? nextError : null;
     }
 
     return validateError(error);

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -141,7 +141,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
     };
 
     if (Array.isArray(error)) {
-      const nextError = error.reduce<Array<Props['error']>>((acc, errorItem) => {
+      const nextError = error.reduce<Array<React.ReactNode>>((acc, errorItem) => {
         const nextErrorItem = validateError(errorItem);
 
         return nextErrorItem ? [...acc, nextErrorItem] : acc;

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -1,4 +1,5 @@
 import { AddIcon } from '@bigcommerce/big-design-icons';
+import { theme } from '@bigcommerce/big-design-theme';
 import React, { createRef } from 'react';
 import 'jest-styled-components';
 
@@ -8,6 +9,9 @@ import { warning } from '../../utils';
 import { FormControlDescription, FormControlError, FormControlLabel, FormGroup } from '../Form';
 
 import { Input } from './index';
+
+const basicBorderStyle = `1px solid ${theme.colors.secondary30}`;
+const errorBorderStyle = `1px solid ${theme.colors.danger40}`;
 
 test('forwards ref', () => {
   const ref = createRef<HTMLInputElement>();
@@ -76,13 +80,15 @@ test('renders a description', () => {
 
 test('renders an error', () => {
   const errorText = 'This is an error';
-  const { queryByText } = render(
+  const { container, queryByText } = render(
     <FormGroup>
       <Input error={errorText} />
     </FormGroup>,
   );
+  const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');
 
   expect(queryByText(errorText)).toBeInTheDocument();
+  expect(styledInputWrapper).toHaveStyleRule('border', errorBorderStyle);
 });
 
 test('accepts a Label Component', () => {
@@ -155,13 +161,15 @@ test('accepts an Error Component', () => {
     </FormControlError>
   );
 
-  const { queryByTestId } = render(
+  const { container, queryByTestId } = render(
     <FormGroup>
       <Input error={CustomError} />
     </FormGroup>,
   );
+  const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');
 
   expect(queryByTestId('test')).toBeInTheDocument();
+  expect(styledInputWrapper).toHaveStyleRule('border', errorBorderStyle);
 });
 
 test('does not accept non-Error Components', () => {
@@ -174,13 +182,15 @@ test('does not accept non-Error Components', () => {
     </div>
   );
 
-  const { queryByTestId } = render(
+  const { container, queryByTestId } = render(
     <FormGroup>
       <Input error={NotAnError} />
     </FormGroup>,
   );
+  const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');
 
   expect(queryByTestId('test')).not.toBeInTheDocument();
+  expect(styledInputWrapper).toHaveStyleRule('border', basicBorderStyle);
 });
 
 test('renders iconLeft', () => {
@@ -224,27 +234,58 @@ test('error shows with valid string', () => {
       <Input error="" />
     </FormGroup>,
   );
+  const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');
 
   expect(container.querySelector('[class*="StyledError"]')).not.toBeInTheDocument();
+  expect(styledInputWrapper).toHaveStyleRule('border', basicBorderStyle);
 
   rerender(
     <FormGroup>
-      <Input error={error} />
+      <Input label="Test" error={error} />
     </FormGroup>,
   );
 
   expect(container.querySelector('[class*="StyledError"]')).toBeInTheDocument();
+  expect(styledInputWrapper).toHaveStyleRule('border', errorBorderStyle);
 });
 
-test('error shows when an array of strings', () => {
-  const errors = ['Error 0', 'Error 1'];
-  const { getByText } = render(
-    <FormGroup>
-      <Input error={errors} />
-    </FormGroup>,
-  );
+describe('error shows when an array of strings', () => {
+  test('empty array', () => {
+    const { container } = render(
+      <FormGroup>
+        <Input error={[]} />
+      </FormGroup>,
+    );
+    const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');
 
-  errors.forEach((error) => expect(getByText(error)).toBeInTheDocument());
+    expect(container.querySelector('[class*="StyledError"]')).not.toBeInTheDocument();
+    expect(styledInputWrapper).toHaveStyleRule('border', basicBorderStyle);
+  });
+
+  test('array with empty strings', () => {
+    const { container } = render(
+      <FormGroup>
+        <Input error={['', '']} />
+      </FormGroup>,
+    );
+    const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');
+
+    expect(container.querySelector('[class*="StyledError"]')).not.toBeInTheDocument();
+    expect(styledInputWrapper).toHaveStyleRule('border', basicBorderStyle);
+  });
+
+  test('array with valid strings', () => {
+    const errors = ['Error 0', 'Error 1'];
+    const { container, getByText } = render(
+      <FormGroup>
+        <Input error={errors} />
+      </FormGroup>,
+    );
+    const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');
+
+    expect(styledInputWrapper).toHaveStyleRule('border', errorBorderStyle);
+    errors.forEach((error) => expect(getByText(error)).toBeInTheDocument());
+  });
 });
 
 test('error shows when an array of Errors', () => {
@@ -254,26 +295,30 @@ test('error shows when an array of Errors', () => {
       Error
     </FormControlError>
   ));
-  const { getByTestId } = render(
+  const { container, getByTestId } = render(
     <FormGroup>
       <Input error={errors} />
     </FormGroup>,
   );
+  const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');
 
   testIds.forEach((id) => expect(getByTestId(id)).toBeInTheDocument());
+  expect(styledInputWrapper).toHaveStyleRule('border', errorBorderStyle);
 });
 
 describe('error does not show when invalid type', () => {
   test('single element', () => {
     const error = <div data-testid="err">Error</div>;
-    const { queryByTestId } = render(
+    const { container, queryByTestId } = render(
       <FormGroup>
         <Input error={error} />
       </FormGroup>,
     );
+    const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');
 
     expect(warning).toHaveBeenCalledTimes(1);
     expect(queryByTestId('err')).not.toBeInTheDocument();
+    expect(styledInputWrapper).toHaveStyleRule('border', basicBorderStyle);
   });
 
   test('array of elements', () => {
@@ -285,14 +330,16 @@ describe('error does not show when invalid type', () => {
       </div>,
     ];
 
-    const { queryByTestId } = render(
+    const { container, queryByTestId } = render(
       <FormGroup>
-        <Input error={errors} />
+        <Input label="Test" error={errors} />
       </FormGroup>,
     );
+    const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');
 
     expect(warning).toHaveBeenCalledTimes(1);
     expect(queryByTestId('err')).not.toBeInTheDocument();
+    expect(styledInputWrapper).toHaveStyleRule('border', errorBorderStyle);
   });
 });
 

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -241,7 +241,7 @@ test('error shows with valid string', () => {
 
   rerender(
     <FormGroup>
-      <Input label="Test" error={error} />
+      <Input error={error} />
     </FormGroup>,
   );
 
@@ -332,7 +332,7 @@ describe('error does not show when invalid type', () => {
 
     const { container, queryByTestId } = render(
       <FormGroup>
-        <Input label="Test" error={errors} />
+        <Input error={errors} />
       </FormGroup>,
     );
     const styledInputWrapper = container.querySelector('[class*="StyledInputWrapper"]');

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -93,9 +93,13 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
     };
 
     if (Array.isArray(error)) {
-      error.forEach(validateError);
+      const nextError = error.reduce<Array<React.ReactNode>>((acc, errorItem) => {
+        const nextErrorItem = validateError(errorItem);
 
-      return error;
+        return nextErrorItem ? [...acc, nextErrorItem] : acc;
+      }, []);
+
+      return nextError.length > 0 ? nextError : null;
     }
 
     return validateError(error);

--- a/packages/big-design/src/components/Textarea/spec.tsx
+++ b/packages/big-design/src/components/Textarea/spec.tsx
@@ -1,4 +1,5 @@
 import 'jest-styled-components';
+import { theme } from '@bigcommerce/big-design-theme';
 import React, { createRef } from 'react';
 
 import { render } from '@test/utils';
@@ -7,6 +8,9 @@ import { warning } from '../../utils';
 import { FormControlDescription, FormControlError, FormControlLabel, FormGroup } from '../Form';
 
 import { Textarea, TextareaProps } from './index';
+
+const basicBorderStyle = `1px solid ${theme.colors.secondary30}`;
+const errorBorderStyle = `1px solid ${theme.colors.danger40}`;
 
 test('forwards ref', () => {
   const ref = createRef<HTMLTextAreaElement>();
@@ -79,13 +83,15 @@ test('renders a description', () => {
 
 test('renders an error', () => {
   const errorText = 'This is an error';
-  const { queryByText } = render(
+  const { container, queryByText } = render(
     <FormGroup>
       <Textarea error={errorText} />
     </FormGroup>,
   );
+  const textarea = container.querySelector('textarea');
 
   expect(queryByText(errorText)).toBeInTheDocument();
+  expect(textarea).toHaveStyleRule('border', errorBorderStyle);
 });
 
 test('accepts a Label Component', () => {
@@ -158,13 +164,15 @@ test('accepts an Error Component', () => {
     </FormControlError>
   );
 
-  const { queryByTestId } = render(
+  const { container, queryByTestId } = render(
     <FormGroup>
       <Textarea error={CustomError} />
     </FormGroup>,
   );
+  const textarea = container.querySelector('textarea');
 
   expect(queryByTestId('test')).toBeInTheDocument();
+  expect(textarea).toHaveStyleRule('border', errorBorderStyle);
 });
 
 test('does not accept non-Error Components', () => {
@@ -177,26 +185,30 @@ test('does not accept non-Error Components', () => {
     </div>
   );
 
-  const { queryByTestId } = render(
+  const { container, queryByTestId } = render(
     <FormGroup>
       <Textarea error={NotAnError} />
     </FormGroup>,
   );
+  const textarea = container.querySelector('textarea');
 
   expect(queryByTestId('test')).not.toBeInTheDocument();
+  expect(textarea).toHaveStyleRule('border', basicBorderStyle);
 });
 
 describe('error does not show when invalid type', () => {
   test('single element', () => {
     const error = <div data-testid="err">Error</div>;
-    const { queryByTestId } = render(
+    const { container, queryByTestId } = render(
       <FormGroup>
         <Textarea error={error} />
       </FormGroup>,
     );
+    const textarea = container.querySelector('textarea');
 
     expect(warning).toHaveBeenCalledTimes(1);
     expect(queryByTestId('err')).not.toBeInTheDocument();
+    expect(textarea).toHaveStyleRule('border', basicBorderStyle);
   });
 
   test('array of elements', () => {
@@ -208,14 +220,16 @@ describe('error does not show when invalid type', () => {
       </div>,
     ];
 
-    const { queryByTestId } = render(
+    const { container, queryByTestId } = render(
       <FormGroup>
         <Textarea error={errors} />
       </FormGroup>,
     );
+    const textarea = container.querySelector('textarea');
 
     expect(warning).toHaveBeenCalledTimes(1);
     expect(queryByTestId('err')).not.toBeInTheDocument();
+    expect(textarea).toHaveStyleRule('border', errorBorderStyle);
   });
 });
 
@@ -254,4 +268,43 @@ test('renders all together', () => {
   );
 
   expect(container.firstChild).toMatchSnapshot();
+});
+
+describe('error shows when an array of strings', () => {
+  test('empty array', () => {
+    const { container } = render(
+      <FormGroup>
+        <Textarea error={[]} />
+      </FormGroup>,
+    );
+    const textarea = container.querySelector('textarea');
+
+    expect(container.querySelector('[class*="StyledError"]')).not.toBeInTheDocument();
+    expect(textarea).toHaveStyleRule('border', basicBorderStyle);
+  });
+
+  test('array with empty strings', () => {
+    const { container } = render(
+      <FormGroup>
+        <Textarea error={['', '']} />
+      </FormGroup>,
+    );
+    const textarea = container.querySelector('textarea');
+
+    expect(container.querySelector('[class*="StyledError"]')).not.toBeInTheDocument();
+    expect(textarea).toHaveStyleRule('border', basicBorderStyle);
+  });
+
+  test('array with valid strings', () => {
+    const errors = ['Error 0', 'Error 1'];
+    const { container, getByText } = render(
+      <FormGroup>
+        <Textarea error={errors} />
+      </FormGroup>,
+    );
+    const textarea = container.querySelector('textarea');
+
+    expect(textarea).toHaveStyleRule('border', errorBorderStyle);
+    errors.forEach((error) => expect(getByText(error)).toBeInTheDocument());
+  });
 });


### PR DESCRIPTION
## What? / Why?
Fixing the error state of the `Input` and `Textarea` components.

Cases when we don't show error state:
- Empty array;
- When we get an empty `error` array after firing `validationError` in the case when we receive error property as an `array` or an `array` with the "invalid" elements.

## Screenshots
### Before:
<img width="463" alt="Screenshot 2020-09-28 at 13 20 40" src="https://user-images.githubusercontent.com/9980803/94427266-7801b780-0197-11eb-949f-696b3abc5670.png">
<img width="460" alt="Screenshot 2020-09-28 at 13 21 18" src="https://user-images.githubusercontent.com/9980803/94427269-789a4e00-0197-11eb-9185-20aa2edd5c59.png">
<img width="688" alt="Screenshot 2020-09-29 at 11 19 43" src="https://user-images.githubusercontent.com/9980803/94531836-c077ae80-0245-11eb-92db-7795775d8be4.png">
<img width="730" alt="Screenshot 2020-09-30 at 12 00 43" src="https://user-images.githubusercontent.com/9980803/94665441-d2745280-0314-11eb-84d6-85ca12c63330.png">
<img width="704" alt="Screenshot 2020-09-30 at 12 01 14" src="https://user-images.githubusercontent.com/9980803/94665442-d3a57f80-0314-11eb-94f4-54766b393e79.png">
<img width="717" alt="Screenshot 2020-09-30 at 12 01 25" src="https://user-images.githubusercontent.com/9980803/94665446-d43e1600-0314-11eb-8f57-1d91a3dd27ff.png">

### After:
<img width="503" alt="Screenshot 2020-09-28 at 13 30 00" src="https://user-images.githubusercontent.com/9980803/94427354-97004980-0197-11eb-9c3c-33dc8ebd6722.png">
<img width="481" alt="Screenshot 2020-09-28 at 13 30 11" src="https://user-images.githubusercontent.com/9980803/94427359-9798e000-0197-11eb-909c-7358c2417f26.png">
<img width="698" alt="Screenshot 2020-09-29 at 11 19 59" src="https://user-images.githubusercontent.com/9980803/94531851-c53c6280-0245-11eb-9956-dbdf329b015b.png">
<img width="703" alt="Screenshot 2020-09-30 at 12 01 46" src="https://user-images.githubusercontent.com/9980803/94665478-dd2ee780-0314-11eb-8440-337c77f05cdc.png">
<img width="714" alt="Screenshot 2020-09-30 at 12 02 02" src="https://user-images.githubusercontent.com/9980803/94665481-ddc77e00-0314-11eb-9bad-47373ce90287.png">
<img width="714" alt="Screenshot 2020-09-30 at 12 02 12" src="https://user-images.githubusercontent.com/9980803/94665482-def8ab00-0314-11eb-9e24-e64f1b682803.png">

## Proof
- Existing unit tests;
- Tested locally.

ping @chanceaclark 
