### PR TITLE
feat(component): add headerId prop to Panel

### DIFF
--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -17,12 +17,13 @@ export interface PanelAction extends Omit<ButtonProps, 'children'> {
 
 export interface PanelProps extends HTMLAttributes<HTMLElement>, MarginProps {
   header?: string;
+  headerId?: string;
   action?: PanelAction;
 }
 
 export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRef, ...props }) => {
   const filteredProps = excludePaddingProps(props);
-  const { action, children, header, ...rest } = filteredProps;
+  const { action, children, header, headerId, ...rest } = filteredProps;
 
   const renderHeader = () => {
     if (!header && !action) {
@@ -35,7 +36,7 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
 
     return (
       <Flex flexDirection="row">
-        {header && <StyledH2>{header}</StyledH2>}
+        {header && <StyledH2 id={headerId}>{header}</StyledH2>}
         {action && <Button {...action}>{action.text}</Button>}
       </Flex>
     );

--- a/packages/big-design/src/components/Panel/spec.tsx
+++ b/packages/big-design/src/components/Panel/spec.tsx
@@ -111,3 +111,13 @@ test("panel action doesn't go to full width", () => {
 
   expect(button).toHaveStyle('width: auto');
 });
+
+test('forwards headerId to heading', () => {
+  const { getByText } = render(
+    <Panel header="Test Header" headerId="test-header">
+      Test
+    </Panel>,
+  );
+
+  expect(getByText('Test Header')).toHaveAttribute('id', 'test-header');
+});

--- a/packages/docs/PropTables/PanelPropTable.tsx
+++ b/packages/docs/PropTables/PanelPropTable.tsx
@@ -9,6 +9,11 @@ const panelProps: Prop[] = [
     description: 'Defines the panel header text.',
   },
   {
+    name: 'headerId',
+    types: 'string',
+    description: 'Gives the header a HTML id attribute. Useful if you need to use hash navigation to a panel header.',
+  },
+  {
     name: 'action',
     types: 'ButtonProps &amp; { text: string }',
     description: 'Defines the panel action button.',


### PR DESCRIPTION
## What

Adds `headerId` as a prop to `Panel` components.

## Why

Gives users the ability to add an `id` attribute to the heading. Useful in situation where you want to use URL hashes to link to `Panel` headings, en lieu of using the `id` on the `Panel` itself.