### PR TITLE
fix(docs): add missing Html component to document

### DIFF
--- a/packages/docs/pages/_document.tsx
+++ b/packages/docs/pages/_document.tsx
@@ -1,4 +1,4 @@
-import Document, { DocumentContext, Head, Main, NextScript } from 'next/document';
+import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
 import React from 'react';
 import { ServerStyleSheet } from 'styled-components';
 
@@ -35,13 +35,13 @@ export default class AppDocument extends Document {
 
   render() {
     return (
-      <html>
+      <Html>
         {this.renderGTM()}
         <body>
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 


### PR DESCRIPTION
```
@bigcommerce/docs: warn  - Your custom Document (pages/_document) did not render all the required subcomponent.
@bigcommerce/docs: Missing component: <Html />
@bigcommerce/docs: Read how to fix here: https://err.sh/next.js/missing-document-component
```

https://github.com/vercel/next.js/blob/master/errors/missing-document-component.md