### PR TITLE
fix(component): prevent autofill overflow on Inputs

### DIFF
--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -55,6 +55,7 @@ exports[`simple form render 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 2.25rem;
+  overflow: hidden;
   position: relative;
   width: 100%;
   border: 1px solid #D9DCE9;

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -24,6 +24,7 @@ exports[`renders all together 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 2.25rem;
+  overflow: hidden;
   position: relative;
   width: 100%;
   border: 1px solid #D9DCE9;

--- a/packages/big-design/src/components/Input/styled.tsx
+++ b/packages/big-design/src/components/Input/styled.tsx
@@ -19,6 +19,7 @@ export const StyledInputWrapper = styled.span<StyledInputWrapperProps>`
   box-sizing: border-box;
   display: flex;
   min-height: ${({ theme }) => addValues(theme.spacing.xxLarge, theme.spacing.xxSmall)};
+  overflow: hidden;
   position: relative;
   width: 100%;
 


### PR DESCRIPTION
Fixes #386.

<img width="509" alt="Screen Shot 2021-01-29 at 10 21 40 AM" src="https://user-images.githubusercontent.com/196129/106300261-e32dca00-621b-11eb-9ae0-c9f36a319c3f.png">
