### PR TITLE
fix(component): add element check to popover closeOnClickOutside effect

### DIFF
--- a/packages/big-design/src/components/Popover/Popover.tsx
+++ b/packages/big-design/src/components/Popover/Popover.tsx
@@ -126,6 +126,10 @@ const InternalPopover: React.FC<InternalPopoverProps> = ({
         return;
       }
 
+      if (anchorElement?.contains(event.target)) {
+        return;
+      }
+
       onClose();
     };
 
@@ -134,7 +138,7 @@ const InternalPopover: React.FC<InternalPopoverProps> = ({
     return () => {
       document.removeEventListener('click', clickHandler);
     };
-  }, [closeOnClickOutside, onClose, popperElement]);
+  }, [anchorElement, closeOnClickOutside, onClose, popperElement]);
 
   // Setup close on Esc key
   useEffect(() => {


### PR DESCRIPTION
## What

Fixes #519

## Why

Event click delegation was running when the `Popover` component mounted, causing the `closeOnClickOutside` effect to run.

The idea is to let the anchor elements `onClick` handler take precedence over `closeOnClickOutside`.

## Testing


https://user-images.githubusercontent.com/10539418/116724117-e022b100-a9a5-11eb-9f4c-c037957ba3e0.mov