### PR TITLE
fix(component): change positioning of Modal

### DIFF
--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -163,7 +163,19 @@ exports[`render open modal 1`] = `
 }
 
 .c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   left: 0;
   position: fixed;
   top: 0;
@@ -214,13 +226,8 @@ exports[`render open modal 1`] = `
     border-radius: 0.25rem;
     box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
     height: auto;
-    left: 50%;
     max-height: 90vh;
     max-width: 720px;
-    top: 50%;
-    -webkit-transform: translate(-50%,-50%);
-    -ms-transform: translate(-50%,-50%);
-    transform: translate(-50%,-50%);
   }
 }
 
@@ -461,7 +468,19 @@ exports[`render open modal without backdrop 1`] = `
 }
 
 .c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   left: 0;
   position: fixed;
   top: 0;
@@ -511,13 +530,8 @@ exports[`render open modal without backdrop 1`] = `
     border-radius: 0.25rem;
     box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
     height: auto;
-    left: 50%;
     max-height: 90vh;
     max-width: 720px;
-    top: 50%;
-    -webkit-transform: translate(-50%,-50%);
-    -ms-transform: translate(-50%,-50%);
-    transform: translate(-50%,-50%);
   }
 }
 

--- a/packages/big-design/src/components/Modal/styled.tsx
+++ b/packages/big-design/src/components/Modal/styled.tsx
@@ -11,7 +11,10 @@ export const StyledModal = styled.div.attrs({
   role: 'dialog',
   tabIndex: -1,
 })<Partial<ModalProps>>`
+  align-items: center;
+  display: flex;
   height: 100%;
+  justify-content: center;
   left: 0;
   position: fixed;
   top: 0;
@@ -38,9 +41,6 @@ export const StyledModalContent = styled(Flex)<{ variant: ModalProps['variant'] 
       ${theme.shadow.floating};
 
       max-width: ${theme.breakpointValues.tablet};
-      left: 50%;
-      top: 50%;
-      transform: translate(-50%, -50%);
       width: 90%;
     `}
 
@@ -54,11 +54,8 @@ export const StyledModalContent = styled(Flex)<{ variant: ModalProps['variant'] 
         ${theme.shadow.floating};
 
         height: auto;
-        left: 50%;
         max-height: 90vh;
         max-width: ${theme.breakpointValues.tablet};
-        top: 50%;
-        transform: translate(-50%, -50%);
       }
 
       ${theme.breakpoints.desktop} {


### PR DESCRIPTION
## What?

Change Modal to center its content with `justify-content` and `align-items` instead of `transform`

## Why?

`transform: translate` messes with drag-n-drop preview positioning
![image](https://user-images.githubusercontent.com/7959201/120414372-8de8fd00-c362-11eb-850b-4bd95ed7697f.png)

## Screenshots/Screen Recordings

Modal
![image](https://user-images.githubusercontent.com/7959201/120414162-3480ce00-c362-11eb-949c-efc9a0646fb7.png)
![image](https://user-images.githubusercontent.com/7959201/120414236-55e1ba00-c362-11eb-89cc-a377d93efe57.png)

Dialog
![image](https://user-images.githubusercontent.com/7959201/120414268-672ac680-c362-11eb-9baa-39d0275c1dbe.png)
![image](https://user-images.githubusercontent.com/7959201/120414328-7a3d9680-c362-11eb-9ad3-ec9c68808a5b.png)


## Testing/Proof

Manually tested on Google Chrome v91.0.4472.77 on MacOS by viewing how Modal component looks and behaves on different viewport sizes.
