### PR TITLE
chore(ci): run eslint on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,10 @@ jobs:
           environment:
             NEXT_TELEMETRY_DISABLED: '1'
 
+      - run:
+          command: yarn run lint
+
+
 workflows:
   version: 2
   build_and_test:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
     'import/resolver': {
       typescript: {
         alwaysTryTypes: true,
-        directory: 'packages/*/tsconfig.json',
+        project: 'packages/*/tsconfig.json',
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "lerna run build --stream",
     "ci": "lerna run ci --stream",
     "diff": "lerna diff",
-    "lint": "eslint . --ext .ts,.tsx,.js && lerna run lint --stream",
+    "lint": "eslint . --ext .ts,.tsx,.js",
     "start": "lerna run start --stream --parallel --ignore @bigcommerce/examples",
     "test": "lerna run test --stream"
   },

--- a/packages/big-design/src/components/Switch/styled.tsx
+++ b/packages/big-design/src/components/Switch/styled.tsx
@@ -68,7 +68,8 @@ export const StyledSwitchLabel = styled.label<SwitchLabelProps>`
     ${withTransition(['background, transform'])}
     ${({ theme }) => theme.shadow.raised}
 
-    background: ${({ checked, theme }) => (checked ? theme.colors.primary40 : theme.colors.white)};
+    background: ${({ checked, theme }) =>
+      checked ? theme.colors.primary40 : theme.colors.white};
     border-radius: ${({ theme }) => theme.borderRadius.circle};
     content: '';
     height: ${({ theme }) => theme.spacing.xLarge};

--- a/packages/big-design/src/components/Typography/styled.tsx
+++ b/packages/big-design/src/components/Typography/styled.tsx
@@ -55,7 +55,6 @@ const textModifiers = (props: TextProps) => css`
     css`
       text-transform: uppercase;
     `}
-
 `;
 
 export const StyledH0 = styled.h1<HeadingProps>`

--- a/packages/docs/pages/Collapse/CollapsePage.tsx
+++ b/packages/docs/pages/Collapse/CollapsePage.tsx
@@ -1,5 +1,5 @@
 import { Collapse, H0, H1, Text } from '@bigcommerce/big-design';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Code, CodePreview } from '../../components';
 import { CollapsePropTable } from '../../PropTables';
@@ -15,7 +15,7 @@ export default () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       {function Example() {
-        const [title, setTitle] = React.useState('Show more');
+        const [title, setTitle] = useState('Show more');
         const handleChange = (isOpen: boolean) => setTitle(isOpen ? 'Show less' : 'Show more');
 
         return (


### PR DESCRIPTION
We currently rely on Husky (git-hook) to run `eslint`. Just noticed we have a few eslint issues, probably from users who skip the git-hook. 

This change runs eslint on ci. We have a single `job` in our `workflow`. I'll open a different PR to split it up.