### PR TITLE
fix(component): remove tabindex and role from Button

### DIFF
--- a/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
@@ -646,8 +646,6 @@ exports[`renders close button 1`] = `
   >
     <button
       class="c7 c8"
-      role="button"
-      tabindex="0"
     >
       <span
         class="c9"

--- a/packages/big-design/src/components/Button/Button.tsx
+++ b/packages/big-design/src/components/Button/Button.tsx
@@ -37,7 +37,7 @@ const RawButton: React.FC<ButtonProps & PrivateProps> = memo(({ forwardedRef, ..
   };
 
   return (
-    <StyledButton className="bd-button" role="button" tabIndex={0} {...props} onClick={handleClick} ref={forwardedRef}>
+    <StyledButton className="bd-button" {...props} onClick={handleClick} ref={forwardedRef}>
       {props.isLoading ? renderLoadingSpinner() : null}
       <ContentWrapper isLoading={props.isLoading}>
         {!props.iconOnly && props.iconLeft}

--- a/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
@@ -109,8 +109,6 @@ exports[`render default button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -229,8 +227,6 @@ exports[`render destructive button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -350,8 +346,6 @@ exports[`render destructive disabled button 1`] = `
 <button
   class="c0 bd-button"
   disabled=""
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -471,8 +465,6 @@ exports[`render disabled button 1`] = `
 <button
   class="c0 bd-button"
   disabled=""
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -599,8 +591,6 @@ exports[`render icon left and right button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -760,8 +750,6 @@ exports[`render icon left button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -904,8 +892,6 @@ exports[`render icon only button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -1047,8 +1033,6 @@ exports[`render icon right button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -1259,8 +1243,6 @@ exports[`render loading button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <div
     class="c1 c2 c3"
@@ -1400,8 +1382,6 @@ exports[`render secondary button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -1520,8 +1500,6 @@ exports[`render secondary destructive button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -1641,8 +1619,6 @@ exports[`render secondary destructive disabled button 1`] = `
 <button
   class="c0 bd-button"
   disabled=""
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -1762,8 +1738,6 @@ exports[`render secondary disabled button 1`] = `
 <button
   class="c0 bd-button"
   disabled=""
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -1883,8 +1857,6 @@ exports[`render subtle button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -2004,8 +1976,6 @@ exports[`render subtle destructive button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -2126,8 +2096,6 @@ exports[`render subtle destructive disabled button 1`] = `
 <button
   class="c0 bd-button"
   disabled=""
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -2248,8 +2216,6 @@ exports[`render subtle disabled button 1`] = `
 <button
   class="c0 bd-button"
   disabled=""
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"

--- a/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
@@ -171,8 +171,6 @@ exports[`renders with close button if onRemove is present 1`] = `
   <button
     aria-label="Remove Test"
     class="c3 c4"
-    role="button"
-    tabindex="0"
     type="button"
   >
     <span

--- a/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
@@ -645,8 +645,6 @@ exports[`renders actions 1`] = `
     >
       <button
         class="c11 bd-button"
-        role="button"
-        tabindex="0"
       >
         <span
           class="c12"
@@ -656,8 +654,6 @@ exports[`renders actions 1`] = `
       </button>
       <button
         class="c11 bd-button"
-        role="button"
-        tabindex="0"
       >
         <span
           class="c12"
@@ -910,8 +906,6 @@ exports[`renders close button 1`] = `
   >
     <button
       class="c8 c9"
-      role="button"
-      tabindex="0"
     >
       <span
         class="c10"

--- a/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
@@ -640,8 +640,6 @@ exports[`renders actions 1`] = `
     >
       <button
         class="c11 bd-button"
-        role="button"
-        tabindex="0"
       >
         <span
           class="c12"
@@ -651,8 +649,6 @@ exports[`renders actions 1`] = `
       </button>
       <button
         class="c11 bd-button"
-        role="button"
-        tabindex="0"
       >
         <span
           class="c12"
@@ -904,8 +900,6 @@ exports[`renders close button 1`] = `
   >
     <button
       class="c8 c9"
-      role="button"
-      tabindex="0"
     >
       <span
         class="c10"

--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -262,8 +262,6 @@ exports[`render open modal 1`] = `
         >
           <button
             class="c5 c6"
-            role="button"
-            tabindex="0"
           >
             <span
               class="c7"
@@ -557,8 +555,6 @@ exports[`render open modal without backdrop 1`] = `
         >
           <button
             class="c5 c6"
-            role="button"
-            tabindex="0"
           >
             <span
               class="c7"
@@ -709,8 +705,6 @@ exports[`renders destructive action button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"
@@ -829,8 +823,6 @@ exports[`renders secondary action button 1`] = `
 
 <button
   class="c0 bd-button"
-  role="button"
-  tabindex="0"
 >
   <span
     class="c1"

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -306,8 +306,6 @@ exports[`render pagination component 1`] = `
         aria-labelledby="bd-dropdown-1-label bd-dropdown-1-toggle-button"
         class="c4 c5"
         id="bd-dropdown-1-toggle-button"
-        role="button"
-        tabindex="0"
       >
         <span
           class="c6"
@@ -352,8 +350,6 @@ exports[`render pagination component 1`] = `
     <button
       class="c10 c5"
       disabled=""
-      role="button"
-      tabindex="0"
     >
       <span
         class="c6"
@@ -385,8 +381,6 @@ exports[`render pagination component 1`] = `
     </button>
     <button
       class="c10 c5"
-      role="button"
-      tabindex="0"
     >
       <span
         class="c6"
@@ -726,8 +720,6 @@ exports[`render pagination component with invalid page info 1`] = `
         aria-labelledby="bd-dropdown-1-label bd-dropdown-1-toggle-button"
         class="c4 c5"
         id="bd-dropdown-1-toggle-button"
-        role="button"
-        tabindex="0"
       >
         <span
           class="c6"
@@ -772,8 +764,6 @@ exports[`render pagination component with invalid page info 1`] = `
     <button
       class="c10 c5"
       disabled=""
-      role="button"
-      tabindex="0"
     >
       <span
         class="c6"
@@ -805,8 +795,6 @@ exports[`render pagination component with invalid page info 1`] = `
     </button>
     <button
       class="c10 c5"
-      role="button"
-      tabindex="0"
     >
       <span
         class="c6"
@@ -1146,8 +1134,6 @@ exports[`render pagination component with invalid range info 1`] = `
         aria-labelledby="bd-dropdown-1-label bd-dropdown-1-toggle-button"
         class="c4 c5"
         id="bd-dropdown-1-toggle-button"
-        role="button"
-        tabindex="0"
       >
         <span
           class="c6"
@@ -1192,8 +1178,6 @@ exports[`render pagination component with invalid range info 1`] = `
     <button
       class="c10 c5"
       disabled=""
-      role="button"
-      tabindex="0"
     >
       <span
         class="c6"
@@ -1226,8 +1210,6 @@ exports[`render pagination component with invalid range info 1`] = `
     <button
       class="c10 c5"
       disabled=""
-      role="button"
-      tabindex="0"
     >
       <span
         class="c6"
@@ -1567,8 +1549,6 @@ exports[`render pagination component with no items 1`] = `
         aria-labelledby="bd-dropdown-1-label bd-dropdown-1-toggle-button"
         class="c4 c5"
         id="bd-dropdown-1-toggle-button"
-        role="button"
-        tabindex="0"
       >
         <span
           class="c6"
@@ -1613,8 +1593,6 @@ exports[`render pagination component with no items 1`] = `
     <button
       class="c10 c5"
       disabled=""
-      role="button"
-      tabindex="0"
     >
       <span
         class="c6"
@@ -1647,8 +1625,6 @@ exports[`render pagination component with no items 1`] = `
     <button
       class="c10 c5"
       disabled=""
-      role="button"
-      tabindex="0"
     >
       <span
         class="c6"

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -356,8 +356,6 @@ exports[`renders a pagination component 1`] = `
             aria-labelledby="bd-dropdown-2-label bd-dropdown-2-toggle-button"
             class="c7 c8"
             id="bd-dropdown-2-toggle-button"
-            role="button"
-            tabindex="0"
           >
             <span
               class="c9"
@@ -402,8 +400,6 @@ exports[`renders a pagination component 1`] = `
         <button
           class="c13 c8"
           disabled=""
-          role="button"
-          tabindex="0"
         >
           <span
             class="c9"
@@ -435,8 +431,6 @@ exports[`renders a pagination component 1`] = `
         </button>
         <button
           class="c13 c8"
-          role="button"
-          tabindex="0"
         >
           <span
             class="c9"


### PR DESCRIPTION
## What

Removes the `tabIndex` and `role` props from `Button` components.

## Why

`<button>` elements already have a default `tabindex="0"` and `role="button"` applied to them via the user-agent. These are unnecessary and can be omitted.