### PR TITLE
fix(docs): dropdown doc fix

### DIFF
--- a/packages/docs/PropTables/DropdownPropTable.tsx
+++ b/packages/docs/PropTables/DropdownPropTable.tsx
@@ -226,7 +226,7 @@ const dropdownItemGroupProps: Prop[] = [
     description: 'If true, adds a line separator above the group.',
   },
   {
-    name: 'options',
+    name: 'items',
     types: 'Array<DropdownItem | DropdownLinkItem>',
     required: true,
     description: (


### PR DESCRIPTION
## What?
Renaming `options` to `items` in the `DropdownItemGroup` doc section.

## Why?
`DropdownItemGroup` interface:
<img width="417" alt="Screenshot 2021-04-13 at 13 15 23" src="https://user-images.githubusercontent.com/9980803/114538622-3f6d8b00-9c5c-11eb-9b33-0c883c874259.png">

## Proof
**Prev view:**
<img width="961" alt="Screenshot 2021-04-13 at 13 13 03" src="https://user-images.githubusercontent.com/9980803/114538678-4d231080-9c5c-11eb-843c-5dc4566fb14f.png">

**Next view:**
<img width="981" alt="Screenshot 2021-04-13 at 13 26 08" src="https://user-images.githubusercontent.com/9980803/114538713-57450f00-9c5c-11eb-9c7f-9bd83acf5215.png">

ping @bigcommerce/frontend 
