### PR TITLE
chore: add @bigcommerce/product-design to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bigcommerce/frontend
+* @bigcommerce/frontend @bigcommerce/product-design


### PR DESCRIPTION
## What

Adds the @bigcommerce/product-design team as codeowners.

## Why

The @bigcommerce/product-design team wants to have more insight on additions/changes from external contributions. Adding the team on all PR's will give more visibility on all development.

**Note: We are still requiring a member of @bigcommerce/frontend team to approve before merging code.**

cc. @valterfatia @eugene-polev