### PR TITLE
feat(component): move Search into its own exposed component

### DIFF
--- a/packages/big-design/jest.config.js
+++ b/packages/big-design/jest.config.js
@@ -9,10 +9,10 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
   coverageThreshold: {
     global: {
-      statements: 95.4,
-      branches: 86.72,
-      functions: 96.73,
-      lines: 95.44,
+      statements: 95,
+      branches: 87,
+      functions: 97,
+      lines: 95,
     },
   },
 };

--- a/packages/big-design/src/components/Search/Search.tsx
+++ b/packages/big-design/src/components/Search/Search.tsx
@@ -1,13 +1,14 @@
 import { SearchIcon } from '@bigcommerce/big-design-icons';
 import React, { FormEvent } from 'react';
 
-import { Button } from '../../Button';
-import { Flex, FlexItem } from '../../Flex';
-import { Form } from '../../Form';
-import { Input } from '../../Input';
-import { TableSearch } from '../types';
+import { Button } from '../Button';
+import { Flex, FlexItem } from '../Flex';
+import { Form } from '../Form';
+import { Input } from '../Input';
 
-export const Search: React.FC<TableSearch> = ({ value, onChange, onSubmit }) => {
+import { SearchProps } from './types';
+
+export const Search: React.FC<SearchProps> = ({ value, onChange, onSubmit }) => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -22,6 +23,7 @@ export const Search: React.FC<TableSearch> = ({ value, onChange, onSubmit }) => 
       <Flex alignItems="center" backgroundColor="white" flexDirection="row" paddingBottom="xxSmall">
         <FlexItem flexGrow={1} marginRight="small">
           <Input
+            aria-label="Search"
             placeholder="Search"
             type="search"
             value={value}

--- a/packages/big-design/src/components/Search/index.ts
+++ b/packages/big-design/src/components/Search/index.ts
@@ -1,0 +1,4 @@
+import { SearchProps as _SearchProps } from './types';
+
+export { Search } from './Search';
+export type SearchProps = _SearchProps;

--- a/packages/big-design/src/components/Search/spec.tsx
+++ b/packages/big-design/src/components/Search/spec.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { Search } from './Search';
+
+test('renders the search component', () => {
+  render(<Search value="Product" onChange={jest.fn()} onSubmit={jest.fn()} />);
+
+  const input = screen.getByLabelText('Search') as HTMLInputElement;
+
+  expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+  expect(input.value).toBe('Product');
+});
+
+test('call onChange when user change value in the input', () => {
+  const onChange = jest.fn();
+
+  render(<Search value="" onChange={onChange} onSubmit={jest.fn()} />);
+
+  const input = screen.getByLabelText('Search') as HTMLInputElement;
+
+  fireEvent.change(input, { target: { value: 'Product' } });
+
+  expect(onChange).toHaveBeenCalled();
+});
+
+test('call onSubmit when user click to the Search button', () => {
+  const onSubmit = jest.fn();
+
+  render(<Search value="submit" onChange={jest.fn()} onSubmit={onSubmit} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /search/i }));
+
+  expect(onSubmit).toHaveBeenCalled();
+});

--- a/packages/big-design/src/components/Search/types.ts
+++ b/packages/big-design/src/components/Search/types.ts
@@ -1,0 +1,8 @@
+import { FormProps } from '../Form';
+import { InputProps } from '../Input';
+
+export interface SearchProps {
+  value: InputProps['value'];
+  onChange: InputProps['onChange'];
+  onSubmit: FormProps['onSubmit'];
+}

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -2,7 +2,9 @@ import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 
 import { useDidUpdate } from '../../hooks';
 import { typedMemo } from '../../utils';
+import { Box } from '../Box';
 import { PillTabItem, PillTabsProps } from '../PillTabs';
+import { Search } from '../Search';
 import { Table, TableColumn, TableItem, TableProps, TableSelectable, TableSortDirection } from '../Table';
 
 import { createReducer, createReducerInit } from './reducer';
@@ -159,21 +161,35 @@ const InternalStatefulTable = <T extends TableItem>({
     [search, state.searchValue, filters],
   );
 
+  const renderSearch = () => {
+    if (!search || !searchProps) {
+      return;
+    }
+
+    return (
+      <Box marginBottom="medium">
+        <Search {...searchProps} />
+      </Box>
+    );
+  };
+
   return (
-    <Table
-      {...rest}
-      columns={state.columns}
-      filters={state.pillTabsProps}
-      itemName={itemName}
-      items={state.currentItems}
-      keyField={keyField}
-      pagination={paginationOptions}
-      search={searchProps}
-      selectable={selectableOptions}
-      sortable={sortableOptions}
-      stickyHeader={stickyHeader}
-      onRowDrop={onRowDrop ? onDragEnd : undefined}
-    />
+    <>
+      {renderSearch()}
+      <Table
+        {...rest}
+        columns={state.columns}
+        filters={state.pillTabsProps}
+        itemName={itemName}
+        items={state.currentItems}
+        keyField={keyField}
+        pagination={paginationOptions}
+        selectable={selectableOptions}
+        sortable={sortableOptions}
+        stickyHeader={stickyHeader}
+        onRowDrop={onRowDrop ? onDragEnd : undefined}
+      />
+    </>
   );
 };
 

--- a/packages/big-design/src/components/Table/Search/index.ts
+++ b/packages/big-design/src/components/Table/Search/index.ts
@@ -1,1 +1,0 @@
-export * from './Search';

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -13,7 +13,6 @@ import { Head } from './Head';
 import { HeaderCell } from './HeaderCell';
 import { DragIconHeaderCell, HeaderCheckboxCell } from './HeaderCell/HeaderCell';
 import { Row } from './Row';
-import { Search } from './Search';
 import { StyledTable, StyledTableFigure } from './styled';
 import { TableColumn, TableItem, TableProps } from './types';
 
@@ -35,7 +34,6 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     sortable,
     stickyHeader,
     style,
-    search,
     ...rest
   } = props;
 
@@ -217,20 +215,8 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     }
 
     return (
-      <Box marginBottom={shouldRenderActions() && !search ? 'none' : 'medium'}>
-        <PillTabs {...filters} />
-      </Box>
-    );
-  };
-
-  const renderSearch = () => {
-    if (!search) {
-      return;
-    }
-
-    return (
       <Box marginBottom={shouldRenderActions() ? 'none' : 'medium'}>
-        <Search {...search} />
+        <PillTabs {...filters} />
       </Box>
     );
   };
@@ -238,7 +224,6 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
   return (
     <>
       {renderPillTabs()}
-      {renderSearch()}
       {shouldRenderActions() && (
         <Actions
           customActions={actions}

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -6,7 +6,6 @@ import { fireEvent, render, screen, waitForElement } from '@test/utils';
 import { PillTabsProps } from '../PillTabs';
 
 import { Table, TableFigure } from './Table';
-import { TableSearch } from './types';
 
 interface SimpleTableOptions {
   className?: string;
@@ -19,7 +18,6 @@ interface SimpleTableOptions {
   itemName?: string;
   style?: CSSProperties;
   pillTabs?: PillTabsProps;
-  search?: TableSearch;
 }
 
 const getSimpleTable = ({
@@ -33,7 +31,6 @@ const getSimpleTable = ({
   items,
   pillTabs,
   style,
-  search,
 }: SimpleTableOptions = {}) => (
   <Table
     className={className}
@@ -44,7 +41,6 @@ const getSimpleTable = ({
     emptyComponent={emptyComponent}
     style={style}
     filters={pillTabs}
-    search={search}
     columns={
       columns || [
         { header: 'Sku', render: ({ sku }) => sku },
@@ -600,54 +596,4 @@ test('it executes the given callback', () => {
   fireEvent.click(inStockBtn);
 
   expect(onPillClick).toHaveBeenCalledWith('in_stock');
-});
-
-describe('test search in the Table', () => {
-  test('renders Table with the search prop', () => {
-    const search = {
-      value: 'Product',
-      onChange: jest.fn(),
-      onSubmit: jest.fn(),
-    };
-
-    const { getByText, getByPlaceholderText } = render(getSimpleTable({ search }));
-    const input = getByPlaceholderText('Search') as HTMLInputElement;
-
-    expect(getByText('Search')).toBeInTheDocument();
-    expect(getByPlaceholderText('Search')).toBeInTheDocument();
-    expect(input.value).toBe(search.value);
-  });
-
-  test('call onChange when user change value in the input', () => {
-    const onChange = jest.fn();
-
-    const search = {
-      onChange,
-      value: '',
-      onSubmit: jest.fn(),
-    };
-
-    const { getByPlaceholderText } = render(getSimpleTable({ search }));
-    const input = getByPlaceholderText('Search') as HTMLInputElement;
-
-    fireEvent.change(input, { target: { value: 'Product' } });
-
-    expect(onChange).toHaveBeenCalled();
-  });
-
-  test('call onSubmit when user click to the Search button', () => {
-    const onSubmit = jest.fn();
-
-    const search = {
-      onSubmit,
-      value: '',
-      onChange: jest.fn(),
-    };
-
-    const { getByText } = render(getSimpleTable({ search }));
-
-    fireEvent.click(getByText('Search'));
-
-    expect(onSubmit).toHaveBeenCalled();
-  });
 });

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -1,8 +1,6 @@
 import { ReactNode } from 'react';
 
 import { MarginProps } from '../../mixins';
-import { FormProps } from '../Form';
-import { InputProps } from '../Input';
 import { PaginationProps } from '../Pagination';
 import { PillTabsProps } from '../PillTabs';
 
@@ -41,12 +39,6 @@ export interface TableColumn<T> extends TableColumnDisplayProps {
 
 export type TablePaginationProps = Omit<PaginationProps, keyof MarginProps>;
 
-export interface TableSearch {
-  value: InputProps['value'];
-  onChange: InputProps['onChange'];
-  onSubmit: FormProps['onSubmit'];
-}
-
 export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElement> {
   actions?: React.ReactNode;
   columns: Array<TableColumn<T>>;
@@ -58,7 +50,6 @@ export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElemen
   filters?: PillTabsProps;
   onRowDrop?(from: number, to: number): void;
   pagination?: TablePaginationProps;
-  search?: TableSearch;
   selectable?: TableSelectable<T>;
   sortable?: TableSortable<T>;
   stickyHeader?: boolean;

--- a/packages/big-design/src/components/index.ts
+++ b/packages/big-design/src/components/index.ts
@@ -27,6 +27,7 @@ export * from './Popover';
 export * from './ProgressBar';
 export * from './ProgressCircle';
 export * from './Radio';
+export * from './Search';
 export * from './Select';
 export * from './StatefulTable';
 export * from './StatefulTree';

--- a/packages/docs/PropTables/SearchPropTable.tsx
+++ b/packages/docs/PropTables/SearchPropTable.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { Prop, PropTable, PropTableWrapper } from '../components';
+
+const searchProps: Prop[] = [
+  {
+    name: 'value',
+    types: 'string',
+    description: 'Value of the search input',
+    required: true,
+  },
+  {
+    name: 'onChange',
+    types: '(event: React.ChangeEvent<HTMLInputElement>) => void',
+    description: 'Native onChange attribute for a HTML input element.',
+    required: true,
+  },
+  {
+    name: 'onSubmit',
+    types: '(event: React.FormEvent<HTMLFormElement>) => void',
+    description: 'Native onSubmit attribute for a HTML form element.',
+    required: true,
+  },
+];
+
+export const SearchPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable title="Search" propList={searchProps} {...props} />
+);

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -54,15 +54,6 @@ const tableProps: Prop[] = [
     description: 'See Pill Tabs component for details.',
   },
   {
-    name: 'search',
-    types: <NextLink href="#table-search-prop-table">Search</NextLink>,
-    description: (
-      <>
-        See <NextLink href="#table-search-prop-table">below</NextLink> for usage.
-      </>
-    ),
-  },
-  {
     name: 'selectable',
     types: <NextLink href="#table-selectable-prop-table">Selectable</NextLink>,
     description: (
@@ -206,27 +197,6 @@ const tableSortableProps: Prop[] = [
   },
 ];
 
-const tableSearchProps: Prop[] = [
-  {
-    name: 'value',
-    types: 'string',
-    description: 'Value of the search input',
-    required: true,
-  },
-  {
-    name: 'onChange',
-    types: '(event: React.ChangeEvent<HTMLInputElement>) => void',
-    description: 'Native onChange attribute for a HTML input element.',
-    required: true,
-  },
-  {
-    name: 'onSubmit',
-    types: '(event: React.FormEvent<HTMLFormElement>) => void',
-    description: 'Native onSubmit attribute for a HTML form element.',
-    required: true,
-  },
-];
-
 export const TablePropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable title="Table" propList={tableProps} {...props} />
 );
@@ -241,8 +211,4 @@ export const TableSelectablePropTable: React.FC<PropTableWrapper> = (props) => (
 
 export const TableSortablePropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable title="Table[Sortable]" propList={tableSortableProps} {...props} />
-);
-
-export const TableSearchPropTable: React.FC<PropTableWrapper> = (props) => (
-  <PropTable title="Table[Search]" propList={tableSearchProps} {...props} />
 );

--- a/packages/docs/PropTables/index.ts
+++ b/packages/docs/PropTables/index.ts
@@ -27,6 +27,7 @@ export * from './PopoverPropTable';
 export * from './ProgressBarPropTable';
 export * from './ProgressCirclePropTable';
 export * from './RadioPropTable';
+export * from './SearchPropTable';
 export * from './SelectPropTable';
 export * from './StatefulTablePropTable';
 export * from './StatefulTreePropTable';

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -110,6 +110,9 @@ export const SideNav: React.FC = () => {
           <SideNavLink href="/Radio/RadioPage" as="/radio">
             Radio
           </SideNavLink>
+          <SideNavLink href="/Search/SearchPage" as="/search">
+            Search
+          </SideNavLink>
           <SideNavLink href="/Select/SelectPage" as="/select">
             Select
           </SideNavLink>

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -55,6 +55,7 @@ module.exports = {
     '/progress-bar': { page: '/Progress/ProgressBarPage' },
     '/progress-circle': { page: '/Progress/ProgressCirclePage' },
     '/radio': { page: '/Radio/RadioPage' },
+    '/search': { page: '/Search/SearchPage' },
     '/select': { page: '/Select/SelectPage' },
     '/spacing': { page: '/Spacing/SpacingPage' },
     '/statefulTable': { page: '/StatefulTable/StatefulTablePage' },

--- a/packages/docs/pages/Search/SearchPage.tsx
+++ b/packages/docs/pages/Search/SearchPage.tsx
@@ -1,0 +1,64 @@
+import { Box, H0, H1, Search, Table } from '@bigcommerce/big-design';
+import React, { useState } from 'react';
+
+import { CodePreview } from '../../components';
+import { SearchPropTable } from '../../PropTables';
+
+const data = [
+  { sku: 'ABS', name: '[Sample] Able Brewing System', stock: 225 },
+  { sku: 'CC3C', name: '[Sample] Chemex Coffeemaker 3 cup', stock: 49 },
+  { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+  { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+  { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+  { sku: 'OCG', name: '[Sample] Oak Cheese Grater', stock: 34 },
+  { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+];
+
+const SearchPage = () => {
+  return (
+    <>
+      <H0>Search</H0>
+
+      <CodePreview scope={{ data }}>
+        {/* jsx-to-string:start */}
+        {function Example() {
+          const [items, setItems] = useState(data);
+          const [searchValue, setSearchValue] = useState('');
+          const onChange = (event: React.ChangeEvent<HTMLInputElement>) => setSearchValue(event.target.value);
+
+          const onSubmit = () => {
+            setItems((prevItems) => {
+              if (searchValue) {
+                return prevItems.filter((item) => item.name.includes(searchValue));
+              }
+
+              return data;
+            });
+          };
+
+          return (
+            <>
+              <Box marginBottom="medium">
+                <Search value={searchValue} onChange={onChange} onSubmit={onSubmit} />
+              </Box>
+              <Table
+                columns={[
+                  { header: 'Sku', hash: 'sku', render: ({ sku }) => sku, isSortable: true },
+                  { header: 'Name', hash: 'name', render: ({ name }) => name, isSortable: true },
+                  { header: 'Stock', hash: 'stock', render: ({ stock }) => stock, isSortable: true },
+                ]}
+                items={items}
+              />
+            </>
+          );
+        }}
+        {/* jsx-to-string:end */}
+      </CodePreview>
+
+      <H1>API</H1>
+      <SearchPropTable />
+    </>
+  );
+};
+
+export default SearchPage;

--- a/packages/docs/pages/Table/TablePage.tsx
+++ b/packages/docs/pages/Table/TablePage.tsx
@@ -5,7 +5,6 @@ import { Code, CodePreview } from '../../components';
 import {
   TableColumnsPropTable,
   TablePropTable,
-  TableSearchPropTable,
   TableSelectablePropTable,
   TableSortablePropTable,
 } from '../../PropTables';
@@ -77,7 +76,6 @@ const TablePage = () => {
       <TableColumnsPropTable id="table-columns-prop-table" />
       <TableSelectablePropTable id="table-selectable-prop-table" />
       <TableSortablePropTable id="table-sortable-prop-table" />
-      <TableSearchPropTable id="table-search-prop-table" />
 
       <H1>Examples</H1>
       <H2>Usage with selectable</H2>
@@ -313,44 +311,6 @@ const TablePage = () => {
               ]}
               items={items}
               filters={pillTabs}
-            />
-          );
-        }}
-        {/* jsx-to-string:end */}
-      </CodePreview>
-
-      <H2>Usage with search</H2>
-
-      <CodePreview scope={{ data }}>
-        {/* jsx-to-string:start */}
-        {function Example() {
-          const [items, setItems] = useState(data);
-          const [searchValue, setSearchValue] = useState('');
-          const onChange = (event: React.ChangeEvent<HTMLInputElement>) => setSearchValue(event.target.value);
-
-          const onSubmit = () => {
-            setItems((prevItems) => {
-              if (searchValue) {
-                return prevItems.filter((item) => item.name.includes(searchValue));
-              }
-
-              return data;
-            });
-          };
-
-          return (
-            <Table
-              columns={[
-                { header: 'Sku', hash: 'sku', render: ({ sku }) => sku, isSortable: true },
-                { header: 'Name', hash: 'name', render: ({ name }) => name, isSortable: true },
-                { header: 'Stock', hash: 'stock', render: ({ stock }) => stock, isSortable: true },
-              ]}
-              items={items}
-              search={{
-                value: searchValue,
-                onChange,
-                onSubmit,
-              }}
             />
           );
         }}


### PR DESCRIPTION
## What?

Moves the `Search` component into its own exposed component and removes it from the `Table` component.

## Why?

TL'DR: The `search` prop wasn't actually being used when we exposed it in the alpha version.

We found while implementing search patterns, that it's easier to compose the UI with compositional components instead of prebuilt UIs. Examposing it in the alpha version gave us some insight in this matter. Also, extracting it out of the `Table` component will allow us to extend this component in the future.

## Screenshots/Screen Recordings

![screencapture-localhost-3000-search-2021-07-06-16_41_33](https://user-images.githubusercontent.com/10539418/124670139-28b08c00-de79-11eb-8f1f-6049f6d20d92.png)

## Testing/Proof

- I migrated the existing tests over from the `Table` tests.
- Also, tested performance on the `StatefulTable` and it's still good.
