### PR TITLE
feat(component): Add drag and drop support to stateful table component

### DIFF
--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -16,12 +16,20 @@ export interface StatefulTableColumn<T> extends Omit<TableColumn<T>, 'isSortable
 export interface StatefulTableProps<T>
   extends Omit<TableProps<T>, 'columns' | 'pagination' | 'selectable' | 'sortable'> {
   columns: Array<StatefulTableColumn<T>>;
-  dragAndDrop?: boolean;
+  draggable?: boolean;
   pagination?: boolean;
   selectable?: boolean;
   defaultSelected?: T[];
   onSelectionChange?: TableSelectable<T>['onSelectionChange'];
 }
+
+const swapArrayElements = <T extends unknown>(array: T[], from: number, to: number) => {
+  if (from > to) {
+    return [...array.slice(0, to), array[from], ...array.slice(to, from), ...array.slice(from + 1, array.length)];
+  } else {
+    return [...array.slice(0, from), ...array.slice(from + 1, to), array[from], ...array.slice(to, array.length)];
+  }
+};
 
 const InternalStatefulTable = <T extends TableItem>({
   columns = [],
@@ -30,7 +38,7 @@ const InternalStatefulTable = <T extends TableItem>({
   items = [],
   keyField,
   onSelectionChange,
-  dragAndDrop = false,
+  draggable = false,
   pagination = false,
   selectable = false,
   stickyHeader = false,
@@ -90,10 +98,9 @@ const InternalStatefulTable = <T extends TableItem>({
 
   const onDragEnd = useCallback(
     (from: number, to: number) => {
-      const itemsClone = [...items];
-      const item = itemsClone.splice(from, 1);
-      itemsClone.splice(to, 0, ...item);
-      dispatch({ type: 'ITEMS_CHANGED', items: itemsClone, isPaginationEnabled: pagination });
+      const updatedItems = swapArrayElements(items, from, to);
+
+      dispatch({ type: 'ITEMS_CHANGED', items: updatedItems, isPaginationEnabled: pagination });
     },
     [items, pagination],
   );
@@ -109,7 +116,7 @@ const InternalStatefulTable = <T extends TableItem>({
       pagination={paginationOptions}
       selectable={selectableOptions}
       sortable={sortableOptions}
-      onRowDrop={dragAndDrop ? onDragEnd : undefined}
+      onRowDrop={draggable ? onDragEnd : undefined}
     />
   );
 };

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -14,12 +14,12 @@ export interface StatefulTableColumn<T> extends Omit<TableColumn<T>, 'isSortable
 }
 
 export interface StatefulTableProps<T>
-  extends Omit<TableProps<T>, 'columns' | 'pagination' | 'selectable' | 'sortable'> {
+  extends Omit<TableProps<T>, 'columns' | 'pagination' | 'selectable' | 'sortable' | 'onRowDrop'> {
   columns: Array<StatefulTableColumn<T>>;
-  draggable?: boolean;
   pagination?: boolean;
   selectable?: boolean;
   defaultSelected?: T[];
+  onRowDrop?(items: T[]): void;
   onSelectionChange?: TableSelectable<T>['onSelectionChange'];
 }
 
@@ -43,7 +43,7 @@ const InternalStatefulTable = <T extends TableItem>({
   items = [],
   keyField,
   onSelectionChange,
-  draggable = false,
+  onRowDrop,
   pagination = false,
   selectable = false,
   stickyHeader = false,
@@ -106,6 +106,9 @@ const InternalStatefulTable = <T extends TableItem>({
       const updatedItems = swapArrayElements(state.currentItems, from, to);
 
       dispatch({ type: 'ITEMS_CHANGED', items: updatedItems, isPaginationEnabled: pagination });
+      if (typeof onRowDrop === 'function') {
+        onRowDrop(updatedItems);
+      }
     },
     [state.currentItems, pagination],
   );
@@ -121,7 +124,7 @@ const InternalStatefulTable = <T extends TableItem>({
       pagination={paginationOptions}
       selectable={selectableOptions}
       sortable={sortableOptions}
-      onRowDrop={draggable ? onDragEnd : undefined}
+      onRowDrop={onRowDrop ? onDragEnd : undefined}
     />
   );
 };

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -23,12 +23,17 @@ export interface StatefulTableProps<T>
   onSelectionChange?: TableSelectable<T>['onSelectionChange'];
 }
 
-const swapArrayElements = <T extends unknown>(array: T[], from: number, to: number) => {
-  if (from > to) {
-    return [...array.slice(0, to), array[from], ...array.slice(to, from), ...array.slice(from + 1, array.length)];
-  } else {
-    return [...array.slice(0, from), ...array.slice(from + 1, to), array[from], ...array.slice(to, array.length)];
-  }
+const swapArrayElements = <T extends unknown>(array: T[], sourceIndex: number, destinationIndex: number) => {
+  const smallerIndex = Math.min(sourceIndex, destinationIndex);
+  const largerIndex = Math.max(sourceIndex, destinationIndex);
+
+  return [
+    ...array.slice(0, smallerIndex),
+    ...(sourceIndex < destinationIndex ? array.slice(smallerIndex + 1, largerIndex + 1) : []),
+    array[sourceIndex],
+    ...(sourceIndex > destinationIndex ? array.slice(smallerIndex, largerIndex) : []),
+    ...array.slice(largerIndex + 1),
+  ];
 };
 
 const InternalStatefulTable = <T extends TableItem>({
@@ -98,11 +103,11 @@ const InternalStatefulTable = <T extends TableItem>({
 
   const onDragEnd = useCallback(
     (from: number, to: number) => {
-      const updatedItems = swapArrayElements(items, from, to);
+      const updatedItems = swapArrayElements(state.currentItems, from, to);
 
       dispatch({ type: 'ITEMS_CHANGED', items: updatedItems, isPaginationEnabled: pagination });
     },
-    [items, pagination],
+    [state.currentItems, pagination],
   );
 
   return (

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -16,6 +16,7 @@ export interface StatefulTableColumn<T> extends Omit<TableColumn<T>, 'isSortable
 export interface StatefulTableProps<T>
   extends Omit<TableProps<T>, 'columns' | 'pagination' | 'selectable' | 'sortable'> {
   columns: Array<StatefulTableColumn<T>>;
+  dragAndDrop?: boolean;
   pagination?: boolean;
   selectable?: boolean;
   defaultSelected?: T[];
@@ -29,6 +30,7 @@ const InternalStatefulTable = <T extends TableItem>({
   items = [],
   keyField,
   onSelectionChange,
+  dragAndDrop = false,
   pagination = false,
   selectable = false,
   stickyHeader = false,
@@ -86,6 +88,16 @@ const InternalStatefulTable = <T extends TableItem>({
     onSort,
   ]);
 
+  const onDragEnd = useCallback(
+    (from: number, to: number) => {
+      const itemsClone = [...items];
+      const item = itemsClone.splice(from, 1);
+      itemsClone.splice(to, 0, ...item);
+      dispatch({ type: 'ITEMS_CHANGED', items: itemsClone, isPaginationEnabled: pagination });
+    },
+    [items, pagination],
+  );
+
   return (
     <Table
       {...rest}
@@ -97,6 +109,7 @@ const InternalStatefulTable = <T extends TableItem>({
       pagination={paginationOptions}
       selectable={selectableOptions}
       sortable={sortableOptions}
+      onRowDrop={dragAndDrop ? onDragEnd : undefined}
     />
   );
 };

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -64,7 +64,8 @@ test('dragAndDrop can be enabled', async () => {
   const spaceKey = { keyCode: 32 };
   const downKey = { keyCode: 40 };
   const name = 'Product A - 1';
-  const { container, getAllByTestId } = render(getSimpleTable({ draggable: true }));
+  const onRowDrop = jest.fn();
+  const { container, getAllByTestId } = render(getSimpleTable({ onRowDrop }));
 
   let dragEls = container.querySelectorAll('[data-rbd-draggable-id]') as NodeListOf<HTMLElement>;
 
@@ -85,6 +86,7 @@ test('dragAndDrop can be enabled', async () => {
 
   // After drag and drop item at index 1 has product name Product A - 1
   expect(names[1].textContent).toBe(name);
+  expect(onRowDrop).toHaveBeenCalled();
 });
 
 test('changing pagination page changes the displayed items', async () => {

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -61,12 +61,30 @@ test('pagination can be enabled', async () => {
 });
 
 test('dragAndDrop can be enabled', async () => {
-  const { container, getByTestId } = render(getSimpleTable({ dragAndDrop: true }));
+  const spaceKey = { keyCode: 32 };
+  const downKey = { keyCode: 40 };
+  const name = 'Product A - 1';
+  const { container, getAllByTestId } = render(getSimpleTable({ draggable: true }));
 
-  const rows = container.querySelectorAll('tbody > tr');
+  let dragEls = container.querySelectorAll('[data-rbd-draggable-id]') as NodeListOf<HTMLElement>;
 
-  expect(rows.length).toBe(25);
-  await waitForElement(() => getByTestId('simple-table'));
+  let names = getAllByTestId('name');
+  // Item at index 0 has product name Product A - 1
+  expect(names[0].textContent).toBe(name);
+
+  dragEls[0].focus();
+  expect(dragEls[0]).toHaveFocus();
+
+  fireEvent.keyDown(dragEls[0], spaceKey);
+  fireEvent.keyDown(dragEls[0], downKey);
+  fireEvent.keyDown(dragEls[0], spaceKey);
+
+  dragEls = container.querySelectorAll('[data-rbd-draggable-id]') as NodeListOf<HTMLElement>;
+
+  names = getAllByTestId('name');
+
+  // After drag and drop item at index 1 has product name Product A - 1
+  expect(names[1].textContent).toBe(name);
 });
 
 test('changing pagination page changes the displayed items', async () => {

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -60,6 +60,15 @@ test('pagination can be enabled', async () => {
   await waitForElement(() => getByTestId('simple-table'));
 });
 
+test('dragAndDrop can be enabled', async () => {
+  const { container, getByTestId } = render(getSimpleTable({ dragAndDrop: true }));
+
+  const rows = container.querySelectorAll('tbody > tr');
+
+  expect(rows.length).toBe(25);
+  await waitForElement(() => getByTestId('simple-table'));
+});
+
 test('changing pagination page changes the displayed items', async () => {
   const { getByTitle, getAllByTestId, getByTestId } = render(getSimpleTable({ pagination: true }));
 

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -20,6 +20,11 @@ const statefulTableProps: Prop[] = [
     required: true,
   },
   {
+    name: 'dragAndDrop',
+    types: 'boolean',
+    description: 'Defines if drag and drop is supported on the table.',
+  },
+  {
     name: 'itemName',
     types: 'string',
     description: 'Item name displayed on the table actions section.',

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -20,11 +20,6 @@ const statefulTableProps: Prop[] = [
     required: true,
   },
   {
-    name: 'draggable',
-    types: 'boolean',
-    description: 'Defines if drag and drop is supported on the table.',
-  },
-  {
     name: 'itemName',
     types: 'string',
     description: 'Item name displayed on the table actions section.',
@@ -78,6 +73,11 @@ const statefulTableProps: Prop[] = [
     name: 'emptyComponent',
     types: 'React.ReactElement',
     description: 'Component to render when there are no items.',
+  },
+  {
+    name: 'onRowDrop',
+    types: '(items: any[]) => void',
+    description: 'Callback called with updated items list once drag and drop action has been completed.',
   },
 ];
 

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -20,7 +20,7 @@ const statefulTableProps: Prop[] = [
     required: true,
   },
   {
-    name: 'dragAndDrop',
+    name: 'draggable',
     types: 'boolean',
     description: 'Defines if drag and drop is supported on the table.',
   },

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -31,6 +31,11 @@ const tableProps: Prop[] = [
     description: 'Unique property identifier for items.',
   },
   {
+    name: 'onRowDrop',
+    types: '(from: number, to: number) => void',
+    description: 'Callback called with form and to index once a row has been dragged and dropped.',
+  },
+  {
     name: 'pagination',
     types: (
       <NextLink href="/Pagination/PaginationPage" as="/pagination">

--- a/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
+++ b/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
@@ -163,6 +163,28 @@ const StatefulTablePage = () => {
         />
         {/* jsx-to-string:end */}
       </CodePreview>
+
+      <H1>Usage with drag and drop</H1>
+
+      <CodePreview>
+        {/* jsx-to-string:start */}
+        <StatefulTable
+          columns={[
+            { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+            { header: 'Name', hash: 'name', render: ({ name }) => name },
+            { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+          ]}
+          items={[
+            { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+            { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+            { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+            { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+            { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+          ]}
+          dragAndDrop
+        />
+        {/* jsx-to-string:end */}
+      </CodePreview>
     </>
   );
 };

--- a/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
+++ b/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
@@ -181,7 +181,7 @@ const StatefulTablePage = () => {
             { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
             { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
           ]}
-          draggable
+          onRowDrop={() => null}
         />
         {/* jsx-to-string:end */}
       </CodePreview>

--- a/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
+++ b/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
@@ -181,7 +181,7 @@ const StatefulTablePage = () => {
             { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
             { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
           ]}
-          dragAndDrop
+          draggable
         />
         {/* jsx-to-string:end */}
       </CodePreview>

--- a/packages/docs/pages/Table/TablePage.tsx
+++ b/packages/docs/pages/Table/TablePage.tsx
@@ -162,9 +162,9 @@ const TablePage = () => {
             <Table
               keyField="sku"
               columns={[
-                { header: 'Sku', hash: 'sku', render: ({ sku }) => sku, isSortable: true },
-                { header: 'Name', hash: 'name', render: ({ name }) => name, isSortable: true },
-                { header: 'Stock', hash: 'stock', render: ({ stock }) => stock, isSortable: true },
+                { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+                { header: 'Name', hash: 'name', render: ({ name }) => name },
+                { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
               ]}
               items={items}
               itemName="Products"
@@ -266,14 +266,12 @@ const TablePage = () => {
 
           return (
             <Table
-              keyField="sku"
               columns={[
                 { header: 'Sku', hash: 'sku', render: ({ sku }) => sku, isSortable: true },
                 { header: 'Name', hash: 'name', render: ({ name }) => name, isSortable: true },
                 { header: 'Stock', hash: 'stock', render: ({ stock }) => stock, isSortable: true },
               ]}
               items={items}
-              itemName="Products"
               onRowDrop={onDragEnd}
             />
           );


### PR DESCRIPTION
## What
Add drag and drop support to `StatefulTable` component.

## Why
[Feature request for Drag and Drop](https://github.com/bigcommerce/big-design/issues/426)

Closes #426.

ping @bigcommerce/frontend @deini @chanceaclark 