### PR TITLE
fix(component): updates progress circle to use em instead of rem due to error in Safari 14

### DIFF
--- a/packages/big-design-theme/src/helpers/helpers.ts
+++ b/packages/big-design-theme/src/helpers/helpers.ts
@@ -1,4 +1,4 @@
-import { math, rem, transparentize } from 'polished';
+import { em, math, rem, transparentize } from 'polished';
 
 import { themeOptions } from '../options';
 
@@ -6,6 +6,7 @@ export interface Helpers {
   addValues(first: string, second: string): string;
   createRGBA(color: string, alpha: number): string;
   remCalc(value: string | number): string;
+  emCalc(value: string | number): string;
 }
 
 export const addValues = (first: string, second: string) => {
@@ -27,4 +28,10 @@ export const remCalc = (value: string | number) => {
   const { htmlFontSize } = themeOptions.getOptions();
 
   return rem(value, htmlFontSize);
+};
+
+export const emCalc = (value: string | number) => {
+  const { htmlFontSize } = themeOptions.getOptions();
+
+  return em(value, htmlFontSize);
 };

--- a/packages/big-design-theme/src/helpers/index.ts
+++ b/packages/big-design-theme/src/helpers/index.ts
@@ -1,8 +1,9 @@
-import { addValues, createRGBA, remCalc } from './helpers';
+import { addValues, createRGBA, emCalc, remCalc } from './helpers';
 
 export * from './helpers';
 export const createHelpers = () => ({
   addValues,
   createRGBA,
+  emCalc,
   remCalc,
 });

--- a/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
@@ -1271,15 +1271,15 @@ exports[`render loading button 1`] = `
     >
       <circle
         class="c5"
-        cx="0.5rem"
-        cy="0.5rem"
-        r="0.4375rem"
+        cx="0.5em"
+        cy="0.5em"
+        r="0.4375em"
       />
       <circle
         class="c6"
-        cx="0.5rem"
-        cy="0.5rem"
-        r="0.4375rem"
+        cx="0.5em"
+        cy="0.5em"
+        r="0.4375em"
       />
     </svg>
   </div>

--- a/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
@@ -79,15 +79,15 @@ exports[`render determinant progress circle 1`] = `
   >
     <circle
       class="c1"
-      cx="1.5rem"
-      cy="1.5rem"
-      r="1.375rem"
+      cx="1.5em"
+      cy="1.5em"
+      r="1.375em"
     />
     <circle
       class="c2"
-      cx="1.5rem"
-      cy="1.5rem"
-      r="1.375rem"
+      cx="1.5em"
+      cy="1.5em"
+      r="1.375em"
     />
     <text
       class="c3"
@@ -173,15 +173,15 @@ exports[`render indeterminant progress bar 1`] = `
   >
     <circle
       class="c1"
-      cx="1.5rem"
-      cy="1.5rem"
-      r="1.375rem"
+      cx="1.5em"
+      cy="1.5em"
+      r="1.375em"
     />
     <circle
       class="c2"
-      cx="1.5rem"
-      cy="1.5rem"
-      r="1.375rem"
+      cx="1.5em"
+      cy="1.5em"
+      r="1.375em"
     />
   </svg>
 </div>
@@ -225,15 +225,15 @@ exports[`render large progress circle 1`] = `
   >
     <circle
       class="c1"
-      cx="2.5rem"
-      cy="2.5rem"
-      r="2.25rem"
+      cx="2.5em"
+      cy="2.5em"
+      r="2.25em"
     />
     <circle
       class="c2"
-      cx="2.5rem"
-      cy="2.5rem"
-      r="2.25rem"
+      cx="2.5em"
+      cy="2.5em"
+      r="2.25em"
     />
   </svg>
 </div>
@@ -277,15 +277,15 @@ exports[`render medium progress circle 1`] = `
   >
     <circle
       class="c1"
-      cx="1.5rem"
-      cy="1.5rem"
-      r="1.375rem"
+      cx="1.5em"
+      cy="1.5em"
+      r="1.375em"
     />
     <circle
       class="c2"
-      cx="1.5rem"
-      cy="1.5rem"
-      r="1.375rem"
+      cx="1.5em"
+      cy="1.5em"
+      r="1.375em"
     />
   </svg>
 </div>
@@ -329,15 +329,15 @@ exports[`render small progress circle 1`] = `
   >
     <circle
       class="c1"
-      cx="1rem"
-      cy="1rem"
-      r="0.875rem"
+      cx="1em"
+      cy="1em"
+      r="0.875em"
     />
     <circle
       class="c2"
-      cx="1rem"
-      cy="1rem"
-      r="0.875rem"
+      cx="1em"
+      cy="1em"
+      r="0.875em"
     />
   </svg>
 </div>
@@ -381,15 +381,15 @@ exports[`render xSmall progress circle 1`] = `
   >
     <circle
       class="c1"
-      cx="0.75rem"
-      cy="0.75rem"
-      r="0.65625rem"
+      cx="0.75em"
+      cy="0.75em"
+      r="0.65625em"
     />
     <circle
       class="c2"
-      cx="0.75rem"
-      cy="0.75rem"
-      r="0.65625rem"
+      cx="0.75em"
+      cy="0.75em"
+      r="0.65625em"
     />
   </svg>
 </div>
@@ -433,15 +433,15 @@ exports[`render xSmall progress circle 2`] = `
   >
     <circle
       class="c1"
-      cx="0.5rem"
-      cy="0.5rem"
-      r="0.4375rem"
+      cx="0.5em"
+      cy="0.5em"
+      r="0.4375em"
     />
     <circle
       class="c2"
-      cx="0.5rem"
-      cy="0.5rem"
-      r="0.4375rem"
+      cx="0.5em"
+      cy="0.5em"
+      r="0.4375em"
     />
   </svg>
 </div>

--- a/packages/big-design/src/components/ProgressCircle/styled.tsx
+++ b/packages/big-design/src/components/ProgressCircle/styled.tsx
@@ -12,7 +12,7 @@ export const StyledProgressCircle = styled.svg<ProgressCircleProps>`
 `;
 
 export const StyledCircle = styled.circle.attrs(({ size, theme }: any) => ({
-  // rem not usable for circle svg cx, cy, and r values
+  // rem not usable for circle svg cx, cy, and r values in Safari 14
   cx: theme.helpers.emCalc(getDimensions(size) / 2),
   cy: theme.helpers.emCalc(getDimensions(size) / 2),
   r: theme.helpers.emCalc(getDimensions(size) / 2 - getStrokeWidth(size) / 2),

--- a/packages/big-design/src/components/ProgressCircle/styled.tsx
+++ b/packages/big-design/src/components/ProgressCircle/styled.tsx
@@ -12,9 +12,10 @@ export const StyledProgressCircle = styled.svg<ProgressCircleProps>`
 `;
 
 export const StyledCircle = styled.circle.attrs(({ size, theme }: any) => ({
-  cx: theme.helpers.remCalc(getDimensions(size) / 2),
-  cy: theme.helpers.remCalc(getDimensions(size) / 2),
-  r: theme.helpers.remCalc(getDimensions(size) / 2 - getStrokeWidth(size) / 2),
+  // rem not usable for circle svg cx, cy, and r values
+  cx: theme.helpers.emCalc(getDimensions(size) / 2),
+  cy: theme.helpers.emCalc(getDimensions(size) / 2),
+  r: theme.helpers.emCalc(getDimensions(size) / 2 - getStrokeWidth(size) / 2),
 }))<ProgressCircleProps>`
   fill: transparent;
   stroke-width: ${({ size, theme }) => theme.helpers.remCalc(getStrokeWidth(size))};


### PR DESCRIPTION
## WHAT
Per title - progress circle crashes due to `rem` in Safari 14 - updated to use `em`, per MDN docs, created `emCalc` utility per 'offline' suggestion by @deini .
<img width="977" alt="Screen Shot 2020-11-12 at 10 15 19 AM" src="https://user-images.githubusercontent.com/37593557/98966972-87cc2580-24d1-11eb-962d-2bb3516dcb8d.png"><img width="866" alt="Screen Shot 2020-11-12 at 10 25 37 AM" src="https://user-images.githubusercontent.com/37593557/98966997-8c90d980-24d1-11eb-92db-befe2c9019e8.png">


