### PR TITLE
fix(component): selected values were not matching state

### DIFF
--- a/packages/big-design/src/components/StatefulTree/hooks/useSelectable.ts
+++ b/packages/big-design/src/components/StatefulTree/hooks/useSelectable.ts
@@ -52,8 +52,9 @@ export const useSelectable = <T extends unknown>({
   useEffect(() => {
     if (defaultSelected) {
       setSelectedNodes(defaultSelected);
+      setSelectedValues(getDefaultSelectedValues({ nodes, selectedNodes: defaultSelected, type }));
     }
-  }, [defaultSelected]);
+  }, [defaultSelected, nodes, type]);
 
   useEffect(() => {
     if (type === 'radio') {


### PR DESCRIPTION
## What

When `defaultSelected` prop changes, the `selectedValues` state didn't update.

## Why

This fixes the issue outlined in #488.

## Screenshot
![BD488](https://user-images.githubusercontent.com/10539418/103226904-c2a7e280-48f2-11eb-8a3a-003b396ffbb0.gif)

Fixes #488.