### PR TITLE
fix(docs): Specify styled-components version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ You can find documentation and examples on our [docs page](https://bigcommerce.g
 
 ### Quick start guide
 
-Add BigDesign and styled-components to your project using `npm`:
+Add BigDesign and styled-components@4 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design styled-components
+npm install @bigcommerce/big-design styled-components@4
 ```
 
 or with `yarn`:
 
 ```
-yarn add @bigcommerce/big-design styled-components
+yarn add @bigcommerce/big-design styled-components@4
 ```
 
 Import the `GlobalStyles` component and use it once in your app. This will set a few styles globally,

--- a/packages/big-design-icons/README.md
+++ b/packages/big-design-icons/README.md
@@ -8,16 +8,16 @@ You can find documentation, list of icons, and examples on our [docs page](https
 
 ### Quick start guide
 
-Add BigDesign Icons and styled-components to your project using `npm`:
+Add BigDesign Icons and styled-components@4 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design-icons styled-components
+npm install @bigcommerce/big-design-icons styled-components@4
 ```
 
 or with `yarn`:
 
 ```
-yarn add @bigcommerce/big-design-icons styled-components
+yarn add @bigcommerce/big-design-icons styled-components@4
 ```
 
 Import any icon component and use it anywhere in your app.

--- a/packages/big-design-theme/README.md
+++ b/packages/big-design-theme/README.md
@@ -17,16 +17,16 @@ This package is only meant to be used directly when more advanced features are n
 
 ### Quick start guide
 
-Add the BigDesign theme and styled-components to your project using `npm`:
+Add the BigDesign theme and styled-components@4 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design-theme styled-components
+npm install @bigcommerce/big-design-theme styled-components@4
 ```
 
 or with `yarn`:
 
 ```
-yarn add @bigcommerce/big-design-theme styled-components
+yarn add @bigcommerce/big-design-theme styled-components@4
 ```
 
 ```tsx

--- a/packages/big-design/README.md
+++ b/packages/big-design/README.md
@@ -8,16 +8,16 @@ You can find documentation and examples on our [docs page](https://bigcommerce.g
 
 ### Quick start guide
 
-Add BigDesign and styled-components to your project using `npm`:
+Add BigDesign and styled-components@4 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design styled-components
+npm install @bigcommerce/big-design styled-components@4
 ```
 
 or with `yarn`:
 
 ```
-yarn add @bigcommerce/big-design styled-components
+yarn add @bigcommerce/big-design styled-components@4
 ```
 
 Import the `GlobalStyles` component and use it once in your app. This will set a few styles globally,

--- a/packages/docs/pages/GettingStarted/GettingStartedPage.tsx
+++ b/packages/docs/pages/GettingStarted/GettingStartedPage.tsx
@@ -90,7 +90,7 @@ const GettingStartedPage = () => {
 
       <Text>Add BigDesign and styled-components to your project:</Text>
       <CodeSnippet showControls={false} language="bash">
-        npm install @bigcommerce/big-design styled-components
+        npm install @bigcommerce/big-design styled-components@4
       </CodeSnippet>
 
       <Text>


### PR DESCRIPTION
# What?

Add version number for `styled-components` in the README.md

# Why?

Currently `npm install styled-components` will install version 5. We depend on version 4.

@bigcommerce/frontend 