### PR TITLE
feat(component): add the option to disable columns in Worksheet

### DIFF
--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -22,6 +22,7 @@ interface CellProps<Item> extends TCell<Item> {
 
 const InternalCell = <T extends WorksheetItem>({
   columnIndex,
+  disabled = false,
   formatting,
   hash,
   options,
@@ -30,8 +31,9 @@ const InternalCell = <T extends WorksheetItem>({
   value,
   validation,
 }: CellProps<T>) => {
-  const cell: TCell<T> = useMemo(() => ({ columnIndex, hash, rowIndex, type, value }), [
+  const cell: TCell<T> = useMemo(() => ({ columnIndex, disabled, hash, rowIndex, type, value }), [
     columnIndex,
+    disabled,
     hash,
     rowIndex,
     type,
@@ -127,15 +129,27 @@ const InternalCell = <T extends WorksheetItem>({
       case 'modal':
         return <ModalEditor cell={cell} formatting={formatting} isEditing={isEditing} />;
       default:
-        return isEditing ? (
+        return isEditing && !disabled ? (
           <TextEditor cell={cell} isEdited={isEdited} onBlur={handleBlur} onKeyDown={handleKeyDown} />
         ) : (
-          <Small color="secondary70" ellipsis title={renderedValue}>
+          <Small color={disabled ? 'secondary50' : 'secondary70'} ellipsis title={renderedValue}>
             {renderedValue}
           </Small>
         );
     }
-  }, [cell, formatting, handleBlur, handleChange, handleKeyDown, isEdited, isEditing, options, renderedValue, type]);
+  }, [
+    cell,
+    disabled,
+    formatting,
+    handleBlur,
+    handleChange,
+    handleKeyDown,
+    isEdited,
+    isEditing,
+    options,
+    renderedValue,
+    type,
+  ]);
 
   return (
     <StyledCell

--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -117,7 +117,6 @@ const InternalCell = <T extends WorksheetItem>({
         return (
           <SelectEditor
             cell={cell}
-            isEdited={isEdited}
             isEditing={isEditing}
             onBlur={handleBlur}
             onChange={handleChange}

--- a/packages/big-design/src/components/Worksheet/Row/Row.tsx
+++ b/packages/big-design/src/components/Worksheet/Row/Row.tsx
@@ -33,6 +33,7 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
       {columns.map((column, columnIndex) => (
         <Cell
           columnIndex={columnIndex}
+          disabled={column.disabled}
           formatting={hasFormatting(column) ? column.formatting : undefined}
           hash={column.hash}
           key={`${rowIndex}-${columnIndex}`}

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -133,7 +133,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
+          class="styled__SelectWrapper-sc-1bx33mv-0 bJTspY"
         >
           <div>
             <div
@@ -346,7 +346,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
+          class="styled__SelectWrapper-sc-1bx33mv-0 bJTspY"
         >
           <div>
             <div
@@ -558,7 +558,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
+          class="styled__SelectWrapper-sc-1bx33mv-0 bJTspY"
         >
           <div>
             <div
@@ -771,7 +771,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
+          class="styled__SelectWrapper-sc-1bx33mv-0 bJTspY"
         >
           <div>
             <div
@@ -982,7 +982,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
+          class="styled__SelectWrapper-sc-1bx33mv-0 bJTspY"
         >
           <div>
             <div
@@ -1195,7 +1195,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
+          class="styled__SelectWrapper-sc-1bx33mv-0 bJTspY"
         >
           <div>
             <div
@@ -1407,7 +1407,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
+          class="styled__SelectWrapper-sc-1bx33mv-0 bJTspY"
         >
           <div>
             <div
@@ -1620,7 +1620,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
+          class="styled__SelectWrapper-sc-1bx33mv-0 bJTspY"
         >
           <div>
             <div
@@ -1833,7 +1833,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
+          class="styled__SelectWrapper-sc-1bx33mv-0 bJTspY"
         >
           <div>
             <div

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -104,6 +104,7 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxLabelContainer-s1u0st-0 jFHYyI"
             >
               <label
+                aria-hidden="false"
                 class="styled__StyledText-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
                 for="bd-checkbox-1"
                 hidden=""
@@ -132,7 +133,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 fyKIqi"
+          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
         >
           <div>
             <div
@@ -316,6 +317,7 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxLabelContainer-s1u0st-0 jFHYyI"
             >
               <label
+                aria-hidden="false"
                 class="styled__StyledText-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
                 for="bd-checkbox-7"
                 hidden=""
@@ -344,7 +346,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 fyKIqi"
+          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
         >
           <div>
             <div
@@ -527,6 +529,7 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxLabelContainer-s1u0st-0 jFHYyI"
             >
               <label
+                aria-hidden="false"
                 class="styled__StyledText-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
                 for="bd-checkbox-13"
                 hidden=""
@@ -555,7 +558,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 fyKIqi"
+          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
         >
           <div>
             <div
@@ -739,6 +742,7 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxLabelContainer-s1u0st-0 jFHYyI"
             >
               <label
+                aria-hidden="false"
                 class="styled__StyledText-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
                 for="bd-checkbox-19"
                 hidden=""
@@ -767,7 +771,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 fyKIqi"
+          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
         >
           <div>
             <div
@@ -949,6 +953,7 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxLabelContainer-s1u0st-0 jFHYyI"
             >
               <label
+                aria-hidden="false"
                 class="styled__StyledText-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
                 for="bd-checkbox-25"
                 hidden=""
@@ -977,7 +982,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 fyKIqi"
+          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
         >
           <div>
             <div
@@ -1161,6 +1166,7 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxLabelContainer-s1u0st-0 jFHYyI"
             >
               <label
+                aria-hidden="false"
                 class="styled__StyledText-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
                 for="bd-checkbox-31"
                 hidden=""
@@ -1189,7 +1195,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 fyKIqi"
+          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
         >
           <div>
             <div
@@ -1372,6 +1378,7 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxLabelContainer-s1u0st-0 jFHYyI"
             >
               <label
+                aria-hidden="false"
                 class="styled__StyledText-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
                 for="bd-checkbox-37"
                 hidden=""
@@ -1400,7 +1407,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 fyKIqi"
+          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
         >
           <div>
             <div
@@ -1584,6 +1591,7 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxLabelContainer-s1u0st-0 jFHYyI"
             >
               <label
+                aria-hidden="false"
                 class="styled__StyledText-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
                 for="bd-checkbox-43"
                 hidden=""
@@ -1612,7 +1620,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 fyKIqi"
+          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
         >
           <div>
             <div
@@ -1796,6 +1804,7 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxLabelContainer-s1u0st-0 jFHYyI"
             >
               <label
+                aria-hidden="false"
                 class="styled__StyledText-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
                 for="bd-checkbox-49"
                 hidden=""
@@ -1824,7 +1833,7 @@ exports[`renders worksheet 1`] = `
         type="select"
       >
         <div
-          class="styled__SelectWrapper-sc-1bx33mv-0 fyKIqi"
+          class="styled__SelectWrapper-sc-1bx33mv-0 jxkUpl"
         >
           <div>
             <div

--- a/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
@@ -35,6 +35,7 @@ const InternalCheckboxEditor = <T extends WorksheetItem>({
   return (
     <CheckboxWrapper>
       <Checkbox
+        disabled={cell.disabled}
         checked={cell.value}
         hiddenLabel={true}
         label={cell.value ? 'Checked' : 'Unchecked'}

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -40,11 +40,9 @@ const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting, isEdit
           {renderedValue}
         </Small>
       </StyledFlexItem>
-      {!cell.disabled && (
-        <StyledButton onClick={handleClick} ref={buttonRef} variant="subtle">
-          Edit
-        </StyledButton>
-      )}
+      <StyledButton disabled={cell.disabled} onClick={handleClick} ref={buttonRef} variant="subtle">
+        Edit
+      </StyledButton>
     </Flex>
   );
 };

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -36,13 +36,15 @@ const InternalModalEditor = <T extends WorksheetItem>({ cell, formatting, isEdit
   return (
     <Flex justifyContent="space-between" alignItems="center" flexWrap="wrap">
       <StyledFlexItem paddingRight="small" flexShrink={1}>
-        <Small color="secondary70" ellipsis title={renderedValue}>
+        <Small color={cell.disabled ? 'secondary50' : 'secondary70'} ellipsis title={renderedValue}>
           {renderedValue}
         </Small>
       </StyledFlexItem>
-      <StyledButton onClick={handleClick} ref={buttonRef} variant="subtle">
-        Edit
-      </StyledButton>
+      {!cell.disabled && (
+        <StyledButton onClick={handleClick} ref={buttonRef} variant="subtle">
+          Edit
+        </StyledButton>
+      )}
     </Flex>
   );
 };

--- a/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
@@ -9,7 +9,6 @@ import { SelectWrapper } from './styled';
 
 export interface SelectEditorProps<Item> {
   cell: Cell<Item>;
-  isEdited: boolean;
   isEditing: boolean;
   options?: WorksheetSelectableColumn<Item>['config']['options'];
   onBlur(): void;
@@ -18,7 +17,6 @@ export interface SelectEditorProps<Item> {
 
 const InternalSelectEditor = <T extends WorksheetItem>({
   cell,
-  isEdited,
   isEditing,
   onBlur,
   onChange,
@@ -50,7 +48,7 @@ const InternalSelectEditor = <T extends WorksheetItem>({
   }, [onBlur, setEditingCell]);
 
   return (
-    <SelectWrapper isEdited={isEdited}>
+    <SelectWrapper>
       <Select
         disabled={cell.disabled}
         filterable={false}

--- a/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
@@ -52,6 +52,7 @@ const InternalSelectEditor = <T extends WorksheetItem>({
   return (
     <SelectWrapper isEdited={isEdited}>
       <Select
+        disabled={cell.disabled}
         filterable={false}
         inputRef={inputRef}
         onClose={handleClose}

--- a/packages/big-design/src/components/Worksheet/editors/SelectEditor/styled.ts
+++ b/packages/big-design/src/components/Worksheet/editors/SelectEditor/styled.ts
@@ -1,5 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 export const SelectWrapper = styled.div<{ isEdited: boolean }>`
   span {
@@ -10,17 +10,21 @@ export const SelectWrapper = styled.div<{ isEdited: boolean }>`
     &:hover:not([disabled]) {
       border: none;
     }
+
+    &[disabled] {
+      background-color: ${({ theme }) => theme.colors.white};
+    }
   }
 
   input {
     font-size: ${({ theme }) => theme.typography.fontSize.small};
     font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
 
-    ${({ isEdited }) =>
-      isEdited &&
-      css`
-        background-color: ${({ theme }) => theme.colors.warning10};
-      `}
+    &[disabled] {
+      background-color: ${({ theme }) => theme.colors.transparent};
+      color: ${({ theme }) => theme.colors.secondary50};
+      cursor: default;
+    }
   }
 
   [role='option'] {

--- a/packages/big-design/src/components/Worksheet/editors/SelectEditor/styled.ts
+++ b/packages/big-design/src/components/Worksheet/editors/SelectEditor/styled.ts
@@ -1,9 +1,9 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
-export const SelectWrapper = styled.div<{ isEdited: boolean }>`
+export const SelectWrapper = styled.div`
   span {
-    background-color: ${({ theme }) => theme.colors.transparent};
+    background-color: ${({ theme }) => theme.colors.inherit};
     border: none;
     box-shadow: none;
 
@@ -21,7 +21,7 @@ export const SelectWrapper = styled.div<{ isEdited: boolean }>`
     font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
 
     &[disabled] {
-      background-color: ${({ theme }) => theme.colors.transparent};
+      background-color: ${({ theme }) => theme.colors.inherit};
       color: ${({ theme }) => theme.colors.secondary50};
       cursor: default;
     }

--- a/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
@@ -28,7 +28,9 @@ export const useEditableCell = <T extends WorksheetItem>(cell: Cell<T>) => {
   }, [focusTable, setEditingCell]);
 
   const handleDoubleClick = useCallback(() => {
-    setEditingCell(cell);
+    if (!cell.disabled) {
+      setEditingCell(cell);
+    }
   }, [cell, setEditingCell]);
 
   const handleBlur = useCallback(() => {

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
@@ -34,14 +34,18 @@ export const useKeyEvents = () => {
       } else {
         switch (key) {
           case 'Enter':
-            editSelectedCell();
+            if (selectedCell && !selectedCell.disabled) {
+              editSelectedCell();
 
-            if (selectedCell && selectedCell.type === 'checkbox') {
-              navigate({ rowIndex: 1, columnIndex: 0 });
+              if (selectedCell.type === 'checkbox') {
+                navigate({ rowIndex: 1, columnIndex: 0 });
+              }
             }
             break;
           case ' ':
-            editSelectedCell();
+            if (selectedCell && !selectedCell.disabled) {
+              editSelectedCell();
+            }
             break;
           case 'ArrowUp':
             navigate({ rowIndex: -1, columnIndex: 0 });

--- a/packages/big-design/src/components/Worksheet/hooks/useNavigation/useNavigation.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useNavigation/useNavigation.ts
@@ -46,8 +46,9 @@ export const useNavigation = <T extends WorksheetItem>(selectedCell: Cell<T>) =>
         const hash = columns[newPosition.columnIndex].hash;
         const type = columns[newPosition.columnIndex].type || 'text';
         const value = rows[newPosition.rowIndex][hash];
+        const disabled = columns[newPosition.columnIndex].disabled || false;
 
-        const cell = { ...newPosition, hash, type, value };
+        const cell = { ...newPosition, disabled, hash, type, value };
 
         setSelectedCells([cell]);
         setSelectedRows([newPosition.rowIndex]);

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -927,7 +927,7 @@ describe('ModalEditor', () => {
   test('renders in disabled state', async () => {
     render(<Worksheet columns={disabledColumns} items={items} onChange={handleChange} />);
 
-    const buttons = screen.queryAllByText('Edit');
+    const buttons = screen.queryAllByRole('button', { name: /edit/i });
 
     expect(buttons).toStrictEqual([]);
 

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -927,9 +927,9 @@ describe('ModalEditor', () => {
   test('renders in disabled state', async () => {
     render(<Worksheet columns={disabledColumns} items={items} onChange={handleChange} />);
 
-    const buttons = screen.queryAllByRole('button', { name: /edit/i });
+    const buttons = screen.getAllByRole('button', { name: /edit/i });
 
-    expect(buttons).toStrictEqual([]);
+    expect(buttons[0]).toHaveAttribute('disabled');
 
     await waitForElement(() => screen.getAllByRole('combobox'));
   });

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -65,11 +65,11 @@ export interface WorksheetModalColumn<Item> extends WorksheetBaseColumn<Item> {
 
 export interface Cell<Item> {
   columnIndex: number;
+  disabled?: boolean;
   hash: keyof Item;
   rowIndex: number;
-  value: Item[keyof Item];
   type: Exclude<WorksheetColumn<Item>['type'], undefined>;
-  disabled?: boolean;
+  value: Item[keyof Item];
 }
 
 export interface WorksheetItem {

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -22,6 +22,7 @@ export type WorksheetColumn<Item> =
   | WorksheetModalColumn<Item>;
 
 interface WorksheetBaseColumn<Item> {
+  disabled?: boolean;
   hash: keyof Item;
   header: string;
   validation?(value: Item[keyof Item]): boolean;
@@ -68,6 +69,7 @@ export interface Cell<Item> {
   rowIndex: number;
   value: Item[keyof Item];
   type: Exclude<WorksheetColumn<Item>['type'], undefined>;
+  disabled?: boolean;
 }
 
 export interface WorksheetItem {

--- a/packages/docs/PropTables/WorksheetPropTable.tsx
+++ b/packages/docs/PropTables/WorksheetPropTable.tsx
@@ -67,6 +67,11 @@ const worksheetTextColumnProps: Prop[] = [
     types: '(value: any) => boolean',
     description: 'Will set a cell as invalid if it returns false.',
   },
+  {
+    name: 'disable',
+    types: 'boolean',
+    description: 'Disables cell manipulation for the entire column.',
+  },
 ];
 
 const worksheetNumberColumnProps: Prop[] = [
@@ -99,6 +104,11 @@ const worksheetNumberColumnProps: Prop[] = [
     types: '(value: any) => boolean',
     description: 'Function to test the validity of the cell.',
   },
+  {
+    name: 'disable',
+    types: 'boolean',
+    description: 'Disables cell manipulation for the entire column.',
+  },
 ];
 
 const worksheetCheckboxColumnProps: Prop[] = [
@@ -125,6 +135,11 @@ const worksheetCheckboxColumnProps: Prop[] = [
     name: 'validation',
     types: '(value: any) => boolean',
     description: 'Function to test the validity of the cell.',
+  },
+  {
+    name: 'disable',
+    types: 'boolean',
+    description: 'Disables cell manipulation for the entire column.',
   },
 ];
 
@@ -161,6 +176,11 @@ const worksheetSelectableColumnProps: Prop[] = [
         See <NextLink href="#worksheet-selectable-config-prop-table">below</NextLink> for usage.
       </>
     ),
+  },
+  {
+    name: 'disable',
+    types: 'boolean',
+    description: 'Disables cell manipulation for the entire column.',
   },
 ];
 
@@ -202,6 +222,11 @@ const worksheetModalColumnProps: Prop[] = [
         See <NextLink href="#worksheet-modal-config-prop-table">below</NextLink> for usage.
       </>
     ),
+  },
+  {
+    name: 'disable',
+    types: 'boolean',
+    description: 'Disables cell manipulation for the entire column.',
   },
 ];
 

--- a/packages/docs/pages/Worksheet/WorksheetPage.tsx
+++ b/packages/docs/pages/Worksheet/WorksheetPage.tsx
@@ -430,6 +430,40 @@ const WorksheetPage = () => {
               {/* jsx-to-string:end */}
             </CodePreview>
           </Panel>
+          <Panel header="Disabled columns">
+            <CodePreview>
+              {/* jsx-to-string:start */}
+              {function Example() {
+                const columns: WorksheetColumn<Partial<Product>>[] = [
+                  { hash: 'productName', header: 'Product name', validation: (value) => !!value },
+                  { hash: 'otherField', header: 'Other field', disabled: true },
+                ];
+
+                const items: Partial<Product>[] = [
+                  {
+                    id: 1,
+                    productName: 'Product 1',
+                    otherField: 'Text',
+                  },
+                  {
+                    id: 2,
+                    productName: 'Product 2',
+                    otherField: 'Text',
+                  },
+                  {
+                    id: 3,
+                    productName: 'Product 3',
+                    otherField: 'Text',
+                  },
+                ];
+
+                return (
+                  <Worksheet columns={columns} items={items} onChange={(items) => items} onErrors={(items) => items} />
+                );
+              }}
+              {/* jsx-to-string:end */}
+            </CodePreview>
+          </Panel>
         </>
       ),
     },


### PR DESCRIPTION
## What?

Add the `disabled` prop for all column types in Worksheet.

## Why?

For the scenarios when a column is only used to display a static value.

## Screenshots/Screen Recordings

![screencapture-localhost-3000-worksheet-2021-07-22-16_30_05](https://user-images.githubusercontent.com/196129/126712067-f468999b-da7d-4b1c-a754-d889c731e90e.png)


## Testing/Proof

Locally. Unit tests.
