### PR TITLE
feat(component): add onOpen and onClose to Selects

### DIFF
--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -36,6 +36,8 @@ export const MultiSelect = typedMemo(
     label,
     labelId,
     maxHeight,
+    onClose,
+    onOpen,
     onOptionsChange,
     options,
     placeholder,
@@ -106,10 +108,18 @@ export const MultiSelect = typedMemo(
       );
     };
 
-    const handleOnIsOpenChange = (changes: Partial<UseComboboxState<SelectOption<T> | SelectAction | null>>) => {
-      if (filterable && changes.isOpen === false) {
+    const handleOnIsOpenChange = ({ isOpen }: Partial<UseComboboxState<SelectOption<T> | SelectAction | null>>) => {
+      if (filterable && !isOpen) {
         // Reset the items if filtered
         setFilteredOptions(flattenedOptions);
+      }
+
+      if (isOpen && typeof onOpen === 'function') {
+        onOpen();
+      }
+
+      if (!isOpen && typeof onClose === 'function') {
+        onClose();
       }
     };
 

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -10,6 +10,8 @@ import { MultiSelect } from './';
 
 const onChange = jest.fn();
 const onActionClick = jest.fn();
+const onOpen = jest.fn();
+const onClose = jest.fn();
 
 const mockOptions = [
   { value: 'us', content: 'United States' },
@@ -54,6 +56,8 @@ const MultiSelectMock = (
     data-testid="multi-select"
     error="Required"
     label="Countries"
+    onClose={onClose}
+    onOpen={onOpen}
     onOptionsChange={onChange}
     options={mockOptions}
     placeholder="Choose country"
@@ -367,6 +371,29 @@ test('clicking on disabled select options should not trigger onItemClick', async
   expect(onChange).not.toHaveBeenCalled();
 
   await waitForElement(() => screen.getByRole('option', { name: /mex/i }));
+});
+
+test('opening the MultiSelect triggers onOpen', async () => {
+  const { getAllByRole, queryByRole } = render(MultiSelectMock);
+  const button = getAllByRole('button')[2];
+
+  fireEvent.click(button);
+
+  expect(onOpen).toHaveBeenCalled();
+
+  await waitForElement(() => queryByRole('listbox'));
+});
+
+test('closing the MultiSelect triggers onClose', async () => {
+  const { getAllByRole, queryByRole } = render(MultiSelectMock);
+  const button = getAllByRole('button')[2];
+
+  fireEvent.click(button);
+  fireEvent.click(button);
+
+  expect(onClose).toHaveBeenCalled();
+
+  await waitForElement(() => queryByRole('listbox'));
 });
 
 test('select should render select action', async () => {

--- a/packages/big-design/src/components/MultiSelect/types.ts
+++ b/packages/big-design/src/components/MultiSelect/types.ts
@@ -21,6 +21,8 @@ interface BaseSelect extends Omit<React.HTMLAttributes<HTMLInputElement>, 'child
   placement?: Placement;
   positionFixed?: boolean;
   required?: boolean;
+  onClose?(): void;
+  onOpen?(): void;
 }
 
 export interface MultiSelectProps<T> extends BaseSelect {

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -35,6 +35,8 @@ export const Select = typedMemo(
     label,
     labelId,
     maxHeight,
+    onClose,
+    onOpen,
     onOptionChange,
     options,
     placeholder,
@@ -108,9 +110,17 @@ export const Select = typedMemo(
     };
 
     const handleOnIsOpenChange = ({ isOpen }: Partial<UseComboboxState<SelectOption<T> | SelectAction | null>>) => {
-      if (filterable && isOpen === false) {
+      if (filterable && !isOpen) {
         // Reset the options when the List is closed
         setFilteredOptions(flattenedOptions);
+      }
+
+      if (isOpen && typeof onOpen === 'function') {
+        onOpen();
+      }
+
+      if (!isOpen && typeof onClose === 'function') {
+        onClose();
       }
     };
 

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -10,6 +10,8 @@ import { Select } from './';
 
 const onChange = jest.fn();
 const onActionClick = jest.fn();
+const onOpen = jest.fn();
+const onClose = jest.fn();
 
 const mockOptions = [
   { value: 'us', content: 'United States' },
@@ -54,6 +56,8 @@ const SelectMock = (
     data-testid="select"
     error="Required"
     label="Countries"
+    onClose={onClose}
+    onOpen={onOpen}
     onOptionChange={onChange}
     options={mockOptions}
     placeholder="Choose country"
@@ -424,6 +428,29 @@ test('clicking on disabled select options should not trigger onItemClick', async
   expect(onChange).not.toHaveBeenCalled();
 
   await waitForElement(() => screen.getByRole('option', { name: /mex/i }));
+});
+
+test('opening the Select triggers onOpen', async () => {
+  const { getByRole, queryByRole } = render(SelectMock);
+  const button = getByRole('button');
+
+  fireEvent.click(button);
+
+  expect(onOpen).toHaveBeenCalled();
+
+  await waitForElement(() => queryByRole('listbox'));
+});
+
+test('closing the Select triggers onClose', async () => {
+  const { getByRole, queryByRole } = render(SelectMock);
+  const button = getByRole('button');
+
+  fireEvent.click(button);
+  fireEvent.click(button);
+
+  expect(onClose).toHaveBeenCalled();
+
+  await waitForElement(() => queryByRole('listbox'));
 });
 
 test('select should render select action', async () => {

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -19,6 +19,8 @@ interface BaseSelect extends Omit<React.HTMLAttributes<HTMLInputElement>, 'child
   placement?: Placement;
   positionFixed?: boolean;
   required?: boolean;
+  onClose?(): void;
+  onOpen?(): void;
 }
 
 export interface SelectProps<T> extends BaseSelect {

--- a/packages/docs/PropTables/MultiSelectPropTable.tsx
+++ b/packages/docs/PropTables/MultiSelectPropTable.tsx
@@ -40,7 +40,7 @@ const selectProps: Prop[] = [
     defaultValue: 'true',
     description: (
       <>
-        Allows you to filter the <Code>SelectOptions</Code> in the <Code>Select</Code>.
+        Allows you to filter the <Code>SelectOptions</Code> in the <Code>MultiSelect</Code>.
       </>
     ),
   },
@@ -49,7 +49,7 @@ const selectProps: Prop[] = [
     types: 'React.Ref<HTMLInputElement> | React.RefObject<HTMLInputElement>',
     description: (
       <>
-        The provided ref will be used for the underlying input element used in the <Code>Select</Code>.
+        The provided ref will be used for the underlying input element used in the <Code>MultiSelect</Code>.
       </>
     ),
   },
@@ -72,6 +72,16 @@ const selectProps: Prop[] = [
         Sets a <Code>max-height</Code> to the dropdown.
       </>
     ),
+  },
+  {
+    name: 'onClose',
+    types: '() => void',
+    description: 'Function that will be called when the MultiSelect is closed.',
+  },
+  {
+    name: 'onOpen',
+    types: '() => void',
+    description: 'Function that will be called when the MultiSelect is opened.',
   },
   {
     name: 'onOptionsChange',

--- a/packages/docs/PropTables/SelectPropTable.tsx
+++ b/packages/docs/PropTables/SelectPropTable.tsx
@@ -74,6 +74,16 @@ const selectProps: Prop[] = [
     ),
   },
   {
+    name: 'onClose',
+    types: '() => void',
+    description: 'Function that will be called when the Select is closed.',
+  },
+  {
+    name: 'onOpen',
+    types: '() => void',
+    description: 'Function that will be called when the Select is opened.',
+  },
+  {
     name: 'onOptionChange',
     types: '(value: any, option: SelectOption) => void',
     required: true,


### PR DESCRIPTION
## What?

Add `onOpen` and `onClose` props to Selects.

## Why?

For some interactions on the Worksheet component (and other uses), I need to know when the dropdown has been opened or closed.

## Testing/Proof

Unit tests and locally
