### PR TITLE
feat(component): implement keyboard navigation for Worksheet

### DIFF
--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -128,8 +128,18 @@ const InternalModal: React.FC<ModalProps> = ({
     () =>
       Array.isArray(actions) && (
         <StyledModalActions justifyContent="flex-end">
-          {actions.map(({ text, ...props }, index) => (
-            <Button key={index} {...props}>
+          {actions.map(({ text, onClick, ...props }, index) => (
+            <Button
+              key={index}
+              {...props}
+              onClick={(event) => {
+                internalTrap.current?.deactivate();
+
+                if (onClick) {
+                  onClick(event);
+                }
+              }}
+            >
               {text}
             </Button>
           ))}

--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -135,7 +135,7 @@ const InternalModal: React.FC<ModalProps> = ({
               onClick={(event) => {
                 internalTrap.current?.deactivate();
 
-                if (onClick) {
+                if (typeof onClick === 'function') {
                   onClick(event);
                 }
               }}

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -330,8 +330,12 @@ export const MultiSelect = typedMemo(
               onClick: () => {
                 !isOpen && openMenu();
               },
-              onFocus: () => {
+              onFocus: (event) => {
                 !isOpen && openMenu();
+
+                if (props.onFocus) {
+                  props.onFocus(event);
+                }
               },
               onKeyDown: (event) => {
                 switch (event.key) {

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -333,7 +333,7 @@ export const MultiSelect = typedMemo(
               onFocus: (event) => {
                 !isOpen && openMenu();
 
-                if (props.onFocus) {
+                if (typeof props.onFocus === 'function') {
                   props.onFocus(event);
                 }
               },

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -251,8 +251,12 @@ export const Select = typedMemo(
               onClick: () => {
                 !isOpen && openMenu();
               },
-              onFocus: () => {
+              onFocus: (event) => {
                 !isOpen && openMenu();
+
+                if (props.onFocus) {
+                  props.onFocus(event);
+                }
               },
               onKeyDown: (event) => {
                 switch (event.key) {

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -254,7 +254,7 @@ export const Select = typedMemo(
               onFocus: (event) => {
                 !isOpen && openMenu();
 
-                if (props.onFocus) {
+                if (typeof props.onFocus === 'function') {
                   props.onFocus(event);
                 }
               },

--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -93,10 +93,23 @@ const InternalCell = <T extends WorksheetItem>({
     setSelectedCells([cell]);
   }, [cell, rowIndex, setSelectedCells, setSelectedRows]);
 
-  const renderedCell = useMemo(() => {
-    const cellValue =
-      value || value === 0 ? (formatting ? formatting(value) : `${value}`) : value !== 'undefined' ? `${value}` : '';
+  const renderedValue = useMemo(() => {
+    if (value !== 'undefined' && value !== '' && !Number.isNaN(value)) {
+      if (typeof formatting === 'function') {
+        return formatting(value);
+      }
 
+      return `${value}`;
+    }
+
+    if (Number.isNaN(value)) {
+      return `${value}`;
+    }
+
+    return '';
+  }, [formatting, value]);
+
+  const renderedCell = useMemo(() => {
     switch (type) {
       case 'select':
         return (
@@ -117,12 +130,12 @@ const InternalCell = <T extends WorksheetItem>({
         return isEditing ? (
           <TextEditor cell={cell} isEdited={isEdited} onBlur={handleBlur} onKeyDown={handleKeyDown} />
         ) : (
-          <Small color="secondary70" ellipsis title={cellValue}>
-            {`${cellValue}`}
+          <Small color="secondary70" ellipsis title={renderedValue}>
+            {renderedValue}
           </Small>
         );
     }
-  }, [cell, formatting, handleBlur, handleChange, handleKeyDown, isEdited, isEditing, options, type, value]);
+  }, [cell, formatting, handleBlur, handleChange, handleKeyDown, isEdited, isEditing, options, renderedValue, type]);
 
   return (
     <StyledCell

--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -94,7 +94,8 @@ const InternalCell = <T extends WorksheetItem>({
   }, [cell, rowIndex, setSelectedCells, setSelectedRows]);
 
   const renderedCell = useMemo(() => {
-    const cellValue = value ? (formatting ? formatting(value) : `${value}`) : value !== 'undefined' ? `${value}` : '';
+    const cellValue =
+      value || value === 0 ? (formatting ? formatting(value) : `${value}`) : value !== 'undefined' ? `${value}` : '';
 
     switch (type) {
       case 'select':

--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -96,11 +96,20 @@ const InternalCell = <T extends WorksheetItem>({
   const renderedCell = useMemo(() => {
     switch (type) {
       case 'select':
-        return <SelectEditor cell={cell} isEdited={isEdited} onChange={handleChange} options={options} />;
+        return (
+          <SelectEditor
+            cell={cell}
+            isEdited={isEdited}
+            isEditing={isEditing}
+            onBlur={handleBlur}
+            onChange={handleChange}
+            options={options}
+          />
+        );
       case 'checkbox':
-        return <CheckboxEditor cell={cell} onChange={handleChange} />;
+        return <CheckboxEditor cell={cell} isEditing={isEditing} onBlur={handleBlur} onChange={handleChange} />;
       case 'modal':
-        return <ModalEditor cell={cell} formatting={formatting} />;
+        return <ModalEditor cell={cell} formatting={formatting} isEditing={isEditing} />;
       default:
         return isEditing ? (
           <TextEditor cell={cell} isEdited={isEdited} onBlur={handleBlur} onKeyDown={handleKeyDown} />
@@ -108,7 +117,8 @@ const InternalCell = <T extends WorksheetItem>({
         value ? (
           <Small color="secondary70">{formatting ? formatting(value) : `${value}`}</Small>
         ) : (
-          <Small color="secondary70">{''}</Small>
+          // In case of NaN casting to string
+          <Small color="secondary70">{value !== 'undefined' ? `${value}` : ''}</Small>
         );
     }
   }, [cell, formatting, handleBlur, handleChange, handleKeyDown, isEdited, isEditing, options, type, value]);

--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -94,6 +94,8 @@ const InternalCell = <T extends WorksheetItem>({
   }, [cell, rowIndex, setSelectedCells, setSelectedRows]);
 
   const renderedCell = useMemo(() => {
+    const cellValue = value ? (formatting ? formatting(value) : `${value}`) : value !== 'undefined' ? `${value}` : '';
+
     switch (type) {
       case 'select':
         return (
@@ -113,12 +115,10 @@ const InternalCell = <T extends WorksheetItem>({
       default:
         return isEditing ? (
           <TextEditor cell={cell} isEdited={isEdited} onBlur={handleBlur} onKeyDown={handleKeyDown} />
-        ) : // In case of NaN casting to string
-        value ? (
-          <Small color="secondary70">{formatting ? formatting(value) : `${value}`}</Small>
         ) : (
-          // In case of NaN casting to string
-          <Small color="secondary70">{value !== 'undefined' ? `${value}` : ''}</Small>
+          <Small color="secondary70" ellipsis title={cellValue}>
+            {`${cellValue}`}
+          </Small>
         );
     }
   }, [cell, formatting, handleBlur, handleChange, handleKeyDown, isEdited, isEditing, options, type, value]);

--- a/packages/big-design/src/components/Worksheet/Cell/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/styled.tsx
@@ -26,7 +26,6 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
     }
   }};
   user-select: none;
-  word-break: break-all;
 
   ${({ isSelected }) =>
     isSelected &&
@@ -45,6 +44,10 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
     css`
       background-color: ${({ theme }) => theme.colors.warning10};
     `}
+
+  & p {
+    display: block;
+  }
 `;
 
 StyledCell.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/Cell/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/styled.tsx
@@ -26,6 +26,7 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
     }
   }};
   user-select: none;
+  word-break: break-all;
 
   ${({ isSelected }) =>
     isSelected &&

--- a/packages/big-design/src/components/Worksheet/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Worksheet/Modal/Modal.tsx
@@ -11,7 +11,7 @@ interface WorksheetModalProps<Item> {
 
 const InternalWorksheetModal = <T extends WorksheetItem>({ column }: WorksheetModalProps<T>) => {
   const { config, hash } = column;
-  const { header, render } = config;
+  const { header, render, saveActionText = 'Save', cancelActionText = 'Cancel' } = config;
 
   const isModalOpen = useStore(useMemo(() => (state) => state.openedModal === hash, [hash]));
   const selectedCell = useStore(useMemo(() => (state) => state.selectedCells[0], []));
@@ -58,12 +58,12 @@ const InternalWorksheetModal = <T extends WorksheetItem>({ column }: WorksheetMo
     <Modal
       actions={[
         {
-          text: 'Cancel',
+          text: cancelActionText,
           variant: 'subtle',
           onClick: handleClose,
         },
         {
-          text: 'Save',
+          text: saveActionText,
           onClick: handleSave,
         },
       ]}

--- a/packages/big-design/src/components/Worksheet/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Worksheet/Modal/Modal.tsx
@@ -15,11 +15,11 @@ const InternalWorksheetModal = <T extends WorksheetItem>({ column }: WorksheetMo
 
   const isModalOpen = useStore(useMemo(() => (state) => state.openedModal === hash, [hash]));
   const selectedCell = useStore(useMemo(() => (state) => state.selectedCells[0], []));
+
   const setOpenModal = useStore((state) => state.setOpenModal);
   const setEditingCell = useStore((state) => state.setEditingCell);
 
   const { focusTable } = useTableFocus();
-
   const { updateItems } = useUpdateItems();
 
   const [newValue, setNewValue] = useState<unknown>(null);

--- a/packages/big-design/src/components/Worksheet/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Worksheet/Modal/Modal.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { typedMemo } from '../../../utils';
 import { Modal } from '../../Modal';
-import { useEditableCell, useStore, useTableFocus } from '../hooks';
+import { useStore, useTableFocus, useUpdateItems } from '../hooks';
 import { WorksheetItem, WorksheetModalColumn } from '../types';
 
 interface WorksheetModalProps<Item> {
@@ -20,7 +20,7 @@ const InternalWorksheetModal = <T extends WorksheetItem>({ column }: WorksheetMo
 
   const { focusTable } = useTableFocus();
 
-  const { handleChange } = useEditableCell<T>(selectedCell);
+  const { updateItems } = useUpdateItems();
 
   const [newValue, setNewValue] = useState<unknown>(null);
 
@@ -38,11 +38,11 @@ const InternalWorksheetModal = <T extends WorksheetItem>({ column }: WorksheetMo
 
   const handleSave = useCallback(() => {
     if (selectedCell && newValue !== null && newValue !== selectedCell.value) {
-      handleChange(newValue);
+      updateItems([selectedCell], [newValue]);
     }
 
     handleClose();
-  }, [handleChange, handleClose, newValue, selectedCell]);
+  }, [handleClose, newValue, selectedCell, updateItems]);
 
   const renderedContent = useMemo(() => {
     const onChange = (newValue: unknown) => {

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -58,7 +58,9 @@ const InternalWorksheet = <T extends WorksheetItem>({
         <tr>
           <Status />
           {columns.map((column, index) => (
-            <Header key={index}>{column.header}</Header>
+            <Header key={index} columnType={column.type}>
+              {column.header}
+            </Header>
           ))}
         </tr>
       </thead>

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -35,6 +35,7 @@ const InternalWorksheet = <T extends WorksheetItem>({
   // Save columns to use in navigation
   useEffect(() => setColumns(columns), [columns, setColumns]);
 
+  // Save ref to focus table when necessary
   useEffect(() => setTableRef(tableRef.current), [setTableRef, tableRef]);
 
   // Call onChange when a cell is edited
@@ -86,7 +87,7 @@ const InternalWorksheet = <T extends WorksheetItem>({
 
   return (
     <UpdateItemsProvider items={rows}>
-      <Table onKeyDown={handleKeyDown} tabIndex={0} ref={tableRef}>
+      <Table onKeyDown={handleKeyDown} ref={tableRef} tabIndex={0}>
         {renderedHeaders}
         {renderedRows}
       </Table>

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -32,20 +32,16 @@ const InternalWorksheet = <T extends WorksheetItem>({
   // Create a new reference since state mutates rows to prevent unecessary rerendering
   useEffect(() => setRows([...items]), [items, setRows]);
 
-  // Save columns to use in navigation
   useEffect(() => setColumns(columns), [columns, setColumns]);
 
-  // Save ref to focus table when necessary
   useEffect(() => setTableRef(tableRef.current), [setTableRef, tableRef]);
 
-  // Call onChange when a cell is edited
   useEffect(() => {
     if (editedCells.length) {
       onChange(editedRows(editedCells, rows));
     }
   }, [editedCells, onChange, rows]);
 
-  // Call onErrors when a cell becomes invalid
   useEffect(() => {
     if (typeof onErrors === 'function' && invalidCells.length) {
       onErrors(invalidRows(invalidCells, rows));

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`renders worksheet 1`] = `
 <table
-  class="styled__Table-sc-16rzzpq-0 jtWGEi"
+  class="styled__Table-sc-16rzzpq-0 eWZhUt"
+  tabindex="0"
 >
   <thead>
     <tr>
@@ -47,7 +48,7 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -58,7 +59,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iNYKgU"
+        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
         type="checkbox"
       >
         <div
@@ -114,7 +115,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -125,7 +126,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ckbwVn"
+        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
         type="select"
       >
         <div
@@ -211,7 +212,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="modal"
       >
         <div
@@ -238,7 +239,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 cRUZl"
+        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
         type="number"
       >
         <p
@@ -254,7 +255,7 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -265,7 +266,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iNYKgU"
+        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
         type="checkbox"
       >
         <div
@@ -321,7 +322,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -332,7 +333,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ckbwVn"
+        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
         type="select"
       >
         <div
@@ -418,7 +419,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="modal"
       >
         <div
@@ -445,7 +446,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 cRUZl"
+        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
         type="number"
       >
         <p
@@ -461,7 +462,7 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -472,7 +473,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iNYKgU"
+        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
         type="checkbox"
       >
         <div
@@ -527,7 +528,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -538,7 +539,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ckbwVn"
+        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
         type="select"
       >
         <div
@@ -624,7 +625,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="modal"
       >
         <div
@@ -651,7 +652,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 cRUZl"
+        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
         type="number"
       >
         <p
@@ -667,7 +668,7 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -678,7 +679,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iNYKgU"
+        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
         type="checkbox"
       >
         <div
@@ -734,7 +735,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -745,7 +746,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ckbwVn"
+        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
         type="select"
       >
         <div
@@ -831,7 +832,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="modal"
       >
         <div
@@ -858,7 +859,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 cRUZl"
+        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
         type="number"
       >
         <p
@@ -874,7 +875,7 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 jpxEqg"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 gEYTOz"
+        class="styled__StyledCell-sc-1bt06ph-0 iuGXPh"
         type="text"
       >
         <p
@@ -883,7 +884,7 @@ exports[`renders worksheet 1`] = `
         />
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iNYKgU"
+        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
         type="checkbox"
       >
         <div
@@ -939,7 +940,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -950,7 +951,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 emuEZs"
+        class="styled__StyledCell-sc-1bt06ph-0 hnZTfc"
         type="select"
       >
         <div
@@ -1036,7 +1037,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="modal"
       >
         <div
@@ -1063,7 +1064,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 cRUZl"
+        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
         type="number"
       >
         <p
@@ -1079,7 +1080,7 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 jpxEqg"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -1090,7 +1091,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iNYKgU"
+        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
         type="checkbox"
       >
         <div
@@ -1146,7 +1147,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -1157,7 +1158,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 emuEZs"
+        class="styled__StyledCell-sc-1bt06ph-0 hnZTfc"
         type="select"
       >
         <div
@@ -1243,7 +1244,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="modal"
       >
         <div
@@ -1270,7 +1271,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 cRUZl"
+        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
         type="number"
       >
         <p
@@ -1286,7 +1287,7 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 jpxEqg"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -1297,7 +1298,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iNYKgU"
+        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
         type="checkbox"
       >
         <div
@@ -1352,7 +1353,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -1363,7 +1364,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ckbwVn"
+        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
         type="select"
       >
         <div
@@ -1449,7 +1450,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="modal"
       >
         <div
@@ -1476,7 +1477,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 cRPtqa"
+        class="styled__StyledCell-sc-1bt06ph-0 cSJiQi"
         type="number"
       >
         <p
@@ -1492,7 +1493,7 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -1503,7 +1504,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iNYKgU"
+        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
         type="checkbox"
       >
         <div
@@ -1559,7 +1560,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -1570,7 +1571,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ckbwVn"
+        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
         type="select"
       >
         <div
@@ -1656,7 +1657,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="modal"
       >
         <div
@@ -1683,7 +1684,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 cRUZl"
+        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
         type="number"
       >
         <p
@@ -1699,7 +1700,7 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -1710,7 +1711,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iNYKgU"
+        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
         type="checkbox"
       >
         <div
@@ -1766,7 +1767,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="text"
       >
         <p
@@ -1777,7 +1778,7 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ckbwVn"
+        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
         type="select"
       >
         <div
@@ -1863,7 +1864,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 ffzctK"
+        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
         type="modal"
       >
         <div
@@ -1890,7 +1891,7 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 cRUZl"
+        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
         type="number"
       >
         <p

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -36,7 +36,7 @@ exports[`renders worksheet 1`] = `
         Other field
       </th>
       <th
-        class="styled__Header-sc-16rzzpq-1 hiiNAX"
+        class="styled__Header-sc-16rzzpq-1 hohMQL"
       >
         Number field
       </th>

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -48,18 +48,19 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Shoes Name Three"
         >
           Shoes Name Three
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
+        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
         type="checkbox"
       >
         <div
@@ -115,18 +116,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Text"
         >
           Text
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
+        class="styled__StyledCell-sc-1bt06ph-0 Dfyyk"
         type="select"
       >
         <div
@@ -212,17 +214,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 vbeVb"
+          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 fWrbhm"
         >
           <div
-            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe"
+            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe styled__StyledFlexItem-zoq9bz-1 dhsfUE"
           >
             <p
-              class="styled__StyledSmall-tqnj75-6 kTSqSt"
+              class="styled__StyledSmall-tqnj75-6 PZvQl"
+              color="secondary70"
+              title="1"
             >
               1
             </p>
@@ -239,12 +243,13 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
+        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
         type="number"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="$50.00"
         >
           $50.00
         </p>
@@ -255,18 +260,19 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Shoes Name Two"
         >
           Shoes Name Two
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
+        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
         type="checkbox"
       >
         <div
@@ -322,18 +328,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Text"
         >
           Text
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
+        class="styled__StyledCell-sc-1bt06ph-0 Dfyyk"
         type="select"
       >
         <div
@@ -419,17 +426,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 vbeVb"
+          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 fWrbhm"
         >
           <div
-            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe"
+            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe styled__StyledFlexItem-zoq9bz-1 dhsfUE"
           >
             <p
-              class="styled__StyledSmall-tqnj75-6 kTSqSt"
+              class="styled__StyledSmall-tqnj75-6 PZvQl"
+              color="secondary70"
+              title="2"
             >
               2
             </p>
@@ -446,12 +455,13 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
+        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
         type="number"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="$50.00"
         >
           $50.00
         </p>
@@ -462,18 +472,19 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Shoes Name One"
         >
           Shoes Name One
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
+        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
         type="checkbox"
       >
         <div
@@ -528,18 +539,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Text"
         >
           Text
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
+        class="styled__StyledCell-sc-1bt06ph-0 Dfyyk"
         type="select"
       >
         <div
@@ -625,17 +637,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 vbeVb"
+          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 fWrbhm"
         >
           <div
-            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe"
+            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe styled__StyledFlexItem-zoq9bz-1 dhsfUE"
           >
             <p
-              class="styled__StyledSmall-tqnj75-6 kTSqSt"
+              class="styled__StyledSmall-tqnj75-6 PZvQl"
+              color="secondary70"
+              title="3"
             >
               3
             </p>
@@ -652,12 +666,13 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
+        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
         type="number"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="$50.00"
         >
           $50.00
         </p>
@@ -668,18 +683,19 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Variant"
         >
           Variant
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
+        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
         type="checkbox"
       >
         <div
@@ -735,18 +751,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Text"
         >
           Text
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
+        class="styled__StyledCell-sc-1bt06ph-0 Dfyyk"
         type="select"
       >
         <div
@@ -832,17 +849,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 vbeVb"
+          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 fWrbhm"
         >
           <div
-            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe"
+            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe styled__StyledFlexItem-zoq9bz-1 dhsfUE"
           >
             <p
-              class="styled__StyledSmall-tqnj75-6 kTSqSt"
+              class="styled__StyledSmall-tqnj75-6 PZvQl"
+              color="secondary70"
+              title="4"
             >
               4
             </p>
@@ -859,12 +878,13 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
+        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
         type="number"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="$50.00"
         >
           $50.00
         </p>
@@ -875,16 +895,17 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 jpxEqg"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iuGXPh"
+        class="styled__StyledCell-sc-1bt06ph-0 iLwcsN"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title=""
         />
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
+        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
         type="checkbox"
       >
         <div
@@ -940,18 +961,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Text"
         >
           Text
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hnZTfc"
+        class="styled__StyledCell-sc-1bt06ph-0 dRdQay"
         type="select"
       >
         <div
@@ -1037,17 +1059,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 vbeVb"
+          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 fWrbhm"
         >
           <div
-            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe"
+            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe styled__StyledFlexItem-zoq9bz-1 dhsfUE"
           >
             <p
-              class="styled__StyledSmall-tqnj75-6 kTSqSt"
+              class="styled__StyledSmall-tqnj75-6 PZvQl"
+              color="secondary70"
+              title="5"
             >
               5
             </p>
@@ -1064,12 +1088,13 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
+        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
         type="number"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="$50.00"
         >
           $50.00
         </p>
@@ -1080,18 +1105,19 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 jpxEqg"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Variant"
         >
           Variant
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
+        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
         type="checkbox"
       >
         <div
@@ -1147,18 +1173,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Text"
         >
           Text
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hnZTfc"
+        class="styled__StyledCell-sc-1bt06ph-0 dRdQay"
         type="select"
       >
         <div
@@ -1244,17 +1271,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 vbeVb"
+          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 fWrbhm"
         >
           <div
-            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe"
+            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe styled__StyledFlexItem-zoq9bz-1 dhsfUE"
           >
             <p
-              class="styled__StyledSmall-tqnj75-6 kTSqSt"
+              class="styled__StyledSmall-tqnj75-6 PZvQl"
+              color="secondary70"
+              title="6"
             >
               6
             </p>
@@ -1271,12 +1300,13 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
+        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
         type="number"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="$50.00"
         >
           $50.00
         </p>
@@ -1287,18 +1317,19 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 jpxEqg"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Variant"
         >
           Variant
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
+        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
         type="checkbox"
       >
         <div
@@ -1353,18 +1384,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Text"
         >
           Text
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
+        class="styled__StyledCell-sc-1bt06ph-0 Dfyyk"
         type="select"
       >
         <div
@@ -1450,17 +1482,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 vbeVb"
+          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 fWrbhm"
         >
           <div
-            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe"
+            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe styled__StyledFlexItem-zoq9bz-1 dhsfUE"
           >
             <p
-              class="styled__StyledSmall-tqnj75-6 kTSqSt"
+              class="styled__StyledSmall-tqnj75-6 PZvQl"
+              color="secondary70"
+              title="7"
             >
               7
             </p>
@@ -1477,12 +1511,13 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 cSJiQi"
+        class="styled__StyledCell-sc-1bt06ph-0 itFNTF"
         type="number"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="$49.00"
         >
           $49.00
         </p>
@@ -1493,18 +1528,19 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Dress Name One"
         >
           Dress Name One
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
+        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
         type="checkbox"
       >
         <div
@@ -1560,18 +1596,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Text"
         >
           Text
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
+        class="styled__StyledCell-sc-1bt06ph-0 Dfyyk"
         type="select"
       >
         <div
@@ -1657,17 +1694,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 vbeVb"
+          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 fWrbhm"
         >
           <div
-            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe"
+            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe styled__StyledFlexItem-zoq9bz-1 dhsfUE"
           >
             <p
-              class="styled__StyledSmall-tqnj75-6 kTSqSt"
+              class="styled__StyledSmall-tqnj75-6 PZvQl"
+              color="secondary70"
+              title="8"
             >
               8
             </p>
@@ -1684,12 +1723,13 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
+        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
         type="number"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="$50.00"
         >
           $50.00
         </p>
@@ -1700,18 +1740,19 @@ exports[`renders worksheet 1`] = `
         class="styled__Status-sc-1aacki0-0 dQfqjh"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Fans Name One"
         >
           Fans Name One
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 AhNUF"
+        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
         type="checkbox"
       >
         <div
@@ -1767,18 +1808,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="text"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="Text"
         >
           Text
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eDEkMO"
+        class="styled__StyledCell-sc-1bt06ph-0 Dfyyk"
         type="select"
       >
         <div
@@ -1864,17 +1906,19 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hchsdF"
+        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 vbeVb"
+          class="styled__StyledBox-sj5f1m-0 jvmRZj styled__StyledFlex-hcvk8l-0 fWrbhm"
         >
           <div
-            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe"
+            class="styled__StyledBox-sj5f1m-0 fEBlfP styled__StyledFlexItem-smjqtt-0 gJMDHe styled__StyledFlexItem-zoq9bz-1 dhsfUE"
           >
             <p
-              class="styled__StyledSmall-tqnj75-6 kTSqSt"
+              class="styled__StyledSmall-tqnj75-6 PZvQl"
+              color="secondary70"
+              title="9"
             >
               9
             </p>
@@ -1891,12 +1935,13 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 frWqJh"
+        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
         type="number"
       >
         <p
-          class="styled__StyledSmall-tqnj75-6 RpFkS"
+          class="styled__StyledSmall-tqnj75-6 PZvQl"
           color="secondary70"
+          title="$50.00"
         >
           $50.00
         </p>

--- a/packages/big-design/src/components/Worksheet/context/updateItems/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/context/updateItems/spec.tsx
@@ -31,6 +31,12 @@ const items: Product[] = [
   },
 ];
 
+const initialStoreState = useStore.getState();
+
+beforeEach(() => {
+  useStore.setState(initialStoreState, true);
+});
+
 describe('UpdateItemsProvider', () => {
   test('updates items', () => {
     const wrapper: React.FC = ({ children }) => <UpdateItemsProvider items={items}>{children}</UpdateItemsProvider>;
@@ -64,5 +70,21 @@ describe('UpdateItemsProvider', () => {
         otherField3: 2,
       },
     ]);
+  });
+
+  test('do not update if value is the same', () => {
+    const wrapper: React.FC = ({ children }) => <UpdateItemsProvider items={items}>{children}</UpdateItemsProvider>;
+
+    const { result: hook } = renderHook(() => useUpdateItems(), { wrapper });
+    const { result: store } = renderHook(() => useStore());
+
+    act(() =>
+      hook.current.updateItems(
+        [{ rowIndex: 0, columnIndex: 0, hash: 'productName', type: 'text', value: 'Shoes Name One' }],
+        ['Shoes Name One'],
+      ),
+    );
+
+    expect(store.current.editedCells).toStrictEqual([]);
   });
 });

--- a/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { typedMemo } from '../../../../utils';
 import { Checkbox } from '../../../Checkbox';
@@ -8,10 +8,23 @@ import { CheckboxWrapper } from './styled';
 
 export interface CheckboxEditorProps<Item> {
   cell: Cell<Item>;
+  isEditing: boolean;
+  onBlur(): void;
   onChange(value: unknown): void;
 }
 
-const InternalCheckboxEditor = <T extends WorksheetItem>({ cell, onChange }: CheckboxEditorProps<T>) => {
+const InternalCheckboxEditor = <T extends WorksheetItem>({
+  cell,
+  isEditing,
+  onBlur,
+  onChange,
+}: CheckboxEditorProps<T>) => {
+  useEffect(() => {
+    if (isEditing) {
+      onChange(!cell.value);
+    }
+  }, [cell.value, isEditing, onChange]);
+
   const handleChange = () => {
     onChange(!cell.value);
   };
@@ -19,9 +32,10 @@ const InternalCheckboxEditor = <T extends WorksheetItem>({ cell, onChange }: Che
   return (
     <CheckboxWrapper>
       <Checkbox
-        label={cell.value ? 'Checked' : 'Unchecked'}
-        hiddenLabel={true}
         checked={cell.value}
+        hiddenLabel={true}
+        label={cell.value ? 'Checked' : 'Unchecked'}
+        onBlur={onBlur}
         onChange={handleChange}
       />
     </CheckboxWrapper>

--- a/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
@@ -21,6 +21,7 @@ const InternalCheckboxEditor = <T extends WorksheetItem>({
 }: CheckboxEditorProps<T>) => {
   useEffect(() => {
     if (isEditing) {
+      // For checkbox we want to change the value when editing is called
       onChange(!cell.value);
     }
   }, [cell.value, isEditing, onChange]);

--- a/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
@@ -24,8 +24,8 @@ const InternalCheckboxEditor = <T extends WorksheetItem>({
   }, [cell, onChange]);
 
   useEffect(() => {
-    // For context, isEditing will only return true when a user has
-    // pressed `enter` or `space` when a checkbox cell is selected.
+    // isEditing will only return true when a user has pressed
+    // `enter` or `space` when a checkbox cell is selected.
     // It is virtually the same as clicking on the checkbox.
     if (isEditing) {
       handleChange();

--- a/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 
 import { typedMemo } from '../../../../utils';
 import { Checkbox } from '../../../Checkbox';
@@ -19,16 +19,18 @@ const InternalCheckboxEditor = <T extends WorksheetItem>({
   onBlur,
   onChange,
 }: CheckboxEditorProps<T>) => {
-  useEffect(() => {
-    if (isEditing) {
-      // For checkbox we want to change the value when editing is called
-      onChange(!cell.value);
-    }
-  }, [cell.value, isEditing, onChange]);
-
-  const handleChange = () => {
+  const handleChange = useCallback(() => {
     onChange(!cell.value);
-  };
+  }, [cell, onChange]);
+
+  useEffect(() => {
+    // For context, isEditing will only return true when a user has
+    // pressed `enter` or `space` when a checkbox cell is selected.
+    // It is virtually the same as clicking on the checkbox.
+    if (isEditing) {
+      handleChange();
+    }
+  }, [cell.value, handleChange, isEditing]);
 
   return (
     <CheckboxWrapper>

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -31,13 +31,13 @@ const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting, isEdit
     setEditingCell(cell);
   }, [cell, setEditingCell]);
 
-  const cellValue = useMemo(() => (formatting ? formatting(value) : `${value}`), [formatting, value]);
+  const renderedValue = useMemo(() => (formatting ? formatting(value) : `${value}`), [formatting, value]);
 
   return (
     <Flex justifyContent="space-between" alignItems="center" flexWrap="wrap">
       <StyledFlexItem paddingRight="small" flexShrink={1}>
-        <Small color="secondary70" ellipsis={true} title={cellValue}>
-          {cellValue}
+        <Small color="secondary70" ellipsis={true} title={renderedValue}>
+          {renderedValue}
         </Small>
       </StyledFlexItem>
       <StyledButton onClick={handleClick} ref={buttonRef} variant="subtle">

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef, useEffect } from 'react';
 
 import { typedMemo } from '../../../../utils';
 import { Flex, FlexItem } from '../../../Flex';
@@ -10,12 +10,21 @@ import { StyledButton } from './styled';
 
 export interface ModalEditorProps<Item> {
   cell: Cell<Item>;
+  isEditing: boolean;
   formatting?: WorksheetModalColumn<Item>['formatting'];
 }
 
-const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting }: ModalEditorProps<T>) => {
+const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting, isEditing }: ModalEditorProps<T>) => {
   const setOpenModal = useStore((state) => state.setOpenModal);
   const { hash, value } = cell;
+
+  const buttonRef = createRef<HTMLButtonElement>();
+
+  useEffect(() => {
+    if (isEditing) {
+      setOpenModal(hash);
+    }
+  }, [hash, isEditing, setOpenModal]);
 
   const handleClick = () => {
     setOpenModal(hash);
@@ -26,7 +35,7 @@ const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting }: Moda
       <FlexItem paddingRight="small">
         <Small>{formatting ? formatting(value) : `${value}`}</Small>
       </FlexItem>
-      <StyledButton onClick={handleClick} variant="subtle">
+      <StyledButton onClick={handleClick} ref={buttonRef} variant="subtle">
         Edit
       </StyledButton>
     </Flex>

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -36,7 +36,7 @@ const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting, isEdit
   return (
     <Flex justifyContent="space-between" alignItems="center" flexWrap="wrap">
       <StyledFlexItem paddingRight="small" flexShrink={1}>
-        <Small color="secondary70" ellipsis={true} title={renderedValue}>
+        <Small color="secondary70" ellipsis title={renderedValue}>
           {renderedValue}
         </Small>
       </StyledFlexItem>

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -1,12 +1,12 @@
-import React, { createRef, useEffect } from 'react';
+import React, { createRef, useCallback, useEffect, useMemo } from 'react';
 
 import { typedMemo } from '../../../../utils';
-import { Flex, FlexItem } from '../../../Flex';
+import { Flex } from '../../../Flex';
 import { Small } from '../../../Typography';
 import { useStore } from '../../hooks';
 import { Cell, WorksheetItem, WorksheetModalColumn } from '../../types';
 
-import { StyledButton } from './styled';
+import { StyledButton, StyledFlexItem } from './styled';
 
 export interface ModalEditorProps<Item> {
   cell: Cell<Item>;
@@ -16,6 +16,7 @@ export interface ModalEditorProps<Item> {
 
 const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting, isEditing }: ModalEditorProps<T>) => {
   const setOpenModal = useStore((state) => state.setOpenModal);
+  const setEditingCell = useStore((state) => state.setEditingCell);
   const { hash, value } = cell;
 
   const buttonRef = createRef<HTMLButtonElement>();
@@ -26,15 +27,20 @@ const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting, isEdit
     }
   }, [hash, isEditing, setOpenModal]);
 
-  const handleClick = () => {
+  const handleClick = useCallback(() => {
     setOpenModal(hash);
-  };
+    setEditingCell(cell);
+  }, [cell, hash, setEditingCell, setOpenModal]);
+
+  const cellValue = useMemo(() => (formatting ? formatting(value) : `${value}`), [formatting, value]);
 
   return (
-    <Flex justifyContent="space-between" alignItems="center">
-      <FlexItem paddingRight="small">
-        <Small>{formatting ? formatting(value) : `${value}`}</Small>
-      </FlexItem>
+    <Flex justifyContent="space-between" alignItems="center" flexWrap="wrap">
+      <StyledFlexItem paddingRight="small" flexShrink={1}>
+        <Small color="secondary70" ellipsis={true} title={cellValue}>
+          {cellValue}
+        </Small>
+      </StyledFlexItem>
       <StyledButton onClick={handleClick} ref={buttonRef} variant="subtle">
         Edit
       </StyledButton>

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -28,9 +28,8 @@ const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting, isEdit
   }, [hash, isEditing, setOpenModal]);
 
   const handleClick = useCallback(() => {
-    setOpenModal(hash);
     setEditingCell(cell);
-  }, [cell, hash, setEditingCell, setOpenModal]);
+  }, [cell, setEditingCell]);
 
   const cellValue = useMemo(() => (formatting ? formatting(value) : `${value}`), [formatting, value]);
 

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/styled.ts
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/styled.ts
@@ -2,6 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { StyleableButton } from '../../../Button/Button';
+import { FlexItem } from '../../../Flex';
 
 export const StyledButton = styled(StyleableButton)`
   font-size: ${({ theme }) => theme.typography.fontSize.small};
@@ -19,4 +20,9 @@ export const StyledButton = styled(StyleableButton)`
   }
 `;
 
+export const StyledFlexItem = styled(FlexItem)`
+  overflow: hidden;
+`;
+
 StyledButton.defaultProps = { theme: defaultTheme };
+StyledFlexItem.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
@@ -40,7 +40,7 @@ const InternalSelectEditor = <T extends WorksheetItem>({
       <Select
         filterable={false}
         inputRef={inputRef}
-        onBlur={onBlur}
+        onClose={onBlur}
         onOptionChange={handleChange}
         options={options}
         value={cell.value}

--- a/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
@@ -1,7 +1,8 @@
-import React, { createRef, useEffect } from 'react';
+import React, { createRef, useCallback, useEffect } from 'react';
 
 import { typedMemo } from '../../../../utils';
 import { Select } from '../../../Select';
+import { useStore } from '../../hooks';
 import { Cell, WorksheetItem, WorksheetSelectableColumn } from '../../types';
 
 import { SelectWrapper } from './styled';
@@ -24,23 +25,37 @@ const InternalSelectEditor = <T extends WorksheetItem>({
   options = [],
 }: SelectEditorProps<T>) => {
   const inputRef = createRef<HTMLInputElement>();
+  const setEditingCell = useStore((state) => state.setEditingCell);
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
       inputRef.current.focus();
     }
-  });
+  }, [inputRef, isEditing]);
 
-  const handleChange = (value: unknown) => {
-    onChange(value);
-  };
+  const handleChange = useCallback(
+    (value: unknown) => {
+      onChange(value);
+    },
+    [onChange],
+  );
+
+  const handleOpen = useCallback(() => {
+    setEditingCell(cell);
+  }, [cell, setEditingCell]);
+
+  const handleClose = useCallback(() => {
+    onBlur();
+    setEditingCell(null);
+  }, [onBlur, setEditingCell]);
 
   return (
     <SelectWrapper isEdited={isEdited}>
       <Select
         filterable={false}
         inputRef={inputRef}
-        onClose={onBlur}
+        onClose={handleClose}
+        onOpen={handleOpen}
         onOptionChange={handleChange}
         options={options}
         value={cell.value}

--- a/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef, useEffect } from 'react';
 
 import { typedMemo } from '../../../../utils';
 import { Select } from '../../../Select';
@@ -9,23 +9,42 @@ import { SelectWrapper } from './styled';
 export interface SelectEditorProps<Item> {
   cell: Cell<Item>;
   isEdited: boolean;
-  onChange(value: unknown): void;
+  isEditing: boolean;
   options?: WorksheetSelectableColumn<Item>['config']['options'];
+  onBlur(): void;
+  onChange(value: unknown): void;
 }
 
 const InternalSelectEditor = <T extends WorksheetItem>({
   cell,
   isEdited,
+  isEditing,
+  onBlur,
   onChange,
   options = [],
 }: SelectEditorProps<T>) => {
+  const inputRef = createRef<HTMLInputElement>();
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+    }
+  });
+
   const handleChange = (value: unknown) => {
     onChange(value);
   };
 
   return (
     <SelectWrapper isEdited={isEdited}>
-      <Select filterable={false} options={options} onOptionChange={handleChange} value={cell.value} />
+      <Select
+        filterable={false}
+        inputRef={inputRef}
+        onBlur={onBlur}
+        onOptionChange={handleChange}
+        options={options}
+        value={cell.value}
+      />
     </SelectWrapper>
   );
 };

--- a/packages/big-design/src/components/Worksheet/editors/TextEditor/TextEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/TextEditor/TextEditor.tsx
@@ -25,7 +25,7 @@ const InternalTextEditor = <T extends WorksheetItem>({ cell, isEdited, onBlur, o
     onKeyDown(event, formatValue(value));
   };
 
-  const formatValue = (value: string) => (cell.type === 'number' ? Number(value) : value);
+  const formatValue = (value: string) => (cell.type === 'number' && value !== '' ? Number(value) : value);
 
   return (
     <StyledInput

--- a/packages/big-design/src/components/Worksheet/hooks/index.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/index.ts
@@ -1,3 +1,6 @@
 export * from './useEditableCell';
+export * from './useKeyEvents';
+export * from './useNavigation';
 export * from './useStore';
+export * from './useTableFocus';
 export * from './useUpdateItems';

--- a/packages/big-design/src/components/Worksheet/hooks/useEditableCell/index.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useEditableCell/index.ts
@@ -1,0 +1,1 @@
+export * from './useEditableCell';

--- a/packages/big-design/src/components/Worksheet/hooks/useEditableCell/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/hooks/useEditableCell/spec.tsx
@@ -28,12 +28,10 @@ describe('useEditableCells', () => {
   const cell: Cell<Product> = { rowIndex: 0, columnIndex: 0, type: 'text', hash: 'category', value: 'Text' };
 
   let preventDefault: () => void;
-  let stopPropagation: () => void;
 
   beforeEach(() => {
     mockUpdateItems = jest.fn();
     preventDefault = jest.fn();
-    stopPropagation = jest.fn();
   });
 
   test('double click', () => {
@@ -64,18 +62,14 @@ describe('useEditableCells', () => {
         ({
           key: 'Enter',
           preventDefault,
-          stopPropagation,
         } as unknown) as React.KeyboardEvent<HTMLInputElement>,
         'New Value',
       );
     });
 
     expect(preventDefault).toHaveBeenCalledTimes(1);
-    expect(stopPropagation).toHaveBeenCalledTimes(1);
     expect(mockUpdateItems).toHaveBeenCalledWith([cell], ['New Value']);
     expect(result.current.isEditing).toBe(false);
-
-    expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: 1, columnIndex: 0 });
   });
 
   test('enter only updates if it has new values', () => {
@@ -87,13 +81,43 @@ describe('useEditableCells', () => {
         ({
           key: 'Enter',
           preventDefault,
-          stopPropagation,
         } as unknown) as React.KeyboardEvent<HTMLInputElement>,
         'Text',
       );
     });
 
     expect(mockUpdateItems).not.toHaveBeenCalled();
+  });
+
+  test('tab', () => {
+    const { result } = renderHook(() => useEditableCell(cell));
+
+    act(() => {
+      result.current.handleKeyDown(
+        ({
+          key: 'Tab',
+          preventDefault,
+        } as unknown) as React.KeyboardEvent<HTMLInputElement>,
+        'New Value',
+      );
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({ columnIndex: 1, rowIndex: 0 });
+
+    act(() => {
+      result.current.handleKeyDown(
+        ({
+          key: 'Tab',
+          preventDefault,
+          shiftKey: true,
+        } as unknown) as React.KeyboardEvent<HTMLInputElement>,
+        'New Value',
+      );
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({ columnIndex: -1, rowIndex: 0 });
+
+    expect(result.current.isEditing).toBe(false);
   });
 
   test('modal and select do not trigger a navigation', () => {
@@ -104,7 +128,6 @@ describe('useEditableCells', () => {
         ({
           key: 'Enter',
           preventDefault,
-          stopPropagation,
         } as unknown) as React.KeyboardEvent<HTMLInputElement>,
         'New Value',
       );
@@ -122,14 +145,12 @@ describe('useEditableCells', () => {
         ({
           key: 'Escape',
           preventDefault,
-          stopPropagation,
         } as unknown) as React.KeyboardEvent<HTMLInputElement>,
         'New Value',
       );
     });
 
     expect(preventDefault).toHaveBeenCalledTimes(1);
-    expect(stopPropagation).toHaveBeenCalledTimes(1);
     expect(result.current.isEditing).toBe(false);
   });
 

--- a/packages/big-design/src/components/Worksheet/hooks/useEditableCell/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/hooks/useEditableCell/spec.tsx
@@ -2,12 +2,12 @@ import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 import { act } from 'react-test-renderer';
 
-import { Cell } from '../types';
+import { Cell } from '../../types';
 
 import { useEditableCell } from './useEditableCell';
 
 let mockUpdateItems = jest.fn();
-jest.mock('./useUpdateItems', () => ({
+jest.mock('../useUpdateItems', () => ({
   useUpdateItems: () => ({
     updateItems: mockUpdateItems,
   }),

--- a/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
@@ -1,11 +1,10 @@
 import React, { useCallback, useMemo } from 'react';
 
-import { Cell, WorksheetItem } from '../types';
-
-import { useNavigation } from './useNavigation';
-import { useStore } from './useStore';
-import { useTableFocus } from './useTableFocus';
-import { useUpdateItems } from './useUpdateItems';
+import { Cell, WorksheetItem } from '../../types';
+import { useNavigation } from '../useNavigation';
+import { useStore } from '../useStore';
+import { useTableFocus } from '../useTableFocus';
+import { useUpdateItems } from '../useUpdateItems';
 
 export type EditableCellOnKeyDown = (event: React.KeyboardEvent<HTMLInputElement>, newValue: unknown) => void;
 

--- a/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
@@ -50,7 +50,6 @@ export const useEditableCell = <T extends WorksheetItem>(cell: Cell<T>) => {
       switch (key) {
         case 'Enter':
           event.preventDefault();
-          event.stopPropagation();
 
           // Only call updateItems if cells have new values
           if (cell.value !== newValue) {
@@ -59,15 +58,18 @@ export const useEditableCell = <T extends WorksheetItem>(cell: Cell<T>) => {
 
           restoreFocus();
 
-          // Navigate down on enter
-          if (cell.type !== 'modal' && cell.type !== 'select') {
-            navigate({ rowIndex: 1, columnIndex: 0 });
-          }
+          break;
+        case 'Tab':
+          event.preventDefault();
+
+          restoreFocus();
+
+          // Navigate lateraly on Tab
+          navigate({ rowIndex: 0, columnIndex: event.shiftKey ? -1 : 1 });
 
           break;
         case 'Escape':
           event.preventDefault();
-          event.stopPropagation();
 
           restoreFocus();
 

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents.ts
@@ -1,0 +1,54 @@
+import { useCallback, useMemo } from 'react';
+
+import { useNavigation } from './useNavigation';
+import { useStore } from './useStore';
+
+export const useKeyEvents = () => {
+  // Get the first cell of the selected values
+  const selectedCell = useStore(useMemo(() => (state) => state.selectedCells[0], []));
+
+  const isEditing = useStore(useMemo(() => (state) => state.editingCell !== null, []));
+  const setEditingCell = useStore((state) => state.setEditingCell);
+
+  const { navigate } = useNavigation(selectedCell);
+
+  const editSelectedCell = useCallback(() => {
+    setEditingCell(selectedCell);
+  }, [selectedCell, setEditingCell]);
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      const key = event.key;
+
+      if (isEditing) {
+        return;
+      }
+
+      event.preventDefault();
+
+      switch (key) {
+        case 'Enter':
+          editSelectedCell();
+          break;
+        case 'ArrowUp':
+          navigate({ rowIndex: -1, columnIndex: 0 });
+          break;
+        case 'ArrowDown':
+          navigate({ rowIndex: 1, columnIndex: 0 });
+          break;
+        case 'ArrowRight':
+          navigate({ rowIndex: 0, columnIndex: 1 });
+          break;
+        case 'Tab':
+          navigate({ rowIndex: 0, columnIndex: event.shiftKey ? -1 : 1 });
+          break;
+        case 'ArrowLeft':
+          navigate({ rowIndex: 0, columnIndex: -1 });
+          break;
+      }
+    },
+    [editSelectedCell, isEditing, navigate],
+  );
+
+  return useMemo(() => ({ handleKeyDown }), [handleKeyDown]);
+};

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents.ts
@@ -13,7 +13,9 @@ export const useKeyEvents = () => {
   const { navigate } = useNavigation(selectedCell);
 
   const editSelectedCell = useCallback(() => {
-    setEditingCell(selectedCell);
+    if (selectedCell) {
+      setEditingCell(selectedCell);
+    }
   }, [selectedCell, setEditingCell]);
 
   const handleKeyDown = useCallback(

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/index.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/index.ts
@@ -1,0 +1,1 @@
+export * from './useKeyEvents';

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/spec.tsx
@@ -102,6 +102,58 @@ describe('useKeyEvents', () => {
     });
   });
 
+  test('space triggers cell edit', () => {
+    const { result: hook } = renderHook(() => useKeyEvents());
+    const { result: store } = renderHook(() => useStore());
+
+    const event = new KeyboardEvent('keydown', { key: ' ' });
+
+    act(() => {
+      hook.current.handleKeyDown(event);
+    });
+
+    expect(store.current.editingCell).toStrictEqual({
+      rowIndex: 0,
+      columnIndex: 0,
+      type: 'text',
+      hash: 'productName',
+      value: 'One',
+    });
+  });
+
+  test('navigates down when cell is checkbox', () => {
+    const { result: hook } = renderHook(() => useKeyEvents());
+    const { result: store } = renderHook(() => useStore());
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter' });
+
+    act(() => {
+      store.current.setSelectedCells([
+        {
+          rowIndex: 0,
+          columnIndex: 0,
+          type: 'checkbox',
+          hash: 'viewInStorefront',
+          value: true,
+        },
+      ]);
+    });
+
+    act(() => {
+      hook.current.handleKeyDown(event);
+    });
+
+    expect(store.current.editingCell).toStrictEqual({
+      rowIndex: 0,
+      columnIndex: 0,
+      type: 'checkbox',
+      hash: 'viewInStorefront',
+      value: true,
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: 1, columnIndex: 0 });
+  });
+
   test('enter does not trigger cell edit if selected cell is missing', () => {
     const { result: hook } = renderHook(() => useKeyEvents());
     const { result: store } = renderHook(() => useStore());
@@ -118,4 +170,49 @@ describe('useKeyEvents', () => {
 
     expect(store.current.editingCell).toStrictEqual(null);
   });
+});
+
+test('enter when editing navigates down', () => {
+  const { result: hook } = renderHook(() => useKeyEvents());
+  const { result: store } = renderHook(() => useStore());
+
+  act(() => {
+    store.current.setEditingCell({
+      rowIndex: 0,
+      columnIndex: 0,
+      type: 'text',
+      hash: 'productName',
+      value: 'One',
+    });
+  });
+
+  const event = new KeyboardEvent('keydown', { key: 'Enter' });
+  hook.current.handleKeyDown(event);
+
+  expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: 1, columnIndex: 0 });
+});
+
+test('tab when editing navigates lateraly', () => {
+  const { result: hook } = renderHook(() => useKeyEvents());
+  const { result: store } = renderHook(() => useStore());
+
+  act(() => {
+    store.current.setEditingCell({
+      rowIndex: 0,
+      columnIndex: 0,
+      type: 'text',
+      hash: 'productName',
+      value: 'One',
+    });
+  });
+
+  let event = new KeyboardEvent('keydown', { key: 'Tab' });
+  hook.current.handleKeyDown(event);
+
+  expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: 0, columnIndex: 1 });
+
+  event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+  hook.current.handleKeyDown(event);
+
+  expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: 0, columnIndex: -1 });
 });

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/spec.tsx
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useKeyEvents } from './useKeyEvents';
+
+const mockNavigate = jest.fn();
+jest.mock('../useNavigation', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+describe('useKeyEvents', () => {
+  test('navigates with keys', () => {
+    const { result } = renderHook(() => useKeyEvents());
+
+    let event = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+    result.current.handleKeyDown(event);
+
+    expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: -1, columnIndex: 0 });
+
+    event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+    result.current.handleKeyDown(event);
+
+    expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: 1, columnIndex: 0 });
+
+    event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
+    result.current.handleKeyDown(event);
+
+    expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: 0, columnIndex: 1 });
+
+    event = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
+    result.current.handleKeyDown(event);
+
+    expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: 0, columnIndex: -1 });
+  });
+
+  test('navigates with tab', () => {
+    const { result } = renderHook(() => useKeyEvents());
+
+    let event = new KeyboardEvent('keydown', { key: 'Tab' });
+    result.current.handleKeyDown(event);
+
+    expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: 0, columnIndex: 1 });
+
+    event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+    result.current.handleKeyDown(event);
+
+    expect(mockNavigate).toHaveBeenCalledWith({ rowIndex: 0, columnIndex: -1 });
+  });
+});

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
-import { useNavigation } from './useNavigation';
-import { useStore } from './useStore';
+import { useNavigation } from '../useNavigation';
+import { useStore } from '../useStore';
 
 export const useKeyEvents = () => {
   // Get the first cell of the selected values

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
@@ -23,33 +23,49 @@ export const useKeyEvents = () => {
       const key = event.key;
 
       if (isEditing) {
-        return;
-      }
+        switch (key) {
+          case 'Enter':
+            navigate({ rowIndex: 1, columnIndex: 0 });
+            break;
+          case 'Tab':
+            navigate({ rowIndex: 0, columnIndex: event.shiftKey ? -1 : 1 });
+            break;
+          default:
+            return;
+        }
+      } else {
+        switch (key) {
+          case 'Enter':
+            editSelectedCell();
 
-      event.preventDefault();
+            if (selectedCell && selectedCell.type === 'checkbox') {
+              navigate({ rowIndex: 1, columnIndex: 0 });
+            }
+            break;
+          case ' ':
+            editSelectedCell();
+            break;
+          case 'ArrowUp':
+            navigate({ rowIndex: -1, columnIndex: 0 });
+            break;
+          case 'ArrowDown':
+            navigate({ rowIndex: 1, columnIndex: 0 });
+            break;
+          case 'ArrowRight':
+            navigate({ rowIndex: 0, columnIndex: 1 });
+            break;
+          case 'Tab':
+            navigate({ rowIndex: 0, columnIndex: event.shiftKey ? -1 : 1 });
+            break;
+          case 'ArrowLeft':
+            navigate({ rowIndex: 0, columnIndex: -1 });
+            break;
+        }
 
-      switch (key) {
-        case 'Enter':
-          editSelectedCell();
-          break;
-        case 'ArrowUp':
-          navigate({ rowIndex: -1, columnIndex: 0 });
-          break;
-        case 'ArrowDown':
-          navigate({ rowIndex: 1, columnIndex: 0 });
-          break;
-        case 'ArrowRight':
-          navigate({ rowIndex: 0, columnIndex: 1 });
-          break;
-        case 'Tab':
-          navigate({ rowIndex: 0, columnIndex: event.shiftKey ? -1 : 1 });
-          break;
-        case 'ArrowLeft':
-          navigate({ rowIndex: 0, columnIndex: -1 });
-          break;
+        event.preventDefault();
       }
     },
-    [editSelectedCell, isEditing, navigate],
+    [editSelectedCell, isEditing, navigate, selectedCell],
   );
 
   return useMemo(() => ({ handleKeyDown }), [handleKeyDown]);

--- a/packages/big-design/src/components/Worksheet/hooks/useNavigation.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useNavigation.ts
@@ -1,0 +1,57 @@
+import { useCallback, useMemo } from 'react';
+
+import { Cell, WorksheetItem } from '../types';
+
+import { useStore } from './useStore';
+
+interface Coordinate {
+  columnIndex: number;
+  rowIndex: number;
+}
+
+export const useNavigation = <T extends WorksheetItem>(selectedCell: Cell<T>) => {
+  const rows = useStore(useMemo(() => (state) => state.rows, []));
+  const columns = useStore(useMemo(() => (state) => state.columns, []));
+
+  const setSelectedCells = useStore((state) => state.setSelectedCells);
+  const setSelectedRows = useStore((state) => state.setSelectedRows);
+
+  const isValidPosition = useCallback(
+    (position: Coordinate) => {
+      const rowLength = rows.length;
+      const columnsLength = columns.length;
+
+      // Check to see if the next indexes fit inside the matrix
+      return (
+        position.rowIndex >= 0 &&
+        position.rowIndex < rowLength &&
+        position.columnIndex >= 0 &&
+        position.columnIndex < columnsLength
+      );
+    },
+    [columns, rows],
+  );
+
+  const navigate = useCallback(
+    (offset: Coordinate) => {
+      const newPosition: Coordinate = {
+        columnIndex: selectedCell.columnIndex + offset.columnIndex,
+        rowIndex: selectedCell.rowIndex + offset.rowIndex,
+      };
+
+      if (isValidPosition(newPosition)) {
+        const hash = columns[newPosition.columnIndex].hash;
+        const type = columns[newPosition.columnIndex].type || 'text';
+        const value = rows[newPosition.rowIndex][hash];
+
+        const cell: Cell<T> = { ...newPosition, hash, type, value };
+
+        setSelectedCells([cell]);
+        setSelectedRows([newPosition.rowIndex]);
+      }
+    },
+    [columns, isValidPosition, rows, selectedCell, setSelectedCells, setSelectedRows],
+  );
+
+  return useMemo(() => ({ navigate }), [navigate]);
+};

--- a/packages/big-design/src/components/Worksheet/hooks/useNavigation.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useNavigation.ts
@@ -44,7 +44,7 @@ export const useNavigation = <T extends WorksheetItem>(selectedCell: Cell<T>) =>
         const type = columns[newPosition.columnIndex].type || 'text';
         const value = rows[newPosition.rowIndex][hash];
 
-        const cell: Cell<T> = { ...newPosition, hash, type, value };
+        const cell = { ...newPosition, hash, type, value };
 
         setSelectedCells([cell]);
         setSelectedRows([newPosition.rowIndex]);

--- a/packages/big-design/src/components/Worksheet/hooks/useNavigation/index.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useNavigation/index.ts
@@ -1,0 +1,1 @@
+export * from './useNavigation';

--- a/packages/big-design/src/components/Worksheet/hooks/useNavigation/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/hooks/useNavigation/spec.tsx
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react-test-renderer';
 
 import { Cell, WorksheetColumn } from '../../types';
 import { useStore } from '../useStore';
@@ -48,15 +49,27 @@ beforeEach(() => {
 describe('useNavigation', () => {
   const cell: Cell<Product> = { rowIndex: 0, columnIndex: 0, type: 'text', hash: 'productName', value: 'One' };
 
-  test('navigations', () => {
-    const { result } = renderHook(() => useNavigation(cell));
+  test('navigates', () => {
+    const { result: hook } = renderHook(() => useNavigation(cell));
+    const { result: store } = renderHook(() => useStore());
 
-    result.current.navigate({ rowIndex: 1, columnIndex: 0 });
+    act(() => {
+      hook.current.navigate({ rowIndex: 1, columnIndex: 0 });
+    });
 
-    const { result: useStateResult } = renderHook(() => useStore((state) => state.selectedCells));
-
-    expect(useStateResult.current).toStrictEqual([
+    expect(store.current.selectedCells).toStrictEqual([
       { rowIndex: 1, columnIndex: 0, type: 'text', hash: 'productName', value: 'Two' },
     ]);
+  });
+
+  test('navigates only on valid position', () => {
+    const { result: hook } = renderHook(() => useNavigation(cell));
+    const { result: store } = renderHook(() => useStore());
+
+    act(() => {
+      hook.current.navigate({ rowIndex: 0, columnIndex: -1 });
+    });
+
+    expect(store.current.selectedCells).toStrictEqual([]);
   });
 });

--- a/packages/big-design/src/components/Worksheet/hooks/useNavigation/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/hooks/useNavigation/spec.tsx
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { Cell, WorksheetColumn } from '../../types';
+import { useStore } from '../useStore';
+
+import { useNavigation } from './useNavigation';
+
+interface Product {
+  id: number;
+  productName: string;
+  visibleOnStorefront: boolean;
+  otherField: string;
+}
+
+const columns: WorksheetColumn<Product>[] = [
+  { hash: 'productName', header: 'Product name', validation: (value: string) => !!value },
+  { hash: 'visibleOnStorefront', header: 'Visible on storefront', type: 'checkbox' },
+  { hash: 'otherField', header: 'Other field' },
+];
+
+const items: Product[] = [
+  {
+    id: 1,
+    productName: 'One',
+    visibleOnStorefront: true,
+    otherField: 'Text',
+  },
+  {
+    id: 2,
+    productName: 'Two',
+    visibleOnStorefront: true,
+    otherField: 'Text',
+  },
+  {
+    id: 3,
+    productName: 'Three',
+    visibleOnStorefront: false,
+    otherField: 'Text',
+  },
+];
+
+const initialStoreState = useStore.getState();
+
+beforeEach(() => {
+  useStore.setState({ ...initialStoreState, rows: items, columns }, true);
+});
+
+describe('useNavigation', () => {
+  const cell: Cell<Product> = { rowIndex: 0, columnIndex: 0, type: 'text', hash: 'productName', value: 'One' };
+
+  test('navigations', () => {
+    const { result } = renderHook(() => useNavigation(cell));
+
+    result.current.navigate({ rowIndex: 1, columnIndex: 0 });
+
+    const { result: useStateResult } = renderHook(() => useStore((state) => state.selectedCells));
+
+    expect(useStateResult.current).toStrictEqual([
+      { rowIndex: 1, columnIndex: 0, type: 'text', hash: 'productName', value: 'Two' },
+    ]);
+  });
+});

--- a/packages/big-design/src/components/Worksheet/hooks/useNavigation/useNavigation.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useNavigation/useNavigation.ts
@@ -33,6 +33,10 @@ export const useNavigation = <T extends WorksheetItem>(selectedCell: Cell<T>) =>
 
   const navigate = useCallback(
     (offset: Coordinate) => {
+      if (!selectedCell) {
+        return;
+      }
+
       const newPosition: Coordinate = {
         columnIndex: selectedCell.columnIndex + offset.columnIndex,
         rowIndex: selectedCell.rowIndex + offset.rowIndex,

--- a/packages/big-design/src/components/Worksheet/hooks/useNavigation/useNavigation.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useNavigation/useNavigation.ts
@@ -1,8 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
-import { Cell, WorksheetItem } from '../types';
-
-import { useStore } from './useStore';
+import { Cell, WorksheetItem } from '../../types';
+import { useStore } from '../useStore';
 
 interface Coordinate {
   columnIndex: number;

--- a/packages/big-design/src/components/Worksheet/hooks/useStore.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useStore.ts
@@ -1,36 +1,48 @@
 import create, { State } from 'zustand';
 
-import { Cell } from '../types';
+import { Cell, WorksheetColumn } from '../types';
 import { deleteCells, mergeCells } from '../utils';
 
 interface BaseState<Item> extends State {
+  columns: WorksheetColumn<Item>[];
   editedCells: Array<Cell<Item>>;
+  editingCell: Cell<Item> | null;
   invalidCells: Array<Cell<Item>>;
   openedModal: keyof Item | null;
   rows: Item[];
   selectedCells: Array<Cell<Item>>;
   selectedRows: number[];
+  tableRef: HTMLTableElement | null;
   addEditedCells: (cells: Array<Cell<Item>>) => void;
   addInvalidCells: (cells: Array<Cell<Item>>) => void;
   removeInvalidCells: (cells: Array<Cell<Item>>) => void;
+  setColumns: (columns: Array<WorksheetColumn<Item>>) => void;
+  setEditingCell: (cell: Cell<Item> | null) => void;
   setOpenModal: (value: keyof Item | null) => void;
   setRows: (rows: Item[]) => void;
   setSelectedCells: (cells: Array<Cell<Item>>) => void;
   setSelectedRows: (rows: number[]) => void;
+  setTableRef: (ref: HTMLTableElement | null) => void;
 }
 
 export const useStore = create<BaseState<any>>((set) => ({
+  columns: [],
   editedCells: [],
+  editingCell: null,
   invalidCells: [],
   openedModal: null,
   rows: [],
   selectedCells: [],
   selectedRows: [],
+  tableRef: null,
   addEditedCells: (cells) => set((state) => ({ ...state, editedCells: mergeCells(state.editedCells, cells) })),
   addInvalidCells: (cells) => set((state) => ({ ...state, invalidCells: mergeCells(state.invalidCells, cells) })),
   removeInvalidCells: (cells) => set((state) => ({ ...state, invalidCells: deleteCells(state.invalidCells, cells) })),
+  setColumns: (columns) => set((state) => ({ ...state, columns })),
+  setEditingCell: (cell) => set((state) => ({ ...state, editingCell: cell })),
   setOpenModal: (value) => set((state) => ({ ...state, openedModal: value })),
   setRows: (rows) => set((state) => ({ ...state, rows })),
   setSelectedCells: (cells) => set((state) => ({ ...state, selectedCells: cells })),
   setSelectedRows: (rowIndexes) => set((state) => ({ ...state, selectedRows: rowIndexes })),
+  setTableRef: (ref) => set((state) => ({ ...state, tableRef: ref })),
 }));

--- a/packages/big-design/src/components/Worksheet/hooks/useStore/index.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useStore/index.ts
@@ -1,0 +1,1 @@
+export * from './useStore';

--- a/packages/big-design/src/components/Worksheet/hooks/useStore/useStore.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useStore/useStore.ts
@@ -1,7 +1,7 @@
 import create, { State } from 'zustand';
 
-import { Cell, WorksheetColumn } from '../types';
-import { deleteCells, mergeCells } from '../utils';
+import { Cell, WorksheetColumn } from '../../types';
+import { deleteCells, mergeCells } from '../../utils';
 
 interface BaseState<Item> extends State {
   columns: WorksheetColumn<Item>[];

--- a/packages/big-design/src/components/Worksheet/hooks/useTableFocus.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useTableFocus.ts
@@ -1,0 +1,15 @@
+import { useCallback, useMemo } from 'react';
+
+import { useStore } from './useStore';
+
+export const useTableFocus = () => {
+  const tableRef = useStore(useMemo(() => (state) => state.tableRef, []));
+
+  const focusTable = useCallback(() => {
+    if (tableRef) {
+      tableRef.focus();
+    }
+  }, [tableRef]);
+
+  return useMemo(() => ({ focusTable }), [focusTable]);
+};

--- a/packages/big-design/src/components/Worksheet/hooks/useTableFocus/index.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useTableFocus/index.ts
@@ -1,0 +1,1 @@
+export * from './useTableFocus';

--- a/packages/big-design/src/components/Worksheet/hooks/useTableFocus/useTableFocus.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useTableFocus/useTableFocus.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { useStore } from './useStore';
+import { useStore } from '../useStore';
 
 export const useTableFocus = () => {
   const tableRef = useStore(useMemo(() => (state) => state.tableRef, []));

--- a/packages/big-design/src/components/Worksheet/hooks/useUpdateItems/index.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useUpdateItems/index.ts
@@ -1,0 +1,1 @@
+export * from './useUpdateItems';

--- a/packages/big-design/src/components/Worksheet/hooks/useUpdateItems/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/hooks/useUpdateItems/spec.tsx
@@ -1,0 +1,9 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useUpdateItems } from './index';
+
+test('throws if is not wrapped in UpdateItemsProvider', () => {
+  const { result: hook } = renderHook(() => useUpdateItems());
+
+  expect(hook.error.message).toContain('UpdateItemsProvider');
+});

--- a/packages/big-design/src/components/Worksheet/hooks/useUpdateItems/useUpdateItems.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useUpdateItems/useUpdateItems.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 
-import { UpdateItemsContext } from '../context';
+import { UpdateItemsContext } from '../../context';
 
 export const useUpdateItems = () => {
   const updateItemsContext = useContext(UpdateItemsContext);

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -463,6 +463,50 @@ describe('formatting', () => {
   });
 });
 
+describe('keyboard navigation', () => {
+  test('navigates with arrow keys', async () => {
+    const { getByText } = render(<Worksheet columns={columns} items={items} onChange={handleChange} />);
+
+    let cell = getByText('Shoes Name Three');
+
+    fireEvent.click(cell);
+
+    expect(cell.parentElement).toHaveStyle('border-color: #3C64F4');
+
+    fireEvent.keyDown(cell, { key: 'ArrowDown' });
+
+    cell = getByText('Shoes Name Two');
+
+    expect(cell.parentElement).toHaveStyle('border-color: #3C64F4');
+
+    await waitForElement(() => screen.getAllByRole('combobox'));
+  });
+
+  test('navigates with tab', async () => {
+    const { getAllByText, getByText } = render(<Worksheet columns={columns} items={items} onChange={handleChange} />);
+
+    const cell = getByText('Shoes Name Three');
+
+    fireEvent.click(cell);
+
+    expect(cell.parentElement).toHaveStyle('border-color: #3C64F4');
+
+    fireEvent.keyDown(cell, { key: 'Tab' });
+    fireEvent.keyDown(cell, { key: 'Tab' });
+
+    const cells = getAllByText('Text');
+
+    expect(cells[0].parentElement).toHaveStyle('border-color: #3C64F4');
+
+    fireEvent.keyDown(cell, { key: 'Tab', shiftKey: true });
+    fireEvent.keyDown(cell, { key: 'Tab', shiftKey: true });
+
+    expect(cell.parentElement).toHaveStyle('border-color: #3C64F4');
+
+    await waitForElement(() => screen.getAllByRole('combobox'));
+  });
+});
+
 describe('TextEditor', () => {
   test('renders TextEditor', async () => {
     const { getByDisplayValue, getByText } = render(

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -1,3 +1,4 @@
+import { theme } from '@bigcommerce/big-design-theme';
 import { fireEvent, render, screen, waitForElement } from '@testing-library/react';
 import React from 'react';
 
@@ -203,8 +204,8 @@ describe('selection', () => {
 
     fireEvent.click(cell);
 
-    expect(cell).toHaveStyle('border-color: #3C64F4');
-    expect(row.firstChild).toHaveStyle('background-color: #3C64F4');
+    expect(cell).toHaveStyle(`border-color: ${theme.colors.primary}`);
+    expect(row.firstChild).toHaveStyle(`background-color: ${theme.colors.primary}`);
 
     await waitForElement(() => screen.getAllByRole('combobox'));
   });
@@ -309,8 +310,8 @@ describe('validation', () => {
     const cell = getByText('$49.00').parentElement as HTMLTableDataCellElement;
     const row = cell.parentElement as HTMLTableRowElement;
 
-    expect(cell).toHaveStyle('border-color: #db3643');
-    expect(row.firstChild).toHaveStyle('background-color: #DB3643');
+    expect(cell).toHaveStyle(`border-color: ${theme.colors.danger}`);
+    expect(row.firstChild).toHaveStyle(`background-color: ${theme.colors.danger}`);
 
     await waitForElement(() => screen.getAllByRole('combobox'));
   });
@@ -471,13 +472,13 @@ describe('keyboard navigation', () => {
 
     fireEvent.click(cell);
 
-    expect(cell.parentElement).toHaveStyle('border-color: #3C64F4');
+    expect(cell.parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
 
     fireEvent.keyDown(cell, { key: 'ArrowDown' });
 
     cell = getByText('Shoes Name Two');
 
-    expect(cell.parentElement).toHaveStyle('border-color: #3C64F4');
+    expect(cell.parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
 
     await waitForElement(() => screen.getAllByRole('combobox'));
   });
@@ -489,19 +490,19 @@ describe('keyboard navigation', () => {
 
     fireEvent.click(cell);
 
-    expect(cell.parentElement).toHaveStyle('border-color: #3C64F4');
+    expect(cell.parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
 
     fireEvent.keyDown(cell, { key: 'Tab' });
     fireEvent.keyDown(cell, { key: 'Tab' });
 
     const cells = getAllByText('Text');
 
-    expect(cells[0].parentElement).toHaveStyle('border-color: #3C64F4');
+    expect(cells[0].parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
 
     fireEvent.keyDown(cell, { key: 'Tab', shiftKey: true });
     fireEvent.keyDown(cell, { key: 'Tab', shiftKey: true });
 
-    expect(cell.parentElement).toHaveStyle('border-color: #3C64F4');
+    expect(cell.parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
 
     await waitForElement(() => screen.getAllByRole('combobox'));
   });
@@ -534,7 +535,7 @@ describe('TextEditor', () => {
 
     cell = getByText('Shoes Name One');
 
-    expect(cell.parentNode).toHaveStyle('background-color: rgb(255, 255, 255);');
+    expect(cell.parentNode).toHaveStyle(`background-color: ${theme.colors.white};`);
 
     fireEvent.doubleClick(cell);
 
@@ -560,13 +561,13 @@ describe('TextEditor', () => {
 
     cell = getByText('Shoes Name One Edit');
 
-    expect(cell.parentNode).toHaveStyle('background-color: #FFF9E6;');
+    expect(cell.parentNode).toHaveStyle(`background-color: ${theme.colors.warning10};`);
 
     fireEvent.doubleClick(cell);
 
     input = getByDisplayValue('Shoes Name One Edit') as HTMLInputElement;
 
-    expect(input).toHaveStyle('background-color: #FFF9E6;');
+    expect(input).toHaveStyle(`background-color: ${theme.colors.warning10};`);
 
     await waitForElement(() => screen.getAllByRole('combobox'));
   });
@@ -640,7 +641,7 @@ describe('SelectEditor', () => {
       },
     ]);
 
-    expect(cells[0]).toHaveStyle('background-color: #FFF9E6;');
+    expect(cells[0]).toHaveStyle(`background-color: ${theme.colors.warning10};`);
 
     await waitForElement(() => screen.getAllByRole('combobox'));
   });
@@ -682,7 +683,9 @@ describe('CheckboxEditor', () => {
       },
     ]);
 
-    expect(cell.parentElement?.parentElement?.parentElement).toHaveStyle('background-color: #FFF9E6;');
+    expect(cell.parentElement?.parentElement?.parentElement).toHaveStyle(
+      `background-color: ${theme.colors.warning10};`,
+    );
 
     await waitForElement(() => screen.getAllByRole('combobox'));
   });
@@ -731,7 +734,7 @@ describe('ModalEditor', () => {
 
     const cell = buttons[3].parentNode?.parentNode?.parentNode;
 
-    expect(cell).toHaveStyle('background-color: #FFF9E6;');
+    expect(cell).toHaveStyle(`background-color: ${theme.colors.warning10};`);
 
     await waitForElement(() => screen.getAllByRole('combobox'));
   });

--- a/packages/big-design/src/components/Worksheet/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/styled.tsx
@@ -6,6 +6,10 @@ export const Table = styled.table`
   border-spacing: 0;
   table-layout: fixed;
   width: 100%;
+
+  &:focus {
+    outline: none;
+  }
 `;
 
 export const Header = styled.th`

--- a/packages/big-design/src/components/Worksheet/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/styled.tsx
@@ -1,6 +1,8 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
+import { WorksheetColumn } from './types';
+
 export const Table = styled.table`
   border-collapse: collapse;
   border-spacing: 0;
@@ -12,7 +14,7 @@ export const Table = styled.table`
   }
 `;
 
-export const Header = styled.th`
+export const Header = styled.th<{ columnType: WorksheetColumn<unknown>['type'] }>`
   background-color: ${({ theme }) => theme.colors.secondary10};
   border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} solid ${theme.colors.secondary30}`};
   box-sizing: border-box;
@@ -20,7 +22,7 @@ export const Header = styled.th`
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   height: ${({ theme }) => theme.helpers.remCalc(52)};
   padding: ${({ theme }) => `0 ${theme.helpers.remCalc(17)}`};
-  text-align: left;
+  text-align: ${({ columnType }) => (columnType === 'number' ? 'right' : 'left')};
 `;
 
 Header.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -50,11 +50,13 @@ export interface WorksheetSelectableColumn<Item> extends WorksheetBaseColumn<Ite
 
 export interface WorksheetModalColumn<Item> extends WorksheetBaseColumn<Item> {
   config: {
+    cancelActionText?: string;
     header?: string;
     render(
       value: Item[keyof Item],
       onChange: (value: Item[keyof Item]) => void,
     ): React.ComponentType<Item> | React.ReactElement;
+    saveActionText?: string;
   };
   formatting?(value: Item[keyof Item]): string;
   type: 'modal';


### PR DESCRIPTION
## What

Add keyboard navigation to Worksheet component

1. Arrow keys navigation
2. Tab & Shift + Tab
3. Enter to modify cells

## Why

Primary effort to have working keyboard commands on the component, with the ultimate goal of adding copy & paste, plus cell multiselect.

## Screenshots

https://user-images.githubusercontent.com/196129/120032328-a4d4cb80-bfbf-11eb-85ca-38dc969194a8.mp4

## Tests
Some unit tests and manually





