### PR TITLE
feat(component): allow formatting of columns

### DIFF
--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -4,17 +4,25 @@ import { typedMemo } from '../../../utils';
 import { Small } from '../../Typography';
 import { CheckboxEditor, ModalEditor, SelectEditor, TextEditor } from '../editors';
 import { useEditableCell, useStore } from '../hooks';
-import { Cell as TCell, WorksheetColumn, WorksheetItem, WorksheetSelectableColumn } from '../types';
+import {
+  Cell as TCell,
+  WorksheetColumn,
+  WorksheetItem,
+  WorksheetSelectableColumn,
+  WorksheetTextColumn,
+} from '../types';
 
 import { StyledCell } from './styled';
 
 interface CellProps<Item> extends TCell<Item> {
   options?: WorksheetSelectableColumn<Item>['config']['options'];
+  formatting?: WorksheetTextColumn<Item>['formatting'];
   validation?: WorksheetColumn<Item>['validation'];
 }
 
 const InternalCell = <T extends WorksheetItem>({
   columnIndex,
+  formatting,
   hash,
   options,
   rowIndex,
@@ -92,16 +100,18 @@ const InternalCell = <T extends WorksheetItem>({
       case 'checkbox':
         return <CheckboxEditor cell={cell} onChange={handleChange} />;
       case 'modal':
-        return <ModalEditor cell={cell} />;
+        return <ModalEditor cell={cell} formatting={formatting} />;
       default:
         return isEditing ? (
           <TextEditor cell={cell} isEdited={isEdited} onBlur={handleBlur} onKeyDown={handleKeyDown} />
+        ) : // In case of NaN casting to string
+        value ? (
+          <Small color="secondary70">{formatting ? formatting(value) : `${value}`}</Small>
         ) : (
-          // In case of NaN casting to string
-          <Small color="secondary70">{value ? value.toString() : ''}</Small>
+          <Small color="secondary70">{''}</Small>
         );
     }
-  }, [cell, handleBlur, handleChange, handleKeyDown, isEdited, isEditing, options, type, value]);
+  }, [cell, formatting, handleBlur, handleChange, handleKeyDown, isEdited, isEditing, options, type, value]);
 
   return (
     <StyledCell

--- a/packages/big-design/src/components/Worksheet/Row/Row.tsx
+++ b/packages/big-design/src/components/Worksheet/Row/Row.tsx
@@ -1,10 +1,16 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { typedMemo } from '../../../utils';
 import { Cell } from '../Cell';
 import { useStore } from '../hooks';
 import { RowStatus } from '../RowStatus';
-import { WorksheetColumn, WorksheetItem } from '../types';
+import {
+  WorksheetColumn,
+  WorksheetItem,
+  WorksheetModalColumn,
+  WorksheetNumberColumn,
+  WorksheetTextColumn,
+} from '../types';
 
 interface RowProps<Item> {
   columns: WorksheetColumn<Item>[];
@@ -14,12 +20,20 @@ interface RowProps<Item> {
 const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>) => {
   const row = useStore(useMemo(() => (state) => state.rows[rowIndex], [rowIndex]));
 
+  const hasFormatting = useCallback((column: WorksheetColumn<T>): column is
+    | WorksheetTextColumn<T>
+    | WorksheetNumberColumn<T>
+    | WorksheetModalColumn<T> => {
+    return column.type === 'text' || column.type === 'number' || column.type === 'modal';
+  }, []);
+
   return (
     <tr>
       <RowStatus rowIndex={rowIndex} />
       {columns.map((column, columnIndex) => (
         <Cell
           columnIndex={columnIndex}
+          formatting={hasFormatting(column) ? column.formatting : undefined}
           hash={column.hash}
           key={`${rowIndex}-${columnIndex}`}
           options={column.type === 'select' ? column.config.options : undefined}

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -245,7 +245,7 @@ exports[`renders worksheet 1`] = `
           class="styled__StyledSmall-tqnj75-6 RpFkS"
           color="secondary70"
         >
-          50
+          $50.00
         </p>
       </td>
     </tr>
@@ -452,7 +452,7 @@ exports[`renders worksheet 1`] = `
           class="styled__StyledSmall-tqnj75-6 RpFkS"
           color="secondary70"
         >
-          50
+          $50.00
         </p>
       </td>
     </tr>
@@ -658,7 +658,7 @@ exports[`renders worksheet 1`] = `
           class="styled__StyledSmall-tqnj75-6 RpFkS"
           color="secondary70"
         >
-          50
+          $50.00
         </p>
       </td>
     </tr>
@@ -865,7 +865,7 @@ exports[`renders worksheet 1`] = `
           class="styled__StyledSmall-tqnj75-6 RpFkS"
           color="secondary70"
         >
-          50
+          $50.00
         </p>
       </td>
     </tr>
@@ -1070,7 +1070,7 @@ exports[`renders worksheet 1`] = `
           class="styled__StyledSmall-tqnj75-6 RpFkS"
           color="secondary70"
         >
-          50
+          $50.00
         </p>
       </td>
     </tr>
@@ -1277,7 +1277,7 @@ exports[`renders worksheet 1`] = `
           class="styled__StyledSmall-tqnj75-6 RpFkS"
           color="secondary70"
         >
-          50
+          $50.00
         </p>
       </td>
     </tr>
@@ -1483,7 +1483,7 @@ exports[`renders worksheet 1`] = `
           class="styled__StyledSmall-tqnj75-6 RpFkS"
           color="secondary70"
         >
-          49
+          $49.00
         </p>
       </td>
     </tr>
@@ -1690,7 +1690,7 @@ exports[`renders worksheet 1`] = `
           class="styled__StyledSmall-tqnj75-6 RpFkS"
           color="secondary70"
         >
-          50
+          $50.00
         </p>
       </td>
     </tr>
@@ -1897,7 +1897,7 @@ exports[`renders worksheet 1`] = `
           class="styled__StyledSmall-tqnj75-6 RpFkS"
           color="secondary70"
         >
-          50
+          $50.00
         </p>
       </td>
     </tr>

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -4,15 +4,16 @@ import { typedMemo } from '../../../../utils';
 import { Flex, FlexItem } from '../../../Flex';
 import { Small } from '../../../Typography';
 import { useStore } from '../../hooks';
-import { Cell, WorksheetItem } from '../../types';
+import { Cell, WorksheetItem, WorksheetModalColumn } from '../../types';
 
 import { StyledButton } from './styled';
 
 export interface ModalEditorProps<Item> {
   cell: Cell<Item>;
+  formatting?: WorksheetModalColumn<Item>['formatting'];
 }
 
-const InternalModalEditor = <T extends WorksheetItem>({ cell }: ModalEditorProps<T>) => {
+const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting }: ModalEditorProps<T>) => {
   const setOpenModal = useStore((state) => state.setOpenModal);
   const { hash, value } = cell;
 
@@ -23,7 +24,7 @@ const InternalModalEditor = <T extends WorksheetItem>({ cell }: ModalEditorProps
   return (
     <Flex justifyContent="space-between" alignItems="center">
       <FlexItem paddingRight="small">
-        <Small>{String(value)}</Small>
+        <Small>{formatting ? formatting(value) : `${value}`}</Small>
       </FlexItem>
       <StyledButton onClick={handleClick} variant="subtle">
         Edit

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -61,7 +61,7 @@ const TreeComponent = (value: string | number | boolean, onChange: (value: strin
 };
 
 const columns: WorksheetColumn<Product>[] = [
-  { hash: 'productName', header: 'Product name', validation: (value) => !!value },
+  { hash: 'productName', header: 'Product name', validation: (value: string) => !!value },
   { hash: 'visibleOnStorefront', header: 'Visible on storefront', type: 'checkbox' },
   { hash: 'otherField', header: 'Other field' },
   {
@@ -75,7 +75,7 @@ const columns: WorksheetColumn<Product>[] = [
         { value: 'cloth', content: 'Cloth' },
       ],
     },
-    validation: (value) => !!value,
+    validation: (value: string) => !!value,
   },
   {
     hash: 'otherField3',
@@ -83,7 +83,13 @@ const columns: WorksheetColumn<Product>[] = [
     type: 'modal',
     config: { header: 'Choose categories', render: TreeComponent },
   },
-  { hash: 'numberField', header: 'Number field', type: 'number', validation: (value) => value >= 50 },
+  {
+    hash: 'numberField',
+    header: 'Number field',
+    type: 'number',
+    validation: (value: number) => value >= 50,
+    formatting: (value: number) => `$${value}.00`,
+  },
 ];
 
 const items: Product[] = [
@@ -300,7 +306,7 @@ describe('validation', () => {
       <Worksheet columns={columns} items={items} onChange={handleChange} onErrors={handleErrors} />,
     );
 
-    const cell = getByText('49').parentElement as HTMLTableDataCellElement;
+    const cell = getByText('$49.00').parentElement as HTMLTableDataCellElement;
     const row = cell.parentElement as HTMLTableRowElement;
 
     expect(cell).toHaveStyle('border-color: #db3643');
@@ -359,7 +365,7 @@ describe('validation', () => {
       },
     ]);
 
-    cell = getByText('49') as HTMLElement;
+    cell = getByText('$49.00') as HTMLElement;
 
     fireEvent.doubleClick(cell);
 
@@ -408,7 +414,7 @@ describe('validation', () => {
       },
     ]);
 
-    cell = getByText('40');
+    cell = getByText('$40.00');
 
     fireEvent.doubleClick(cell);
 
@@ -444,6 +450,16 @@ describe('validation', () => {
         errors: ['otherField2'],
       },
     ]);
+  });
+});
+
+describe('formatting', () => {
+  test('formats values', async () => {
+    const { getAllByText } = render(<Worksheet columns={columns} items={items} onChange={handleChange} />);
+
+    expect(getAllByText('$50.00').length).toBe(8);
+
+    await waitForElement(() => screen.getAllByRole('combobox'));
   });
 });
 
@@ -516,7 +532,7 @@ describe('TextEditor', () => {
       <Worksheet columns={columns} items={items} onChange={handleChange} />,
     );
 
-    const cell = getByText('49') as HTMLElement;
+    const cell = getByText('$49.00') as HTMLElement;
 
     fireEvent.doubleClick(cell);
 

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -15,25 +15,40 @@ export interface WorksheetError<Item extends WorksheetItem> {
 }
 
 export type WorksheetColumn<Item> =
-  | WorksheetBaseColumn<Item>
+  | WorksheetTextColumn<Item>
+  | WorksheetNumberColumn<Item>
+  | WorksheetCheckboxColumn<Item>
   | WorksheetSelectableColumn<Item>
   | WorksheetModalColumn<Item>;
 
 interface WorksheetBaseColumn<Item> {
   hash: keyof Item;
   header: string;
-  type?: 'text' | 'number' | 'checkbox';
   validation?(value: Item[keyof Item]): boolean;
 }
 
-export interface WorksheetSelectableColumn<Item> extends Omit<WorksheetBaseColumn<Item>, 'type'> {
+export interface WorksheetTextColumn<Item> extends WorksheetBaseColumn<Item> {
+  type?: 'text';
+  formatting?(value: Item[keyof Item]): string;
+}
+
+export interface WorksheetNumberColumn<Item> extends WorksheetBaseColumn<Item> {
+  type: 'number';
+  formatting?(value: Item[keyof Item]): string;
+}
+
+export interface WorksheetCheckboxColumn<Item> extends WorksheetBaseColumn<Item> {
+  type: 'checkbox';
+}
+
+export interface WorksheetSelectableColumn<Item> extends WorksheetBaseColumn<Item> {
   config: {
     options: SelectOption<unknown>[];
   };
   type: 'select';
 }
 
-export interface WorksheetModalColumn<Item> extends Omit<WorksheetBaseColumn<Item>, 'type'> {
+export interface WorksheetModalColumn<Item> extends WorksheetBaseColumn<Item> {
   config: {
     header?: string;
     render(
@@ -41,6 +56,7 @@ export interface WorksheetModalColumn<Item> extends Omit<WorksheetBaseColumn<Ite
       onChange: (value: Item[keyof Item]) => void,
     ): React.ComponentType<Item> | React.ReactElement;
   };
+  formatting?(value: Item[keyof Item]): string;
   type: 'modal';
 }
 
@@ -49,10 +65,7 @@ export interface Cell<Item> {
   hash: keyof Item;
   rowIndex: number;
   value: Item[keyof Item];
-  type: Exclude<
-    WorksheetColumn<Item>['type'] | WorksheetSelectableColumn<Item>['type'] | WorksheetModalColumn<Item>['type'],
-    undefined
-  >;
+  type: Exclude<WorksheetColumn<Item>['type'], undefined>;
 }
 
 export interface WorksheetItem {


### PR DESCRIPTION
## What
Allow the Text, Number, and Modal column types to be formatted.

## Why
Allow custom text readability.

## API
```
{
  hash: 'numberField',
  header: 'Number field',
  type: 'number',
  validation: (value: number) => value >= 50,
  formatting: (value: number) => `$${value}.00`,
},
```

## Screenshot

<img width="203" alt="Screen Shot 2021-05-14 at 2 47 00 PM" src="https://user-images.githubusercontent.com/196129/118321524-54d80e00-b4c3-11eb-840d-ed6836cc6bb2.png">


