### PR TITLE
fix: hide arrow if Node children is an empty array

### DIFF
--- a/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
@@ -133,7 +133,7 @@ const InternalTreeNode = <T extends unknown>({
 
   const renderedChildren = useMemo(
     () =>
-      children && (
+      children?.length && (
         <StyledUl role="group" show={isExpanded}>
           {children?.map((child, index) => (
             <TreeNode {...child} key={index} />

--- a/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
@@ -121,7 +121,7 @@ const InternalTreeNode = <T extends unknown>({
 
   const renderedArrow = useMemo(
     () =>
-      children ? (
+      children?.length ? (
         <StyledArrowWrapper expanded={isExpanded} flexShrink={0}>
           <ChevronRightIcon color="secondary60" focusable={false} size="xLarge" />
         </StyledArrowWrapper>


### PR DESCRIPTION
## What
Don't show arrow if `TreeNode` children prop is an empty array

## Why
Now TreeNode with an empty array as children is displayed with an arrow, and when node is "expanded" no sub-nodes are displayed and it may seem like a bug

First Node has an empty array as a children prop, second has no children prop, third has a child
![image](https://user-images.githubusercontent.com/7959201/110106180-05ce7800-7db2-11eb-80cd-9f6f9fdc92cb.png)



## Proof
Same Nodes with my proposed changes
![image](https://user-images.githubusercontent.com/7959201/110106411-55ad3f00-7db2-11eb-9ace-6b0596d91b0a.png)

