### PR TITLE
feat(component): pass id to Tooltip wrapper

### DIFF
--- a/packages/big-design/src/components/Tooltip/Tooltip.tsx
+++ b/packages/big-design/src/components/Tooltip/Tooltip.tsx
@@ -14,7 +14,7 @@ export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   inline?: boolean;
 }
 
-export const Tooltip: React.FC<TooltipProps> = memo(({ children, inline = true, modifiers, trigger, ...props }) => {
+export const Tooltip: React.FC<TooltipProps> = memo(({ children, inline = true, modifiers, trigger, id, ...props }) => {
   const [isVisible, setIsVisible] = useState(false);
   const [tooltipContainer, setTooltipContainer] = useState<HTMLDivElement | null>(null);
   const tooltipModifiers = useMemo(() => {
@@ -82,7 +82,7 @@ export const Tooltip: React.FC<TooltipProps> = memo(({ children, inline = true, 
             <Popper placement={props.placement || 'top'} modifiers={tooltipModifiers}>
               {({ placement, ref, style }) =>
                 isVisible && (
-                  <StyledTooltip ref={ref} style={style} data-placement={placement}>
+                  <StyledTooltip id={id} ref={ref} style={style} data-placement={placement}>
                     {renderContent()}
                   </StyledTooltip>
                 )

--- a/packages/big-design/src/components/Tooltip/spec.tsx
+++ b/packages/big-design/src/components/Tooltip/spec.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { Tooltip } from './Tooltip';
+
+test('passes id to tooltip wrapper', async () => {
+  render(
+    <Tooltip id="test-id" trigger="Trigger" placement="auto">
+      Testing
+    </Tooltip>,
+  );
+
+  const trigger = screen.getByText('Trigger');
+
+  fireEvent.mouseOver(trigger);
+
+  const testing = await screen.findByText('Testing');
+
+  expect(testing.parentElement).toHaveAttribute('id', 'test-id');
+});


### PR DESCRIPTION
## What?

Passes the `id` prop to the Tooltip wrapper.

## Why?

Missing functionality that should have been there.

## Screenshots/Screen Recordings

<img width="771" alt="Screen Shot 2021-06-25 at 09 02 36" src="https://user-images.githubusercontent.com/10539418/123437641-839ed500-d595-11eb-96a6-1166983370e5.png">

## Testing/Proof

Added unit tests and testing manually in the browser.
