### PR TITLE
docs(component): updates switch docs not for use in forms

### DIFF
--- a/packages/docs/pages/Switch/SwitchPage.tsx
+++ b/packages/docs/pages/Switch/SwitchPage.tsx
@@ -18,7 +18,7 @@ const SwitchPage = () => (
       {function Example() {
         const [checked, setChecked] = useState(false);
         const handleChange = () => setChecked(!checked);
-        const boxColor = checked ? 'brand' : 'secondary20';
+        const boxColor = checked ? 'white' : 'secondary20';
 
         return (
           <Box display="inline-block" padding="xLarge" backgroundColor={boxColor}>

--- a/packages/docs/pages/Switch/SwitchPage.tsx
+++ b/packages/docs/pages/Switch/SwitchPage.tsx
@@ -1,4 +1,4 @@
-import { Box, H0, H1, Switch, Text } from '@bigcommerce/big-design';
+import { H0, H1, Switch, Text } from '@bigcommerce/big-design';
 import React, { useState } from 'react';
 
 import { Code, CodePreview } from '../../components';
@@ -19,11 +19,7 @@ const SwitchPage = () => (
         const [checked, setChecked] = useState(false);
         const handleChange = () => setChecked(!checked);
 
-        return (
-          <Box>
-            <Switch checked={checked} onChange={handleChange} />
-          </Box>
-        );
+        return <Switch checked={checked} onChange={handleChange} />;
       }}
       {/* jsx-to-string:end */}
     </CodePreview>

--- a/packages/docs/pages/Switch/SwitchPage.tsx
+++ b/packages/docs/pages/Switch/SwitchPage.tsx
@@ -18,10 +18,9 @@ const SwitchPage = () => (
       {function Example() {
         const [checked, setChecked] = useState(false);
         const handleChange = () => setChecked(!checked);
-        const boxColor = checked ? 'white' : 'secondary20';
 
         return (
-          <Box display="inline-block" padding="xLarge" backgroundColor={boxColor}>
+          <Box>
             <Switch checked={checked} onChange={handleChange} />
           </Box>
         );

--- a/packages/docs/pages/Switch/SwitchPage.tsx
+++ b/packages/docs/pages/Switch/SwitchPage.tsx
@@ -1,4 +1,4 @@
-import { Form, FormGroup, H0, H1, Switch, Text } from '@bigcommerce/big-design';
+import { Box, H0, H1, Switch, Text } from '@bigcommerce/big-design';
 import React, { useState } from 'react';
 
 import { Code, CodePreview } from '../../components';
@@ -9,7 +9,8 @@ const SwitchPage = () => (
     <H0>Switch</H0>
 
     <Text>
-      Switches are a stylized <Code>input[type="checkbox"]</Code> with controllable checked/unchecked states.
+      Switches are a stylized <Code>input[type="checkbox"]</Code> with controllable checked/unchecked states. Switches
+      are intended to be used for immediate toggle actions and are therefore not intended to be used in forms.
     </Text>
 
     <CodePreview>
@@ -17,13 +18,12 @@ const SwitchPage = () => (
       {function Example() {
         const [checked, setChecked] = useState(false);
         const handleChange = () => setChecked(!checked);
+        const boxColor = checked ? 'brand' : 'secondary20';
 
         return (
-          <Form>
-            <FormGroup>
-              <Switch checked={checked} onChange={handleChange} />
-            </FormGroup>
-          </Form>
+          <Box display="inline-block" padding="xLarge" backgroundColor={boxColor}>
+            <Switch checked={checked} onChange={handleChange} />
+          </Box>
         );
       }}
       {/* jsx-to-string:end */}


### PR DESCRIPTION
### WHAT
Updates `Switch` documentation to state that this component is for immediate "toggle" changes and is thus not appropriate for use in submittable forms. Removes `Form` from code example, replaces with `Box` - background changes color for visual representation of component usage, but I'm happy to use better examples.
<img width="300" alt="Screen Shot 2020-11-23 at 2 58 04 PM" src="https://user-images.githubusercontent.com/37593557/100014679-55a5a800-2d9c-11eb-932b-245244da4980.png"><img width="300" alt="Screen Shot 2020-11-23 at 4 40 52 PM" src="https://user-images.githubusercontent.com/37593557/100023499-b2a85a80-2daa-11eb-81f3-e9981c6a6195.png">


