### PR TITLE
fix(component): set fixed position for dropdown in pagination

### DIFF
--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -87,6 +87,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
               hash: `${range}`,
               onItemClick: handleRangeChange,
             }))}
+            positionFixed={true}
             toggle={
               <StyledButton variant="subtle" iconRight={<ArrowDropDownIcon size="xxLarge" />}>
                 {showRanges()}

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -332,7 +332,7 @@ exports[`render pagination component 1`] = `
       </button>
       <div
         class="c8"
-        style="position: absolute; left: 0px; top: 0px;"
+        style="position: fixed; left: 0px; top: 0px;"
       >
         <ul
           aria-labelledby="bd-dropdown-1-label"
@@ -746,7 +746,7 @@ exports[`render pagination component with invalid page info 1`] = `
       </button>
       <div
         class="c8"
-        style="position: absolute; left: 0px; top: 0px;"
+        style="position: fixed; left: 0px; top: 0px;"
       >
         <ul
           aria-labelledby="bd-dropdown-1-label"
@@ -1160,7 +1160,7 @@ exports[`render pagination component with invalid range info 1`] = `
       </button>
       <div
         class="c8"
-        style="position: absolute; left: 0px; top: 0px;"
+        style="position: fixed; left: 0px; top: 0px;"
       >
         <ul
           aria-labelledby="bd-dropdown-1-label"
@@ -1575,7 +1575,7 @@ exports[`render pagination component with no items 1`] = `
       </button>
       <div
         class="c8"
-        style="position: absolute; left: 0px; top: 0px;"
+        style="position: fixed; left: 0px; top: 0px;"
       >
         <ul
           aria-labelledby="bd-dropdown-1-label"

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -382,7 +382,7 @@ exports[`renders a pagination component 1`] = `
           </button>
           <div
             class="c11"
-            style="position: absolute; left: 0px; top: 0px;"
+            style="position: fixed; left: 0px; top: 0px;"
           >
             <ul
               aria-labelledby="bd-dropdown-2-label"


### PR DESCRIPTION
Sets dropdown on the `Pagination` component to fixed position.

Fixes #401 

## Proof

Wrapped a `StatefulTable` in a `TableFigure` component for quick testing.

<img width="618" alt="Screen Shot 2021-02-17 at 10 35 22 AM" src="https://user-images.githubusercontent.com/196129/108242261-54251b00-7112-11eb-8074-07ba5510f938.png">

