### PR TITLE
chore(component): remove filters prop from Table component

### DIFF
--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import { useDidUpdate } from '../../hooks';
 import { typedMemo } from '../../utils';
 import { Box } from '../Box';
-import { PillTabItem, PillTabsProps } from '../PillTabs';
+import { PillTabItem, PillTabs, PillTabsProps } from '../PillTabs';
 import { Search } from '../Search';
 import { Table, TableColumn, TableItem, TableProps, TableSelectable, TableSortDirection } from '../Table';
 
@@ -161,6 +161,18 @@ const InternalStatefulTable = <T extends TableItem>({
     [search, state.searchValue, filters],
   );
 
+  const renderPills = () => {
+    if (!filters || !state.pillTabsProps) {
+      return null;
+    }
+
+    return (
+      <Box marginBottom="medium">
+        <PillTabs {...state.pillTabsProps} />
+      </Box>
+    );
+  };
+
   const renderSearch = () => {
     if (!search || !searchProps) {
       return;
@@ -175,11 +187,11 @@ const InternalStatefulTable = <T extends TableItem>({
 
   return (
     <>
+      {renderPills()}
       {renderSearch()}
       <Table
         {...rest}
         columns={state.columns}
-        filters={state.pillTabsProps}
         itemName={itemName}
         items={state.currentItems}
         keyField={keyField}

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -4,8 +4,6 @@ import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautif
 import { useEventCallback, useUniqueId } from '../../hooks';
 import { MarginProps } from '../../mixins';
 import { typedMemo } from '../../utils';
-import { Box } from '../Box';
-import { PillTabs } from '../PillTabs';
 
 import { Actions } from './Actions';
 import { Body } from './Body';
@@ -22,7 +20,6 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     className,
     columns,
     emptyComponent,
-    filters,
     headerless = false,
     id,
     itemName,
@@ -209,21 +206,8 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     return null;
   };
 
-  const renderPillTabs = () => {
-    if (!filters) {
-      return;
-    }
-
-    return (
-      <Box marginBottom={shouldRenderActions() ? 'none' : 'medium'}>
-        <PillTabs {...filters} />
-      </Box>
-    );
-  };
-
   return (
     <>
-      {renderPillTabs()}
       {shouldRenderActions() && (
         <Actions
           customActions={actions}

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -84,6 +84,23 @@ exports[`renders a pagination component 1`] = `
   flex-shrink: 1;
 }
 
+.c12 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
+.c6 {
+  position: relative;
+}
+
 .c7 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
@@ -258,23 +275,6 @@ exports[`renders a pagination component 1`] = `
   grid-auto-flow: column;
   grid-gap: 0.5rem;
   visibility: visible;
-}
-
-.c12 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
-}
-
-.c6 {
-  position: relative;
 }
 
 .c8 {

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -3,8 +3,6 @@ import 'jest-styled-components';
 
 import { fireEvent, render, screen, waitForElement } from '@test/utils';
 
-import { PillTabsProps } from '../PillTabs';
-
 import { Table, TableFigure } from './Table';
 
 interface SimpleTableOptions {
@@ -17,7 +15,6 @@ interface SimpleTableOptions {
   id?: string;
   itemName?: string;
   style?: CSSProperties;
-  pillTabs?: PillTabsProps;
 }
 
 const getSimpleTable = ({
@@ -29,7 +26,6 @@ const getSimpleTable = ({
   id,
   itemName,
   items,
-  pillTabs,
   style,
 }: SimpleTableOptions = {}) => (
   <Table
@@ -40,7 +36,6 @@ const getSimpleTable = ({
     itemName={itemName}
     emptyComponent={emptyComponent}
     style={style}
-    filters={pillTabs}
     columns={
       columns || [
         { header: 'Sku', render: ({ sku }) => sku },
@@ -547,53 +542,4 @@ describe('draggable', () => {
 
     expect(onRowDrop).toHaveBeenCalledWith(0, 1);
   });
-});
-
-test('it renders pill tabs with the pillTabs prop', () => {
-  const items = [
-    {
-      title: 'In Stock',
-      id: 'in_stock',
-    },
-    {
-      title: 'Low Stock',
-      id: 'low_stock',
-    },
-  ];
-  const pillTabs: PillTabsProps = {
-    onPillClick: jest.fn(),
-    activePills: [],
-    items,
-  };
-  const { getByText } = render(getSimpleTable({ pillTabs }));
-  const inStock = getByText('In Stock');
-  const lowStock = getByText('Low Stock');
-
-  expect(inStock).toBeInTheDocument();
-  expect(lowStock).toBeInTheDocument();
-});
-
-test('it executes the given callback', () => {
-  const onPillClick = jest.fn();
-  const items = [
-    {
-      title: 'In Stock',
-      id: 'in_stock',
-    },
-    {
-      title: 'Low Stock',
-      id: 'low_stock',
-    },
-  ];
-  const pillTabs: PillTabsProps = {
-    onPillClick,
-    activePills: [],
-    items,
-  };
-  const { getByText } = render(getSimpleTable({ pillTabs }));
-  const inStockBtn = getByText('In Stock');
-
-  fireEvent.click(inStockBtn);
-
-  expect(onPillClick).toHaveBeenCalledWith('in_stock');
 });

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 
 import { MarginProps } from '../../mixins';
 import { PaginationProps } from '../Pagination';
-import { PillTabsProps } from '../PillTabs';
 
 import { TableColumnDisplayProps } from './mixins';
 
@@ -47,7 +46,6 @@ export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElemen
   itemName?: string;
   items: T[];
   keyField?: string;
-  filters?: PillTabsProps;
   onRowDrop?(from: number, to: number): void;
   pagination?: TablePaginationProps;
   selectable?: TableSelectable<T>;

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -45,15 +45,6 @@ const tableProps: Prop[] = [
     description: 'See pagination component for details.',
   },
   {
-    name: 'filters',
-    types: (
-      <NextLink href="/PillTabs/PillTabsPage" as="/pill-tabs">
-        Pill Tabs
-      </NextLink>
-    ),
-    description: 'See Pill Tabs component for details.',
-  },
-  {
     name: 'selectable',
     types: <NextLink href="#table-selectable-prop-table">Selectable</NextLink>,
     description: (

--- a/packages/docs/pages/Table/TablePage.tsx
+++ b/packages/docs/pages/Table/TablePage.tsx
@@ -1,4 +1,4 @@
-import { H0, H1, H2, PillTabsProps, Small, Table, TableFigure, TableItem, Text } from '@bigcommerce/big-design';
+import { H0, H1, H2, Small, Table, TableFigure, TableItem, Text } from '@bigcommerce/big-design';
 import React, { useEffect, useState } from 'react';
 
 import { Code, CodePreview } from '../../components';
@@ -274,43 +274,6 @@ const TablePage = () => {
               ]}
               items={items}
               onRowDrop={onDragEnd}
-            />
-          );
-        }}
-        {/* jsx-to-string:end */}
-      </CodePreview>
-
-      <H2>Usage with filters</H2>
-
-      <CodePreview scope={{ data }}>
-        {/* jsx-to-string:start */}
-        {function Example() {
-          const [items, setItems] = useState(data);
-          const [activePills, setActivePills] = useState<string[]>([]);
-          const pillTabs: PillTabsProps = {
-            activePills,
-            onPillClick: (id) => {
-              const isFilterActive = !activePills.includes(id);
-              const newItems = isFilterActive ? items.filter((item) => item.stock < 10) : data;
-              const updatedPills = isFilterActive
-                ? [...activePills, id]
-                : activePills.filter((activePillId) => activePillId !== id);
-
-              setItems(newItems);
-              setActivePills(updatedPills);
-            },
-            items: [{ title: 'Low Stock', id: 'low_stock' }],
-          };
-
-          return (
-            <Table
-              columns={[
-                { header: 'Sku', hash: 'sku', render: ({ sku }) => sku, isSortable: true },
-                { header: 'Name', hash: 'name', render: ({ name }) => name, isSortable: true },
-                { header: 'Stock', hash: 'stock', render: ({ stock }) => stock, isSortable: true },
-              ]}
-              items={items}
-              filters={pillTabs}
             />
           );
         }}


### PR DESCRIPTION
## What?

Removes the `filters` prop from the `Table` component.

## Why?

Similar to #557; it's better as a compositional component rather than apart of the `Table` component. Still apart of `StatefulTable`.

## Screenshots/Screen Recordings
N/A

## Testing/Proof

Removed unit tests and ensure they worked correctly for the `StatefulTable`.
