### PR TITLE
fix(datepicker): fix order of days displayed

### DIFF
--- a/packages/big-design/src/utils/localizationProvider/localizationProvider.ts
+++ b/packages/big-design/src/utils/localizationProvider/localizationProvider.ts
@@ -34,7 +34,7 @@ export const createLocalizationProvider = (locale: string) => {
     monthFormatter.format(new Date(0, month, 1)),
   );
 
-  const daysShort = [1, 2, 3, 4, 5, 6, 7].map((day) => dayFormatter.format(new Date(0, 9, day, 12)));
+  const daysShort = [0, 1, 2, 3, 4, 5, 6].map((day) => dayFormatter.format(new Date(0, 9, day, 12)));
 
   const timeFormatter = Intl.DateTimeFormat(locale, {
     hour: 'numeric',


### PR DESCRIPTION
# What
Fixes issue in Datepicker as to how days row is setup. 

## Screenshot
<img width="1680" alt="Screen Shot 2020-10-07 at 9 07 53 pm" src="https://user-images.githubusercontent.com/7134802/95317871-7e073f00-08e1-11eb-945d-231f674f03cf.png">


ping @bigcommerce/frontend @chanceaclark 
