### PR TITLE
fix(component): fix button group state

### DIFF
--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -18,6 +18,12 @@ export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement>, Margin
   actions: ButtonGroupAction[];
 }
 
+interface ActionsState {
+  isVisible: boolean;
+  action: ButtonGroupAction;
+  ref: React.RefObject<HTMLDivElement>;
+}
+
 const excludeIconProps = ({
   iconOnly,
   iconRight,
@@ -29,9 +35,17 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(({ actions, ...wrapp
   const parentRef = createRef<HTMLDivElement>();
   const dropdownRef = createRef<HTMLDivElement>();
   const [isMenuVisible, setIsMenuVisible] = useState(false);
-  const [actionsState, setActionsState] = useState(
-    actions.map((action) => ({ isVisible: true, action: excludeIconProps(action), ref: createRef<HTMLDivElement>() })),
-  );
+  const [actionsState, setActionsState] = useState<ActionsState[]>([]);
+
+  useEffect(() => {
+    setActionsState(
+      actions.map((action) => ({
+        isVisible: true,
+        action: excludeIconProps(action),
+        ref: createRef<HTMLDivElement>(),
+      })),
+    );
+  }, [actions]);
 
   const hideOverflowedActions = useCallback(() => {
     const parentWidth = parentRef.current?.offsetWidth;


### PR DESCRIPTION
## What?
Update `actionsState ` on every `actions` prop change for avoiding wrong behavior with callbacks.

## Why?
The component doesn't re-render on props change.

## Screenshots/Screen Recordings

before:
https://user-images.githubusercontent.com/9980803/125099509-c22da700-e0e0-11eb-964a-cda9326876af.mov

after:
https://user-images.githubusercontent.com/9980803/125099562-cfe32c80-e0e0-11eb-850d-ee425459c573.mov


## Testing/Proof
Locally

ping @chanceaclark 