### PR TITLE
fix: open select when clicked and visually hide list

### DIFF
--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -6,6 +6,7 @@ import { useIsomorphicLayoutEffect, useWindowSize } from '../../hooks';
 import { StyledList } from './styled';
 
 export interface ListProps extends HTMLAttributes<HTMLUListElement> {
+  isOpen: boolean;
   maxHeight: number;
   update(): Promise<Partial<State> | null>;
 }

--- a/packages/big-design/src/components/List/styled.tsx
+++ b/packages/big-design/src/components/List/styled.tsx
@@ -1,9 +1,12 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { hideVisually } from 'polished';
 import styled from 'styled-components';
 
 import { ListProps } from './List';
 
 export const StyledList = styled.ul<Partial<ListProps>>`
+  ${({ isOpen }) => !isOpen && hideVisually()}
+
   ${({ theme }) => theme.shadow.raised};
 
   background-color: ${({ theme }) => theme.colors.white};

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -419,6 +419,7 @@ export const MultiSelect = typedMemo(
             <List
               {...getMenuProps({ ref })}
               data-placement={popperPlacement}
+              isOpen={isOpen}
               maxHeight={maxHeight}
               style={popperStyle}
               update={update}

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -61,6 +61,16 @@ exports[`render pagination component 1`] = `
 }
 
 .c8 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
@@ -473,6 +483,16 @@ exports[`render pagination component with invalid page info 1`] = `
 }
 
 .c8 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
@@ -885,6 +905,16 @@ exports[`render pagination component with invalid range info 1`] = `
 }
 
 .c8 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
@@ -1298,6 +1328,16 @@ exports[`render pagination component with no items 1`] = `
 }
 
 .c8 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -250,6 +250,9 @@ export const Select = typedMemo(
                 {...getInputProps({
                   autoComplete: 'no',
                   disabled,
+                  onClick: () => {
+                    !isOpen && openMenu();
+                  },
                   onFocus: () => {
                     !isOpen && openMenu();
                   },
@@ -419,6 +422,7 @@ export const Select = typedMemo(
             <List
               {...getMenuProps({ ref })}
               data-placement={popperPlacement}
+              isOpen={isOpen}
               maxHeight={maxHeight}
               style={popperStyle}
               update={update}

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -80,6 +80,16 @@ exports[`renders a pagination component 1`] = `
 }
 
 .c11 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;


### PR DESCRIPTION
## What
Open list when Select is clicked. Visually hide the list when select is closed.

## Why
Should fix #459 & fix #460. I was, however, unable to reproduce #459 but I'm hoping these changes fix it.