### PR TITLE
fix(component): add missing prop to open dropdown

### DIFF
--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -197,6 +197,7 @@ export const Dropdown = memo(
                 ref,
               })}
               data-placement={popperPlacement}
+              isOpen={isOpen}
               maxHeight={maxHeight}
               style={popperStyle}
               update={update}

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -298,6 +298,7 @@ export const Select = typedMemo(
       isOpen,
       onOptionChange,
       openMenu,
+      selectedOption,
       placeholder,
       renderToggle,
       required,

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -240,6 +240,7 @@ test('select menu opens/closes when input button is clicked', async () => {
   const button = getByRole('button');
 
   fireEvent.click(button);
+  expect(queryByRole('listbox')).not.toBeEmptyDOMElement();
 
   fireEvent.click(button);
   expect(queryByRole('listbox')).toBeEmptyDOMElement();


### PR DESCRIPTION
Dropdown's `<List />` component was missing the `isOpen` prop.

Will lurk the `Downshift` library to figure out why `getMenuProps` returns `any`, which caused an oversight by me thinking `ts` would catch an issue like this.