### PR TITLE
fix(component): do not shrink the radio button

### DIFF
--- a/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
@@ -63,6 +63,9 @@ exports[`render Radio (checked + disabled) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: 1.25rem;
   position: relative;
   -webkit-user-select: none;
@@ -189,6 +192,9 @@ exports[`render Radio (checked) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: 1.25rem;
   position: relative;
   -webkit-user-select: none;
@@ -356,6 +362,9 @@ exports[`render Radio (unchecked + description object) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: 1.25rem;
   position: relative;
   -webkit-user-select: none;
@@ -506,6 +515,9 @@ exports[`render Radio (unchecked + description text) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: 1.25rem;
   position: relative;
   -webkit-user-select: none;
@@ -643,6 +655,9 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: 1.25rem;
   position: relative;
   -webkit-user-select: none;
@@ -768,6 +783,9 @@ exports[`render Radio (unchecked) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: 1.25rem;
   position: relative;
   -webkit-user-select: none;

--- a/packages/big-design/src/components/Radio/styled.tsx
+++ b/packages/big-design/src/components/Radio/styled.tsx
@@ -32,6 +32,7 @@ export const StyledRadio = styled.label<StyledRadioProps>`
   color: ${({ theme }) => theme.colors.white};
   cursor: pointer;
   display: inline-block;
+  flex-shrink: 0;
   height: ${({ theme }) => theme.spacing.large};
   position: relative;
   user-select: none;

--- a/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
@@ -877,7 +877,7 @@ exports[`renders Tree component radio-select 1`] = `
       >
         <label
           aria-hidden="true"
-          class="styled__StyledRadio-sc-1x9u9a8-3 jACwtB"
+          class="styled__StyledRadio-sc-1x9u9a8-3 kDSEZF"
         />
       </div>
       <div
@@ -938,7 +938,7 @@ exports[`renders Tree component radio-select 1`] = `
       >
         <label
           aria-hidden="true"
-          class="styled__StyledRadio-sc-1x9u9a8-3 jACwtB"
+          class="styled__StyledRadio-sc-1x9u9a8-3 kDSEZF"
         />
       </div>
       <div
@@ -1010,7 +1010,7 @@ exports[`renders Tree component radio-select 1`] = `
       >
         <label
           aria-hidden="true"
-          class="styled__StyledRadio-sc-1x9u9a8-3 jACwtB"
+          class="styled__StyledRadio-sc-1x9u9a8-3 kDSEZF"
         />
       </div>
       <div
@@ -1062,7 +1062,7 @@ exports[`renders Tree component radio-select 1`] = `
       >
         <label
           aria-hidden="true"
-          class="styled__StyledRadio-sc-1x9u9a8-3 lcaPsc"
+          class="styled__StyledRadio-sc-1x9u9a8-3 dGoEi"
           disabled=""
         />
       </div>
@@ -1135,7 +1135,7 @@ exports[`renders Tree component radio-select 1`] = `
       >
         <label
           aria-hidden="true"
-          class="styled__StyledRadio-sc-1x9u9a8-3 jACwtB"
+          class="styled__StyledRadio-sc-1x9u9a8-3 kDSEZF"
         />
       </div>
       <div


### PR DESCRIPTION
## What?
Fixing on the radio button. A content might shrink the radio button on different screens.

##  Screenshots

**Before:**
<img width="618" alt="Screenshot 2020-10-19 at 18 06 02" src="https://user-images.githubusercontent.com/15989398/96469330-c6095880-1235-11eb-96d5-4316e268cff0.png">

**After:**
<img width="625" alt="Screenshot 2020-10-19 at 18 05 49" src="https://user-images.githubusercontent.com/15989398/96469356-cb66a300-1235-11eb-9c3d-55d54bc8e54a.png">

## Proof
Tested locally.

ping @golcinho @chanceaclark 
