### PR TITLE
feat(component): add Pill Tabs component

### DIFF
--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -92,7 +92,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
         data-testid="pilltabs-dropdown-toggle"
         isVisible={isMenuVisible}
         ref={dropdownRef}
-        role="dropdown"
+        role="listitem"
       >
         <Dropdown items={dropdownItems} toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />} />
       </StyledFlexItem>

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -4,7 +4,7 @@ import React, { createRef, useCallback, useEffect, useMemo, useState } from 'rea
 import { useWindowResizeListener } from '../../hooks';
 import { Button } from '../Button';
 import { Dropdown } from '../Dropdown';
-import { Flex, FlexItem } from '../Flex';
+import { Flex } from '../Flex';
 
 import { StyledFlexItem, StyledPillTab } from './styled';
 
@@ -17,6 +17,8 @@ export interface PillTabItem {
 interface PillTabsProps {
   items: PillTabItem[];
 }
+
+const DROPDOWN_MENU_WIDTH = 42;
 
 export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
   const parentRef = createRef<HTMLDivElement>();
@@ -44,7 +46,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
         return stateObj;
       }
 
-      if (remainingWidth - pillWidth > 42) {
+      if (remainingWidth - pillWidth > DROPDOWN_MENU_WIDTH) {
         remainingWidth = remainingWidth - pillWidth;
 
         return {
@@ -86,13 +88,11 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
       }));
 
     return (
-      <FlexItem alignSelf="flex-end">
-        <Dropdown items={dropdownItems} toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />} />
-      </FlexItem>
+      <Dropdown items={dropdownItems} toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />} />
     );
   }, [pillsState]);
 
-  const renderPills = useMemo(
+  const renderedPills = useMemo(
     () =>
       items.map((item, index) => (
         <StyledFlexItem key={index} ref={pillsState[index].ref} isVisible={pillsState[index].isVisible}>
@@ -106,14 +106,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
 
   return (
     <Flex flexDirection="row" flexWrap="nowrap" ref={parentRef}>
-      {items.map((item, index) => (
-        <StyledFlexItem key={index} ref={pillsState[index].ref} isVisible={pillsState[index].isVisible}>
-          <StyledPillTab onClick={() => item.onClick(item)} variant="subtle" isActive={item.isActive}>
-            {item.text}
-          </StyledPillTab>
-        </StyledFlexItem>
-      ))}
-      {renderPills}
+      {renderedPills}
       {isMenuVisible ? renderDropdown() : null}
     </Flex>
   );

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -1,14 +1,14 @@
 import { MoreHorizIcon } from '@bigcommerce/big-design-icons';
-import React, { createRef, useCallback, useEffect, useState } from 'react';
+import React, { createRef, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useWindowResizeListener } from '../../hooks';
 import { Button } from '../Button';
 import { Dropdown } from '../Dropdown';
-import { Flex } from '../Flex';
+import { Flex, FlexItem } from '../Flex';
 
 import { StyledFlexItem, StyledPillTab } from './styled';
 
-interface PillTabItem {
+export interface PillTabItem {
   text: string;
   isActive: boolean;
   onClick(item: PillTabItem): void;
@@ -36,19 +36,16 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
     }
 
     let remainingWidth = parentWidth;
-    console.log('----- REMAINING: ', remainingWidth);
 
     const newState = pillsState.map((stateObj) => {
       const pillWidth = stateObj.ref.current?.offsetWidth;
 
-      console.log('pillWidth', pillWidth);
       if (!pillWidth) {
         return stateObj;
       }
 
-      if (remainingWidth - pillWidth > 48) {
+      if (remainingWidth - pillWidth > 42) {
         remainingWidth = remainingWidth - pillWidth;
-        console.log('Remaining width: ', remainingWidth);
 
         return {
           ...stateObj,
@@ -89,9 +86,23 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
       }));
 
     return (
-      <Dropdown items={dropdownItems} toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />} />
+      <FlexItem alignSelf="flex-end">
+        <Dropdown items={dropdownItems} toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />} />
+      </FlexItem>
     );
   }, [pillsState]);
+
+  const renderPills = useMemo(
+    () =>
+      items.map((item, index) => (
+        <StyledFlexItem key={index} ref={pillsState[index].ref} isVisible={pillsState[index].isVisible}>
+          <StyledPillTab onClick={() => item.onClick(item)} variant="subtle" isActive={item.isActive}>
+            {item.text}
+          </StyledPillTab>
+        </StyledFlexItem>
+      )),
+    [items, pillsState],
+  );
 
   return (
     <Flex flexDirection="row" flexWrap="nowrap" ref={parentRef}>
@@ -102,6 +113,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
           </StyledPillTab>
         </StyledFlexItem>
       ))}
+      {renderPills}
       {isMenuVisible ? renderDropdown() : null}
     </Flex>
   );

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -31,7 +31,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     })),
   );
 
-  const hideOverflownPills = useCallback(() => {
+  const hideOverflowedPills = useCallback(() => {
     const parentWidth = parentRef.current?.offsetWidth;
     const dropdownWidth = dropdownRef.current?.offsetWidth;
 
@@ -119,11 +119,11 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
   );
 
   useEffect(() => {
-    hideOverflownPills();
-  }, [items, parentRef, pillsState, hideOverflownPills]);
+    hideOverflowedPills();
+  }, [items, parentRef, pillsState, hideOverflowedPills]);
 
   useWindowResizeListener(() => {
-    hideOverflownPills();
+    hideOverflowedPills();
   });
 
   return items.length > 0 ? (

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -22,6 +22,7 @@ export interface PillTabsProps {
 export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillClick }) => {
   const parentRef = createRef<HTMLDivElement>();
   const dropdownRef = createRef<HTMLDivElement>();
+  const [isMenuVisible, setIsMenuVisible] = useState(false);
   const [pillsState, setPillsState] = useState(
     items.map((item) => ({
       isVisible: true,
@@ -29,7 +30,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       ref: createRef<HTMLDivElement>(),
     })),
   );
-  const [isMenuVisible, setIsMenuVisible] = useState(false);
+
   const hideOverflownPills = useCallback(() => {
     const parentWidth = parentRef.current?.offsetWidth;
     const dropdownWidth = dropdownRef.current?.offsetWidth;
@@ -71,19 +72,11 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     }
   }, [items, parentRef, dropdownRef, pillsState]);
 
-  useEffect(() => {
-    hideOverflownPills();
-  }, [items, parentRef, pillsState, hideOverflownPills]);
-
-  useWindowResizeListener(() => {
-    hideOverflownPills();
-  });
-
-  const renderDropdown = useCallback(() => {
+  const renderedDropdown = useMemo(() => {
     const dropdownItems = pillsState
       .filter((stateObj) => !stateObj.isVisible)
       .map((stateObj) => {
-        const item = items.find((i) => i.title === stateObj.item.title);
+        const item = items.find(({ title }) => title === stateObj.item.title);
         const isActive = item ? activePills.includes(item.id) : false;
 
         return {
@@ -109,12 +102,14 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
           key={index}
           ref={pillsState[index].ref}
           isVisible={pillsState[index].isVisible}
+          role="listitem"
         >
           <StyledPillTab
             disabled={!pillsState[index].isVisible}
             variant="subtle"
             isActive={activePills.includes(item.id)}
             onClick={() => onPillClick(item.id)}
+            marginRight="xLarge"
           >
             {item.title}
           </StyledPillTab>
@@ -123,12 +118,20 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     [items, pillsState, activePills, onPillClick],
   );
 
-  return (
-    <Flex data-testid="pilltabs-wrapper" flexDirection="row" flexWrap="nowrap" ref={parentRef}>
+  useEffect(() => {
+    hideOverflownPills();
+  }, [items, parentRef, pillsState, hideOverflownPills]);
+
+  useWindowResizeListener(() => {
+    hideOverflownPills();
+  });
+
+  return items.length > 0 ? (
+    <Flex data-testid="pilltabs-wrapper" flexDirection="row" flexWrap="nowrap" ref={parentRef} role="list">
       {renderedPills}
-      {renderDropdown()}
+      {renderedDropdown}
     </Flex>
-  );
+  ) : null;
 };
 
 PillTabs.displayName = 'Pill Tabs';

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -9,16 +9,17 @@ import { Flex } from '../Flex';
 import { StyledFlexItem, StyledPillTab } from './styled';
 
 export interface PillTabItem {
-  text: string;
-  isActive: boolean;
-  onClick(item: PillTabItem): void;
+  id: string;
+  title: string;
 }
 
 export interface PillTabsProps {
   items: PillTabItem[];
+  activePills: string[];
+  onPillClick: (item: PillTabItem) => void;
 }
 
-export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
+export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillClick }) => {
   const parentRef = createRef<HTMLDivElement>();
   const dropdownRef = createRef<HTMLDivElement>();
   const [pillsState, setPillsState] = useState(
@@ -82,13 +83,14 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
     const dropdownItems = pillsState
       .filter((stateObj) => !stateObj.isVisible)
       .map((stateObj) => {
-        const item = items.find((i) => i.text === stateObj.item.text);
+        const item = items.find((i) => i.title === stateObj.item.title);
+        const isActive = item ? activePills.includes(item.id) : false;
 
         return {
-          content: stateObj.item.text,
-          onItemClick: () => stateObj.item.onClick(stateObj.item),
-          hash: stateObj.item.text.toLowerCase(),
-          icon: item?.isActive ? <CheckIcon /> : undefined,
+          content: stateObj.item.title,
+          onItemClick: () => onPillClick(stateObj.item),
+          hash: stateObj.item.title.toLowerCase(),
+          icon: isActive ? <CheckIcon /> : undefined,
         };
       });
 
@@ -97,7 +99,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
         <Dropdown items={dropdownItems} toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />} />
       </StyledFlexItem>
     );
-  }, [items, pillsState, isMenuVisible, dropdownRef]);
+  }, [items, pillsState, isMenuVisible, dropdownRef, activePills, onPillClick]);
 
   const renderedPills = useMemo(
     () =>
@@ -110,15 +112,15 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
         >
           <StyledPillTab
             disabled={!pillsState[index].isVisible}
-            onClick={() => item.onClick(item)}
             variant="subtle"
-            isActive={item.isActive}
+            isActive={activePills.includes(item.id)}
+            onClick={() => onPillClick(item)}
           >
-            {item.text}
+            {item.title}
           </StyledPillTab>
         </StyledFlexItem>
       )),
-    [items, pillsState],
+    [items, pillsState, activePills, onPillClick],
   );
 
   return (

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -18,10 +18,11 @@ export interface PillTabsProps {
   items: PillTabItem[];
 }
 
-const DROPDOWN_MENU_WIDTH = 42;
+// const DROPDOWN_MENU_WIDTH = 42;
 
 export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
   const parentRef = createRef<HTMLDivElement>();
+  const dropdownRef = createRef<HTMLDivElement>();
   const [pillsState, setPillsState] = useState(
     items.map((item) => ({
       isVisible: true,
@@ -32,8 +33,9 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
   const [isMenuVisible, setIsMenuVisible] = useState(false);
   const hideOverflownPills = useCallback(() => {
     const parentWidth = parentRef.current?.offsetWidth;
+    const dropdownWidth = dropdownRef.current?.offsetWidth;
 
-    if (!parentWidth) {
+    if (!parentWidth || !dropdownWidth) {
       return;
     }
 
@@ -46,7 +48,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
         return stateObj;
       }
 
-      if (remainingWidth - pillWidth > DROPDOWN_MENU_WIDTH) {
+      if (remainingWidth - pillWidth > dropdownWidth) {
         remainingWidth = remainingWidth - pillWidth;
 
         return {
@@ -68,7 +70,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
       setIsMenuVisible(newVisiblePills.length !== items.length);
       setPillsState(newState);
     }
-  }, [items, parentRef, pillsState]);
+  }, [items, parentRef, dropdownRef, pillsState]);
 
   useEffect(() => {
     hideOverflownPills();
@@ -93,14 +95,11 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
       });
 
     return (
-      <Dropdown
-        items={dropdownItems}
-        toggle={
-          <Button data-testid="pilltabs-dropdown-toggle" iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />
-        }
-      />
+      <StyledFlexItem data-testid="pilltabs-dropdown-toggle" isVisible={isMenuVisible} ref={dropdownRef}>
+        <Dropdown items={dropdownItems} toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />} />
+      </StyledFlexItem>
     );
-  }, [items, pillsState]);
+  }, [items, pillsState, isMenuVisible, dropdownRef]);
 
   const renderedPills = useMemo(
     () =>
@@ -127,7 +126,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
   return (
     <Flex data-testid="pilltabs-wrapper" flexDirection="row" flexWrap="nowrap" ref={parentRef}>
       {renderedPills}
-      {isMenuVisible ? renderDropdown() : null}
+      {renderDropdown()}
     </Flex>
   );
 };

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -16,7 +16,7 @@ export interface PillTabItem {
 export interface PillTabsProps {
   items: PillTabItem[];
   activePills: string[];
-  onPillClick: (item: PillTabItem) => void;
+  onPillClick: (itemId: string) => void;
 }
 
 export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillClick }) => {
@@ -88,7 +88,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
 
         return {
           content: stateObj.item.title,
-          onItemClick: () => onPillClick(stateObj.item),
+          onItemClick: () => onPillClick(stateObj.item.id),
           hash: stateObj.item.title.toLowerCase(),
           icon: isActive ? <CheckIcon /> : undefined,
         };
@@ -114,7 +114,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
             disabled={!pillsState[index].isVisible}
             variant="subtle"
             isActive={activePills.includes(item.id)}
-            onClick={() => onPillClick(item)}
+            onClick={() => onPillClick(item.id)}
           >
             {item.title}
           </StyledPillTab>

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -1,0 +1,110 @@
+import { MoreHorizIcon } from '@bigcommerce/big-design-icons';
+import React, { createRef, useCallback, useEffect, useState } from 'react';
+
+import { useWindowResizeListener } from '../../hooks';
+import { Button } from '../Button';
+import { Dropdown } from '../Dropdown';
+import { Flex } from '../Flex';
+
+import { StyledFlexItem, StyledPillTab } from './styled';
+
+interface PillTabItem {
+  text: string;
+  isActive: boolean;
+  onClick(item: PillTabItem): void;
+}
+
+interface PillTabsProps {
+  items: PillTabItem[];
+}
+
+export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
+  const parentRef = createRef<HTMLDivElement>();
+  const [pillsState, setPillsState] = useState(
+    items.map((item) => ({
+      isVisible: true,
+      item,
+      ref: createRef<HTMLDivElement>(),
+    })),
+  );
+  const [isMenuVisible, setIsMenuVisible] = useState(false);
+  const hideOverflownPills = useCallback(() => {
+    const parentWidth = parentRef.current?.offsetWidth;
+
+    if (!parentWidth) {
+      return;
+    }
+
+    let remainingWidth = parentWidth;
+    console.log('----- REMAINING: ', remainingWidth);
+
+    const newState = pillsState.map((stateObj) => {
+      const pillWidth = stateObj.ref.current?.offsetWidth;
+
+      console.log('pillWidth', pillWidth);
+      if (!pillWidth) {
+        return stateObj;
+      }
+
+      if (remainingWidth - pillWidth > 48) {
+        remainingWidth = remainingWidth - pillWidth;
+        console.log('Remaining width: ', remainingWidth);
+
+        return {
+          ...stateObj,
+          isVisible: true,
+        };
+      }
+
+      return {
+        ...stateObj,
+        isVisible: false,
+      };
+    });
+
+    const visiblePills = pillsState.filter((stateObj) => stateObj.isVisible);
+    const newVisiblePills = newState.filter((stateObj) => stateObj.isVisible);
+
+    if (visiblePills.length !== newVisiblePills.length) {
+      setIsMenuVisible(newVisiblePills.length !== items.length);
+      setPillsState(newState);
+    }
+  }, [items, parentRef, pillsState]);
+
+  useEffect(() => {
+    hideOverflownPills();
+  }, [items, parentRef, pillsState, hideOverflownPills]);
+
+  useWindowResizeListener(() => {
+    hideOverflownPills();
+  });
+
+  const renderDropdown = useCallback(() => {
+    const dropdownItems = pillsState
+      .filter((stateObj) => !stateObj.isVisible)
+      .map((stateObj) => ({
+        content: stateObj.item.text,
+        onItemClick: () => stateObj.item.onClick(stateObj.item),
+        hash: stateObj.item.text.toLowerCase(),
+      }));
+
+    return (
+      <Dropdown items={dropdownItems} toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />} />
+    );
+  }, [pillsState]);
+
+  return (
+    <Flex flexDirection="row" flexWrap="nowrap" ref={parentRef}>
+      {items.map((item, index) => (
+        <StyledFlexItem key={index} ref={pillsState[index].ref} isVisible={pillsState[index].isVisible}>
+          <StyledPillTab onClick={() => item.onClick(item)} variant="subtle" isActive={item.isActive}>
+            {item.text}
+          </StyledPillTab>
+        </StyledFlexItem>
+      ))}
+      {isMenuVisible ? renderDropdown() : null}
+    </Flex>
+  );
+};
+
+PillTabs.displayName = 'Pill Tabs';

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -88,7 +88,12 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       });
 
     return (
-      <StyledFlexItem data-testid="pilltabs-dropdown-toggle" isVisible={isMenuVisible} ref={dropdownRef}>
+      <StyledFlexItem
+        data-testid="pilltabs-dropdown-toggle"
+        isVisible={isMenuVisible}
+        ref={dropdownRef}
+        role="dropdown"
+      >
         <Dropdown items={dropdownItems} toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />} />
       </StyledFlexItem>
     );

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -1,4 +1,4 @@
-import { MoreHorizIcon } from '@bigcommerce/big-design-icons';
+import { CheckIcon, MoreHorizIcon } from '@bigcommerce/big-design-icons';
 import React, { createRef, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useWindowResizeListener } from '../../hooks';
@@ -14,7 +14,7 @@ export interface PillTabItem {
   onClick(item: PillTabItem): void;
 }
 
-interface PillTabsProps {
+export interface PillTabsProps {
   items: PillTabItem[];
 }
 
@@ -81,22 +81,42 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
   const renderDropdown = useCallback(() => {
     const dropdownItems = pillsState
       .filter((stateObj) => !stateObj.isVisible)
-      .map((stateObj) => ({
-        content: stateObj.item.text,
-        onItemClick: () => stateObj.item.onClick(stateObj.item),
-        hash: stateObj.item.text.toLowerCase(),
-      }));
+      .map((stateObj) => {
+        const item = items.find((i) => i.text === stateObj.item.text);
+
+        return {
+          content: stateObj.item.text,
+          onItemClick: () => stateObj.item.onClick(stateObj.item),
+          hash: stateObj.item.text.toLowerCase(),
+          icon: item?.isActive ? <CheckIcon /> : undefined,
+        };
+      });
 
     return (
-      <Dropdown items={dropdownItems} toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />} />
+      <Dropdown
+        items={dropdownItems}
+        toggle={
+          <Button data-testid="pilltabs-dropdown-toggle" iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />
+        }
+      />
     );
-  }, [pillsState]);
+  }, [items, pillsState]);
 
   const renderedPills = useMemo(
     () =>
       items.map((item, index) => (
-        <StyledFlexItem key={index} ref={pillsState[index].ref} isVisible={pillsState[index].isVisible}>
-          <StyledPillTab onClick={() => item.onClick(item)} variant="subtle" isActive={item.isActive}>
+        <StyledFlexItem
+          data-testid={`pilltabs-pill-${index}`}
+          key={index}
+          ref={pillsState[index].ref}
+          isVisible={pillsState[index].isVisible}
+        >
+          <StyledPillTab
+            disabled={!pillsState[index].isVisible}
+            onClick={() => item.onClick(item)}
+            variant="subtle"
+            isActive={item.isActive}
+          >
             {item.text}
           </StyledPillTab>
         </StyledFlexItem>
@@ -105,7 +125,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
   );
 
   return (
-    <Flex flexDirection="row" flexWrap="nowrap" ref={parentRef}>
+    <Flex data-testid="pilltabs-wrapper" flexDirection="row" flexWrap="nowrap" ref={parentRef}>
       {renderedPills}
       {isMenuVisible ? renderDropdown() : null}
     </Flex>

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -18,8 +18,6 @@ export interface PillTabsProps {
   items: PillTabItem[];
 }
 
-// const DROPDOWN_MENU_WIDTH = 42;
-
 export const PillTabs: React.FC<PillTabsProps> = ({ items }) => {
   const parentRef = createRef<HTMLDivElement>();
   const dropdownRef = createRef<HTMLDivElement>();

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -319,6 +319,7 @@ exports[`dropdown is not visible if items fit 1`] = `
       <div
         class="c1 c3 c6"
         data-testid="pilltabs-dropdown-toggle"
+        role="dropdown"
       >
         <div
           class="c1 c7"
@@ -696,6 +697,7 @@ exports[`it renders the given tabs 1`] = `
       <div
         class="c1 c3 c6"
         data-testid="pilltabs-dropdown-toggle"
+        role="dropdown"
       >
         <div
           class="c1 c7"
@@ -1105,6 +1107,7 @@ exports[`only the pills that fit are visible 1`] = `
       <div
         class="c1 c3 "
         data-testid="pilltabs-dropdown-toggle"
+        role="dropdown"
       >
         <div
           class="c1 c7"
@@ -1513,6 +1516,7 @@ exports[`only the pills that fit are visible 2 1`] = `
       <div
         class="c1 c3 "
         data-testid="pilltabs-dropdown-toggle"
+        role="dropdown"
       >
         <div
           class="c1 c7"
@@ -1920,6 +1924,7 @@ exports[`renders all the filters if they fit 1`] = `
       <div
         class="c1 c3 c6"
         data-testid="pilltabs-dropdown-toggle"
+        role="dropdown"
       >
         <div
           class="c1 c7"
@@ -2314,6 +2319,7 @@ exports[`renders dropdown if items do not fit 1`] = `
       <div
         class="c1 c3 "
         data-testid="pilltabs-dropdown-toggle"
+        role="dropdown"
       >
         <div
           class="c1 c7"

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -1,0 +1,2373 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dropdown is not visible if items fit 1`] = `
+.c9 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  box-sizing: border-box;
+  z-index: 1060;
+}
+
+.c2 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.c4 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c4.c4 {
+  margin-right: 1.5rem;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c4 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c4:active {
+  background-color: #DBE3FE;
+}
+
+.c4:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c4:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c4[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c8 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  padding: 0 0.5rem;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c8 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c8:active {
+  background-color: #DBE3FE;
+}
+
+.c8:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c8:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c8[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c5 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+  visibility: visible;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
+.c7 {
+  position: relative;
+}
+
+.c6 {
+  position: absolute;
+  visibility: hidden;
+  z-index: -1070;
+}
+
+.c0 {
+  width: 200px;
+}
+
+@media (min-width:720px) {
+  .c4 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c4 {
+    width: auto;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 {
+    width: auto;
+  }
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="wrapper"
+  >
+    <div
+      class="c1 c2"
+      data-testid="pilltabs-wrapper"
+      role="list"
+    >
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-pill-0"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+        >
+          <span
+            class="c5"
+          >
+            In stock
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 c6"
+        data-testid="pilltabs-dropdown-toggle"
+      >
+        <div
+          class="c1 c7"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="bd-dropdown-3-label bd-dropdown-3-toggle-button"
+            class="c8 bd-button"
+            id="bd-dropdown-3-toggle-button"
+          >
+            <span
+              class="c5"
+            >
+              <svg
+                aria-labelledby="bd-icon-4"
+                class="c9"
+                fill="currentColor"
+                height="24"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <title
+                  id="bd-icon-4"
+                >
+                  add
+                </title>
+                <path
+                  d="M0 0h24v24H0V0z"
+                  fill="none"
+                />
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="c10"
+            style="position: absolute; left: 0px; top: 0px;"
+          >
+            <ul
+              aria-labelledby="bd-dropdown-3-label"
+              class="c11"
+              id="bd-dropdown-3-menu"
+              role="listbox"
+              tabindex="-1"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`it renders the given tabs 1`] = `
+.c9 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  box-sizing: border-box;
+  z-index: 1060;
+}
+
+.c2 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.c4 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c4.c4 {
+  margin-right: 1.5rem;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c4 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c4:active {
+  background-color: #DBE3FE;
+}
+
+.c4:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c4:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c4[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c8 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  padding: 0 0.5rem;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c8 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c8:active {
+  background-color: #DBE3FE;
+}
+
+.c8:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c8:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c8[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c5 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+  visibility: visible;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
+.c7 {
+  position: relative;
+}
+
+.c6 {
+  position: absolute;
+  visibility: hidden;
+  z-index: -1070;
+}
+
+.c0 {
+  width: 200px;
+}
+
+@media (min-width:720px) {
+  .c4 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c4 {
+    width: auto;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 {
+    width: auto;
+  }
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="wrapper"
+  >
+    <div
+      class="c1 c2"
+      data-testid="pilltabs-wrapper"
+      role="list"
+    >
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-pill-0"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+        >
+          <span
+            class="c5"
+          >
+            In stock
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 c6"
+        data-testid="pilltabs-dropdown-toggle"
+      >
+        <div
+          class="c1 c7"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="bd-dropdown-1-label bd-dropdown-1-toggle-button"
+            class="c8 bd-button"
+            id="bd-dropdown-1-toggle-button"
+          >
+            <span
+              class="c5"
+            >
+              <svg
+                aria-labelledby="bd-icon-2"
+                class="c9"
+                fill="currentColor"
+                height="24"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <title
+                  id="bd-icon-2"
+                >
+                  add
+                </title>
+                <path
+                  d="M0 0h24v24H0V0z"
+                  fill="none"
+                />
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="c10"
+            style="position: absolute; left: 0px; top: 0px;"
+          >
+            <ul
+              aria-labelledby="bd-dropdown-1-label"
+              class="c11"
+              id="bd-dropdown-1-menu"
+              role="listbox"
+              tabindex="-1"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`only the pills that fit are visible 1`] = `
+.c9 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  box-sizing: border-box;
+  z-index: 1060;
+}
+
+.c2 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.c4 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c4.c4 {
+  margin-right: 1.5rem;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c4 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c4:active {
+  background-color: #DBE3FE;
+}
+
+.c4:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c4:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c4[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c8 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  padding: 0 0.5rem;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c8 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c8:active {
+  background-color: #DBE3FE;
+}
+
+.c8:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c8:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c8[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c5 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+  visibility: visible;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
+.c7 {
+  position: relative;
+}
+
+.c6 {
+  position: absolute;
+  visibility: hidden;
+  z-index: -1070;
+}
+
+.c0 {
+  width: 200px;
+}
+
+@media (min-width:720px) {
+  .c4 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c4 {
+    width: auto;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 {
+    width: auto;
+  }
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="wrapper"
+  >
+    <div
+      class="c1 c2"
+      data-testid="pilltabs-wrapper"
+      role="list"
+    >
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-pill-0"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+        >
+          <span
+            class="c5"
+          >
+            In stock
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 c6"
+        data-testid="pilltabs-pill-1"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+          disabled=""
+        >
+          <span
+            class="c5"
+          >
+            Filter 2
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 c6"
+        data-testid="pilltabs-pill-2"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+          disabled=""
+        >
+          <span
+            class="c5"
+          >
+            Filter 3
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-dropdown-toggle"
+      >
+        <div
+          class="c1 c7"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="bd-dropdown-11-label bd-dropdown-11-toggle-button"
+            class="c8 bd-button"
+            id="bd-dropdown-11-toggle-button"
+          >
+            <span
+              class="c5"
+            >
+              <svg
+                aria-labelledby="bd-icon-12"
+                class="c9"
+                fill="currentColor"
+                height="24"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <title
+                  id="bd-icon-12"
+                >
+                  add
+                </title>
+                <path
+                  d="M0 0h24v24H0V0z"
+                  fill="none"
+                />
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="c10"
+            style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
+          >
+            <ul
+              aria-labelledby="bd-dropdown-11-label"
+              class="c11"
+              id="bd-dropdown-11-menu"
+              role="listbox"
+              tabindex="-1"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`only the pills that fit are visible 2 1`] = `
+.c9 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  box-sizing: border-box;
+  z-index: 1060;
+}
+
+.c2 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.c4 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c4.c4 {
+  margin-right: 1.5rem;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c4 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c4:active {
+  background-color: #DBE3FE;
+}
+
+.c4:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c4:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c4[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c8 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  padding: 0 0.5rem;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c8 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c8:active {
+  background-color: #DBE3FE;
+}
+
+.c8:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c8:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c8[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c5 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+  visibility: visible;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
+.c7 {
+  position: relative;
+}
+
+.c6 {
+  position: absolute;
+  visibility: hidden;
+  z-index: -1070;
+}
+
+.c0 {
+  width: 200px;
+}
+
+@media (min-width:720px) {
+  .c4 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c4 {
+    width: auto;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 {
+    width: auto;
+  }
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="wrapper"
+  >
+    <div
+      class="c1 c2"
+      data-testid="pilltabs-wrapper"
+      role="list"
+    >
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-pill-0"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+        >
+          <span
+            class="c5"
+          >
+            In stock
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-pill-1"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+        >
+          <span
+            class="c5"
+          >
+            Filter 2
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 c6"
+        data-testid="pilltabs-pill-2"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+          disabled=""
+        >
+          <span
+            class="c5"
+          >
+            Filter 3
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-dropdown-toggle"
+      >
+        <div
+          class="c1 c7"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="bd-dropdown-15-label bd-dropdown-15-toggle-button"
+            class="c8 bd-button"
+            id="bd-dropdown-15-toggle-button"
+          >
+            <span
+              class="c5"
+            >
+              <svg
+                aria-labelledby="bd-icon-16"
+                class="c9"
+                fill="currentColor"
+                height="24"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <title
+                  id="bd-icon-16"
+                >
+                  add
+                </title>
+                <path
+                  d="M0 0h24v24H0V0z"
+                  fill="none"
+                />
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="c10"
+            style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
+          >
+            <ul
+              aria-labelledby="bd-dropdown-15-label"
+              class="c11"
+              id="bd-dropdown-15-menu"
+              role="listbox"
+              tabindex="-1"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders all the filters if they fit 1`] = `
+.c9 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  box-sizing: border-box;
+  z-index: 1060;
+}
+
+.c2 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.c4 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c4.c4 {
+  margin-right: 1.5rem;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c4 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c4:active {
+  background-color: #DBE3FE;
+}
+
+.c4:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c4:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c4[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c8 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  padding: 0 0.5rem;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c8 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c8:active {
+  background-color: #DBE3FE;
+}
+
+.c8:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c8:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c8[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c5 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+  visibility: visible;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
+.c7 {
+  position: relative;
+}
+
+.c6 {
+  position: absolute;
+  visibility: hidden;
+  z-index: -1070;
+}
+
+.c0 {
+  width: 200px;
+}
+
+@media (min-width:720px) {
+  .c4 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c4 {
+    width: auto;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 {
+    width: auto;
+  }
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="wrapper"
+  >
+    <div
+      class="c1 c2"
+      data-testid="pilltabs-wrapper"
+      role="list"
+    >
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-pill-0"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+        >
+          <span
+            class="c5"
+          >
+            In stock
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-pill-1"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+        >
+          <span
+            class="c5"
+          >
+            Filter 2
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-pill-2"
+        role="listitem"
+      >
+        <button
+          class="c4 "
+        >
+          <span
+            class="c5"
+          >
+            Filter 3
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 c6"
+        data-testid="pilltabs-dropdown-toggle"
+      >
+        <div
+          class="c1 c7"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="bd-dropdown-9-label bd-dropdown-9-toggle-button"
+            class="c8 bd-button"
+            id="bd-dropdown-9-toggle-button"
+          >
+            <span
+              class="c5"
+            >
+              <svg
+                aria-labelledby="bd-icon-10"
+                class="c9"
+                fill="currentColor"
+                height="24"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <title
+                  id="bd-icon-10"
+                >
+                  add
+                </title>
+                <path
+                  d="M0 0h24v24H0V0z"
+                  fill="none"
+                />
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="c10"
+            style="position: absolute; left: 0px; top: 0px;"
+          >
+            <ul
+              aria-labelledby="bd-dropdown-9-label"
+              class="c11"
+              id="bd-dropdown-9-menu"
+              role="listbox"
+              tabindex="-1"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders dropdown if items do not fit 1`] = `
+.c9 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c10 {
+  box-sizing: border-box;
+  z-index: 1060;
+}
+
+.c2 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.c5 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c5.c5 {
+  margin-right: 1.5rem;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c5 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c5:active {
+  background-color: #DBE3FE;
+}
+
+.c5:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c5:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c5[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c8 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  pointer-events: auto;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  padding: 0 0.5rem;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c8 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c8:active {
+  background-color: #DBE3FE;
+}
+
+.c8:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c8:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c8[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c6 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+  visibility: visible;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
+.c7 {
+  position: relative;
+}
+
+.c4 {
+  position: absolute;
+  visibility: hidden;
+  z-index: -1070;
+}
+
+.c0 {
+  width: 200px;
+}
+
+@media (min-width:720px) {
+  .c5 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c5 {
+    width: auto;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c8 {
+    width: auto;
+  }
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="wrapper"
+  >
+    <div
+      class="c1 c2"
+      data-testid="pilltabs-wrapper"
+      role="list"
+    >
+      <div
+        class="c1 c3 c4"
+        data-testid="pilltabs-pill-0"
+        role="listitem"
+      >
+        <button
+          class="c5 "
+          disabled=""
+        >
+          <span
+            class="c6"
+          >
+            In stock
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 c4"
+        data-testid="pilltabs-pill-1"
+        role="listitem"
+      >
+        <button
+          class="c5 "
+          disabled=""
+        >
+          <span
+            class="c6"
+          >
+            Long filter name
+          </span>
+        </button>
+      </div>
+      <div
+        class="c1 c3 "
+        data-testid="pilltabs-dropdown-toggle"
+      >
+        <div
+          class="c1 c7"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="bd-dropdown-5-label bd-dropdown-5-toggle-button"
+            class="c8 bd-button"
+            id="bd-dropdown-5-toggle-button"
+          >
+            <span
+              class="c6"
+            >
+              <svg
+                aria-labelledby="bd-icon-6"
+                class="c9"
+                fill="currentColor"
+                height="24"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <title
+                  id="bd-icon-6"
+                >
+                  add
+                </title>
+                <path
+                  d="M0 0h24v24H0V0z"
+                  fill="none"
+                />
+                <path
+                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="c10"
+            style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
+          >
+            <ul
+              aria-labelledby="bd-dropdown-5-label"
+              class="c11"
+              id="bd-dropdown-5-menu"
+              role="listbox"
+              tabindex="-1"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -319,7 +319,7 @@ exports[`dropdown is not visible if items fit 1`] = `
       <div
         class="c1 c3 c6"
         data-testid="pilltabs-dropdown-toggle"
-        role="dropdown"
+        role="listitem"
       >
         <div
           class="c1 c7"
@@ -697,7 +697,7 @@ exports[`it renders the given tabs 1`] = `
       <div
         class="c1 c3 c6"
         data-testid="pilltabs-dropdown-toggle"
-        role="dropdown"
+        role="listitem"
       >
         <div
           class="c1 c7"
@@ -1107,7 +1107,7 @@ exports[`only the pills that fit are visible 1`] = `
       <div
         class="c1 c3 "
         data-testid="pilltabs-dropdown-toggle"
-        role="dropdown"
+        role="listitem"
       >
         <div
           class="c1 c7"
@@ -1516,7 +1516,7 @@ exports[`only the pills that fit are visible 2 1`] = `
       <div
         class="c1 c3 "
         data-testid="pilltabs-dropdown-toggle"
-        role="dropdown"
+        role="listitem"
       >
         <div
           class="c1 c7"
@@ -1924,7 +1924,7 @@ exports[`renders all the filters if they fit 1`] = `
       <div
         class="c1 c3 c6"
         data-testid="pilltabs-dropdown-toggle"
-        role="dropdown"
+        role="listitem"
       >
         <div
           class="c1 c7"
@@ -2319,7 +2319,7 @@ exports[`renders dropdown if items do not fit 1`] = `
       <div
         class="c1 c3 "
         data-testid="pilltabs-dropdown-toggle"
-        role="dropdown"
+        role="listitem"
       >
         <div
           class="c1 c7"

--- a/packages/big-design/src/components/PillTabs/index.ts
+++ b/packages/big-design/src/components/PillTabs/index.ts
@@ -1,0 +1,1 @@
+export * from './PillTabs';

--- a/packages/big-design/src/components/PillTabs/spec.tsx
+++ b/packages/big-design/src/components/PillTabs/spec.tsx
@@ -39,9 +39,10 @@ test('it renders the given tabs', () => {
     },
   ];
 
-  const { getByText } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
+  const { container, getByText } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
   const inStock = getByText('In stock');
 
+  expect(container).toMatchSnapshot();
   expect(inStock).not.toHaveStyle(HIDDEN_STYLES);
 });
 
@@ -69,15 +70,18 @@ test('dropdown is not visible if items fit', () => {
     },
   ];
 
-  const { getByText, queryByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
+  const { container, getByText, queryByTestId } = render(
+    <TestComponent activePills={[]} items={items} onPillClick={onClick} />,
+  );
   const inStock = getByText('In stock');
   const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
 
+  expect(container).toMatchSnapshot();
   expect(inStock).not.toHaveStyle(HIDDEN_STYLES);
   expect(dropdownToggle).toHaveStyle(HIDDEN_STYLES);
 });
 
-test('renders dropdown if items dont fit', async () => {
+test('renders dropdown if items do not fit', async () => {
   Object.defineProperties(window.HTMLElement.prototype, {
     offsetWidth: {
       get() {
@@ -104,12 +108,15 @@ test('renders dropdown if items dont fit', async () => {
     },
   ];
 
-  const { getByText, queryByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
+  const { container, getByText, queryByTestId } = render(
+    <TestComponent activePills={[]} items={items} onPillClick={onClick} />,
+  );
   await wait();
 
   const inStock = getByText('Long filter name');
   const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
 
+  expect(container).toMatchSnapshot();
   expect(inStock).not.toHaveStyle(HIDDEN_STYLES);
   expect(dropdownToggle).not.toHaveStyle(HIDDEN_STYLES);
 });
@@ -146,7 +153,9 @@ test('renders all the filters if they fit', async () => {
     },
   ];
 
-  const { getByText, queryByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
+  const { container, getByText, queryByTestId } = render(
+    <TestComponent activePills={[]} items={items} onPillClick={onClick} />,
+  );
   await wait();
 
   const inStock = getByText('In stock');
@@ -154,6 +163,7 @@ test('renders all the filters if they fit', async () => {
   const filter3 = getByText('Filter 3');
   const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
 
+  expect(container).toMatchSnapshot();
   expect(inStock).not.toHaveStyle(HIDDEN_STYLES);
   expect(filter2).not.toHaveStyle(HIDDEN_STYLES);
   expect(filter3).not.toHaveStyle(HIDDEN_STYLES);
@@ -208,7 +218,9 @@ test('only the pills that fit are visible', async () => {
     },
   ];
 
-  const { queryByTestId, getByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
+  const { container, queryByTestId, getByTestId } = render(
+    <TestComponent activePills={[]} items={items} onPillClick={onClick} />,
+  );
   await wait();
 
   const inStock = getByTestId('pilltabs-pill-0');
@@ -216,6 +228,7 @@ test('only the pills that fit are visible', async () => {
   const filter3 = getByTestId('pilltabs-pill-2');
   const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
 
+  expect(container).toMatchSnapshot();
   expect(inStock).not.toHaveStyle(HIDDEN_STYLES);
   expect(filter2).toHaveStyle(HIDDEN_STYLES);
   expect(filter3).toHaveStyle(HIDDEN_STYLES);
@@ -266,7 +279,9 @@ test('only the pills that fit are visible 2', async () => {
     },
   ];
 
-  const { queryByTestId, getByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
+  const { container, queryByTestId, getByTestId } = render(
+    <TestComponent activePills={[]} items={items} onPillClick={onClick} />,
+  );
   await wait();
 
   const inStock = getByTestId('pilltabs-pill-0');
@@ -274,6 +289,7 @@ test('only the pills that fit are visible 2', async () => {
   const filter3 = getByTestId('pilltabs-pill-2');
   const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
 
+  expect(container).toMatchSnapshot();
   expect(inStock).not.toHaveStyle(HIDDEN_STYLES);
   expect(filter2).not.toHaveStyle(HIDDEN_STYLES);
   expect(filter3).toHaveStyle(HIDDEN_STYLES);

--- a/packages/big-design/src/components/PillTabs/spec.tsx
+++ b/packages/big-design/src/components/PillTabs/spec.tsx
@@ -297,7 +297,7 @@ test('it executes the given callback on click', () => {
 
   fireEvent.click(inStock);
 
-  expect(onClick).toHaveBeenCalledWith(item1);
+  expect(onClick).toHaveBeenCalledWith(item1.id);
 });
 
 test('cannot click on a hidden item', async () => {

--- a/packages/big-design/src/components/PillTabs/spec.tsx
+++ b/packages/big-design/src/components/PillTabs/spec.tsx
@@ -1,0 +1,336 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { fireEvent, render } from '@testing-library/react';
+import 'jest-styled-components';
+import React from 'react';
+import styled from 'styled-components';
+
+import { PillTabs, PillTabsProps } from './PillTabs';
+
+const Wrapper = styled.div`
+  width: 200px;
+`;
+
+Wrapper.defaultProps = { theme: defaultTheme };
+
+const TestComponent: React.FC<PillTabsProps> = ({ items }) => {
+  return (
+    <Wrapper data-testid="wrapper">
+      <PillTabs items={items} />
+    </Wrapper>
+  );
+};
+
+const originalPrototype = Object.getOwnPropertyDescriptors(window.HTMLElement.prototype);
+
+afterAll(() => Object.defineProperties(window.HTMLElement.prototype, originalPrototype));
+
+test('it renders the given tabs', () => {
+  const onClick = jest.fn();
+  const items = [
+    {
+      text: 'In stock',
+      isActive: false,
+      onClick,
+    },
+  ];
+
+  const { getByText } = render(<TestComponent items={items} />);
+  const inStock = getByText('In stock');
+
+  expect(inStock).toBeInTheDocument();
+});
+
+test('does not render dropdown if items fit', () => {
+  const onClick = jest.fn();
+  const items = [
+    {
+      text: 'In stock',
+      isActive: false,
+      onClick,
+    },
+  ];
+
+  const { getByText, queryByTestId } = render(<TestComponent items={items} />);
+  const inStock = getByText('In stock');
+  const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
+
+  expect(inStock).toBeInTheDocument();
+  expect(dropdownToggle).not.toBeInTheDocument();
+});
+
+test('renders dropdown if items dont fit', () => {
+  Object.defineProperties(window.HTMLElement.prototype, {
+    offsetWidth: {
+      get() {
+        if (this.dataset.testid === 'pilltabs-wrapper') {
+          return 400;
+        }
+
+        return parseFloat(this.style.width) || 300;
+      },
+    },
+  });
+
+  const onClick = jest.fn();
+  const items = [
+    {
+      text: 'In stock',
+      isActive: false,
+      onClick,
+    },
+    {
+      text: 'Long filter name',
+      isActive: false,
+      onClick,
+    },
+  ];
+
+  const { getByText, queryByTestId } = render(<TestComponent items={items} />);
+
+  const inStock = getByText('Long filter name');
+  const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
+
+  expect(inStock).toBeInTheDocument();
+  expect(dropdownToggle).toBeInTheDocument();
+});
+
+test('renders all the filters if they fit', () => {
+  Object.defineProperties(window.HTMLElement.prototype, {
+    offsetWidth: {
+      get() {
+        if (this.dataset.testid === 'pilltabs-wrapper') {
+          return 400;
+        }
+
+        return parseFloat(this.style.width) || 50;
+      },
+    },
+  });
+
+  const onClick = jest.fn();
+  const items = [
+    {
+      text: 'In stock',
+      isActive: false,
+      onClick,
+    },
+    {
+      text: 'Filter 2',
+      isActive: false,
+      onClick,
+    },
+    {
+      text: 'Filter 3',
+      isActive: false,
+      onClick,
+    },
+  ];
+
+  const { getByText, queryByTestId } = render(<TestComponent items={items} />);
+
+  const inStock = getByText('In stock');
+  const filter2 = getByText('Filter 2');
+  const filter3 = getByText('Filter 3');
+  const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
+
+  expect(inStock).toBeInTheDocument();
+  expect(filter2).toBeInTheDocument();
+  expect(filter3).toBeInTheDocument();
+  expect(dropdownToggle).not.toBeInTheDocument();
+});
+
+test('only the pills that fit are visible', () => {
+  Object.defineProperties(window.HTMLElement.prototype, {
+    offsetWidth: {
+      get() {
+        if (this.dataset.testid === 'pilltabs-wrapper') {
+          return 400;
+        }
+
+        if (this.dataset.testid === 'pilltabs-pill-0') {
+          return 350;
+        }
+
+        return parseFloat(this.style.width) || 50;
+      },
+    },
+  });
+
+  const onClick = jest.fn();
+  const items = [
+    {
+      text: 'In stock',
+      isActive: false,
+      onClick,
+    },
+    {
+      text: 'Filter 2',
+      isActive: false,
+      onClick,
+    },
+    {
+      text: 'Filter 3',
+      isActive: false,
+      onClick,
+    },
+  ];
+
+  const { queryByTestId, getByTestId } = render(<TestComponent items={items} />);
+
+  const inStock = getByTestId('pilltabs-pill-0');
+  const filter2 = getByTestId('pilltabs-pill-1');
+  const filter3 = getByTestId('pilltabs-pill-2');
+  const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
+
+  expect(inStock).not.toHaveStyle({
+    'z-index': -defaultTheme.zIndex.tooltip,
+    position: 'absolute',
+    visibility: 'hidden',
+  });
+  expect(filter2).toHaveStyle({
+    'z-index': -defaultTheme.zIndex.tooltip,
+    position: 'absolute',
+    visibility: 'hidden',
+  });
+  expect(filter3).toHaveStyle({
+    'z-index': -defaultTheme.zIndex.tooltip,
+    position: 'absolute',
+    visibility: 'hidden',
+  });
+  expect(dropdownToggle).toBeInTheDocument();
+});
+
+test('only the pills that fit are visible 2', () => {
+  Object.defineProperties(window.HTMLElement.prototype, {
+    offsetWidth: {
+      get() {
+        if (this.dataset.testid === 'pilltabs-wrapper') {
+          return 400;
+        }
+
+        if (this.dataset.testid === 'pilltabs-pill-0') {
+          return 100;
+        }
+
+        if (this.dataset.testid === 'pilltabs-pill-1') {
+          return 100;
+        }
+
+        if (this.dataset.testid === 'pilltabs-pill-2') {
+          return 300;
+        }
+
+        return parseFloat(this.style.width) || 50;
+      },
+    },
+  });
+
+  const onClick = jest.fn();
+  const items = [
+    {
+      text: 'In stock',
+      isActive: false,
+      onClick,
+    },
+    {
+      text: 'Filter 2',
+      isActive: false,
+      onClick,
+    },
+    {
+      text: 'Filter 3',
+      isActive: false,
+      onClick,
+    },
+  ];
+
+  const { queryByTestId, getByTestId } = render(<TestComponent items={items} />);
+
+  const inStock = getByTestId('pilltabs-pill-0');
+  const filter2 = getByTestId('pilltabs-pill-1');
+  const filter3 = getByTestId('pilltabs-pill-2');
+  const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
+
+  expect(inStock).not.toHaveStyle({
+    'z-index': -defaultTheme.zIndex.tooltip,
+    position: 'absolute',
+    visibility: 'hidden',
+  });
+  expect(filter2).not.toHaveStyle({
+    'z-index': -defaultTheme.zIndex.tooltip,
+    position: 'absolute',
+    visibility: 'hidden',
+  });
+  expect(filter3).toHaveStyle({
+    'z-index': -defaultTheme.zIndex.tooltip,
+    position: 'absolute',
+    visibility: 'hidden',
+  });
+  expect(dropdownToggle).toBeInTheDocument();
+});
+
+test('it executes the given callback on click', () => {
+  const onClick1 = jest.fn();
+  const onClick2 = jest.fn();
+  const item1 = {
+    text: 'In stock',
+    isActive: false,
+    onClick: onClick1,
+  };
+  const item2 = {
+    text: 'Not in stock',
+    isActive: false,
+    onClick: onClick2,
+  };
+  const items = [item1, item2];
+
+  const { getByText } = render(<TestComponent items={items} />);
+  const inStock = getByText('In stock');
+
+  fireEvent.click(inStock);
+
+  expect(onClick1).toHaveBeenCalledWith(item1);
+  expect(onClick2).not.toHaveBeenCalled();
+});
+
+test('cannot click on a hidden item', () => {
+  Object.defineProperties(window.HTMLElement.prototype, {
+    offsetWidth: {
+      get() {
+        if (this.dataset.testid === 'pilltabs-wrapper') {
+          return 400;
+        }
+
+        if (this.dataset.testid === 'pilltabs-pill-0') {
+          return 350;
+        }
+
+        if (this.dataset.testid === 'pilltabs-pill-1') {
+          return 200;
+        }
+
+        return parseFloat(this.style.width) || 50;
+      },
+    },
+  });
+  const onClick1 = jest.fn();
+  const onClick2 = jest.fn();
+  const item1 = {
+    text: 'In stock',
+    isActive: false,
+    onClick: onClick1,
+  };
+  const item2 = {
+    text: 'Not in stock',
+    isActive: false,
+    onClick: onClick2,
+  };
+  const items = [item1, item2];
+
+  const { getByText } = render(<TestComponent items={items} />);
+  const notInStock = getByText('Not in stock');
+
+  fireEvent.click(notInStock);
+
+  expect(onClick2).not.toHaveBeenCalled();
+});

--- a/packages/big-design/src/components/PillTabs/spec.tsx
+++ b/packages/big-design/src/components/PillTabs/spec.tsx
@@ -12,10 +12,10 @@ const Wrapper = styled.div`
 
 Wrapper.defaultProps = { theme: defaultTheme };
 
-const TestComponent: React.FC<PillTabsProps> = ({ items }) => {
+const TestComponent: React.FC<PillTabsProps> = ({ activePills, items, onPillClick }) => {
   return (
     <Wrapper data-testid="wrapper">
-      <PillTabs items={items} />
+      <PillTabs activePills={activePills} items={items} onPillClick={onPillClick} />
     </Wrapper>
   );
 };
@@ -34,13 +34,12 @@ test('it renders the given tabs', () => {
   const onClick = jest.fn();
   const items = [
     {
-      text: 'In stock',
-      isActive: false,
-      onClick,
+      title: 'In stock',
+      id: 'filter1',
     },
   ];
 
-  const { getByText } = render(<TestComponent items={items} />);
+  const { getByText } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
   const inStock = getByText('In stock');
 
   expect(inStock).not.toHaveStyle(HIDDEN_STYLES);
@@ -65,13 +64,12 @@ test('dropdown is not visible if items fit', () => {
   const onClick = jest.fn();
   const items = [
     {
-      text: 'In stock',
-      isActive: false,
-      onClick,
+      title: 'In stock',
+      id: 'filter1',
     },
   ];
 
-  const { getByText, queryByTestId } = render(<TestComponent items={items} />);
+  const { getByText, queryByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
   const inStock = getByText('In stock');
   const dropdownToggle = queryByTestId('pilltabs-dropdown-toggle');
 
@@ -95,18 +93,18 @@ test('renders dropdown if items dont fit', async () => {
   const onClick = jest.fn();
   const items = [
     {
-      text: 'In stock',
-      isActive: false,
-      onClick,
+      title: 'In stock',
+
+      id: 'filter1',
     },
     {
-      text: 'Long filter name',
-      isActive: false,
-      onClick,
+      title: 'Long filter name',
+
+      id: 'filter1',
     },
   ];
 
-  const { getByText, queryByTestId } = render(<TestComponent items={items} />);
+  const { getByText, queryByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
   await wait();
 
   const inStock = getByText('Long filter name');
@@ -132,23 +130,23 @@ test('renders all the filters if they fit', async () => {
   const onClick = jest.fn();
   const items = [
     {
-      text: 'In stock',
-      isActive: false,
-      onClick,
+      title: 'In stock',
+
+      id: 'filter1',
     },
     {
-      text: 'Filter 2',
-      isActive: false,
-      onClick,
+      title: 'Filter 2',
+
+      id: 'filter1',
     },
     {
-      text: 'Filter 3',
-      isActive: false,
-      onClick,
+      title: 'Filter 3',
+
+      id: 'filter1',
     },
   ];
 
-  const { getByText, queryByTestId } = render(<TestComponent items={items} />);
+  const { getByText, queryByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
   await wait();
 
   const inStock = getByText('In stock');
@@ -194,23 +192,23 @@ test('only the pills that fit are visible', async () => {
   const onClick = jest.fn();
   const items = [
     {
-      text: 'In stock',
-      isActive: false,
-      onClick,
+      title: 'In stock',
+
+      id: 'filter1',
     },
     {
-      text: 'Filter 2',
-      isActive: false,
-      onClick,
+      title: 'Filter 2',
+
+      id: 'filter1',
     },
     {
-      text: 'Filter 3',
-      isActive: false,
-      onClick,
+      title: 'Filter 3',
+
+      id: 'filter1',
     },
   ];
 
-  const { queryByTestId, getByTestId } = render(<TestComponent items={items} />);
+  const { queryByTestId, getByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
   await wait();
 
   const inStock = getByTestId('pilltabs-pill-0');
@@ -252,23 +250,23 @@ test('only the pills that fit are visible 2', async () => {
   const onClick = jest.fn();
   const items = [
     {
-      text: 'In stock',
-      isActive: false,
-      onClick,
+      title: 'In stock',
+
+      id: 'filter1',
     },
     {
-      text: 'Filter 2',
-      isActive: false,
-      onClick,
+      title: 'Filter 2',
+
+      id: 'filter1',
     },
     {
-      text: 'Filter 3',
-      isActive: false,
-      onClick,
+      title: 'Filter 3',
+
+      id: 'filter1',
     },
   ];
 
-  const { queryByTestId, getByTestId } = render(<TestComponent items={items} />);
+  const { queryByTestId, getByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
   await wait();
 
   const inStock = getByTestId('pilltabs-pill-0');
@@ -283,27 +281,23 @@ test('only the pills that fit are visible 2', async () => {
 });
 
 test('it executes the given callback on click', () => {
-  const onClick1 = jest.fn();
-  const onClick2 = jest.fn();
+  const onClick = jest.fn();
   const item1 = {
-    text: 'In stock',
-    isActive: false,
-    onClick: onClick1,
+    title: 'In stock',
+    id: 'filter1',
   };
   const item2 = {
-    text: 'Not in stock',
-    isActive: false,
-    onClick: onClick2,
+    title: 'Not in stock',
+    id: 'filter2',
   };
   const items = [item1, item2];
 
-  const { getByText } = render(<TestComponent items={items} />);
+  const { getByText } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
   const inStock = getByText('In stock');
 
   fireEvent.click(inStock);
 
-  expect(onClick1).toHaveBeenCalledWith(item1);
-  expect(onClick2).not.toHaveBeenCalled();
+  expect(onClick).toHaveBeenCalledWith(item1);
 });
 
 test('cannot click on a hidden item', async () => {
@@ -330,21 +324,18 @@ test('cannot click on a hidden item', async () => {
       },
     },
   });
-  const onClick1 = jest.fn();
-  const onClick2 = jest.fn();
+  const onClick = jest.fn();
   const item1 = {
-    text: 'In stock',
-    isActive: false,
-    onClick: onClick1,
+    title: 'In stock',
+    id: 'filter1',
   };
   const item2 = {
-    text: 'Not in stock',
-    isActive: false,
-    onClick: onClick2,
+    title: 'Not in stock',
+    id: 'filter2',
   };
   const items = [item1, item2];
 
-  const { getByText, getByTestId } = render(<TestComponent items={items} />);
+  const { getByText, getByTestId } = render(<TestComponent activePills={[]} items={items} onPillClick={onClick} />);
 
   await wait();
   const notInStock = getByText('Not in stock');
@@ -353,5 +344,5 @@ test('cannot click on a hidden item', async () => {
   fireEvent.click(notInStock);
 
   expect(filter1).toHaveStyle(HIDDEN_STYLES);
-  expect(onClick2).not.toHaveBeenCalled();
+  expect(onClick).not.toHaveBeenCalled();
 });

--- a/packages/big-design/src/components/PillTabs/styled.tsx
+++ b/packages/big-design/src/components/PillTabs/styled.tsx
@@ -1,3 +1,4 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { StyleableButton } from '../Button/private';
@@ -26,8 +27,11 @@ export const StyledFlexItem = styled(FlexItem)<StyledFlexItemProps>`
     !props.isVisible &&
     css`
       /* TODO: Best way to hide? */
-      visibility: hidden;
       position: absolute;
+      visibility: hidden;
       z-index: ${({ theme }) => -theme.zIndex.tooltip};
     `}
 `;
+
+StyledPillTab.defaultProps = { theme: defaultTheme };
+StyledFlexItem.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/PillTabs/styled.tsx
+++ b/packages/big-design/src/components/PillTabs/styled.tsx
@@ -28,6 +28,6 @@ export const StyledFlexItem = styled(FlexItem)<StyledFlexItemProps>`
       /* TODO: Best way to hide? */
       visibility: hidden;
       position: absolute;
-      z-index: -1000;
+      z-index: ${({ theme }) => -theme.zIndex.tooltip};
     `}
 `;

--- a/packages/big-design/src/components/PillTabs/styled.tsx
+++ b/packages/big-design/src/components/PillTabs/styled.tsx
@@ -13,8 +13,6 @@ interface StyledFlexItemProps {
 }
 
 export const StyledPillTab = styled(StyleableButton)<StyledPillTabProps>`
-  margin-right: ${({ theme }) => theme.spacing.xLarge};
-
   ${(props) =>
     props.isActive &&
     css`

--- a/packages/big-design/src/components/PillTabs/styled.tsx
+++ b/packages/big-design/src/components/PillTabs/styled.tsx
@@ -1,0 +1,33 @@
+import styled, { css } from 'styled-components';
+
+import { StyleableButton } from '../Button/private';
+import { FlexItem } from '../Flex';
+
+interface StyledPillTabProps {
+  isActive: boolean;
+}
+
+interface StyledFlexItemProps {
+  isVisible: boolean;
+}
+
+export const StyledPillTab = styled(StyleableButton)<StyledPillTabProps>`
+  margin-right: ${({ theme }) => theme.spacing.xLarge};
+
+  ${(props) =>
+    props.isActive &&
+    css`
+      background-color: ${({ theme }) => theme.colors.primary20};
+    `}
+`;
+
+export const StyledFlexItem = styled(FlexItem)<StyledFlexItemProps>`
+  ${(props) =>
+    !props.isVisible &&
+    css`
+      /* TODO: Best way to hide? */
+      visibility: hidden;
+      position: absolute;
+      z-index: -1000;
+    `}
+`;

--- a/packages/big-design/src/components/PillTabs/styled.tsx
+++ b/packages/big-design/src/components/PillTabs/styled.tsx
@@ -26,7 +26,6 @@ export const StyledFlexItem = styled(FlexItem)<StyledFlexItemProps>`
   ${(props) =>
     !props.isVisible &&
     css`
-      /* TODO: Best way to hide? */
       position: absolute;
       visibility: hidden;
       z-index: ${({ theme }) => -theme.zIndex.tooltip};

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -132,8 +132,8 @@ const InternalStatefulTable = <T extends TableItem>({
 
     const pillTabsProps: PillTabsProps = {
       activePills: state.activePills,
-      onPillClick: (item) => {
-        dispatch({ type: 'TOGGLE_PILL', pillId: item.id, filter: tableFilters.filter });
+      onPillClick: (pillId) => {
+        dispatch({ type: 'TOGGLE_PILL', pillId, filter: tableFilters.filter });
       },
       items: tableFilters.pillTabs,
     };

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -20,10 +20,10 @@ export interface StatefulTableColumn<T> extends Omit<TableColumn<T>, 'isSortable
 }
 
 export interface StatefulTableProps<T>
-  extends Omit<TableProps<T>, 'columns' | 'pagination' | 'pillTabs' | 'selectable' | 'sortable' | 'onRowDrop'> {
+  extends Omit<TableProps<T>, 'columns' | 'pagination' | 'filters' | 'selectable' | 'sortable' | 'onRowDrop'> {
   columns: Array<StatefulTableColumn<T>>;
   pagination?: boolean;
-  tableFilters?: StatefulTablePillTabFilter<T>;
+  filters?: StatefulTablePillTabFilter<T>;
   selectable?: boolean;
   defaultSelected?: T[];
   onRowDrop?(items: T[]): void;
@@ -52,7 +52,7 @@ const InternalStatefulTable = <T extends TableItem>({
   onSelectionChange,
   onRowDrop,
   pagination = false,
-  tableFilters,
+  filters,
   selectable = false,
   stickyHeader = false,
   ...rest
@@ -61,11 +61,7 @@ const InternalStatefulTable = <T extends TableItem>({
   const reducerInit = useMemo(() => createReducerInit<T>(), []);
   const sortable = useMemo(() => columns.some((column) => column.sortKey || column.sortFn), [columns]);
 
-  const [state, dispatch] = useReducer(
-    reducer,
-    { columns, defaultSelected, items, pagination, tableFilters },
-    reducerInit,
-  );
+  const [state, dispatch] = useReducer(reducer, { columns, defaultSelected, items, pagination, filters }, reducerInit);
 
   const columnsChangedCallback = useCallback(() => dispatch({ type: 'COLUMNS_CHANGED', columns }), [columns]);
   const itemsChangedCallback = useCallback(
@@ -126,33 +122,33 @@ const InternalStatefulTable = <T extends TableItem>({
   );
 
   useEffect(() => {
-    if (!tableFilters) {
+    if (!filters) {
       return;
     }
 
     const pillTabsProps: PillTabsProps = {
       activePills: state.activePills,
       onPillClick: (pillId) => {
-        dispatch({ type: 'TOGGLE_PILL', pillId, filter: tableFilters.filter });
+        dispatch({ type: 'TOGGLE_PILL', pillId, filter: filters.filter });
       },
-      items: tableFilters.pillTabs,
+      items: filters.pillTabs,
     };
 
     dispatch({ type: 'SET_PILL_TABS_PROPS', pillTabsProps });
-  }, [tableFilters, state.activePills]);
+  }, [filters, state.activePills]);
 
   return (
     <Table
       {...rest}
       columns={state.columns}
+      filters={state.pillTabsProps}
       itemName={itemName}
       items={state.currentItems}
       keyField={keyField}
-      stickyHeader={stickyHeader}
       pagination={paginationOptions}
-      pillTabs={state.pillTabsProps}
       selectable={selectableOptions}
       sortable={sortableOptions}
+      stickyHeader={stickyHeader}
       onRowDrop={onRowDrop ? onDragEnd : undefined}
     />
   );

--- a/packages/big-design/src/components/StatefulTable/reducer.ts
+++ b/packages/big-design/src/components/StatefulTable/reducer.ts
@@ -201,9 +201,6 @@ export const createReducer = <T>(): Reducer<State<T>, Action<T>> => (state, acti
       }
 
       const isCurrentPillActive = !state.activePills.includes(action.pillId);
-      // const updatedPills = isCurrentPillActive
-      //   ? [...state.pillTabsProps.items, { ...toggledPill }]
-      //   : pillTabs.filter((pill) => pill.id !== action.pillId);
       const activePills = isCurrentPillActive
         ? [...state.activePills, toggledPill.id]
         : state.activePills.filter((activeFilter) => activeFilter !== toggledPill.id);
@@ -228,7 +225,6 @@ export const createReducer = <T>(): Reducer<State<T>, Action<T>> => (state, acti
           currentPage: 1,
           totalItems: currentItems.length,
         },
-        // pillTabs: updatedPills,
         currentItems,
         filteredItems: currentItems,
       };

--- a/packages/big-design/src/components/StatefulTable/reducer.ts
+++ b/packages/big-design/src/components/StatefulTable/reducer.ts
@@ -200,8 +200,8 @@ export const createReducer = <T>(): Reducer<State<T>, Action<T>> => (state, acti
         return state;
       }
 
-      const isCurrentPillActive = !state.activePills.includes(action.pillId);
-      const activePills = isCurrentPillActive
+      const isToggledPillActive = !state.activePills.includes(action.pillId);
+      const activePills = isToggledPillActive
         ? [...state.activePills, toggledPill.id]
         : state.activePills.filter((activeFilter) => activeFilter !== toggledPill.id);
       const currentItems =

--- a/packages/big-design/src/components/StatefulTable/reducer.ts
+++ b/packages/big-design/src/components/StatefulTable/reducer.ts
@@ -215,11 +215,20 @@ export const createReducer = <T>(): Reducer<State<T>, Action<T>> => (state, acti
       const activeFilters = isCurrentPillActive
         ? [...state.activeFilters, action.filterHash]
         : state.activeFilters.filter((activeFilter) => activeFilter !== action.filterHash);
-      const currentItems = activeFilters.reduce((filteredItems, filterHash) => {
-        const filter = state.filters[filterHash];
+      const currentItems =
+        activeFilters.length > 0
+          ? activeFilters
+              .map((filterHash) => {
+                const filter = state.filters[filterHash];
 
-        return filter(filteredItems);
-      }, state.items);
+                return filter(state.items);
+              })
+              .reduce((results, filteredItems) => {
+                const dedupedItems = filteredItems.filter((item) => !results.includes(item));
+
+                return [...results, ...dedupedItems];
+              }, [])
+          : state.items;
 
       return {
         ...state,

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -326,11 +326,11 @@ test('renders headers by default and hides then via prop', () => {
 });
 
 test('renders pill tabs with the pillTabFilters prop', () => {
-  const tableFilters: StatefulTablePillTabFilter<TestItem> = {
+  const filters: StatefulTablePillTabFilter<TestItem> = {
     pillTabs: [{ title: 'In stock', id: 'in_stock' }],
     filter: (_itemId, items) => items.filter((item) => item.stock > 0),
   };
-  const { getByText } = render(getSimpleTable({ tableFilters }));
+  const { getByText } = render(getSimpleTable({ filters }));
   const customFilter = getByText('In stock');
 
   expect(customFilter).toBeInTheDocument();
@@ -338,11 +338,11 @@ test('renders pill tabs with the pillTabFilters prop', () => {
 });
 
 test('it executes the filter function on click', async () => {
-  const pillTabFilters: StatefulTablePillTabFilter<TestItem> = {
+  const filters: StatefulTablePillTabFilter<TestItem> = {
     pillTabs: [{ title: 'In stock', id: 'in_stock' }],
     filter: (_itemId, items) => items.filter((item) => item.stock === 1),
   };
-  const { container, getByText, getByTestId } = render(getSimpleTable({ tableFilters: pillTabFilters }));
+  const { container, getByText, getByTestId } = render(getSimpleTable({ filters }));
 
   const customFilter = getByText('In stock');
 
@@ -355,11 +355,11 @@ test('it executes the filter function on click', async () => {
 });
 
 test('can paginate on filtered rows', async () => {
-  const pillTabFilters: StatefulTablePillTabFilter<TestItem> = {
+  const filters: StatefulTablePillTabFilter<TestItem> = {
     pillTabs: [{ title: 'Low stock', id: 'in_stock' }],
     filter: (_itemId, items) => items.filter((item) => item.stock < 40),
   };
-  const { getByText, getByTestId } = render(getSimpleTable({ tableFilters: pillTabFilters, pagination: true }));
+  const { getByText, getByTestId } = render(getSimpleTable({ filters, pagination: true }));
   const customFilter = getByText('Low stock');
 
   fireEvent.click(customFilter);
@@ -371,11 +371,11 @@ test('can paginate on filtered rows', async () => {
 });
 
 test('can undo filter actions', async () => {
-  const pillTabFilters: StatefulTablePillTabFilter<TestItem> = {
+  const filters: StatefulTablePillTabFilter<TestItem> = {
     pillTabs: [{ title: 'Stock 1', id: 'in_stock' }],
     filter: (_itemId, items) => items.filter((item) => item.stock === 1),
   };
-  const { container, getByText, getByTestId } = render(getSimpleTable({ tableFilters: pillTabFilters }));
+  const { container, getByText, getByTestId } = render(getSimpleTable({ filters }));
   const customFilter = getByText('Stock 1');
 
   fireEvent.click(customFilter);
@@ -392,7 +392,7 @@ test('can undo filter actions', async () => {
 });
 
 test('can stack filter actions (OR logic)', async () => {
-  const pillTabFilters: StatefulTablePillTabFilter<TestItem> = {
+  const filters: StatefulTablePillTabFilter<TestItem> = {
     pillTabs: [
       { title: 'Stock 1', id: 'stock_1' },
       { title: 'Stock 2', id: 'stock_2' },
@@ -400,7 +400,7 @@ test('can stack filter actions (OR logic)', async () => {
     filter: (itemId, items) =>
       itemId === 'stock_1' ? items.filter((item) => item.stock === 1) : items.filter((item) => item.stock === 2),
   };
-  const { container, getByText, getByTestId } = render(getSimpleTable({ tableFilters: pillTabFilters }));
+  const { container, getByText, getByTestId } = render(getSimpleTable({ filters }));
   const customFilter1 = getByText('Stock 1');
   const customFilter2 = getByText('Stock 2');
 
@@ -415,7 +415,7 @@ test('can stack filter actions (OR logic)', async () => {
 });
 
 test('can undo stacked filter actions', async () => {
-  const pillTabFilters: StatefulTablePillTabFilter<TestItem> = {
+  const filters: StatefulTablePillTabFilter<TestItem> = {
     pillTabs: [
       { title: 'Stock 1', id: 'stock_1' },
       { title: 'Stock 2', id: 'stock_2' },
@@ -423,7 +423,7 @@ test('can undo stacked filter actions', async () => {
     filter: (itemId, items) =>
       itemId === 'stock_1' ? items.filter((item) => item.stock === 1) : items.filter((item) => item.stock === 2),
   };
-  const { container, getByText, getByTestId } = render(getSimpleTable({ tableFilters: pillTabFilters }));
+  const { container, getByText, getByTestId } = render(getSimpleTable({ filters }));
   const customFilter1 = getByText('Stock 1');
   const customFilter2 = getByText('Stock 2');
 

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -400,7 +400,7 @@ test('can undo filter actions', () => {
   expect(rows.length).toBe(104);
 });
 
-test('can stack filter actions', () => {
+test('can stack filter actions (OR logic)', () => {
   const pillTabFilters: StatefulTablePillTabFilter<TestItem>[] = [
     {
       text: 'Stock 1',
@@ -408,21 +408,21 @@ test('can stack filter actions', () => {
       filter: (items) => items.filter((item) => item.stock === 1),
     },
     {
-      text: 'Stock 1 or 2',
+      text: 'Stock 2',
       hash: 'stock_2',
-      filter: (items) => items.filter((item) => item.stock === 1 || item.stock === 2),
+      filter: (items) => items.filter((item) => item.stock === 2),
     },
   ];
   const { container, getByText } = render(getSimpleTable({ pillTabFilters }));
   const customFilter1 = getByText('Stock 1');
-  const customFilter2 = getByText('Stock 1 or 2');
+  const customFilter2 = getByText('Stock 2');
 
   fireEvent.click(customFilter1);
   fireEvent.click(customFilter2);
 
   const rows = container.querySelectorAll('tbody > tr');
 
-  expect(rows.length).toBe(1);
+  expect(rows.length).toBe(2);
 });
 
 test('can undo stacked filter actions', () => {
@@ -433,25 +433,25 @@ test('can undo stacked filter actions', () => {
       filter: (items) => items.filter((item) => item.stock === 1),
     },
     {
-      text: 'Stock 1 or 2',
+      text: 'Stock 2',
       hash: 'stock_2',
-      filter: (items) => items.filter((item) => item.stock === 1 || item.stock === 2),
+      filter: (items) => items.filter((item) => item.stock === 2),
     },
   ];
   const { container, getByText } = render(getSimpleTable({ pillTabFilters }));
   const customFilter1 = getByText('Stock 1');
-  const customFilter2 = getByText('Stock 1 or 2');
+  const customFilter2 = getByText('Stock 2');
 
   fireEvent.click(customFilter1);
   fireEvent.click(customFilter2);
 
   let rows = container.querySelectorAll('tbody > tr');
-  expect(rows.length).toBe(1);
+  expect(rows.length).toBe(2);
 
   fireEvent.click(customFilter1);
 
   rows = container.querySelectorAll('tbody > tr');
-  expect(rows.length).toBe(2);
+  expect(rows.length).toBe(1);
 
   fireEvent.click(customFilter2);
 

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -215,10 +215,10 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     }
 
     return shouldRenderActions() ? (
-      <PillTabs items={pillTabs} />
+      <PillTabs {...pillTabs} />
     ) : (
       <Box marginBottom="medium">
-        <PillTabs items={pillTabs} />
+        <PillTabs {...pillTabs} />
       </Box>
     );
   };

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -18,10 +18,11 @@ import { TableColumn, TableItem, TableProps } from './types';
 
 const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactElement<TableProps<T>> => {
   const {
+    actions,
     className,
     columns,
-    actions,
     emptyComponent,
+    filters,
     headerless = false,
     id,
     itemName,
@@ -29,7 +30,6 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     keyField = 'id',
     onRowDrop,
     pagination,
-    pillTabs,
     selectable,
     sortable,
     stickyHeader,
@@ -210,13 +210,13 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
   };
 
   const renderPillTabs = () => {
-    if (!pillTabs) {
+    if (!filters) {
       return;
     }
 
     return (
       <Box marginBottom={shouldRenderActions() ? 'none' : 'medium'}>
-        <PillTabs {...pillTabs} />
+        <PillTabs {...filters} />
       </Box>
     );
   };

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -4,6 +4,7 @@ import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautif
 import { useEventCallback, useUniqueId } from '../../hooks';
 import { MarginProps } from '../../mixins';
 import { typedMemo } from '../../utils';
+import { PillTabs } from '../PillTabs';
 
 import { Actions } from './Actions';
 import { Body } from './Body';
@@ -27,6 +28,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     keyField = 'id',
     onRowDrop,
     pagination,
+    pillTabs,
     selectable,
     sortable,
     stickyHeader,
@@ -206,8 +208,13 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     return null;
   };
 
+  const renderPillTabs = () => {
+    return pillTabs ? <PillTabs items={pillTabs} /> : null;
+  };
+
   return (
     <>
+      {renderPillTabs()}
       {shouldRenderActions() && (
         <Actions
           customActions={actions}

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -4,6 +4,7 @@ import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautif
 import { useEventCallback, useUniqueId } from '../../hooks';
 import { MarginProps } from '../../mixins';
 import { typedMemo } from '../../utils';
+import { Box } from '../Box';
 import { PillTabs } from '../PillTabs';
 
 import { Actions } from './Actions';
@@ -209,7 +210,17 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
   };
 
   const renderPillTabs = () => {
-    return pillTabs ? <PillTabs items={pillTabs} /> : null;
+    if (!pillTabs) {
+      return;
+    }
+
+    return shouldRenderActions() ? (
+      <PillTabs items={pillTabs} />
+    ) : (
+      <Box marginBottom="medium">
+        <PillTabs items={pillTabs} />
+      </Box>
+    );
   };
 
   return (

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -214,10 +214,8 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
       return;
     }
 
-    return shouldRenderActions() ? (
-      <PillTabs {...pillTabs} />
-    ) : (
-      <Box marginBottom="medium">
+    return (
+      <Box marginBottom={shouldRenderActions() ? 'none' : 'medium'}>
         <PillTabs {...pillTabs} />
       </Box>
     );

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -84,23 +84,6 @@ exports[`renders a pagination component 1`] = `
   flex-shrink: 1;
 }
 
-.c12 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
-}
-
-.c6 {
-  position: relative;
-}
-
 .c7 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
@@ -275,6 +258,23 @@ exports[`renders a pagination component 1`] = `
   grid-auto-flow: column;
   grid-gap: 0.5rem;
   visibility: visible;
+}
+
+.c12 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
+.c6 {
+  position: relative;
 }
 
 .c8 {

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -3,7 +3,7 @@ import 'jest-styled-components';
 
 import { fireEvent, render, screen, waitForElement } from '@test/utils';
 
-import { PillTabItem } from '../PillTabs';
+import { PillTabsProps } from '../PillTabs';
 
 import { Table, TableFigure } from './Table';
 
@@ -17,7 +17,7 @@ interface SimpleTableOptions {
   id?: string;
   itemName?: string;
   style?: CSSProperties;
-  pillTabs?: PillTabItem[];
+  pillTabs?: PillTabsProps;
 }
 
 const getSimpleTable = ({
@@ -520,18 +520,21 @@ describe('draggable', () => {
 });
 
 test('it renders pill tabs with the pillTabs prop', () => {
-  const pillTabs = [
+  const items = [
     {
-      text: 'In Stock',
-      isActive: false,
-      onClick: jest.fn(),
+      title: 'In Stock',
+      id: 'in_stock',
     },
     {
-      text: 'Low Stock',
-      isActive: false,
-      onClick: jest.fn(),
+      title: 'Low Stock',
+      id: 'low_stock',
     },
   ];
+  const pillTabs: PillTabsProps = {
+    onPillClick: jest.fn(),
+    activePills: [],
+    items,
+  };
   const { getByText } = render(getSimpleTable({ pillTabs }));
   const inStock = getByText('In Stock');
   const lowStock = getByText('Low Stock');
@@ -541,24 +544,29 @@ test('it renders pill tabs with the pillTabs prop', () => {
 });
 
 test('it executes the given callback', () => {
-  const inStockCb = jest.fn();
-  const inStock = {
-    text: 'In Stock',
-    isActive: false,
-    onClick: inStockCb,
-  };
-  const pillTabs = [
-    inStock,
+  const onPillClick = jest.fn();
+  const items = [
     {
-      text: 'Low Stock',
-      isActive: false,
-      onClick: jest.fn(),
+      title: 'In Stock',
+      id: 'in_stock',
+    },
+    {
+      title: 'Low Stock',
+      id: 'low_stock',
     },
   ];
+  const pillTabs: PillTabsProps = {
+    onPillClick,
+    activePills: [],
+    items,
+  };
   const { getByText } = render(getSimpleTable({ pillTabs }));
   const inStockBtn = getByText('In Stock');
 
   fireEvent.click(inStockBtn);
 
-  expect(inStockCb).toHaveBeenCalledWith(inStock);
+  expect(onPillClick).toHaveBeenCalledWith({
+    title: 'In Stock',
+    id: 'in_stock',
+  });
 });

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -565,8 +565,5 @@ test('it executes the given callback', () => {
 
   fireEvent.click(inStockBtn);
 
-  expect(onPillClick).toHaveBeenCalledWith({
-    title: 'In Stock',
-    id: 'in_stock',
-  });
+  expect(onPillClick).toHaveBeenCalledWith('in_stock');
 });

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -40,7 +40,7 @@ const getSimpleTable = ({
     itemName={itemName}
     emptyComponent={emptyComponent}
     style={style}
-    pillTabs={pillTabs}
+    filters={pillTabs}
     columns={
       columns || [
         { header: 'Sku', render: ({ sku }) => sku },

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -3,6 +3,8 @@ import 'jest-styled-components';
 
 import { fireEvent, render, screen, waitForElement } from '@test/utils';
 
+import { PillTabItem } from '../PillTabs';
+
 import { Table, TableFigure } from './Table';
 
 interface SimpleTableOptions {
@@ -15,6 +17,7 @@ interface SimpleTableOptions {
   id?: string;
   itemName?: string;
   style?: CSSProperties;
+  pillTabs?: PillTabItem[];
 }
 
 const getSimpleTable = ({
@@ -26,6 +29,7 @@ const getSimpleTable = ({
   id,
   itemName,
   items,
+  pillTabs,
   style,
 }: SimpleTableOptions = {}) => (
   <Table
@@ -36,6 +40,7 @@ const getSimpleTable = ({
     itemName={itemName}
     emptyComponent={emptyComponent}
     style={style}
+    pillTabs={pillTabs}
     columns={
       columns || [
         { header: 'Sku', render: ({ sku }) => sku },
@@ -512,4 +517,48 @@ describe('draggable', () => {
 
     expect(onRowDrop).toHaveBeenCalledWith(0, 1);
   });
+});
+
+test('it renders pill tabs with the pillTabs prop', () => {
+  const pillTabs = [
+    {
+      text: 'In Stock',
+      isActive: false,
+      onClick: jest.fn(),
+    },
+    {
+      text: 'Low Stock',
+      isActive: false,
+      onClick: jest.fn(),
+    },
+  ];
+  const { getByText } = render(getSimpleTable({ pillTabs }));
+  const inStock = getByText('In Stock');
+  const lowStock = getByText('Low Stock');
+
+  expect(inStock).toBeInTheDocument();
+  expect(lowStock).toBeInTheDocument();
+});
+
+test('it executes the given callback', () => {
+  const inStockCb = jest.fn();
+  const inStock = {
+    text: 'In Stock',
+    isActive: false,
+    onClick: inStockCb,
+  };
+  const pillTabs = [
+    inStock,
+    {
+      text: 'Low Stock',
+      isActive: false,
+      onClick: jest.fn(),
+    },
+  ];
+  const { getByText } = render(getSimpleTable({ pillTabs }));
+  const inStockBtn = getByText('In Stock');
+
+  fireEvent.click(inStockBtn);
+
+  expect(inStockCb).toHaveBeenCalledWith(inStock);
 });

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 import { MarginProps } from '../../mixins';
 import { PaginationProps } from '../Pagination';
-import { PillTabItem } from '../PillTabs';
+import { PillTabsProps } from '../PillTabs';
 
 import { TableColumnDisplayProps } from './mixins';
 
@@ -46,7 +46,7 @@ export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElemen
   itemName?: string;
   items: T[];
   keyField?: string;
-  pillTabs?: PillTabItem[];
+  pillTabs?: PillTabsProps;
   onRowDrop?(from: number, to: number): void;
   pagination?: TablePaginationProps;
   selectable?: TableSelectable<T>;

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -46,7 +46,7 @@ export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElemen
   itemName?: string;
   items: T[];
   keyField?: string;
-  pillTabs?: PillTabsProps;
+  filters?: PillTabsProps;
   onRowDrop?(from: number, to: number): void;
   pagination?: TablePaginationProps;
   selectable?: TableSelectable<T>;

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 
 import { MarginProps } from '../../mixins';
 import { PaginationProps } from '../Pagination';
+import { PillTabItem } from '../PillTabs';
 
 import { TableColumnDisplayProps } from './mixins';
 
@@ -45,6 +46,7 @@ export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElemen
   itemName?: string;
   items: T[];
   keyField?: string;
+  pillTabs?: PillTabItem[];
   onRowDrop?(from: number, to: number): void;
   pagination?: TablePaginationProps;
   selectable?: TableSelectable<T>;

--- a/packages/big-design/src/components/index.ts
+++ b/packages/big-design/src/components/index.ts
@@ -21,6 +21,7 @@ export * from './Modal';
 export * from './MultiSelect';
 export * from './Pagination';
 export * from './Panel';
+export * from './PillTabs';
 export * from './Popover';
 export * from './ProgressBar';
 export * from './ProgressCircle';

--- a/packages/big-design/src/hooks/index.ts
+++ b/packages/big-design/src/hooks/index.ts
@@ -4,4 +4,5 @@ export * from './useEventCallback';
 export * from './useIsomorphicLayoutEffect';
 export * from './useRafState';
 export * from './useUniqueId';
+export * from './useWindowResizeListener';
 export * from './useWindowSize';

--- a/packages/big-design/src/hooks/useWindowResizeListener.ts
+++ b/packages/big-design/src/hooks/useWindowResizeListener.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+export const useWindowResizeListener = (callback: () => void) => {
+  useEffect(() => {
+    window.addEventListener('resize', callback);
+
+    return () => {
+      window.removeEventListener('resize', callback);
+    };
+  }, [callback]);
+};

--- a/packages/big-design/src/hooks/useWindowSize.ts
+++ b/packages/big-design/src/hooks/useWindowSize.ts
@@ -1,8 +1,7 @@
-import { useEffect } from 'react';
-
 import { isClient } from '../utils';
 
 import { useRafState } from './useRafState';
+import { useWindowResizeListener } from './useWindowResizeListener';
 
 interface State {
   height: number;
@@ -14,21 +13,14 @@ export const useWindowSize = () => {
     height: isClient ? window.innerHeight : -1,
     width: isClient ? window.innerWidth : -1,
   });
+  const resizeHandler = () => {
+    setState({
+      height: window.innerHeight,
+      width: window.innerWidth,
+    });
+  };
 
-  useEffect(() => {
-    const resizeHandler = () => {
-      setState({
-        height: window.innerHeight,
-        width: window.innerWidth,
-      });
-    };
-
-    window.addEventListener('resize', resizeHandler);
-
-    return () => {
-      window.removeEventListener('resize', resizeHandler);
-    };
-  }, [setState]);
+  useWindowResizeListener(resizeHandler);
 
   if (!isClient) {
     return state;

--- a/packages/docs/PropTables/PillTabsPropTable.tsx
+++ b/packages/docs/PropTables/PillTabsPropTable.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { NextLink, Prop, PropTable, PropTableWrapper } from '../components';
+
+const pillTabsPropTable: Prop[] = [
+  {
+    description: (
+      <>
+        See <NextLink href="#pill-tabs-items-prop-table">below</NextLink> for usage.
+      </>
+    ),
+    name: 'items',
+    required: true,
+    types: <NextLink href="#pill-tabs-items-prop-table">PillTabItem[]</NextLink>,
+  },
+];
+
+export const PillTabsPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable title="Pill Tabs" propList={pillTabsPropTable} {...props} />
+);
+
+const tabItemProps: Prop[] = [
+  {
+    name: 'text',
+    types: 'string',
+    description: 'The text inside the Pill Tab Item',
+    required: true,
+  },
+  {
+    name: 'isActive',
+    types: 'boolean',
+    description: 'Flag that determines whether the tab is active or not',
+    required: true,
+  },
+  {
+    name: 'onClick',
+    types: 'funtion',
+    description: 'A callback to execute whenever the Pill Tab Item is clicked',
+    required: true,
+  },
+];
+
+export const PillTabItemPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable title="PillTabs[PillTabItem]" propList={tabItemProps} {...props} />
+);

--- a/packages/docs/PropTables/PillTabsPropTable.tsx
+++ b/packages/docs/PropTables/PillTabsPropTable.tsx
@@ -6,7 +6,7 @@ const pillTabsPropTable: Prop[] = [
   {
     name: 'activePills',
     types: 'string[]',
-    description: 'The currently active pill ids as an array of strings',
+    description: 'The currently active pill ids as an array of strings.',
   },
   {
     description: (

--- a/packages/docs/PropTables/PillTabsPropTable.tsx
+++ b/packages/docs/PropTables/PillTabsPropTable.tsx
@@ -4,6 +4,11 @@ import { NextLink, Prop, PropTable, PropTableWrapper } from '../components';
 
 const pillTabsPropTable: Prop[] = [
   {
+    name: 'activePills',
+    types: 'string[]',
+    description: 'The currently active pill ids as an array of strings',
+  },
+  {
     description: (
       <>
         See <NextLink href="#pill-tabs-items-prop-table">below</NextLink> for usage.
@@ -13,6 +18,12 @@ const pillTabsPropTable: Prop[] = [
     required: true,
     types: <NextLink href="#pill-tabs-items-prop-table">PillTabItem[]</NextLink>,
   },
+  {
+    name: 'onPillClick',
+    types: '(itemId: string) => void',
+    description: 'Function that will get called when a pill tab is clicked.',
+    required: true,
+  },
 ];
 
 export const PillTabsPropTable: React.FC<PropTableWrapper> = (props) => (
@@ -21,22 +32,16 @@ export const PillTabsPropTable: React.FC<PropTableWrapper> = (props) => (
 
 const tabItemProps: Prop[] = [
   {
-    name: 'text',
+    name: 'title',
     types: 'string',
-    description: 'The text inside the Pill Tab Item',
+    description: 'The text inside the Pill Tab Item.',
     required: true,
   },
   {
-    name: 'isActive',
-    types: 'boolean',
-    description: 'Flag that determines whether the tab is active or not',
+    description: 'A unique identifier for the pill.',
+    name: 'id',
     required: true,
-  },
-  {
-    name: 'onClick',
-    types: 'funtion',
-    description: 'A callback to execute whenever the Pill Tab Item is clicked',
-    required: true,
+    types: 'string',
   },
 ];
 

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -80,11 +80,11 @@ const statefulTableProps: Prop[] = [
     description: 'Callback called with updated items list once drag and drop action has been completed.',
   },
   {
-    name: 'pillTabFilters',
-    types: <NextLink href="#stateful-table-pill-tab-filters-prop-table">PillTabFilter[]</NextLink>,
+    name: 'tableFilters',
+    types: <NextLink href="#stateful-table-filters-prop-table">TableFilters</NextLink>,
     description: (
       <>
-        See <NextLink href="#stateful-table-pill-tab-filters-prop-table">below</NextLink> for usage.
+        See <NextLink href="#stateful-table-filters-prop-table">below</NextLink> for usage.
       </>
     ),
   },
@@ -156,20 +156,23 @@ const tableColumnsProps: Prop[] = [
   },
 ];
 
-const tablePillTabFiltersProps: Prop[] = [
+const tableFiltersProps: Prop[] = [
   {
-    name: 'text',
-    types: 'string',
-    description: 'The text to display inside the Pill Tab.',
-  },
-  {
-    name: 'hash',
-    types: 'string',
-    description: 'A unique identifier for the filtering function.',
+    description: (
+      <>
+        An array of pill tab items to render in the table. See{' '}
+        <NextLink href="/PillTabs/PillTabPage" as="/pill-tabs">
+          Pill Tabs
+        </NextLink>{' '}
+        for usage.
+      </>
+    ),
+    name: 'pillTabs',
+    types: 'PillTabItem[]',
   },
   {
     name: 'filter',
-    types: '(items: Item[]) => Item[]',
+    types: '(itemId: string, items: Item[]) => Item[]',
     description: 'A function that takes the current items and filters them according to the desired functionality.',
   },
 ];
@@ -182,6 +185,6 @@ export const StatefulTableColumnsPropTable: React.FC<PropTableWrapper> = (props)
   <PropTable title="StatefulTable[Columns]" propList={tableColumnsProps} {...props} />
 );
 
-export const StatefulTablePillTabFiltersPropTable: React.FC<PropTableWrapper> = (props) => (
-  <PropTable title="StatefulTable[PillTabFilters]" propList={tablePillTabFiltersProps} {...props} />
+export const StatefulTableFiltersPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable title="StatefulTable[TableFilters]" propList={tableFiltersProps} {...props} />
 );

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -80,8 +80,8 @@ const statefulTableProps: Prop[] = [
     description: 'Callback called with updated items list once drag and drop action has been completed.',
   },
   {
-    name: 'tableFilters',
-    types: <NextLink href="#stateful-table-filters-prop-table">TableFilters</NextLink>,
+    name: 'filters',
+    types: <NextLink href="#stateful-table-filters-prop-table">Filters</NextLink>,
     description: (
       <>
         See <NextLink href="#stateful-table-filters-prop-table">below</NextLink> for usage.
@@ -156,7 +156,7 @@ const tableColumnsProps: Prop[] = [
   },
 ];
 
-const tableFiltersProps: Prop[] = [
+const filterProps: Prop[] = [
   {
     description: (
       <>
@@ -186,5 +186,5 @@ export const StatefulTableColumnsPropTable: React.FC<PropTableWrapper> = (props)
 );
 
 export const StatefulTableFiltersPropTable: React.FC<PropTableWrapper> = (props) => (
-  <PropTable title="StatefulTable[TableFilters]" propList={tableFiltersProps} {...props} />
+  <PropTable title="StatefulTable[Filters]" propList={filterProps} {...props} />
 );

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -79,6 +79,15 @@ const statefulTableProps: Prop[] = [
     types: '(items: any[]) => void',
     description: 'Callback called with updated items list once drag and drop action has been completed.',
   },
+  {
+    name: 'pillTabFilters',
+    types: <NextLink href="#stateful-table-pill-tab-filters-prop-table">PillTabFilter[]</NextLink>,
+    description: (
+      <>
+        See <NextLink href="#stateful-table-pill-tab-filters-prop-table">below</NextLink> for usage.
+      </>
+    ),
+  },
 ];
 
 const tableColumnsProps: Prop[] = [
@@ -147,10 +156,32 @@ const tableColumnsProps: Prop[] = [
   },
 ];
 
+const tablePillTabFiltersProps: Prop[] = [
+  {
+    name: 'text',
+    types: 'string',
+    description: 'The text to display inside the Pill Tab.',
+  },
+  {
+    name: 'hash',
+    types: 'string',
+    description: 'A unique identifier for the filtering function.',
+  },
+  {
+    name: 'filter',
+    types: '(items: Item[]) => Item[]',
+    description: 'A function that takes the current items and filters them according to the desired functionality.',
+  },
+];
+
 export const StatefulTablePropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable title="StatefulTable" propList={statefulTableProps} {...props} />
 );
 
 export const StatefulTableColumnsPropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable title="StatefulTable[Columns]" propList={tableColumnsProps} {...props} />
+);
+
+export const StatefulTablePillTabFiltersPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable title="StatefulTable[PillTabFilters]" propList={tablePillTabFiltersProps} {...props} />
 );

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -45,7 +45,7 @@ const tableProps: Prop[] = [
     description: 'See pagination component for details.',
   },
   {
-    name: 'pillTabs',
+    name: 'filters',
     types: (
       <NextLink href="/PillTabs/PillTabsPage" as="/pill-tabs">
         Pill Tabs

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -45,6 +45,15 @@ const tableProps: Prop[] = [
     description: 'See pagination component for details.',
   },
   {
+    name: 'pillTabs',
+    types: (
+      <NextLink href="/PillTabs/PillTabsPage" as="/pill-tabs">
+        Pill Tabs
+      </NextLink>
+    ),
+    description: 'See Pill Tabs component for details.',
+  },
+  {
     name: 'selectable',
     types: <NextLink href="#table-selectable-prop-table">Selectable</NextLink>,
     description: (

--- a/packages/docs/PropTables/index.ts
+++ b/packages/docs/PropTables/index.ts
@@ -21,6 +21,7 @@ export * from './MultiSelectPropTable';
 export * from './PaddingPropTable';
 export * from './PaginationPropTable';
 export * from './PanelPropTable';
+export * from './PillTabsPropTable';
 export * from './PopoverPropTable';
 export * from './ProgressBarPropTable';
 export * from './ProgressCirclePropTable';

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -101,6 +101,9 @@ export const SideNav: React.FC = () => {
           <SideNavLink href="/Link/LinkPage" as="/link">
             Link
           </SideNavLink>
+          <SideNavLink href="/PillTabs/PillTabsPage" as="/pill-tabs">
+            Pill Tabs
+          </SideNavLink>
           <SideNavLink href="/Radio/RadioPage" as="/radio">
             Radio
           </SideNavLink>

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -49,6 +49,7 @@ module.exports = {
     '/padding': { page: '/Padding/PaddingPage' },
     '/pagination': { page: '/Pagination/PaginationPage' },
     '/panel': { page: '/Panel/PanelPage' },
+    '/pill-tabs': { page: '/PillTabs/PillTabsPage' },
     '/popover': { page: '/Popover/PopoverPage' },
     '/progress-bar': { page: '/Progress/ProgressBarPage' },
     '/progress-circle': { page: '/Progress/ProgressCirclePage' },

--- a/packages/docs/pages/PillTabs/PillTabsPage.tsx
+++ b/packages/docs/pages/PillTabs/PillTabsPage.tsx
@@ -10,11 +10,7 @@ const PillTabsPage = () => (
 
     <Text>
       The <Code primary>Pill Tabs</Code> component is used to provide a set of filters that act on a collection of
-      items. For usage with tables, see their respective components.{' '}
-      <Link href="https://design.bigcommerce.com/components/tabs" target="_blank">
-        MISSING URL
-      </Link>
-      .
+      items. For usage with tables, see their respective components.
     </Text>
 
     <CodePreview>

--- a/packages/docs/pages/PillTabs/PillTabsPage.tsx
+++ b/packages/docs/pages/PillTabs/PillTabsPage.tsx
@@ -1,0 +1,98 @@
+import { Flex, FlexItem, H0, H1, Link, Panel, PillTabs, Text } from '@bigcommerce/big-design';
+import React, { useState } from 'react';
+
+import { Code, CodePreview } from '../../components';
+import { PillTabItemPropTable, PillTabsPropTable } from '../../PropTables';
+
+const PillTabsPage = () => (
+  <>
+    <H0>Pill Tabs</H0>
+
+    <Text>
+      The <Code primary>Pill Tabs</Code> component is used to provide a set of filters that act on a collection of
+      items. For usage with tables, see their respective components.{' '}
+      <Link href="https://design.bigcommerce.com/components/tabs" target="_blank">
+        MISSING URL
+      </Link>
+      .
+    </Text>
+
+    <CodePreview>
+      {/* jsx-to-string:start */}
+      {function Example() {
+        const [activeTabs, setActiveTabs] = useState({
+          shipping: false,
+          orders: false,
+        });
+        const Card: React.FC<{ name: string; description: string }> = ({ name, description }) => (
+          <Flex border="box" flexDirection="column" padding="medium" margin="small">
+            <FlexItem marginBottom="small">
+              <Text bold>{name}</Text>
+            </FlexItem>
+            <FlexItem flexGrow={1}>
+              <Text>{description}</Text>
+            </FlexItem>
+            <FlexItem>
+              <Link href="#">Install</Link>
+            </FlexItem>
+          </Flex>
+        );
+        const pillTabItems = [
+          {
+            isActive: activeTabs.shipping,
+            text: 'Shipping',
+            onClick: () => setActiveTabs({ ...activeTabs, shipping: !activeTabs.shipping }),
+          },
+          {
+            isActive: activeTabs.orders,
+            text: 'Orders',
+            onClick: () => setActiveTabs({ ...activeTabs, orders: !activeTabs.orders }),
+          },
+        ];
+        const cards = [
+          {
+            name: 'Shipping App Pro',
+            description: 'All your shipping needs in a one stop shop.',
+            type: 'shipping',
+          },
+          {
+            name: 'Order Tracker Deluxe',
+            description: 'Track your orders across all your devices.',
+            type: 'orders',
+          },
+          {
+            name: 'Expedited Shipper',
+            description: 'The best rush rates in the country.',
+            type: 'shipping',
+          },
+          {
+            name: 'Inventory Wizard',
+            description: 'Inventory tracking app to cover all your needs.',
+            type: 'other',
+          },
+        ];
+        const isFiltered = Object.values(activeTabs).some(Boolean);
+        const filteredCards = cards.filter((card) => activeTabs[card.type]);
+        const appCards = isFiltered ? filteredCards : cards;
+
+        return (
+          <Panel header="App Marketplace">
+            <PillTabs items={pillTabItems} />
+            <Flex>
+              {appCards.map(({ name, description }) => (
+                <Card key={name} name={name} description={description} />
+              ))}
+            </Flex>
+          </Panel>
+        );
+      }}
+      {/* jsx-to-string:end */}
+    </CodePreview>
+
+    <H1>API</H1>
+    <PillTabsPropTable />
+    <PillTabItemPropTable id="pill-tabs-items-prop-table" />
+  </>
+);
+
+export default PillTabsPage;

--- a/packages/docs/pages/PillTabs/PillTabsPage.tsx
+++ b/packages/docs/pages/PillTabs/PillTabsPage.tsx
@@ -16,10 +16,7 @@ const PillTabsPage = () => (
     <CodePreview>
       {/* jsx-to-string:start */}
       {function Example() {
-        const [activeTabs, setActiveTabs] = useState({
-          shipping: false,
-          orders: false,
-        });
+        const [activePills, setActivePills] = useState<string[]>([]);
         const Card: React.FC<{ name: string; description: string }> = ({ name, description }) => (
           <Flex border="box" flexDirection="column" padding="medium" margin="small">
             <FlexItem marginBottom="small">
@@ -33,18 +30,18 @@ const PillTabsPage = () => (
             </FlexItem>
           </Flex>
         );
-        const pillTabItems = [
-          {
-            isActive: activeTabs.shipping,
-            text: 'Shipping',
-            onClick: () => setActiveTabs({ ...activeTabs, shipping: !activeTabs.shipping }),
-          },
-          {
-            isActive: activeTabs.orders,
-            text: 'Orders',
-            onClick: () => setActiveTabs({ ...activeTabs, orders: !activeTabs.orders }),
-          },
+        const items = [
+          { title: 'Shipping', id: 'shipping' },
+          { title: 'Orders', id: 'orders' },
         ];
+        const onPillClick = (pillId: string) => {
+          const isPillActive = !activePills.includes(pillId);
+          const updatedPills = isPillActive
+            ? [...activePills, pillId]
+            : activePills.filter((activePillId) => activePillId !== pillId);
+
+          setActivePills(updatedPills);
+        };
         const cards = [
           {
             name: 'Shipping App Pro',
@@ -67,13 +64,13 @@ const PillTabsPage = () => (
             type: 'other',
           },
         ];
-        const isFiltered = Object.values(activeTabs).some(Boolean);
-        const filteredCards = cards.filter((card) => activeTabs[card.type]);
+        const isFiltered = Boolean(activePills.length);
+        const filteredCards = cards.filter((card) => activePills.includes(card.type));
         const appCards = isFiltered ? filteredCards : cards;
 
         return (
           <Panel header="App Marketplace">
-            <PillTabs items={pillTabItems} />
+            <PillTabs activePills={activePills} items={items} onPillClick={onPillClick} />
             <Flex>
               {appCards.map(({ name, description }) => (
                 <Card key={name} name={name} description={description} />

--- a/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
+++ b/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
@@ -2,7 +2,11 @@ import { H0, H1, H2, StatefulTable, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { CodePreview, NextLink } from '../../components';
-import { StatefulTableColumnsPropTable, StatefulTablePropTable } from '../../PropTables';
+import {
+  StatefulTableColumnsPropTable,
+  StatefulTablePillTabFiltersPropTable,
+  StatefulTablePropTable,
+} from '../../PropTables';
 
 const items = [
   { sku: '3137737c', name: 'Rice - Wild', stock: 29 },
@@ -143,6 +147,7 @@ const StatefulTablePage = () => {
       <H1>API</H1>
       <StatefulTablePropTable />
       <StatefulTableColumnsPropTable id="stateful-table-columns-prop-table" />
+      <StatefulTablePillTabFiltersPropTable id="stateful-table-pill-tab-filters-prop-table" />
 
       <H1>Examples</H1>
       <H2>Usage with pagination, selection, and sorting.</H2>
@@ -182,6 +187,39 @@ const StatefulTablePage = () => {
             { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
           ]}
           onRowDrop={() => null}
+        />
+        {/* jsx-to-string:end */}
+      </CodePreview>
+
+      <H1>Usage with Pill Tab filters</H1>
+
+      <CodePreview>
+        {/* jsx-to-string:start */}
+        <StatefulTable
+          columns={[
+            { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+            { header: 'Name', hash: 'name', render: ({ name }) => name },
+            { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+          ]}
+          items={[
+            { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+            { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+            { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 0 },
+            { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+            { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+          ]}
+          pillTabFilters={[
+            {
+              text: 'Low Stock',
+              hash: 'low_stock',
+              filter: (items) => items.filter((item) => item.stock < 10),
+            },
+            {
+              text: 'Out of Stock',
+              hash: 'out_stock',
+              filter: (items) => items.filter((item) => item.stock === 0),
+            },
+          ]}
         />
         {/* jsx-to-string:end */}
       </CodePreview>

--- a/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
+++ b/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
@@ -2,11 +2,7 @@ import { H0, H1, H2, StatefulTable, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { CodePreview, NextLink } from '../../components';
-import {
-  StatefulTableColumnsPropTable,
-  StatefulTablePillTabFiltersPropTable,
-  StatefulTablePropTable,
-} from '../../PropTables';
+import { StatefulTableColumnsPropTable, StatefulTableFiltersPropTable, StatefulTablePropTable } from '../../PropTables';
 
 const items = [
   { sku: '3137737c', name: 'Rice - Wild', stock: 29 },
@@ -147,7 +143,7 @@ const StatefulTablePage = () => {
       <H1>API</H1>
       <StatefulTablePropTable />
       <StatefulTableColumnsPropTable id="stateful-table-columns-prop-table" />
-      <StatefulTablePillTabFiltersPropTable id="stateful-table-pill-tab-filters-prop-table" />
+      <StatefulTableFiltersPropTable id="stateful-table-filters-prop-table" />
 
       <H1>Examples</H1>
       <H2>Usage with pagination, selection, and sorting.</H2>
@@ -208,18 +204,22 @@ const StatefulTablePage = () => {
             { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
             { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
           ]}
-          pillTabFilters={[
-            {
-              text: 'Low Stock',
-              hash: 'low_stock',
-              filter: (items) => items.filter((item) => item.stock < 10),
-            },
-            {
-              text: 'Out of Stock',
-              hash: 'out_stock',
-              filter: (items) => items.filter((item) => item.stock === 0),
-            },
-          ]}
+          tableFilters={{
+            filter: (pillId, items) =>
+              pillId === 'low_stock'
+                ? items.filter((item) => item.stock !== 0 && item.stock < 10)
+                : items.filter((item) => item.stock === 0),
+            pillTabs: [
+              {
+                id: 'low_stock',
+                title: 'Low Stock',
+              },
+              {
+                id: 'out_of_stock',
+                title: 'Out of Stock',
+              },
+            ],
+          }}
         />
         {/* jsx-to-string:end */}
       </CodePreview>

--- a/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
+++ b/packages/docs/pages/StatefulTable/StatefulTablePage.tsx
@@ -187,7 +187,7 @@ const StatefulTablePage = () => {
         {/* jsx-to-string:end */}
       </CodePreview>
 
-      <H1>Usage with Pill Tab filters</H1>
+      <H1>Usage with filters</H1>
 
       <CodePreview>
         {/* jsx-to-string:start */}
@@ -204,7 +204,7 @@ const StatefulTablePage = () => {
             { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
             { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
           ]}
-          tableFilters={{
+          filters={{
             filter: (pillId, items) =>
               pillId === 'low_stock'
                 ? items.filter((item) => item.stock !== 0 && item.stock < 10)

--- a/packages/docs/pages/Table/TablePage.tsx
+++ b/packages/docs/pages/Table/TablePage.tsx
@@ -278,6 +278,44 @@ const TablePage = () => {
         }}
         {/* jsx-to-string:end */}
       </CodePreview>
+
+      <H1>Usage with Pill Tabs</H1>
+
+      <CodePreview scope={{ data }}>
+        {/* jsx-to-string:start */}
+        {function Example() {
+          const [items, setItems] = useState(data);
+          const [activeFilters, setActiveFilters] = useState({
+            lowStock: false,
+          });
+          const pillTabs = [
+            {
+              isActive: activeFilters.lowStock,
+              text: 'Low Stock',
+              onClick: () => {
+                const isFilterActive = !activeFilters.lowStock;
+                const newItems = isFilterActive ? items.filter((item) => item.stock < 10) : data;
+
+                setItems(newItems);
+                setActiveFilters({ lowStock: isFilterActive });
+              },
+            },
+          ];
+
+          return (
+            <Table
+              columns={[
+                { header: 'Sku', hash: 'sku', render: ({ sku }) => sku, isSortable: true },
+                { header: 'Name', hash: 'name', render: ({ name }) => name, isSortable: true },
+                { header: 'Stock', hash: 'stock', render: ({ stock }) => stock, isSortable: true },
+              ]}
+              items={items}
+              pillTabs={pillTabs}
+            />
+          );
+        }}
+        {/* jsx-to-string:end */}
+      </CodePreview>
     </>
   );
 };

--- a/packages/docs/pages/Table/TablePage.tsx
+++ b/packages/docs/pages/Table/TablePage.tsx
@@ -288,7 +288,7 @@ const TablePage = () => {
           const [activePills, setActivePills] = useState<string[]>([]);
           const pillTabs: PillTabsProps = {
             activePills,
-            onPillClick: ({ id }) => {
+            onPillClick: (id) => {
               const isFilterActive = !activePills.includes(id);
               const newItems = isFilterActive ? items.filter((item) => item.stock < 10) : data;
               const updatedPills = isFilterActive

--- a/packages/docs/pages/Table/TablePage.tsx
+++ b/packages/docs/pages/Table/TablePage.tsx
@@ -1,4 +1,4 @@
-import { H0, H1, Small, Table, TableFigure, TableItem, Text } from '@bigcommerce/big-design';
+import { H0, H1, PillTabsProps, Small, Table, TableFigure, TableItem, Text } from '@bigcommerce/big-design';
 import React, { useEffect, useState } from 'react';
 
 import { Code, CodePreview } from '../../components';
@@ -285,22 +285,21 @@ const TablePage = () => {
         {/* jsx-to-string:start */}
         {function Example() {
           const [items, setItems] = useState(data);
-          const [activeFilters, setActiveFilters] = useState({
-            lowStock: false,
-          });
-          const pillTabs = [
-            {
-              isActive: activeFilters.lowStock,
-              text: 'Low Stock',
-              onClick: () => {
-                const isFilterActive = !activeFilters.lowStock;
-                const newItems = isFilterActive ? items.filter((item) => item.stock < 10) : data;
+          const [activePills, setActivePills] = useState<string[]>([]);
+          const pillTabs: PillTabsProps = {
+            activePills,
+            onPillClick: ({ id }) => {
+              const isFilterActive = !activePills.includes(id);
+              const newItems = isFilterActive ? items.filter((item) => item.stock < 10) : data;
+              const updatedPills = isFilterActive
+                ? [...activePills, id]
+                : activePills.filter((activePillId) => activePillId !== id);
 
-                setItems(newItems);
-                setActiveFilters({ lowStock: isFilterActive });
-              },
+              setItems(newItems);
+              setActivePills(updatedPills);
             },
-          ];
+            items: [{ title: 'Low Stock', id: 'low_stock' }],
+          };
 
           return (
             <Table

--- a/packages/docs/pages/Table/TablePage.tsx
+++ b/packages/docs/pages/Table/TablePage.tsx
@@ -279,7 +279,7 @@ const TablePage = () => {
         {/* jsx-to-string:end */}
       </CodePreview>
 
-      <H1>Usage with Pill Tabs</H1>
+      <H1>Usage with filters</H1>
 
       <CodePreview scope={{ data }}>
         {/* jsx-to-string:start */}
@@ -309,7 +309,7 @@ const TablePage = () => {
                 { header: 'Stock', hash: 'stock', render: ({ stock }) => stock, isSortable: true },
               ]}
               items={items}
-              pillTabs={pillTabs}
+              filters={pillTabs}
             />
           );
         }}

--- a/packages/docs/pages/_app.tsx
+++ b/packages/docs/pages/_app.tsx
@@ -24,7 +24,7 @@ const gridTemplate = {
   `,
   tablet: `
     ". nav main ." 1fr
-    / 1fr 210px minmax(min-content, 1050px) 1fr;
+    / 1fr 210px minmax(0, 1050px) 1fr;
   `,
 };
 


### PR DESCRIPTION
## What
Adds the Pill Tabs component

## Background
This component is meant to be a collection of "Views" that are presented as a group of buttons on the top of a Panel. These "Views" act on a collection of items. Tables and Stateful Tables are prime usecases for filterable items that can be used with the Pill Tabs component. Other usecases outside of tables exist, such as an "App Marketplace" or such, a collection of "cards" inside a panel that could also benefit from Pill Tabs

Because of its prime usage with Tables, I have integrated the component as a prop in both the `Table` and the `StatefulTable`. 

## Raw component, Integrations with Table & StatefulTable

**Raw usage:**
Because the `Pill Tabs` can also exist outside tables, a raw `PillTabs` component is exposed

**For the case of `Table`:**
- New Props `filters?` allows for a `PillTabsProps` object to be provided for the table to render. It is up to the developer to keep track of state.

**For the case of `StatefulTable`:**
- New prop `filters?` allows for a `StatefulTablePillTabFilter` object to be provided. The StatefulTable keeps track of active filters, and the current view of filtered items

## Usage & API

**In Pill Tabs (raw component):**

```
interface PillTabItem {
  id: string;
  title: string;
}

interface PillTabsProps {
  items: PillTabItem[];
  activePills: string[];
  onPillClick: (item: PillTabItem) => void;
}
```

**In Stateful Table:**
New prop `filters?: StatefulTablePillTabFilter<T>;`

```
interface StatefulTablePillTabFilter<T> {
  pillTabs: PillTabItem[];
  filter(itemId: string, items: T[]): T[];
}
```

**In Table (same as raw component):**
New prop `filters?: PillTabsProps;`

```
interface PillTabItem {
  id: string;
  title: string;
}

interface PillTabsProps {
  items: PillTabItem[];
  activePills: string[];
  onPillClick: (item: PillTabItem) => void;
}
```

## Some Screenshots
<img width="691" alt="Screen Shot 2021-04-05 at 10 17 45 AM" src="https://user-images.githubusercontent.com/6025510/113592041-48c27c00-95fa-11eb-946e-30d04bd02e49.png">
<img width="682" alt="Screen Shot 2021-04-05 at 10 17 55 AM" src="https://user-images.githubusercontent.com/6025510/113592055-4c560300-95fa-11eb-9330-7de72abcdb70.png">
<img width="1002" alt="Screen Shot 2021-04-05 at 10 20 20 AM" src="https://user-images.githubusercontent.com/6025510/113592069-4f50f380-95fa-11eb-8097-4bf22dfd225d.png">
<img width="1007" alt="Screen Shot 2021-04-05 at 10 20 26 AM" src="https://user-images.githubusercontent.com/6025510/113592081-52e47a80-95fa-11eb-8b14-d4a0dc8f9e0e.png">
<img width="983" alt="Screen Shot 2021-04-05 at 10 21 23 AM" src="https://user-images.githubusercontent.com/6025510/113592098-57109800-95fa-11eb-9d46-54fc2caf7b30.png">

