### PR TITLE
refactor(component): return items on handlers

### DIFF
--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -8,6 +8,7 @@ import { Row } from './Row';
 import { Status } from './RowStatus/styled';
 import { Header, Table } from './styled';
 import { WorksheetItem, Worksheet as WorksheetProps } from './types';
+import { editedRows, invalidRows } from './utils';
 
 const InternalWorksheet = <T extends WorksheetItem>({
   columns,
@@ -26,15 +27,15 @@ const InternalWorksheet = <T extends WorksheetItem>({
 
   useEffect(() => {
     if (editedCells.length) {
-      onChange(editedCells);
+      onChange(editedRows(editedCells, rows));
     }
-  }, [editedCells, onChange]);
+  }, [editedCells, onChange, rows]);
 
   useEffect(() => {
     if (typeof onErrors === 'function' && invalidCells.length) {
-      onErrors(invalidCells);
+      onErrors(invalidRows(invalidCells, rows));
     }
-  }, [invalidCells, onErrors]);
+  }, [invalidCells, onErrors, rows]);
 
   const renderedHeaders = useMemo(
     () => (

--- a/packages/big-design/src/components/Worksheet/editors/TextEditor/styled.ts
+++ b/packages/big-design/src/components/Worksheet/editors/TextEditor/styled.ts
@@ -5,7 +5,6 @@ export const StyledInput = styled.input<{ isEdited: boolean }>`
   border: 0;
   font-size: ${({ theme }) => theme.typography.fontSize.small};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
-  height: 100%;
   line-height: ${({ theme }) => theme.lineHeight.small};
   margin: 0;
   padding: 0;

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -6,6 +6,7 @@ import { WorksheetColumn } from './types';
 import { Worksheet } from './Worksheet';
 
 interface Product {
+  id: number;
   productName: string;
   visibleOnStorefront: boolean;
   otherField: string;
@@ -35,6 +36,7 @@ const columns: WorksheetColumn<Product>[] = [
 
 const items: Product[] = [
   {
+    id: 1,
     productName: 'Shoes Name Three',
     visibleOnStorefront: true,
     otherField: 'Text',
@@ -43,6 +45,7 @@ const items: Product[] = [
     numberField: 50,
   },
   {
+    id: 2,
     productName: 'Shoes Name Two',
     visibleOnStorefront: true,
     otherField: 'Text',
@@ -51,6 +54,7 @@ const items: Product[] = [
     numberField: 50,
   },
   {
+    id: 3,
     productName: 'Shoes Name One',
     visibleOnStorefront: false,
     otherField: 'Text',
@@ -59,6 +63,7 @@ const items: Product[] = [
     numberField: 50,
   },
   {
+    id: 4,
     productName: 'Variant',
     visibleOnStorefront: true,
     otherField: 'Text',
@@ -67,6 +72,7 @@ const items: Product[] = [
     numberField: 50,
   },
   {
+    id: 5,
     productName: '',
     visibleOnStorefront: true,
     otherField: 'Text',
@@ -75,6 +81,7 @@ const items: Product[] = [
     numberField: 50,
   },
   {
+    id: 6,
     productName: 'Variant',
     visibleOnStorefront: true,
     otherField: 'Text',
@@ -83,6 +90,7 @@ const items: Product[] = [
     numberField: 50,
   },
   {
+    id: 7,
     productName: 'Variant',
     visibleOnStorefront: false,
     otherField: 'Text',
@@ -91,6 +99,7 @@ const items: Product[] = [
     numberField: 49,
   },
   {
+    id: 8,
     productName: 'Dress Name One',
     visibleOnStorefront: true,
     otherField: 'Text',
@@ -99,6 +108,7 @@ const items: Product[] = [
     numberField: 50,
   },
   {
+    id: 9,
     productName: 'Fans Name One',
     visibleOnStorefront: true,
     otherField: 'Text',
@@ -189,7 +199,15 @@ describe('edition', () => {
     expect(cell).toBeDefined();
     expect(handleChange).toHaveBeenCalledTimes(1);
     expect(handleChange).toHaveBeenCalledWith([
-      { columnIndex: 0, hash: 'productName', rowIndex: 2, type: 'text', value: 'Shoes Name One Edit' },
+      {
+        id: 3,
+        productName: 'Shoes Name One Edit',
+        visibleOnStorefront: false,
+        otherField: 'Text',
+        otherField2: 'leather',
+        otherField3: 'Field',
+        numberField: 50,
+      },
     ]);
 
     fireEvent.doubleClick(cell);
@@ -203,7 +221,15 @@ describe('edition', () => {
     expect(cell).toBeDefined();
     expect(handleChange).toHaveBeenCalledTimes(2);
     expect(handleChange).toHaveBeenCalledWith([
-      { columnIndex: 0, hash: 'productName', rowIndex: 2, type: 'text', value: 'Shoes Name One Edit 2' },
+      {
+        id: 3,
+        productName: 'Shoes Name One Edit 2',
+        visibleOnStorefront: false,
+        otherField: 'Text',
+        otherField2: 'leather',
+        otherField3: 'Field',
+        numberField: 50,
+      },
     ]);
 
     let cells = getAllByDisplayValue('Plastic');
@@ -220,8 +246,24 @@ describe('edition', () => {
 
     expect(handleChange).toHaveBeenCalledTimes(3);
     expect(handleChange).toHaveBeenCalledWith([
-      { columnIndex: 0, hash: 'productName', rowIndex: 2, type: 'text', value: 'Shoes Name One Edit 2' },
-      { columnIndex: 3, hash: 'otherField2', rowIndex: 0, type: 'select', value: 'cloth' },
+      {
+        id: 3,
+        productName: 'Shoes Name One Edit 2',
+        visibleOnStorefront: false,
+        otherField: 'Text',
+        otherField2: 'leather',
+        otherField3: 'Field',
+        numberField: 50,
+      },
+      {
+        id: 1,
+        productName: 'Shoes Name Three',
+        visibleOnStorefront: true,
+        otherField: 'Text',
+        otherField2: 'cloth',
+        otherField3: 'Field',
+        numberField: 50,
+      },
     ]);
 
     cells = getAllByLabelText('Checked');
@@ -232,9 +274,24 @@ describe('edition', () => {
 
     expect(handleChange).toHaveBeenCalledTimes(4);
     expect(handleChange).toHaveBeenCalledWith([
-      { columnIndex: 0, hash: 'productName', rowIndex: 2, type: 'text', value: 'Shoes Name One Edit 2' },
-      { columnIndex: 3, hash: 'otherField2', rowIndex: 0, type: 'select', value: 'cloth' },
-      { columnIndex: 1, hash: 'visibleOnStorefront', rowIndex: 0, type: 'checkbox', value: false },
+      {
+        id: 3,
+        productName: 'Shoes Name One Edit 2',
+        visibleOnStorefront: false,
+        otherField: 'Text',
+        otherField2: 'leather',
+        otherField3: 'Field',
+        numberField: 50,
+      },
+      {
+        id: 1,
+        productName: 'Shoes Name Three',
+        visibleOnStorefront: false,
+        otherField: 'Text',
+        otherField2: 'cloth',
+        otherField3: 'Field',
+        numberField: 50,
+      },
     ]);
 
     await waitForElement(() => screen.getAllByRole('combobox'));
@@ -243,6 +300,7 @@ describe('edition', () => {
   test('edition does not mutate items array', () => {
     // At this point, if our previous tests mutated the items array, this value would be different
     expect(items[2]).toStrictEqual({
+      id: 3,
       productName: 'Shoes Name One',
       visibleOnStorefront: false,
       otherField: 'Text',
@@ -280,10 +338,42 @@ describe('validation', () => {
 
     expect(handleErrors).toBeCalledTimes(1);
     expect(handleErrors).toBeCalledWith([
-      { columnIndex: 0, hash: 'productName', rowIndex: 4, type: 'text', value: '' },
-      { columnIndex: 3, hash: 'otherField2', rowIndex: 4, type: 'select', value: '' },
-      { columnIndex: 3, hash: 'otherField2', rowIndex: 5, type: 'select', value: '' },
-      { columnIndex: 5, hash: 'numberField', rowIndex: 6, type: 'number', value: 49 },
+      {
+        item: {
+          id: 5,
+          productName: '',
+          visibleOnStorefront: true,
+          otherField: 'Text',
+          otherField2: '',
+          otherField3: 'Field',
+          numberField: 50,
+        },
+        errors: ['productName', 'otherField2'],
+      },
+      {
+        item: {
+          id: 6,
+          productName: 'Variant',
+          visibleOnStorefront: true,
+          otherField: 'Text',
+          otherField2: '',
+          otherField3: 'Field',
+          numberField: 50,
+        },
+        errors: ['otherField2'],
+      },
+      {
+        item: {
+          id: 7,
+          productName: 'Variant',
+          visibleOnStorefront: false,
+          otherField: 'Text',
+          otherField2: 'leather',
+          otherField3: 'Field',
+          numberField: 49,
+        },
+        errors: ['numberField'],
+      },
     ]);
 
     cell = getByText('49') as HTMLElement;
@@ -297,10 +387,42 @@ describe('validation', () => {
 
     expect(handleErrors).toBeCalledTimes(2);
     expect(handleErrors).toBeCalledWith([
-      { columnIndex: 0, hash: 'productName', rowIndex: 4, type: 'text', value: '' },
-      { columnIndex: 3, hash: 'otherField2', rowIndex: 4, type: 'select', value: '' },
-      { columnIndex: 3, hash: 'otherField2', rowIndex: 5, type: 'select', value: '' },
-      { columnIndex: 5, hash: 'numberField', rowIndex: 6, type: 'number', value: 40 },
+      {
+        item: {
+          id: 5,
+          productName: '',
+          visibleOnStorefront: true,
+          otherField: 'Text',
+          otherField2: '',
+          otherField3: 'Field',
+          numberField: 50,
+        },
+        errors: ['productName', 'otherField2'],
+      },
+      {
+        item: {
+          id: 6,
+          productName: 'Variant',
+          visibleOnStorefront: true,
+          otherField: 'Text',
+          otherField2: '',
+          otherField3: 'Field',
+          numberField: 50,
+        },
+        errors: ['otherField2'],
+      },
+      {
+        item: {
+          id: 7,
+          productName: 'Variant',
+          visibleOnStorefront: false,
+          otherField: 'Text',
+          otherField2: 'leather',
+          otherField3: 'Field',
+          numberField: 40,
+        },
+        errors: ['numberField'],
+      },
     ]);
 
     cell = getByText('40');
@@ -314,9 +436,30 @@ describe('validation', () => {
 
     expect(handleErrors).toBeCalledTimes(3);
     expect(handleErrors).toBeCalledWith([
-      { columnIndex: 0, hash: 'productName', rowIndex: 4, type: 'text', value: '' },
-      { columnIndex: 3, hash: 'otherField2', rowIndex: 4, type: 'select', value: '' },
-      { columnIndex: 3, hash: 'otherField2', rowIndex: 5, type: 'select', value: '' },
+      {
+        item: {
+          id: 5,
+          productName: '',
+          visibleOnStorefront: true,
+          otherField: 'Text',
+          otherField2: '',
+          otherField3: 'Field',
+          numberField: 50,
+        },
+        errors: ['productName', 'otherField2'],
+      },
+      {
+        item: {
+          id: 6,
+          productName: 'Variant',
+          visibleOnStorefront: true,
+          otherField: 'Text',
+          otherField2: '',
+          otherField3: 'Field',
+          numberField: 50,
+        },
+        errors: ['otherField2'],
+      },
     ]);
   });
 });
@@ -387,7 +530,15 @@ describe('TextEditor', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(handleChange).toHaveBeenCalledWith([
-      { columnIndex: 5, hash: 'numberField', rowIndex: 6, type: 'number', value: 80 },
+      {
+        id: 7,
+        productName: 'Variant',
+        visibleOnStorefront: false,
+        otherField: 'Text',
+        otherField2: 'leather',
+        otherField3: 'Field',
+        numberField: 80,
+      },
     ]);
 
     await waitForElement(() => screen.getAllByRole('combobox'));

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -4,7 +4,12 @@ export interface Worksheet<Item extends WorksheetItem> {
   columns: Array<WorksheetColumn<Item>>;
   items: Item[];
   onChange(items: Array<Cell<Item>>): void;
-  onErrors?(items: Array<Cell<Item>>): void;
+  onErrors?(items: WorksheetError<Item>[]): void;
+}
+
+export interface WorksheetError<Item extends WorksheetItem> {
+  item: Item;
+  errors: (keyof Item)[];
 }
 
 export type WorksheetColumn<Item> = WorksheetBaseColumn<Item> | WorksheetSelectableColumn<Item>;

--- a/packages/big-design/src/components/Worksheet/utils.ts
+++ b/packages/big-design/src/components/Worksheet/utils.ts
@@ -25,26 +25,34 @@ export const deleteCells = <T extends WorksheetItem>(oldCells: Cell<T>[], newCel
   );
 
 export const editedRows = <T extends WorksheetItem>(editedCells: Cell<T>[], rows: T[]) =>
-  editedCells.reduce<T[]>((accum, editedCell) => {
-    const row = rows[editedCell.rowIndex];
+  editedCells.reduce<T[]>((accum, { rowIndex }) => {
+    const row = rows[rowIndex];
 
+    // Check to see if the row already exists in accum
     if (accum.find((editedRow) => editedRow === row)) {
       return accum;
     } else {
+      // Only append new rows
       return [...accum, row];
     }
   }, []);
 
-export const invalidRows = <T extends WorksheetItem>(invalidCells: Cell<T>[], rows: T[]) =>
-  invalidCells.reduce<WorksheetError<T>[]>((accum, invalidCell) => {
-    const row = rows[invalidCell.rowIndex];
-    const rowIndex = accum.findIndex((invalidRow) => invalidRow.item === row);
+export const invalidRows = <T extends WorksheetItem>(invalidCells: Cell<T>[], rows: T[]) => {
+  const mapObj = new Map();
 
-    if (rowIndex >= 0) {
-      accum[rowIndex].errors = [...accum[rowIndex].errors, invalidCell.hash];
-
-      return accum;
+  // Create Map with each row and append errors per row
+  invalidCells.forEach(({ rowIndex, hash }) => {
+    const row = rows[rowIndex];
+    if (mapObj.has(row)) {
+      const errors = mapObj.get(row);
+      mapObj.set(row, new Set([...errors, hash]));
     } else {
-      return [...accum, { item: row, errors: [invalidCell['hash']] }];
+      mapObj.set(row, new Set([hash]));
     }
-  }, []);
+  });
+
+  return Array.from(mapObj).map<WorksheetError<T>>(([item, errors]) => ({
+    item,
+    errors: Array.from(errors),
+  }));
+};

--- a/packages/big-design/src/components/Worksheet/utils.ts
+++ b/packages/big-design/src/components/Worksheet/utils.ts
@@ -1,6 +1,6 @@
-import { Cell } from './types';
+import { Cell, WorksheetError, WorksheetItem } from './types';
 
-export const mergeCells = <T extends unknown>(oldCells: Cell<T>[], newCells: Cell<T>[]) =>
+export const mergeCells = <T extends WorksheetItem>(oldCells: Cell<T>[], newCells: Cell<T>[]) =>
   newCells.reduce(
     (accum, newCell) => {
       const index = oldCells.findIndex(
@@ -18,8 +18,33 @@ export const mergeCells = <T extends unknown>(oldCells: Cell<T>[], newCells: Cel
     [...oldCells], // Note: returns a new array every time
   );
 
-export const deleteCells = <T extends unknown>(oldCells: Cell<T>[], newCells: Cell<T>[]) =>
+export const deleteCells = <T extends WorksheetItem>(oldCells: Cell<T>[], newCells: Cell<T>[]) =>
   oldCells.filter(
     (oldCell) =>
       !newCells.find((newCell) => newCell.columnIndex === oldCell.columnIndex && newCell.rowIndex === oldCell.rowIndex),
   );
+
+export const editedRows = <T extends WorksheetItem>(editedCells: Cell<T>[], rows: T[]) =>
+  editedCells.reduce<T[]>((accum, editedCell) => {
+    const row = rows[editedCell.rowIndex];
+
+    if (accum.find((editedRow) => editedRow === row)) {
+      return accum;
+    } else {
+      return [...accum, row];
+    }
+  }, []);
+
+export const invalidRows = <T extends WorksheetItem>(invalidCells: Cell<T>[], rows: T[]) =>
+  invalidCells.reduce<WorksheetError<T>[]>((accum, invalidCell) => {
+    const row = rows[invalidCell.rowIndex];
+    const rowIndex = accum.findIndex((invalidRow) => invalidRow.item === row);
+
+    if (rowIndex >= 0) {
+      accum[rowIndex].errors = [...accum[rowIndex].errors, invalidCell.hash];
+
+      return accum;
+    } else {
+      return [...accum, { item: row, errors: [invalidCell['hash']] }];
+    }
+  }, []);


### PR DESCRIPTION
## What
Changed the API to return the items modified and not just a `cell` object, which in hindsight shouldn't be exposed to the user.

## Why
This is a byproduct of thinking of how to implement the `modal` column type.

## Examples
When an item is changed, `onChange` is now called with an array of items edited.
```
[
  {
    id: 7,
    productName: 'Variant',
    visibleOnStorefront: false,
    otherField: 'Text',
    otherField2: 'leather',
    otherField3: 'Field',
    numberField: 80,
  },
  {
    id: 1,
    productName: 'Shoes Name Three',
    visibleOnStorefront: false,
    otherField: 'Text',
    otherField2: 'cloth',
    otherField3: 'Field',
    numberField: 50,
  },
]
```

For errors, it returns an array of objects with the item and the fields that didn't pass validation for that item.

```
[
  {
    item: {
      id: 5,
      productName: '',
      visibleOnStorefront: true,
      otherField: 'Text',
      otherField2: '',
      otherField3: 'Field',
      numberField: 50,
    },
    errors: ['productName', 'otherField2'],
  },
  {
    item: {
      id: 6,
      productName: 'Variant',
      visibleOnStorefront: true,
      otherField: 'Text',
      otherField2: '',
      otherField3: 'Field',
      numberField: 50,
    },
    errors: ['otherField2'],
  },
]
```