### PR TITLE
chore(deps): upgrade to styled-components v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,31 @@ You can find documentation and examples on our [docs page](https://bigcommerce.g
 
 ### Quick start guide
 
-Add BigDesign and styled-components@4 to your project using `npm`:
+Add BigDesign and styled-components@5 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design styled-components@4
+npm install @bigcommerce/big-design styled-components@5
 ```
 
 or with `yarn`:
 
 ```
-yarn add @bigcommerce/big-design styled-components@4
+yarn add @bigcommerce/big-design styled-components@5
 ```
 
-Import the `GlobalStyles` component and use it once in your app. This will set a few styles globally,
-including a base font family, [Source Sans Pro](https://fonts.google.com/specimen/Source+Sans+Pro) and [normalize.css](https://github.com/necolas/normalize.css/). We recommend placing it close to your root component.
-Then import any component, such as `Button`, to use it anywhere in your app.
+Add the font as a `<link>` in your `index.html`/`<head>` element.
+
+```html
+<head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600&display=swap" rel="stylesheet" />
+</head>
+```
+
+Import the `GlobalStyles` component and use it once in your app. This will set a few styles globally
+and add [normalize.css](https://github.com/necolas/normalize.css/). We recommend placing it close to
+your root component. Then import any component, such as `Button`, to use it anywhere in your app.
 
 ```jsx
 import { Button, GlobalStyles } from '@bigcommerce/big-design';

--- a/packages/big-design-icons/README.md
+++ b/packages/big-design-icons/README.md
@@ -8,16 +8,16 @@ You can find documentation, list of icons, and examples on our [docs page](https
 
 ### Quick start guide
 
-Add BigDesign Icons and styled-components@4 to your project using `npm`:
+Add BigDesign Icons and styled-components@5 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design-icons styled-components@4
+npm install @bigcommerce/big-design-icons styled-components@5
 ```
 
 or with `yarn`:
 
 ```
-yarn add @bigcommerce/big-design-icons styled-components@4
+yarn add @bigcommerce/big-design-icons styled-components@5
 ```
 
 Import any icon component and use it anywhere in your app.

--- a/packages/big-design-icons/package.json
+++ b/packages/big-design-icons/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
-    "styled-components": "^4.3.0"
+    "styled-components": "^5.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",
@@ -63,8 +63,8 @@
     "@svgr/plugin-svgo": "^5.0.1",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",
-    "@types/styled-components": "^4.1.12",
-    "babel-plugin-styled-components": "^1.10.6",
+    "@types/styled-components": "^5.1.11",
+    "babel-plugin-styled-components": "^1.13.2",
     "camelcase": "^5.3.1",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.4",
@@ -76,7 +76,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "rimraf": "^3.0.2",
-    "styled-components": "^4.3.0",
+    "styled-components": "^5.3.0",
     "typescript": "^4.3.5",
     "typescript-styled-plugin": "^0.15.0"
   }

--- a/packages/big-design-theme/README.md
+++ b/packages/big-design-theme/README.md
@@ -17,16 +17,16 @@ This package is only meant to be used directly when more advanced features are n
 
 ### Quick start guide
 
-Add the BigDesign theme and styled-components@4 to your project using `npm`:
+Add the BigDesign theme and styled-components@5 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design-theme styled-components@4
+npm install @bigcommerce/big-design-theme styled-components@5
 ```
 
 or with `yarn`:
 
 ```
-yarn add @bigcommerce/big-design-theme styled-components@4
+yarn add @bigcommerce/big-design-theme styled-components@5
 ```
 
 ```tsx

--- a/packages/big-design-theme/package.json
+++ b/packages/big-design-theme/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
-    "styled-components": "^4.3.0"
+    "styled-components": "^5.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",
@@ -53,16 +53,16 @@
     "@babel/preset-typescript": "^7.12.1",
     "@bigcommerce/configs": "^0.15.0-alpha.0",
     "@types/jest": "^25.2.1",
-    "@types/styled-components": "^4.1.12",
+    "@types/styled-components": "^5.1.11",
     "babel-jest": "^25.5.1",
-    "babel-plugin-styled-components": "^1.10.6",
+    "babel-plugin-styled-components": "^1.13.2",
     "concurrently": "^6.2.0",
     "jest": "^25.5.4",
-    "jest-styled-components": "^6.3.1",
+    "jest-styled-components": "^7.0.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "rimraf": "^3.0.2",
-    "styled-components": "^4.3.0",
+    "styled-components": "^5.3.0",
     "typescript": "^4.3.5",
     "typescript-styled-plugin": "^0.15.0"
   }

--- a/packages/big-design/README.md
+++ b/packages/big-design/README.md
@@ -8,21 +8,31 @@ You can find documentation and examples on our [docs page](https://bigcommerce.g
 
 ### Quick start guide
 
-Add BigDesign and styled-components@4 to your project using `npm`:
+Add BigDesign and styled-components@5 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design styled-components@4
+npm install @bigcommerce/big-design styled-components@5
 ```
 
 or with `yarn`:
 
 ```
-yarn add @bigcommerce/big-design styled-components@4
+yarn add @bigcommerce/big-design styled-components@5
 ```
 
-Import the `GlobalStyles` component and use it once in your app. This will set a few styles globally,
-including a base font family, [Source Sans Pro](https://fonts.google.com/specimen/Source+Sans+Pro) and [normalize.css](https://github.com/necolas/normalize.css/). We recommend placing it close to your root component.
-Then import any component, such as `Button`, to use it anywhere in your app.
+Add the font as a `<link>` in your `index.html`/`<head>` element.
+
+```html
+<head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600&display=swap" rel="stylesheet" />
+</head>
+```
+
+Import the `GlobalStyles` component and use it once in your app. This will set a few styles globally
+and add [normalize.css](https://github.com/necolas/normalize.css/). We recommend placing it close to
+your root component. Then import any component, such as `Button`, to use it anywhere in your app.
 
 ```jsx
 import { Button, GlobalStyles } from '@bigcommerce/big-design';

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
-    "styled-components": "^4.3.0"
+    "styled-components": "^5.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",
@@ -73,17 +73,17 @@
     "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-dom": "^17.0.1",
     "@types/react-test-renderer": "^17.0.1",
-    "@types/styled-components": "^4.1.12",
+    "@types/styled-components": "^5.1.11",
     "babel-jest": "^25.5.1",
-    "babel-plugin-styled-components": "^1.10.6",
+    "babel-plugin-styled-components": "^1.13.2",
     "concurrently": "^6.2.0",
     "jest": "^25.5.4",
-    "jest-styled-components": "^6.3.1",
+    "jest-styled-components": "^7.0.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-test-renderer": "^17.0.1",
     "rimraf": "^3.0.2",
-    "styled-components": "^4.3.0",
+    "styled-components": "^5.3.0",
     "typescript": "^4.3.5",
     "typescript-styled-plugin": "^0.15.0"
   }

--- a/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
@@ -25,11 +25,25 @@ exports[`render default (success) Alert 1`] = `
   grid-area: messages;
 }
 
+.c6 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: eMLfYp .5s ease-in-out;
-  animation: eMLfYp .5s ease-in-out;
+  -webkit-animation: jBcSpD .5s ease-in-out;
+  animation: jBcSpD .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -43,20 +57,9 @@ exports[`render default (success) Alert 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c7 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c6:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -93,7 +96,7 @@ exports[`render default (success) Alert 1`] = `
       class="c0"
     >
       <span
-        class="c6"
+        class="c6 c7"
       >
         Success
       </span>
@@ -128,11 +131,25 @@ exports[`render error Alert 1`] = `
   grid-area: messages;
 }
 
+.c6 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: eMLfYp .5s ease-in-out;
-  animation: eMLfYp .5s ease-in-out;
+  -webkit-animation: jBcSpD .5s ease-in-out;
+  animation: jBcSpD .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -146,20 +163,9 @@ exports[`render error Alert 1`] = `
   border-left: 0.25rem solid #DB3643;
 }
 
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c7 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c6:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -192,7 +198,7 @@ exports[`render error Alert 1`] = `
       class="c0"
     >
       <span
-        class="c6"
+        class="c6 c7"
       >
         Error
       </span>
@@ -227,11 +233,25 @@ exports[`render info Alert 1`] = `
   grid-area: messages;
 }
 
+.c6 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: eMLfYp .5s ease-in-out;
-  animation: eMLfYp .5s ease-in-out;
+  -webkit-animation: jBcSpD .5s ease-in-out;
+  animation: jBcSpD .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -245,20 +265,9 @@ exports[`render info Alert 1`] = `
   border-left: 0.25rem solid #0B38D9;
 }
 
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c7 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c6:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -295,7 +304,7 @@ exports[`render info Alert 1`] = `
       class="c0"
     >
       <span
-        class="c6"
+        class="c6 c7"
       >
         Info
       </span>
@@ -330,11 +339,25 @@ exports[`render warning Alert 1`] = `
   grid-area: messages;
 }
 
+.c6 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: eMLfYp .5s ease-in-out;
-  animation: eMLfYp .5s ease-in-out;
+  -webkit-animation: jBcSpD .5s ease-in-out;
+  animation: jBcSpD .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -348,20 +371,9 @@ exports[`render warning Alert 1`] = `
   border-left: 0.25rem solid #FFAE00;
 }
 
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c7 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c6:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -394,7 +406,7 @@ exports[`render warning Alert 1`] = `
       class="c0"
     >
       <span
-        class="c6"
+        class="c6 c7"
       >
         Warning
       </span>
@@ -412,7 +424,7 @@ exports[`renders close button 1`] = `
   width: 1.5rem;
 }
 
-.c10 {
+.c11 {
   vertical-align: middle;
   height: 1.25rem;
   width: 1.25rem;
@@ -422,7 +434,7 @@ exports[`renders close button 1`] = `
   box-sizing: border-box;
 }
 
-.c7 {
+.c8 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -473,36 +485,36 @@ exports[`renders close button 1`] = `
   font-weight: 600;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
 }
 
-.c7[disabled] {
+.c8[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c7 + .bd-button {
+.c8 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c7:active {
+.c8:active {
   background-color: #0B38D9;
 }
 
-.c7:focus {
+.c8:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c7:hover:not(:active) {
+.c8:hover:not(:active) {
   background-color: #2852EB;
 }
 
-.c7[disabled] {
+.c8[disabled] {
   background-color: #D9DCE9;
 }
 
-.c9 {
+.c10 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -516,7 +528,7 @@ exports[`renders close button 1`] = `
   visibility: visible;
 }
 
-.c8 {
+.c9 {
   background-color: transparent;
   border: none;
   color: #313440;
@@ -524,19 +536,19 @@ exports[`renders close button 1`] = `
   padding: 0;
 }
 
-.c8:active {
+.c9:active {
   background-color: #DBE3FE;
 }
 
-.c8:focus {
+.c9:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c8:hover:not(:active) {
+.c9:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c8[disabled] {
+.c9[disabled] {
   color: #D9DCE9;
 }
 
@@ -553,11 +565,25 @@ exports[`renders close button 1`] = `
   grid-area: messages;
 }
 
+.c6 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: eMLfYp .5s ease-in-out;
-  animation: eMLfYp .5s ease-in-out;
+  -webkit-animation: jBcSpD .5s ease-in-out;
+  animation: jBcSpD .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -571,31 +597,20 @@ exports[`renders close button 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c7 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c6:last-child {
-  margin-bottom: 0;
-}
-
 @media (min-width:720px) {
-  .c7 + .bd-button {
+  .c8 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c7 {
+  .c8 {
     width: auto;
   }
 }
@@ -634,7 +649,7 @@ exports[`renders close button 1`] = `
       class="c0"
     >
       <span
-        class="c6"
+        class="c6 c7"
       >
         Success
       </span>
@@ -645,13 +660,13 @@ exports[`renders close button 1`] = `
     class="c0 "
   >
     <button
-      class="c7 c8"
+      class="c8 c9"
     >
       <span
-        class="c9"
+        class="c10"
       >
         <svg
-          class="c10"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -698,11 +713,34 @@ exports[`renders header 1`] = `
   grid-area: messages;
 }
 
+.c6 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.c8 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c8:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: eMLfYp .5s ease-in-out;
-  animation: eMLfYp .5s ease-in-out;
+  -webkit-animation: jBcSpD .5s ease-in-out;
+  animation: jBcSpD .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -716,31 +754,14 @@ exports[`renders header 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.5rem;
-  margin: 0 0 0.5rem;
+.c7 {
   line-height: 1rem;
   margin-bottom: 0.25rem;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c9 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c7:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -774,7 +795,7 @@ exports[`renders header 1`] = `
     class="c0 c5"
   >
     <h4
-      class="c6"
+      class="c6 c7"
     >
       Header
     </h4>
@@ -782,7 +803,7 @@ exports[`renders header 1`] = `
       class="c0"
     >
       <span
-        class="c7"
+        class="c8 c9"
       >
         Success
       </span>
@@ -800,7 +821,7 @@ exports[`renders with external link 1`] = `
   width: 1.5rem;
 }
 
-.c9 {
+.c10 {
   vertical-align: middle;
   height: 1rem;
   width: 1rem;
@@ -823,7 +844,7 @@ exports[`renders with external link 1`] = `
   grid-area: messages;
 }
 
-.c7 {
+.c8 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -844,26 +865,40 @@ exports[`renders with external link 1`] = `
   align-items: center;
 }
 
-.c7:active {
+.c8:active {
   color: #0024A6;
 }
 
-.c7:hover:not(:active) {
+.c8:hover:not(:active) {
   color: #0024A6;
 }
 
-.c7 svg {
+.c8 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   margin-left: 0.25rem;
 }
 
+.c6 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: eMLfYp .5s ease-in-out;
-  animation: eMLfYp .5s ease-in-out;
+  -webkit-animation: jBcSpD .5s ease-in-out;
+  animation: jBcSpD .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -877,23 +912,12 @@ exports[`renders with external link 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c7 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c6:last-child {
-  margin-bottom: 0;
-}
-
-.c8 {
+.c9 {
   font-size: 0.875rem;
   vertical-align: middle;
 }
@@ -932,13 +956,13 @@ exports[`renders with external link 1`] = `
       class="c0"
     >
       <span
-        class="c6"
+        class="c6 c7"
       >
         Success
       </span>
        
       <a
-        class="c7 c8"
+        class="c8 c9"
         href="#"
         target="_blank"
       >
@@ -946,7 +970,7 @@ exports[`renders with external link 1`] = `
           Link
         </span>
         <svg
-          class="c9"
+          class="c10"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -993,7 +1017,7 @@ exports[`renders with link 1`] = `
   grid-area: messages;
 }
 
-.c7 {
+.c8 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -1006,19 +1030,33 @@ exports[`renders with link 1`] = `
   text-decoration: none;
 }
 
-.c7:active {
+.c8:active {
   color: #0024A6;
 }
 
-.c7:hover:not(:active) {
+.c8:hover:not(:active) {
   color: #0024A6;
+}
+
+.c6 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
 }
 
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: eMLfYp .5s ease-in-out;
-  animation: eMLfYp .5s ease-in-out;
+  -webkit-animation: jBcSpD .5s ease-in-out;
+  animation: jBcSpD .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -1032,23 +1070,12 @@ exports[`renders with link 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c7 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c6:last-child {
-  margin-bottom: 0;
-}
-
-.c8 {
+.c9 {
   font-size: 0.875rem;
   vertical-align: middle;
 }
@@ -1087,13 +1114,13 @@ exports[`renders with link 1`] = `
       class="c0"
     >
       <span
-        class="c6"
+        class="c6 c7"
       >
         Success
       </span>
        
       <a
-        class="c7 c8"
+        class="c8 c9"
         href="#"
       >
         Link

--- a/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
@@ -1072,16 +1072,13 @@ exports[`render loading button 1`] = `
 }
 
 .c6 {
-  fill: transparent;
-  stroke-width: 0.125rem;
-  stroke: #ECEEF5;
   stroke-dasharray: 43.982297150257104 43.982297150257104;
   stroke: #3C64F4;
   -webkit-transform-origin: 50% 50%;
   -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: cWvsXs 1s ease-out infinite;
-  animation: cWvsXs 1s ease-out infinite;
+  -webkit-animation: fxwtRW 1s ease-out infinite;
+  animation: fxwtRW 1s ease-out infinite;
   stroke-dashoffset: 43.982297150257104;
   -webkit-transform: rotate(-90deg);
   -ms-transform: rotate(-90deg);
@@ -1258,7 +1255,7 @@ exports[`render loading button 1`] = `
         r="0.4375em"
       />
       <circle
-        class="c6"
+        class="c5 c6"
         cx="0.5em"
         cy="0.5em"
         r="0.4375em"

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -1,26 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`render Checkbox checked 1`] = `
-.c4 {
+.c5 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c6 {
+.c7 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  cursor: pointer;
 }
 
-.c6:last-child {
+.c7:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c8 {
+  cursor: pointer;
+}
+
+.c6 {
   margin-left: 0.5rem;
 }
 
@@ -48,7 +51,7 @@ exports[`render Checkbox checked 1`] = `
   width: 1px;
 }
 
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -79,7 +82,7 @@ exports[`render Checkbox checked 1`] = `
   width: 1.25rem;
 }
 
-.c3:hover {
+.c4:hover {
   border-color: #3C64F4;
 }
 
@@ -87,7 +90,7 @@ exports[`render Checkbox checked 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3 svg {
+.c4 svg {
   opacity: 1;
 }
 
@@ -104,11 +107,11 @@ exports[`render Checkbox checked 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     for="bd-checkbox-1"
   >
     <svg
-      class="c4"
+      class="c5"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -126,10 +129,10 @@ exports[`render Checkbox checked 1`] = `
     </svg>
   </label>
   <div
-    class="c5"
+    class="c6"
   >
     <label
-      class="c6"
+      class="c7 c8"
       for="bd-checkbox-1"
       id="bd-checkbox_label-2"
     >
@@ -140,27 +143,30 @@ exports[`render Checkbox checked 1`] = `
 `;
 
 exports[`render Checkbox disabled checked 1`] = `
-.c4 {
+.c5 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c6 {
+.c7 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
+.c8 {
   cursor: pointer;
   cursor: not-allowed;
 }
 
-.c6:last-child {
-  margin-bottom: 0;
-}
-
-.c5 {
+.c6 {
   margin-left: 0.5rem;
 }
 
@@ -188,15 +194,7 @@ exports[`render Checkbox disabled checked 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c7 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c1:focus + .c8 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -234,7 +232,7 @@ exports[`render Checkbox disabled checked 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3 svg {
+.c4 svg {
   opacity: 1;
 }
 
@@ -252,12 +250,12 @@ exports[`render Checkbox disabled checked 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     disabled=""
     for="bd-checkbox-1"
   >
     <svg
-      class="c4"
+      class="c5"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -275,11 +273,11 @@ exports[`render Checkbox disabled checked 1`] = `
     </svg>
   </label>
   <div
-    class="c5"
+    class="c6"
   >
     <label
       aria-hidden="true"
-      class="c6"
+      class="c7 c8"
       disabled=""
       for="bd-checkbox-1"
       id="bd-checkbox_label-2"
@@ -291,27 +289,30 @@ exports[`render Checkbox disabled checked 1`] = `
 `;
 
 exports[`render Checkbox disabled indeterminate 1`] = `
-.c4 {
+.c5 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c6 {
+.c7 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
+.c8 {
   cursor: pointer;
   cursor: not-allowed;
 }
 
-.c6:last-child {
-  margin-bottom: 0;
-}
-
-.c5 {
+.c6 {
   margin-left: 0.5rem;
 }
 
@@ -339,15 +340,7 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c7 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c1:focus + .c8 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -385,12 +378,8 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3 svg {
+.c4 svg {
   opacity: 1;
-}
-
-.c1:focus + .c9 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
 <div
@@ -405,12 +394,12 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     disabled=""
     for="bd-checkbox-1"
   >
     <svg
-      class="c4"
+      class="c5"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -428,11 +417,11 @@ exports[`render Checkbox disabled indeterminate 1`] = `
     </svg>
   </label>
   <div
-    class="c5"
+    class="c6"
   >
     <label
       aria-hidden="true"
-      class="c6"
+      class="c7 c8"
       disabled=""
       for="bd-checkbox-1"
       id="bd-checkbox_label-2"
@@ -444,27 +433,30 @@ exports[`render Checkbox disabled indeterminate 1`] = `
 `;
 
 exports[`render Checkbox disabled unchecked 1`] = `
-.c4 {
+.c5 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c6 {
+.c7 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
+.c8 {
   cursor: pointer;
   cursor: not-allowed;
 }
 
-.c6:last-child {
-  margin-bottom: 0;
-}
-
-.c5 {
+.c6 {
   margin-left: 0.5rem;
 }
 
@@ -492,19 +484,7 @@ exports[`render Checkbox disabled unchecked 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c7 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c1:focus + .c8 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c1:focus + .c9 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -542,7 +522,7 @@ exports[`render Checkbox disabled unchecked 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3 svg {
+.c4 svg {
   opacity: 0;
 }
 
@@ -559,12 +539,12 @@ exports[`render Checkbox disabled unchecked 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     disabled=""
     for="bd-checkbox-1"
   >
     <svg
-      class="c4"
+      class="c5"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -582,11 +562,11 @@ exports[`render Checkbox disabled unchecked 1`] = `
     </svg>
   </label>
   <div
-    class="c5"
+    class="c6"
   >
     <label
       aria-hidden="true"
-      class="c6"
+      class="c7 c8"
       disabled=""
       for="bd-checkbox-1"
       id="bd-checkbox_label-2"
@@ -598,26 +578,29 @@ exports[`render Checkbox disabled unchecked 1`] = `
 `;
 
 exports[`render Checkbox indeterminate 1`] = `
-.c4 {
+.c5 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c6 {
+.c7 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  cursor: pointer;
 }
 
-.c6:last-child {
+.c7:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c8 {
+  cursor: pointer;
+}
+
+.c6 {
   margin-left: 0.5rem;
 }
 
@@ -645,7 +628,7 @@ exports[`render Checkbox indeterminate 1`] = `
   width: 1px;
 }
 
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -676,7 +659,7 @@ exports[`render Checkbox indeterminate 1`] = `
   width: 1.25rem;
 }
 
-.c3:hover {
+.c4:hover {
   border-color: #3C64F4;
 }
 
@@ -684,12 +667,8 @@ exports[`render Checkbox indeterminate 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3 svg {
+.c4 svg {
   opacity: 1;
-}
-
-.c1:focus + .c7 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
 <div
@@ -703,11 +682,11 @@ exports[`render Checkbox indeterminate 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     for="bd-checkbox-1"
   >
     <svg
-      class="c4"
+      class="c5"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -725,10 +704,10 @@ exports[`render Checkbox indeterminate 1`] = `
     </svg>
   </label>
   <div
-    class="c5"
+    class="c6"
   >
     <label
-      class="c6"
+      class="c7 c8"
       for="bd-checkbox-1"
       id="bd-checkbox_label-2"
     >
@@ -739,26 +718,29 @@ exports[`render Checkbox indeterminate 1`] = `
 `;
 
 exports[`render Checkbox unchecked 1`] = `
-.c4 {
+.c5 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c6 {
+.c7 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  cursor: pointer;
 }
 
-.c6:last-child {
+.c7:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c8 {
+  cursor: pointer;
+}
+
+.c6 {
   margin-left: 0.5rem;
 }
 
@@ -786,11 +768,7 @@ exports[`render Checkbox unchecked 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c7 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -821,7 +799,7 @@ exports[`render Checkbox unchecked 1`] = `
   width: 1.25rem;
 }
 
-.c3:hover {
+.c4:hover {
   border-color: #B4BAD1;
 }
 
@@ -829,7 +807,7 @@ exports[`render Checkbox unchecked 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3 svg {
+.c4 svg {
   opacity: 0;
 }
 
@@ -845,11 +823,11 @@ exports[`render Checkbox unchecked 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     for="bd-checkbox-1"
   >
     <svg
-      class="c4"
+      class="c5"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -867,10 +845,10 @@ exports[`render Checkbox unchecked 1`] = `
     </svg>
   </label>
   <div
-    class="c5"
+    class="c6"
   >
     <label
-      class="c6"
+      class="c7 c8"
       for="bd-checkbox-1"
       id="bd-checkbox_label-2"
     >
@@ -881,13 +859,25 @@ exports[`render Checkbox unchecked 1`] = `
 `;
 
 exports[`render Checkbox with description object 1`] = `
-.c4 {
+.c5 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
 .c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -897,24 +887,15 @@ exports[`render Checkbox with description object 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c7:last-child {
-  margin-bottom: 0;
-}
-
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-  cursor: pointer;
-}
-
-.c6:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
 .c8 {
+  cursor: pointer;
+}
+
+.c10 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -927,19 +908,19 @@ exports[`render Checkbox with description object 1`] = `
   text-decoration: none;
 }
 
-.c8:active {
+.c10:active {
   color: #0024A6;
 }
 
-.c8:hover:not(:active) {
+.c10:hover:not(:active) {
   color: #0024A6;
 }
 
-.c9 {
+.c11 {
   font-size: 0.875rem;
 }
 
-.c5 {
+.c6 {
   margin-left: 0.5rem;
 }
 
@@ -967,11 +948,7 @@ exports[`render Checkbox with description object 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c10 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -1002,7 +979,7 @@ exports[`render Checkbox with description object 1`] = `
   width: 1.25rem;
 }
 
-.c3:hover {
+.c4:hover {
   border-color: #B4BAD1;
 }
 
@@ -1010,7 +987,7 @@ exports[`render Checkbox with description object 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3 svg {
+.c4 svg {
   opacity: 0;
 }
 
@@ -1027,11 +1004,11 @@ exports[`render Checkbox with description object 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     for="bd-checkbox-1"
   >
     <svg
-      class="c4"
+      class="c5"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -1049,22 +1026,22 @@ exports[`render Checkbox with description object 1`] = `
     </svg>
   </label>
   <div
-    class="c5"
+    class="c6"
   >
     <label
-      class="c6"
+      class="c7 c8"
       for="bd-checkbox-1"
       id="bd-checkbox_label-2"
     >
       Unchecked
     </label>
     <p
-      class="c7"
+      class="c9"
     >
       description
        
       <a
-        class="c8 c9"
+        class="c10 c11"
         href="bar"
         target="foo"
       >
@@ -1076,13 +1053,25 @@ exports[`render Checkbox with description object 1`] = `
 `;
 
 exports[`render Checkbox with description string 1`] = `
-.c4 {
+.c5 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
 .c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -1092,24 +1081,15 @@ exports[`render Checkbox with description string 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c7:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
+.c8 {
   cursor: pointer;
 }
 
-.c6:last-child {
-  margin-bottom: 0;
-}
-
-.c5 {
+.c6 {
   margin-left: 0.5rem;
 }
 
@@ -1137,11 +1117,7 @@ exports[`render Checkbox with description string 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c8 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -1172,7 +1148,7 @@ exports[`render Checkbox with description string 1`] = `
   width: 1.25rem;
 }
 
-.c3:hover {
+.c4:hover {
   border-color: #B4BAD1;
 }
 
@@ -1180,7 +1156,7 @@ exports[`render Checkbox with description string 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3 svg {
+.c4 svg {
   opacity: 0;
 }
 
@@ -1197,11 +1173,11 @@ exports[`render Checkbox with description string 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     for="bd-checkbox-1"
   >
     <svg
-      class="c4"
+      class="c5"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -1219,17 +1195,17 @@ exports[`render Checkbox with description string 1`] = `
     </svg>
   </label>
   <div
-    class="c5"
+    class="c6"
   >
     <label
-      class="c6"
+      class="c7 c8"
       for="bd-checkbox-1"
       id="bd-checkbox_label-2"
     >
       Unchecked
     </label>
     <p
-      class="c7"
+      class="c9"
     >
       description text
     </p>

--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -1,6 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`simple form render 1`] = `
+.c1 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.75rem;
+  margin: 0 0 0.75rem;
+}
+
+.c5 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
 .c3 {
   color: #313440;
   margin: 0 0 1rem;
@@ -15,26 +33,17 @@ exports[`simple form render 1`] = `
   margin-bottom: 0;
 }
 
-.c2 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1.25rem;
-  font-weight: 600;
-  line-height: 1.75rem;
-  margin: 0 0 0.75rem;
-}
-
 .c2:not(:last-child) {
   margin-bottom: 0.25rem;
 }
 
-.c1 {
+.c0 {
   border: none;
   margin: 0 0 1.5rem;
   padding: 0;
 }
 
-.c1:last-child {
+.c0:last-child {
   margin: 0;
 }
 
@@ -146,39 +155,34 @@ exports[`simple form render 1`] = `
   margin-bottom: 0;
 }
 
-.c5 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.5rem;
-  margin: 0 0 0.5rem;
+.c6 {
   cursor: pointer;
   display: inline-block;
   margin-bottom: 0.25rem;
 }
 
-.c5::after {
+.c6::after {
   color: #5E637A;
   content: ' (optional)';
   font-weight: 400;
 }
 
 @media (min-width:720px) {
-  .c0 .c6,
-  .c0 .styled__StyledTextareaWrapper-sc-c1uos0-0 {
-    max-width: 26rem;
-  }
+
+}
+
+@media (min-width:720px) {
+
 }
 
 <form
-  class="c0"
+  class=""
 >
   <fieldset
-    class="c1"
+    class="c0"
   >
     <legend
-      class="c2"
+      class="c1 c2"
     >
       Primary contact
     </legend>
@@ -192,7 +196,7 @@ exports[`simple form render 1`] = `
     >
       <div>
         <label
-          class="c5"
+          class="c5 c6"
           for="bd-input-1"
         >
           First Name
@@ -203,7 +207,7 @@ exports[`simple form render 1`] = `
           This is an example description for First Name
         </p>
         <span
-          class="c6 c7"
+          class="c7"
         >
           <div
             class="c8"
@@ -222,7 +226,7 @@ exports[`simple form render 1`] = `
     >
       <div>
         <label
-          class="c5"
+          class="c5 c6"
           for="bd-input-2"
         >
           Middle Name
@@ -233,7 +237,7 @@ exports[`simple form render 1`] = `
           This is an example description for Last Name. Featuring a Left Icon.
         </p>
         <span
-          class="c6 c7"
+          class="c7"
         >
           <div
             class="c8"

--- a/packages/big-design/src/components/GlobalStyles/GlobalStyles.tsx
+++ b/packages/big-design/src/components/GlobalStyles/GlobalStyles.tsx
@@ -5,8 +5,6 @@ import { createGlobalStyle } from 'styled-components';
 export const GlobalStyles = createGlobalStyle`
   ${normalize()}
 
-  @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600');
-
   body {
     font-family: ${({ theme }) => theme.typography.fontFamily};
   }

--- a/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
@@ -30,6 +30,20 @@ exports[`render default (success) InlineMessage 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
@@ -41,20 +55,9 @@ exports[`render default (success) InlineMessage 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c7:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -91,7 +94,7 @@ exports[`render default (success) InlineMessage 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Success
       </span>
@@ -131,6 +134,20 @@ exports[`render error InlineMessage 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
@@ -142,20 +159,9 @@ exports[`render error InlineMessage 1`] = `
   border-left: 0.25rem solid #DB3643;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c7:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -188,7 +194,7 @@ exports[`render error InlineMessage 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Error
       </span>
@@ -228,6 +234,20 @@ exports[`render info InlineMessage 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
@@ -239,20 +259,9 @@ exports[`render info InlineMessage 1`] = `
   border-left: 0.25rem solid #0B38D9;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c7:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -289,7 +298,7 @@ exports[`render info InlineMessage 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Info
       </span>
@@ -329,6 +338,20 @@ exports[`render warning InlineMessage 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
@@ -340,20 +363,9 @@ exports[`render warning InlineMessage 1`] = `
   border-left: 0.25rem solid #FFAE00;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c7:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -386,7 +398,7 @@ exports[`render warning InlineMessage 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Warning
       </span>
@@ -413,12 +425,12 @@ exports[`renders actions 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c9 {
   margin-top: 0.5rem;
   box-sizing: border-box;
 }
 
-.c9 {
+.c10 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
@@ -442,7 +454,7 @@ exports[`renders actions 1`] = `
   display: flex;
 }
 
-.c11 {
+.c12 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -492,42 +504,42 @@ exports[`renders actions 1`] = `
   color: #3C64F4;
 }
 
-.c11.c11 {
+.c12.c12 {
   margin-bottom: 0.5rem;
   margin-left: 0.25rem;
   margin-right: 0.25rem;
 }
 
-.c11:focus {
+.c12:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c12[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c12 + .bd-button {
   margin-left: 0.5rem;
 }
 
-.c11:active {
+.c12:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c12:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c12:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c12[disabled] {
   color: #D9DCE9;
 }
 
-.c12 {
+.c13 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -554,6 +566,20 @@ exports[`renders actions 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
@@ -565,37 +591,26 @@ exports[`renders actions 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c7:last-child {
-  margin-bottom: 0;
-}
-
-.c10 {
+.c11 {
   margin-bottom: -0.5rem;
   margin-left: -0.25rem;
   margin-right: -0.25rem;
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c12 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c12 {
     width: auto;
   }
 }
@@ -634,29 +649,29 @@ exports[`renders actions 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Success
       </span>
        
     </div>
     <div
-      class="c8 c9 c10"
+      class="c9 c10 c11"
     >
       <button
-        class="c11 bd-button"
+        class="c12 bd-button"
       >
         <span
-          class="c12"
+          class="c13"
         >
           First Action
         </span>
       </button>
       <button
-        class="c11 bd-button"
+        class="c12 bd-button"
       >
         <span
-          class="c12"
+          class="c13"
         >
           Second Action
         </span>
@@ -674,7 +689,7 @@ exports[`renders close button 1`] = `
   width: 1.25rem;
 }
 
-.c11 {
+.c12 {
   vertical-align: middle;
   height: 1rem;
   width: 1rem;
@@ -689,7 +704,7 @@ exports[`renders close button 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c9 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -740,36 +755,36 @@ exports[`renders close button 1`] = `
   font-weight: 600;
 }
 
-.c8:focus {
+.c9:focus {
   outline: none;
 }
 
-.c8[disabled] {
+.c9[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c8 + .bd-button {
+.c9 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c8:active {
+.c9:active {
   background-color: #0B38D9;
 }
 
-.c8:focus {
+.c9:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c8:hover:not(:active) {
+.c9:hover:not(:active) {
   background-color: #2852EB;
 }
 
-.c8[disabled] {
+.c9[disabled] {
   background-color: #D9DCE9;
 }
 
-.c10 {
+.c11 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -783,7 +798,7 @@ exports[`renders close button 1`] = `
   visibility: visible;
 }
 
-.c9 {
+.c10 {
   background-color: transparent;
   border: none;
   color: #313440;
@@ -791,19 +806,19 @@ exports[`renders close button 1`] = `
   padding: 0;
 }
 
-.c9:active {
+.c10:active {
   background-color: #DBE3FE;
 }
 
-.c9:focus {
+.c10:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9:hover:not(:active) {
+.c10:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   color: #D9DCE9;
 }
 
@@ -820,6 +835,20 @@ exports[`renders close button 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
@@ -831,31 +860,20 @@ exports[`renders close button 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c7:last-child {
-  margin-bottom: 0;
-}
-
 @media (min-width:720px) {
-  .c8 + .bd-button {
+  .c9 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c8 {
+  .c9 {
     width: auto;
   }
 }
@@ -894,7 +912,7 @@ exports[`renders close button 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Success
       </span>
@@ -905,14 +923,14 @@ exports[`renders close button 1`] = `
     class="c3 "
   >
     <button
-      class="c8 c9"
+      class="c9 c10"
     >
       <span
-        class="c10"
+        class="c11"
       >
         <svg
           aria-labelledby="bd-icon-2"
-          class="c11"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -969,6 +987,29 @@ exports[`renders header 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.c9 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c9:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
@@ -980,32 +1021,15 @@ exports[`renders header 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.5rem;
-  margin: 0 0 0.5rem;
+.c8 {
   font-size: 0.875rem;
   line-height: 1.25rem;
   margin-bottom: 0;
 }
 
-.c8 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c10 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c8:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -1039,7 +1063,7 @@ exports[`renders header 1`] = `
     class="c3 c6"
   >
     <h4
-      class="c7"
+      class="c7 c8"
     >
       Header
     </h4>
@@ -1047,7 +1071,7 @@ exports[`renders header 1`] = `
       class="c3"
     >
       <span
-        class="c8"
+        class="c9 c10"
       >
         Success
       </span>
@@ -1065,7 +1089,7 @@ exports[`renders with external link 1`] = `
   width: 1.25rem;
 }
 
-.c10 {
+.c11 {
   vertical-align: middle;
   height: 1rem;
   width: 1rem;
@@ -1093,7 +1117,7 @@ exports[`renders with external link 1`] = `
   grid-area: messages;
 }
 
-.c8 {
+.c9 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -1114,19 +1138,33 @@ exports[`renders with external link 1`] = `
   align-items: center;
 }
 
-.c8:active {
+.c9:active {
   color: #0024A6;
 }
 
-.c8:hover:not(:active) {
+.c9:hover:not(:active) {
   color: #0024A6;
 }
 
-.c8 svg {
+.c9 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   margin-left: 0.25rem;
+}
+
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
 }
 
 .c2 {
@@ -1140,23 +1178,12 @@ exports[`renders with external link 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c7:last-child {
-  margin-bottom: 0;
-}
-
-.c9 {
+.c10 {
   font-size: 0.875rem;
   vertical-align: middle;
 }
@@ -1195,13 +1222,13 @@ exports[`renders with external link 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Success
       </span>
        
       <a
-        class="c8 c9"
+        class="c9 c10"
         href="#"
         target="_blank"
       >
@@ -1209,7 +1236,7 @@ exports[`renders with external link 1`] = `
           Link
         </span>
         <svg
-          class="c10"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1261,7 +1288,7 @@ exports[`renders with link 1`] = `
   grid-area: messages;
 }
 
-.c8 {
+.c9 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -1274,12 +1301,26 @@ exports[`renders with link 1`] = `
   text-decoration: none;
 }
 
-.c8:active {
+.c9:active {
   color: #0024A6;
 }
 
-.c8:hover:not(:active) {
+.c9:hover:not(:active) {
   color: #0024A6;
+}
+
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
 }
 
 .c2 {
@@ -1293,23 +1334,12 @@ exports[`renders with link 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c7:last-child {
-  margin-bottom: 0;
-}
-
-.c9 {
+.c10 {
   font-size: 0.875rem;
   vertical-align: middle;
 }
@@ -1348,13 +1378,13 @@ exports[`renders with link 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Success
       </span>
        
       <a
-        class="c8 c9"
+        class="c9 c10"
         href="#"
       >
         Link

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders all together 1`] = `
-.c4 {
+.c5 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c2 {
+.c3 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border,box-shadow;
@@ -30,15 +30,15 @@ exports[`renders all together 1`] = `
   border: 1px solid #D9DCE9;
 }
 
-.c2:hover:not([disabled]) {
+.c3:hover:not([disabled]) {
   border: 1px solid #B4BAD1;
 }
 
-.c2[disabled] {
+.c3[disabled] {
   background-color: #ECEEF5;
 }
 
-.c6 {
+.c7 {
   background-color: inherit;
   border: 0;
   box-sizing: border-box;
@@ -55,40 +55,40 @@ exports[`renders all together 1`] = `
   min-height: 2.125rem;
 }
 
-.c6:focus {
+.c7:focus {
   outline: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #B4BAD1;
   font-size: 1rem;
 }
 
-.c6::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #B4BAD1;
   font-size: 1rem;
 }
 
-.c6:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #B4BAD1;
   font-size: 1rem;
 }
 
-.c6::placeholder {
+.c7::placeholder {
   color: #B4BAD1;
   font-size: 1rem;
 }
 
-.c6:-webkit-autofill {
+.c7:-webkit-autofill {
   background-color: #F0F3FF !important;
   -webkit-box-shadow: 0 0 0px 1000px #F0F3FF inset;
 }
 
-.c6[disabled] {
+.c7[disabled] {
   background-color: #ECEEF5;
 }
 
-.c3 {
+.c4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -106,7 +106,7 @@ exports[`renders all together 1`] = `
   left: 0;
 }
 
-.c7 {
+.c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -124,7 +124,7 @@ exports[`renders all together 1`] = `
   right: 0;
 }
 
-.c5 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -143,7 +143,16 @@ exports[`renders all together 1`] = `
   height: 100%;
 }
 
-.c1 {
+.c0 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.c2 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -153,23 +162,17 @@ exports[`renders all together 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c1:last-child {
+.c2:last-child {
   margin-bottom: 0;
 }
 
-.c0 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.5rem;
-  margin: 0 0 0.5rem;
+.c1 {
   cursor: pointer;
   display: inline-block;
   margin-bottom: 0.25rem;
 }
 
-.c0::after {
+.c1::after {
   color: #5E637A;
   content: ' (optional)';
   font-weight: 400;
@@ -177,24 +180,24 @@ exports[`renders all together 1`] = `
 
 <div>
   <label
-    class="c0"
+    class="c0 c1"
     for="bd-input-1"
   >
     This is a label
   </label>
   <p
-    class="c1"
+    class="c2"
   >
     This is a description
   </p>
   <span
-    class="c2"
+    class="c3"
   >
     <div
-      class="c3"
+      class="c4"
     >
       <svg
-        class="c4"
+        class="c5"
         data-testid="icon-left"
         fill="currentColor"
         height="24"
@@ -213,18 +216,18 @@ exports[`renders all together 1`] = `
       </svg>
     </div>
     <div
-      class="c5"
+      class="c6"
     >
       <input
-        class="c6"
+        class="c7"
         id="bd-input-1"
       />
     </div>
     <div
-      class="c7"
+      class="c8"
     >
       <svg
-        class="c4"
+        class="c5"
         data-testid="icon-right"
         fill="currentColor"
         height="24"

--- a/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
@@ -30,6 +30,20 @@ exports[`render default (success) Message 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -40,20 +54,9 @@ exports[`render default (success) Message 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c7:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -90,7 +93,7 @@ exports[`render default (success) Message 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Success
       </span>
@@ -130,6 +133,20 @@ exports[`render error Message 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -140,20 +157,9 @@ exports[`render error Message 1`] = `
   border-left: 0.25rem solid #DB3643;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c7:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -186,7 +192,7 @@ exports[`render error Message 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Error
       </span>
@@ -226,6 +232,20 @@ exports[`render info Message 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -236,20 +256,9 @@ exports[`render info Message 1`] = `
   border-left: 0.25rem solid #0B38D9;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c7:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -286,7 +295,7 @@ exports[`render info Message 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Info
       </span>
@@ -326,6 +335,20 @@ exports[`render warning Message 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -336,20 +359,9 @@ exports[`render warning Message 1`] = `
   border-left: 0.25rem solid #FFAE00;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c7:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -382,7 +394,7 @@ exports[`render warning Message 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Warning
       </span>
@@ -409,12 +421,12 @@ exports[`renders actions 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c9 {
   margin-top: 0.5rem;
   box-sizing: border-box;
 }
 
-.c9 {
+.c10 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
@@ -438,7 +450,7 @@ exports[`renders actions 1`] = `
   display: flex;
 }
 
-.c11 {
+.c12 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -488,42 +500,42 @@ exports[`renders actions 1`] = `
   color: #3C64F4;
 }
 
-.c11.c11 {
+.c12.c12 {
   margin-bottom: 0.5rem;
   margin-left: 0.25rem;
   margin-right: 0.25rem;
 }
 
-.c11:focus {
+.c12:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c12[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c12 + .bd-button {
   margin-left: 0.5rem;
 }
 
-.c11:active {
+.c12:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c12:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c12:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c12[disabled] {
   color: #D9DCE9;
 }
 
-.c12 {
+.c13 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -550,6 +562,20 @@ exports[`renders actions 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -560,37 +586,26 @@ exports[`renders actions 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c7:last-child {
-  margin-bottom: 0;
-}
-
-.c10 {
+.c11 {
   margin-bottom: -0.5rem;
   margin-left: -0.25rem;
   margin-right: -0.25rem;
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c12 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c12 {
     width: auto;
   }
 }
@@ -629,29 +644,29 @@ exports[`renders actions 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Success
       </span>
        
     </div>
     <div
-      class="c8 c9 c10"
+      class="c9 c10 c11"
     >
       <button
-        class="c11 bd-button"
+        class="c12 bd-button"
       >
         <span
-          class="c12"
+          class="c13"
         >
           First Action
         </span>
       </button>
       <button
-        class="c11 bd-button"
+        class="c12 bd-button"
       >
         <span
-          class="c12"
+          class="c13"
         >
           Second Action
         </span>
@@ -669,7 +684,7 @@ exports[`renders close button 1`] = `
   width: 1.5rem;
 }
 
-.c11 {
+.c12 {
   vertical-align: middle;
   height: 1.25rem;
   width: 1.25rem;
@@ -684,7 +699,7 @@ exports[`renders close button 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c9 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -735,36 +750,36 @@ exports[`renders close button 1`] = `
   font-weight: 600;
 }
 
-.c8:focus {
+.c9:focus {
   outline: none;
 }
 
-.c8[disabled] {
+.c9[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c8 + .bd-button {
+.c9 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c8:active {
+.c9:active {
   background-color: #0B38D9;
 }
 
-.c8:focus {
+.c9:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c8:hover:not(:active) {
+.c9:hover:not(:active) {
   background-color: #2852EB;
 }
 
-.c8[disabled] {
+.c9[disabled] {
   background-color: #D9DCE9;
 }
 
-.c10 {
+.c11 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -778,7 +793,7 @@ exports[`renders close button 1`] = `
   visibility: visible;
 }
 
-.c9 {
+.c10 {
   background-color: transparent;
   border: none;
   color: #313440;
@@ -786,19 +801,19 @@ exports[`renders close button 1`] = `
   padding: 0;
 }
 
-.c9:active {
+.c10:active {
   background-color: #DBE3FE;
 }
 
-.c9:focus {
+.c10:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9:hover:not(:active) {
+.c10:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   color: #D9DCE9;
 }
 
@@ -815,6 +830,20 @@ exports[`renders close button 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -825,31 +854,20 @@ exports[`renders close button 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c7:last-child {
-  margin-bottom: 0;
-}
-
 @media (min-width:720px) {
-  .c8 + .bd-button {
+  .c9 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c8 {
+  .c9 {
     width: auto;
   }
 }
@@ -888,7 +906,7 @@ exports[`renders close button 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Success
       </span>
@@ -899,14 +917,14 @@ exports[`renders close button 1`] = `
     class="c3 "
   >
     <button
-      class="c8 c9"
+      class="c9 c10"
     >
       <span
-        class="c10"
+        class="c11"
       >
         <svg
           aria-labelledby="bd-icon-2"
-          class="c11"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -963,6 +981,29 @@ exports[`renders header 1`] = `
   grid-area: messages;
 }
 
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.c9 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c9:last-child {
+  margin-bottom: 0;
+}
+
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -973,31 +1014,14 @@ exports[`renders header 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.5rem;
-  margin: 0 0 0.5rem;
+.c8 {
   line-height: 1.25rem;
   margin-bottom: 0;
 }
 
-.c8 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c10 {
   color: #313440;
   vertical-align: middle;
-}
-
-.c8:last-child {
-  margin-bottom: 0;
 }
 
 <div
@@ -1031,7 +1055,7 @@ exports[`renders header 1`] = `
     class="c3 c6"
   >
     <h4
-      class="c7"
+      class="c7 c8"
     >
       Header
     </h4>
@@ -1039,7 +1063,7 @@ exports[`renders header 1`] = `
       class="c3"
     >
       <span
-        class="c8"
+        class="c9 c10"
       >
         Success
       </span>
@@ -1057,7 +1081,7 @@ exports[`renders with external link 1`] = `
   width: 1.5rem;
 }
 
-.c10 {
+.c11 {
   vertical-align: middle;
   height: 1rem;
   width: 1rem;
@@ -1085,7 +1109,7 @@ exports[`renders with external link 1`] = `
   grid-area: messages;
 }
 
-.c8 {
+.c9 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -1106,19 +1130,33 @@ exports[`renders with external link 1`] = `
   align-items: center;
 }
 
-.c8:active {
+.c9:active {
   color: #0024A6;
 }
 
-.c8:hover:not(:active) {
+.c9:hover:not(:active) {
   color: #0024A6;
 }
 
-.c8 svg {
+.c9 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   margin-left: 0.25rem;
+}
+
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
 }
 
 .c2 {
@@ -1131,23 +1169,12 @@ exports[`renders with external link 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c7:last-child {
-  margin-bottom: 0;
-}
-
-.c9 {
+.c10 {
   font-size: 0.875rem;
   vertical-align: middle;
 }
@@ -1186,13 +1213,13 @@ exports[`renders with external link 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Success
       </span>
        
       <a
-        class="c8 c9"
+        class="c9 c10"
         href="#"
         target="_blank"
       >
@@ -1200,7 +1227,7 @@ exports[`renders with external link 1`] = `
           Link
         </span>
         <svg
-          class="c10"
+          class="c11"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1252,7 +1279,7 @@ exports[`renders with link 1`] = `
   grid-area: messages;
 }
 
-.c8 {
+.c9 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -1265,12 +1292,26 @@ exports[`renders with link 1`] = `
   text-decoration: none;
 }
 
-.c8:active {
+.c9:active {
   color: #0024A6;
 }
 
-.c8:hover:not(:active) {
+.c9:hover:not(:active) {
   color: #0024A6;
+}
+
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
 }
 
 .c2 {
@@ -1283,23 +1324,12 @@ exports[`renders with link 1`] = `
   border-left: 0.25rem solid #2AAB3F;
 }
 
-.c7 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
+.c8 {
   color: #313440;
   vertical-align: middle;
 }
 
-.c7:last-child {
-  margin-bottom: 0;
-}
-
-.c9 {
+.c10 {
   font-size: 0.875rem;
   vertical-align: middle;
 }
@@ -1338,13 +1368,13 @@ exports[`renders with link 1`] = `
       class="c3"
     >
       <span
-        class="c7"
+        class="c7 c8"
       >
         Success
       </span>
        
       <a
-        class="c8 c9"
+        class="c9 c10"
         href="#"
       >
         Link

--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -314,7 +314,31 @@ exports[`render open modal without backdrop 1`] = `
 <body
   style="overflow-y: hidden;"
 >
-  <div />
+  @media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:1025px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+<div />
   .c8 {
   vertical-align: middle;
   height: 1.5rem;
@@ -704,6 +728,22 @@ exports[`renders destructive action button 1`] = `
   visibility: visible;
 }
 
+@media (min-width:0px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
 @media (min-width:720px) {
   .c0 + .bd-button {
     margin-top: 0;
@@ -715,6 +755,26 @@ exports[`renders destructive action button 1`] = `
   .c0 {
     width: auto;
   }
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:1025px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
 }
 
 <button
@@ -822,6 +882,22 @@ exports[`renders secondary action button 1`] = `
   visibility: visible;
 }
 
+@media (min-width:0px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
 @media (min-width:720px) {
   .c0 + .bd-button {
     margin-top: 0;
@@ -833,6 +909,26 @@ exports[`renders secondary action button 1`] = `
   .c0 {
     width: auto;
   }
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:1025px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
 }
 
 <button

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -307,7 +307,7 @@ exports[`dropdown is not visible if items fit 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
         >
           <span
             class="c5"
@@ -685,7 +685,7 @@ exports[`it renders the given tabs 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
         >
           <span
             class="c5"
@@ -1063,7 +1063,7 @@ exports[`only the pills that fit are visible 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
         >
           <span
             class="c5"
@@ -1078,7 +1078,7 @@ exports[`only the pills that fit are visible 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
           disabled=""
         >
           <span
@@ -1094,7 +1094,7 @@ exports[`only the pills that fit are visible 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
           disabled=""
         >
           <span
@@ -1473,7 +1473,7 @@ exports[`only the pills that fit are visible 2 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
         >
           <span
             class="c5"
@@ -1488,7 +1488,7 @@ exports[`only the pills that fit are visible 2 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
         >
           <span
             class="c5"
@@ -1503,7 +1503,7 @@ exports[`only the pills that fit are visible 2 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
           disabled=""
         >
           <span
@@ -1882,7 +1882,7 @@ exports[`renders all the filters if they fit 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
         >
           <span
             class="c5"
@@ -1897,7 +1897,7 @@ exports[`renders all the filters if they fit 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
         >
           <span
             class="c5"
@@ -1912,7 +1912,7 @@ exports[`renders all the filters if they fit 1`] = `
         role="listitem"
       >
         <button
-          class="c4 "
+          class="c4 styled__StyledPillTab-sc-1n62hko-0"
         >
           <span
             class="c5"
@@ -2290,7 +2290,7 @@ exports[`renders dropdown if items do not fit 1`] = `
         role="listitem"
       >
         <button
-          class="c5 "
+          class="c5 styled__StyledPillTab-sc-1n62hko-0"
           disabled=""
         >
           <span
@@ -2306,7 +2306,7 @@ exports[`renders dropdown if items do not fit 1`] = `
         role="listitem"
       >
         <button
-          class="c5 "
+          class="c5 styled__StyledPillTab-sc-1n62hko-0"
           disabled=""
         >
           <span

--- a/packages/big-design/src/components/ProgressBar/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/ProgressBar/__snapshots__/spec.tsx.snap
@@ -46,8 +46,8 @@ exports[`render indeterminant progress bar 1`] = `
   background-color: #3C64F4;
   height: 100%;
   overflow: hidden;
-  -webkit-animation: jIOEOd 2s ease-in-out infinite;
-  animation: jIOEOd 2s ease-in-out infinite;
+  -webkit-animation: cdRApH 2s ease-in-out infinite;
+  animation: cdRApH 2s ease-in-out infinite;
   position: relative;
   width: 6.25%;
 }

--- a/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
@@ -48,9 +48,6 @@ exports[`render determinant progress circle 1`] = `
 }
 
 .c2 {
-  fill: transparent;
-  stroke-width: 0.25rem;
-  stroke: #ECEEF5;
   stroke-dasharray: 138.23007675795088 138.23007675795088;
   stroke: #3C64F4;
   -webkit-transform-origin: 50% 50%;
@@ -84,7 +81,7 @@ exports[`render determinant progress circle 1`] = `
       r="1.375em"
     />
     <circle
-      class="c2"
+      class="c1 c2"
       cx="1.5em"
       cy="1.5em"
       r="1.375em"
@@ -148,16 +145,13 @@ exports[`render indeterminant progress bar 1`] = `
 }
 
 .c2 {
-  fill: transparent;
-  stroke-width: 0.25rem;
-  stroke: #ECEEF5;
   stroke-dasharray: 138.23007675795088 138.23007675795088;
   stroke: #3C64F4;
   -webkit-transform-origin: 50% 50%;
   -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: dpAsNn 1s ease-out infinite;
-  animation: dpAsNn 1s ease-out infinite;
+  -webkit-animation: dfVSSu 1s ease-out infinite;
+  animation: dfVSSu 1s ease-out infinite;
   stroke-dashoffset: 138.23007675795088;
   -webkit-transform: rotate(-90deg);
   -ms-transform: rotate(-90deg);
@@ -178,7 +172,7 @@ exports[`render indeterminant progress bar 1`] = `
       r="1.375em"
     />
     <circle
-      class="c2"
+      class="c1 c2"
       cx="1.5em"
       cy="1.5em"
       r="1.375em"
@@ -200,16 +194,13 @@ exports[`render large progress circle 1`] = `
 }
 
 .c2 {
-  fill: transparent;
-  stroke-width: 0.5rem;
-  stroke: #ECEEF5;
   stroke-dasharray: 226.1946710584651 226.1946710584651;
   stroke: #3C64F4;
   -webkit-transform-origin: 50% 50%;
   -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: ibtQPx 1s ease-out infinite;
-  animation: ibtQPx 1s ease-out infinite;
+  -webkit-animation: krEchf 1s ease-out infinite;
+  animation: krEchf 1s ease-out infinite;
   stroke-dashoffset: 226.1946710584651;
   -webkit-transform: rotate(-90deg);
   -ms-transform: rotate(-90deg);
@@ -230,7 +221,7 @@ exports[`render large progress circle 1`] = `
       r="2.25em"
     />
     <circle
-      class="c2"
+      class="c1 c2"
       cx="2.5em"
       cy="2.5em"
       r="2.25em"
@@ -252,16 +243,13 @@ exports[`render medium progress circle 1`] = `
 }
 
 .c2 {
-  fill: transparent;
-  stroke-width: 0.25rem;
-  stroke: #ECEEF5;
   stroke-dasharray: 138.23007675795088 138.23007675795088;
   stroke: #3C64F4;
   -webkit-transform-origin: 50% 50%;
   -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: dpAsNn 1s ease-out infinite;
-  animation: dpAsNn 1s ease-out infinite;
+  -webkit-animation: dfVSSu 1s ease-out infinite;
+  animation: dfVSSu 1s ease-out infinite;
   stroke-dashoffset: 138.23007675795088;
   -webkit-transform: rotate(-90deg);
   -ms-transform: rotate(-90deg);
@@ -282,7 +270,7 @@ exports[`render medium progress circle 1`] = `
       r="1.375em"
     />
     <circle
-      class="c2"
+      class="c1 c2"
       cx="1.5em"
       cy="1.5em"
       r="1.375em"
@@ -304,16 +292,13 @@ exports[`render small progress circle 1`] = `
 }
 
 .c2 {
-  fill: transparent;
-  stroke-width: 0.25rem;
-  stroke: #ECEEF5;
   stroke-dasharray: 87.96459430051421 87.96459430051421;
   stroke: #3C64F4;
   -webkit-transform-origin: 50% 50%;
   -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: cYXnLG 1s ease-out infinite;
-  animation: cYXnLG 1s ease-out infinite;
+  -webkit-animation: kpuuIv 1s ease-out infinite;
+  animation: kpuuIv 1s ease-out infinite;
   stroke-dashoffset: 87.96459430051421;
   -webkit-transform: rotate(-90deg);
   -ms-transform: rotate(-90deg);
@@ -334,7 +319,7 @@ exports[`render small progress circle 1`] = `
       r="0.875em"
     />
     <circle
-      class="c2"
+      class="c1 c2"
       cx="1em"
       cy="1em"
       r="0.875em"
@@ -356,16 +341,13 @@ exports[`render xSmall progress circle 1`] = `
 }
 
 .c2 {
-  fill: transparent;
-  stroke-width: 0.1875rem;
-  stroke: #ECEEF5;
   stroke-dasharray: 65.97344572538566 65.97344572538566;
   stroke: #3C64F4;
   -webkit-transform-origin: 50% 50%;
   -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: ceJQKV 1s ease-out infinite;
-  animation: ceJQKV 1s ease-out infinite;
+  -webkit-animation: hiqbsE 1s ease-out infinite;
+  animation: hiqbsE 1s ease-out infinite;
   stroke-dashoffset: 65.97344572538566;
   -webkit-transform: rotate(-90deg);
   -ms-transform: rotate(-90deg);
@@ -386,7 +368,7 @@ exports[`render xSmall progress circle 1`] = `
       r="0.65625em"
     />
     <circle
-      class="c2"
+      class="c1 c2"
       cx="0.75em"
       cy="0.75em"
       r="0.65625em"
@@ -408,16 +390,13 @@ exports[`render xSmall progress circle 2`] = `
 }
 
 .c2 {
-  fill: transparent;
-  stroke-width: 0.125rem;
-  stroke: #ECEEF5;
   stroke-dasharray: 43.982297150257104 43.982297150257104;
   stroke: #3C64F4;
   -webkit-transform-origin: 50% 50%;
   -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: cWvsXs 1s ease-out infinite;
-  animation: cWvsXs 1s ease-out infinite;
+  -webkit-animation: fxwtRW 1s ease-out infinite;
+  animation: fxwtRW 1s ease-out infinite;
   stroke-dashoffset: 43.982297150257104;
   -webkit-transform: rotate(-90deg);
   -ms-transform: rotate(-90deg);
@@ -438,7 +417,7 @@ exports[`render xSmall progress circle 2`] = `
       r="0.4375em"
     />
     <circle
-      class="c2"
+      class="c1 c2"
       cx="0.5em"
       cy="0.5em"
       r="0.4375em"

--- a/packages/big-design/src/components/ProgressCircle/styled.tsx
+++ b/packages/big-design/src/components/ProgressCircle/styled.tsx
@@ -22,7 +22,6 @@ export const StyledCircle = styled.circle.attrs(({ size, theme }: any) => ({
   stroke: ${({ theme }) => theme.colors.secondary20};
 `;
 
-// @ts-expect-error TODO: Remove after upgrading to styled-components v5
 export const StyledCircleFiller = styled(StyledCircle)<ProgressCircleProps>`
   stroke-dasharray: ${({ size }) => getStrokeDashArray(size)};
   stroke: ${({ theme }) => theme.colors.primary};

--- a/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
@@ -1,21 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`render Radio (checked + disabled) 1`] = `
-.c5 {
+.c6 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
+.c7 {
   cursor: pointer;
   cursor: not-allowed;
 }
 
-.c5:last-child {
-  margin-bottom: 0;
-}
-
-.c4 {
+.c5 {
   margin-left: 0.5rem;
 }
 
@@ -43,15 +46,7 @@ exports[`render Radio (checked + disabled) 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c6 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c1:focus + .c7 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,box-shadow;
@@ -81,7 +76,7 @@ exports[`render Radio (checked + disabled) 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3:after {
+.c4:after {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: opacity;
@@ -100,7 +95,7 @@ exports[`render Radio (checked + disabled) 1`] = `
   width: 0.75rem;
 }
 
-.c3:after {
+.c4:after {
   opacity: 1;
 }
 
@@ -118,16 +113,16 @@ exports[`render Radio (checked + disabled) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     disabled=""
     for="bd-radio-1"
   />
   <div
-    class="c4"
+    class="c5"
   >
     <label
       aria-hidden="true"
-      class="c5"
+      class="c6 c7"
       disabled=""
       for="bd-radio-1"
       id="bd-radio_label-2"
@@ -139,20 +134,23 @@ exports[`render Radio (checked + disabled) 1`] = `
 `;
 
 exports[`render Radio (checked) 1`] = `
-.c5 {
+.c6 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  cursor: pointer;
 }
 
-.c5:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c4 {
+.c7 {
+  cursor: pointer;
+}
+
+.c5 {
   margin-left: 0.5rem;
 }
 
@@ -180,7 +178,7 @@ exports[`render Radio (checked) 1`] = `
   width: 1px;
 }
 
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,box-shadow;
@@ -204,7 +202,7 @@ exports[`render Radio (checked) 1`] = `
   width: 1.25rem;
 }
 
-.c3:hover {
+.c4:hover {
   border-color: #2852EB;
 }
 
@@ -212,7 +210,7 @@ exports[`render Radio (checked) 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3:after {
+.c4:after {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: opacity;
@@ -231,7 +229,7 @@ exports[`render Radio (checked) 1`] = `
   width: 0.75rem;
 }
 
-.c3:after {
+.c4:after {
   opacity: 1;
 }
 
@@ -248,14 +246,14 @@ exports[`render Radio (checked) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     for="bd-radio-1"
   />
   <div
-    class="c4"
+    class="c5"
   >
     <label
-      class="c5"
+      class="c6 c7"
       for="bd-radio-1"
       id="bd-radio_label-2"
     >
@@ -269,6 +267,18 @@ exports[`render Radio (unchecked + description object) 1`] = `
 .c6 {
   color: #313440;
   margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
+.c8 {
+  color: #313440;
+  margin: 0 0 1rem;
   color: #5E637A;
   font-size: 0.875rem;
   font-weight: 400;
@@ -276,11 +286,11 @@ exports[`render Radio (unchecked + description object) 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c6:last-child {
+.c8:last-child {
   margin-bottom: 0;
 }
 
-.c7 {
+.c9 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -293,32 +303,23 @@ exports[`render Radio (unchecked + description object) 1`] = `
   text-decoration: none;
 }
 
-.c7:active {
+.c9:active {
   color: #0024A6;
 }
 
-.c7:hover:not(:active) {
+.c9:hover:not(:active) {
   color: #0024A6;
 }
 
-.c8 {
+.c10 {
   font-size: 0.875rem;
 }
 
-.c5 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
+.c7 {
   cursor: pointer;
 }
 
-.c5:last-child {
-  margin-bottom: 0;
-}
-
-.c4 {
+.c5 {
   margin-left: 0.5rem;
 }
 
@@ -346,11 +347,7 @@ exports[`render Radio (unchecked + description object) 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c9 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,box-shadow;
@@ -374,7 +371,7 @@ exports[`render Radio (unchecked + description object) 1`] = `
   width: 1.25rem;
 }
 
-.c3:hover {
+.c4:hover {
   border-color: #B4BAD1;
 }
 
@@ -382,7 +379,7 @@ exports[`render Radio (unchecked + description object) 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3:after {
+.c4:after {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: opacity;
@@ -413,26 +410,26 @@ exports[`render Radio (unchecked + description object) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     for="bd-radio-1"
   />
   <div
-    class="c4"
+    class="c5"
   >
     <label
-      class="c5"
+      class="c6 c7"
       for="bd-radio-1"
       id="bd-radio_label-2"
     >
       Unchecked
     </label>
     <p
-      class="c6"
+      class="c8"
     >
       description
        
       <a
-        class="c7 c8"
+        class="c9 c10"
         href="bar"
         target="foo"
       >
@@ -447,6 +444,18 @@ exports[`render Radio (unchecked + description text) 1`] = `
 .c6 {
   color: #313440;
   margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
+.c8 {
+  color: #313440;
+  margin: 0 0 1rem;
   color: #5E637A;
   font-size: 0.875rem;
   font-weight: 400;
@@ -454,24 +463,15 @@ exports[`render Radio (unchecked + description text) 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c6:last-child {
+.c8:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
+.c7 {
   cursor: pointer;
 }
 
-.c5:last-child {
-  margin-bottom: 0;
-}
-
-.c4 {
+.c5 {
   margin-left: 0.5rem;
 }
 
@@ -499,11 +499,7 @@ exports[`render Radio (unchecked + description text) 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c7 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,box-shadow;
@@ -527,7 +523,7 @@ exports[`render Radio (unchecked + description text) 1`] = `
   width: 1.25rem;
 }
 
-.c3:hover {
+.c4:hover {
   border-color: #B4BAD1;
 }
 
@@ -535,7 +531,7 @@ exports[`render Radio (unchecked + description text) 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3:after {
+.c4:after {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: opacity;
@@ -566,21 +562,21 @@ exports[`render Radio (unchecked + description text) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     for="bd-radio-1"
   />
   <div
-    class="c4"
+    class="c5"
   >
     <label
-      class="c5"
+      class="c6 c7"
       for="bd-radio-1"
       id="bd-radio_label-2"
     >
       Unchecked
     </label>
     <p
-      class="c6"
+      class="c8"
     >
       description
     </p>
@@ -589,21 +585,24 @@ exports[`render Radio (unchecked + description text) 1`] = `
 `;
 
 exports[`render Radio (unchecked + disabled) 1`] = `
-.c5 {
+.c6 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
+.c7 {
   cursor: pointer;
   cursor: not-allowed;
 }
 
-.c5:last-child {
-  margin-bottom: 0;
-}
-
-.c4 {
+.c5 {
   margin-left: 0.5rem;
 }
 
@@ -631,19 +630,7 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c6 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c1:focus + .c7 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c1:focus + .c8 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,box-shadow;
@@ -673,7 +660,7 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3:after {
+.c4:after {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: opacity;
@@ -705,16 +692,16 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     disabled=""
     for="bd-radio-1"
   />
   <div
-    class="c4"
+    class="c5"
   >
     <label
       aria-hidden="true"
-      class="c5"
+      class="c6 c7"
       disabled=""
       for="bd-radio-1"
       id="bd-radio_label-2"
@@ -726,20 +713,23 @@ exports[`render Radio (unchecked + disabled) 1`] = `
 `;
 
 exports[`render Radio (unchecked) 1`] = `
-.c5 {
+.c6 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  cursor: pointer;
 }
 
-.c5:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c4 {
+.c7 {
+  cursor: pointer;
+}
+
+.c5 {
   margin-left: 0.5rem;
 }
 
@@ -767,11 +757,7 @@ exports[`render Radio (unchecked) 1`] = `
   width: 1px;
 }
 
-.c1:focus + .c6 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,box-shadow;
@@ -795,7 +781,7 @@ exports[`render Radio (unchecked) 1`] = `
   width: 1.25rem;
 }
 
-.c3:hover {
+.c4:hover {
   border-color: #B4BAD1;
 }
 
@@ -803,7 +789,7 @@ exports[`render Radio (unchecked) 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c3:after {
+.c4:after {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: opacity;
@@ -834,14 +820,14 @@ exports[`render Radio (unchecked) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3"
+    class="c3 c4"
     for="bd-radio-1"
   />
   <div
-    class="c4"
+    class="c5"
   >
     <label
-      class="c5"
+      class="c6 c7"
       for="bd-radio-1"
       id="bd-radio_label-2"
     >

--- a/packages/big-design/src/components/Stepper/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Stepper/__snapshots__/spec.tsx.snap
@@ -21,22 +21,22 @@ exports[`renders Stepper 1`] = `
   background-color: #3C64F4;
 }
 
-.c12 {
+.c13 {
   margin-bottom: 1.5rem;
   box-sizing: border-box;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   background-color: #D9DCE9;
 }
 
-.c16 {
+.c17 {
   box-sizing: border-box;
   background-color: #8C93AD;
 }
 
-.c17 {
+.c18 {
   box-sizing: border-box;
   background-color: #D9DCE9;
 }
@@ -101,9 +101,33 @@ exports[`renders Stepper 1`] = `
   display: grid;
 }
 
-.c13 {
+.c14 {
   grid-gap: 1rem;
   display: grid;
+}
+
+.c11 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c11:last-child {
+  margin-bottom: 0;
+}
+
+.c19 {
+  color: #8C93AD;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c19:last-child {
+  margin-bottom: 0;
 }
 
 .c4 {
@@ -134,30 +158,8 @@ exports[`renders Stepper 1`] = `
   width: 100%;
 }
 
-.c11 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
+.c12 {
   grid-area: text;
-}
-
-.c11:last-child {
-  margin-bottom: 0;
-}
-
-.c18 {
-  color: #8C93AD;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-  grid-area: text;
-}
-
-.c18:last-child {
-  margin-bottom: 0;
 }
 
 @media (min-width:0px) {
@@ -219,71 +221,71 @@ exports[`renders Stepper 1`] = `
 }
 
 @media (min-width:0px) {
-  .c12 {
+  .c13 {
     display: grid;
   }
 }
 
 @media (min-width:720px) {
-  .c12 {
+  .c13 {
     display: grid;
   }
 }
 
 @media (min-width:720px) {
-  .c12 {
+  .c13 {
     margin-right: 0.5rem;
   }
 }
 
 @media (min-width:0px) {
-  .c15 {
+  .c16 {
     display: none;
   }
 }
 
 @media (min-width:720px) {
-  .c15 {
+  .c16 {
     display: block;
   }
 }
 
 @media (min-width:0px) {
-  .c16 {
+  .c17 {
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;
   }
 }
 
 @media (min-width:720px) {
-  .c16 {
+  .c17 {
     padding-top: 0;
     padding-bottom: 0;
   }
 }
 
 @media (min-width:0px) {
-  .c16 {
+  .c17 {
     padding-left: 0.5rem;
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c16 {
+  .c17 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
 @media (min-width:0px) {
-  .c17 {
+  .c18 {
     display: none;
   }
 }
 
 @media (min-width:720px) {
-  .c17 {
+  .c18 {
     display: none;
   }
 }
@@ -301,13 +303,13 @@ exports[`renders Stepper 1`] = `
 }
 
 @media (min-width:0px) {
-  .c13 {
+  .c14 {
     display: grid;
   }
 }
 
 @media (min-width:720px) {
-  .c13 {
+  .c14 {
     display: grid;
   }
 }
@@ -322,7 +324,7 @@ exports[`renders Stepper 1`] = `
 }
 
 @media (min-width:720px) {
-  .c14 {
+  .c15 {
     border: 0;
     -webkit-clip: rect(0 0 0 0);
     clip: rect(0 0 0 0);
@@ -383,14 +385,14 @@ exports[`renders Stepper 1`] = `
       display="[object Object]"
     />
     <p
-      class="c11"
+      class="c11 c12"
       color="secondary70"
     >
       Login
     </p>
   </div>
   <div
-    class="c12 c13 c4"
+    class="c13 c14 c4"
     display="[object Object]"
   >
     <div
@@ -398,13 +400,13 @@ exports[`renders Stepper 1`] = `
     >
       <span>
         <span
-          class="c14"
+          class="c15"
         >
           Step
         </span>
          2 
         <span
-          class="c14"
+          class="c15"
         >
           of 
           3
@@ -412,11 +414,11 @@ exports[`renders Stepper 1`] = `
       </span>
     </div>
     <div
-      class="c15 c10"
+      class="c16 c10"
       display="[object Object]"
     />
     <p
-      class="c11"
+      class="c11 c12"
       color="secondary70"
     >
       Settings
@@ -427,17 +429,17 @@ exports[`renders Stepper 1`] = `
     display="[object Object]"
   >
     <div
-      class="c16 c6 c7"
+      class="c17 c6 c7"
     >
       <span>
         <span
-          class="c14"
+          class="c15"
         >
           Step
         </span>
          3 
         <span
-          class="c14"
+          class="c15"
         >
           of 
           3
@@ -445,11 +447,11 @@ exports[`renders Stepper 1`] = `
       </span>
     </div>
     <div
-      class="c17 c10"
+      class="c18 c10"
       display="[object Object]"
     />
     <p
-      class="c18"
+      class="c19 c12"
       color="secondary50"
     >
       Import

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -548,7 +548,7 @@ exports[`renders a simple table 1`] = `
   id="bd-table-1"
 >
   <thead
-    class=""
+    class="styled__StyledTableHead-sc-1p8j1x-0"
   >
     <tr>
       <th
@@ -581,7 +581,7 @@ exports[`renders a simple table 1`] = `
     </tr>
   </thead>
   <tbody
-    class=""
+    class="styled__StyledTableBody-sc-1bwe2hn-0"
   >
     <tr
       class="c5"
@@ -702,23 +702,23 @@ exports[`renders a table figure 1`] = `
 `;
 
 exports[`selectable renders selectable actions and checkboxes 1`] = `
-.c9 {
+.c10 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
+}
+
+.c1 {
+  margin-right: 0.25rem;
+  box-sizing: border-box;
 }
 
 .c3 {
   box-sizing: border-box;
 }
 
-.c13 {
+.c15 {
   margin-right: 1rem;
-  box-sizing: border-box;
-}
-
-.c1 {
-  margin-right: 0.25rem;
   box-sizing: border-box;
 }
 
@@ -765,20 +765,19 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   flex-shrink: 0;
 }
 
-.c14 {
+.c12 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
-  margin: 0;
 }
 
-.c14:last-child {
+.c12:last-child {
   margin-bottom: 0;
 }
 
-.c12 {
+.c14 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -787,16 +786,24 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin-left: 0.75rem;
 }
 
-.c12:last-child {
+.c14:last-child {
   margin-bottom: 0;
 }
 
-.c11 {
+.c16 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0;
+}
+
+.c16:last-child {
+  margin-bottom: 0;
+}
+
+.c13 {
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -810,11 +817,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   width: 1px;
 }
 
-.c11:last-child {
-  margin-bottom: 0;
-}
-
-.c10 {
+.c11 {
   margin-left: 0.5rem;
 }
 
@@ -842,7 +845,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   width: 1px;
 }
 
-.c8 {
+.c9 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -873,7 +876,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   width: 1.25rem;
 }
 
-.c8:hover {
+.c9:hover {
   border-color: #B4BAD1;
 }
 
@@ -881,7 +884,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c8 svg {
+.c9 svg {
   opacity: 0;
 }
 
@@ -927,11 +930,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         />
         <label
           aria-hidden="true"
-          class="c8"
+          class="c8 c9"
           for="bd-checkbox-2"
         >
           <svg
-            class="c9"
+            class="c10"
             fill="currentColor"
             height="24"
             stroke="currentColor"
@@ -949,10 +952,10 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
           </svg>
         </label>
         <div
-          class="c10"
+          class="c11"
         >
           <label
-            class="c11"
+            class="c12 c13"
             for="bd-checkbox-2"
             hidden=""
             id="bd-checkbox_label-3"
@@ -962,17 +965,17 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         </div>
       </div>
       <p
-        class="c12"
+        class="c14"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c13 c2"
+    class="c15 c2"
   >
     <p
-      class="c14"
+      class="c16"
     >
       Product
     </p>

--- a/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders all together 1`] = `
-.c2 {
+.c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13,7 +13,7 @@ exports[`renders all together 1`] = `
   position: relative;
 }
 
-.c3 {
+.c4 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border,box-shadow;
@@ -30,55 +30,41 @@ exports[`renders all together 1`] = `
   border: 1px solid #D9DCE9;
 }
 
-.c3:hover:not([disabled]) {
+.c4:hover:not([disabled]) {
   border: 1px solid #B4BAD1;
 }
 
-.c3:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 0 4px #DBE3FE;
 }
 
-.c3[disabled] {
+.c4[disabled] {
   background-color: #ECEEF5;
 }
 
-.c3::-webkit-input-placeholder {
+.c4::-webkit-input-placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
 }
 
-.c3::-moz-placeholder {
+.c4::-moz-placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
 }
 
-.c3:-ms-input-placeholder {
+.c4:-ms-input-placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
 }
 
-.c3::placeholder {
+.c4::placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
-}
-
-.c1 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
-}
-
-.c1:last-child {
-  margin-bottom: 0;
 }
 
 .c0 {
@@ -88,12 +74,29 @@ exports[`renders all together 1`] = `
   font-weight: 600;
   line-height: 1.5rem;
   margin: 0 0 0.5rem;
+}
+
+.c2 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c2:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
   cursor: pointer;
   display: inline-block;
   margin-bottom: 0.25rem;
 }
 
-.c0::after {
+.c1::after {
   color: #5E637A;
   content: ' (optional)';
   font-weight: 400;
@@ -101,21 +104,21 @@ exports[`renders all together 1`] = `
 
 <div>
   <label
-    class="c0"
+    class="c0 c1"
     for="bd-textarea-1"
   >
     This is a label
   </label>
   <p
-    class="c1"
+    class="c2"
   >
     This is a description
   </p>
   <span
-    class="c2"
+    class="c3"
   >
     <textarea
-      class="c3"
+      class="c4"
       id="bd-textarea-1"
       rows="3"
     />

--- a/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
@@ -3,24 +3,24 @@
 exports[`renders simple tree 1`] = `
 <ul
   aria-multiselectable="false"
-  class="styled__StyledUl-sc-6366r7-0 iHJsrG"
+  class="styled__StyledUl-sc-6366r7-0 hzNMDM"
   role="tree"
   style="overflow: hidden;"
 >
   <li
     aria-expanded="false"
-    class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    class="styled__StyledLi-sc-1073t7q-0 ldordH"
     role="treeitem"
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 ftWMUg styled__StyledFlex-sc-1073t7q-3 follZc"
+      class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 bIUvrh styled__StyledFlex-sc-1073t7q-3 dKOZZC"
     >
       <div
-        class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledArrowWrapper-sc-1073t7q-1 eFYBMc"
+        class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledArrowWrapper-sc-1073t7q-1 halJjp"
       >
         <svg
-          class="base__StyledIcon-sc-a9u0e1-0 fIiSXl"
+          class="base__StyledIcon-sc-a9u0e1-0 kwHAib"
           color="secondary60"
           fill="currentColor"
           focusable="false"
@@ -40,10 +40,10 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <div
-        class="styled__StyledBox-sc-sj5f1m-0 cITQi styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledFlexItem-sc-1073t7q-4 fYuUQB"
+        class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
       >
         <svg
-          class="base__StyledIcon-sc-a9u0e1-0 dcaOlN"
+          class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
           color="primary30"
           fill="currentColor"
           height="24"
@@ -62,30 +62,30 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <span
-        class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 bodesl"
+        class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 kYSPkb gbMvLN"
         color="secondary70"
       >
         Test Node 0
       </span>
     </div>
     <ul
-      class="styled__StyledUl-sc-6366r7-0 dJzoXA"
+      class="styled__StyledUl-sc-6366r7-0 ePnAUJ"
       role="group"
     >
       <li
         aria-expanded="false"
-        class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+        class="styled__StyledLi-sc-1073t7q-0 ldordH"
         role="treeitem"
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 ftWMUg styled__StyledFlex-sc-1073t7q-3 follZc"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 bIUvrh styled__StyledFlex-sc-1073t7q-3 dKOZZC"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledArrowWrapper-sc-1073t7q-1 eFYBMc"
+            class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledArrowWrapper-sc-1073t7q-1 halJjp"
           >
             <svg
-              class="base__StyledIcon-sc-a9u0e1-0 fIiSXl"
+              class="base__StyledIcon-sc-a9u0e1-0 kwHAib"
               color="secondary60"
               fill="currentColor"
               focusable="false"
@@ -105,10 +105,10 @@ exports[`renders simple tree 1`] = `
             </svg>
           </div>
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 cITQi styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledFlexItem-sc-1073t7q-4 fYuUQB"
+            class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
           >
             <svg
-              class="base__StyledIcon-sc-a9u0e1-0 dcaOlN"
+              class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
               color="primary30"
               fill="currentColor"
               height="24"
@@ -127,33 +127,33 @@ exports[`renders simple tree 1`] = `
             </svg>
           </div>
           <span
-            class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 bodesl"
+            class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 kYSPkb gbMvLN"
             color="secondary70"
           >
             Test Node 5
           </span>
         </div>
         <ul
-          class="styled__StyledUl-sc-6366r7-0 dJzoXA"
+          class="styled__StyledUl-sc-6366r7-0 ePnAUJ"
           role="group"
         >
           <li
             aria-expanded="false"
-            class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+            class="styled__StyledLi-sc-1073t7q-0 ldordH"
             role="treeitem"
             tabindex="-1"
           >
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 ftWMUg styled__StyledFlex-sc-1073t7q-3 follZc"
+              class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 bIUvrh styled__StyledFlex-sc-1073t7q-3 dKOZZC"
             >
               <div
-                class="styled__StyledGap-sc-1073t7q-5 NiMQL"
+                class="styled__StyledGap-sc-1073t7q-5 jtlobL"
               />
               <div
-                class="styled__StyledBox-sc-sj5f1m-0 cITQi styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledFlexItem-sc-1073t7q-4 fYuUQB"
+                class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
               >
                 <svg
-                  class="base__StyledIcon-sc-a9u0e1-0 dcaOlN"
+                  class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
                   color="primary30"
                   fill="currentColor"
                   height="24"
@@ -172,7 +172,7 @@ exports[`renders simple tree 1`] = `
                 </svg>
               </div>
               <span
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 bodesl"
+                class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 kYSPkb gbMvLN"
                 color="secondary70"
               >
                 Test Node 9
@@ -185,18 +185,18 @@ exports[`renders simple tree 1`] = `
   </li>
   <li
     aria-expanded="false"
-    class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    class="styled__StyledLi-sc-1073t7q-0 ldordH"
     role="treeitem"
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 ftWMUg styled__StyledFlex-sc-1073t7q-3 follZc"
+      class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 bIUvrh styled__StyledFlex-sc-1073t7q-3 dKOZZC"
     >
       <div
-        class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledArrowWrapper-sc-1073t7q-1 eFYBMc"
+        class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledArrowWrapper-sc-1073t7q-1 halJjp"
       >
         <svg
-          class="base__StyledIcon-sc-a9u0e1-0 fIiSXl"
+          class="base__StyledIcon-sc-a9u0e1-0 kwHAib"
           color="secondary60"
           fill="currentColor"
           focusable="false"
@@ -216,10 +216,10 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <div
-        class="styled__StyledBox-sc-sj5f1m-0 cITQi styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledFlexItem-sc-1073t7q-4 fYuUQB"
+        class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
       >
         <svg
-          class="base__StyledIcon-sc-a9u0e1-0 dcaOlN"
+          class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
           color="primary30"
           fill="currentColor"
           height="24"
@@ -238,33 +238,33 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <span
-        class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 bodesl"
+        class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 kYSPkb gbMvLN"
         color="secondary70"
       >
         Test Node 1
       </span>
     </div>
     <ul
-      class="styled__StyledUl-sc-6366r7-0 dJzoXA"
+      class="styled__StyledUl-sc-6366r7-0 ePnAUJ"
       role="group"
     >
       <li
         aria-expanded="false"
-        class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+        class="styled__StyledLi-sc-1073t7q-0 ldordH"
         role="treeitem"
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 ftWMUg styled__StyledFlex-sc-1073t7q-3 follZc"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 bIUvrh styled__StyledFlex-sc-1073t7q-3 dKOZZC"
         >
           <div
-            class="styled__StyledGap-sc-1073t7q-5 NiMQL"
+            class="styled__StyledGap-sc-1073t7q-5 jtlobL"
           />
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 cITQi styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledFlexItem-sc-1073t7q-4 fYuUQB"
+            class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
           >
             <svg
-              class="base__StyledIcon-sc-a9u0e1-0 dcaOlN"
+              class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
               color="primary30"
               fill="currentColor"
               height="24"
@@ -283,7 +283,7 @@ exports[`renders simple tree 1`] = `
             </svg>
           </div>
           <span
-            class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 bodesl"
+            class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 kYSPkb gbMvLN"
             color="secondary70"
           >
             Test Node 6
@@ -294,21 +294,21 @@ exports[`renders simple tree 1`] = `
   </li>
   <li
     aria-expanded="false"
-    class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    class="styled__StyledLi-sc-1073t7q-0 ldordH"
     role="treeitem"
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 ftWMUg styled__StyledFlex-sc-1073t7q-3 follZc"
+      class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 bIUvrh styled__StyledFlex-sc-1073t7q-3 dKOZZC"
     >
       <div
-        class="styled__StyledGap-sc-1073t7q-5 NiMQL"
+        class="styled__StyledGap-sc-1073t7q-5 jtlobL"
       />
       <div
-        class="styled__StyledBox-sc-sj5f1m-0 cITQi styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledFlexItem-sc-1073t7q-4 fYuUQB"
+        class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
       >
         <svg
-          class="base__StyledIcon-sc-a9u0e1-0 dcaOlN"
+          class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
           color="primary30"
           fill="currentColor"
           height="24"
@@ -327,7 +327,7 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <span
-        class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 bodesl"
+        class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 kYSPkb gbMvLN"
         color="secondary70"
       >
         Category
@@ -336,18 +336,18 @@ exports[`renders simple tree 1`] = `
   </li>
   <li
     aria-expanded="false"
-    class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    class="styled__StyledLi-sc-1073t7q-0 ldordH"
     role="treeitem"
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 ftWMUg styled__StyledFlex-sc-1073t7q-3 follZc"
+      class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 bIUvrh styled__StyledFlex-sc-1073t7q-3 dKOZZC"
     >
       <div
-        class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledArrowWrapper-sc-1073t7q-1 eFYBMc"
+        class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledArrowWrapper-sc-1073t7q-1 halJjp"
       >
         <svg
-          class="base__StyledIcon-sc-a9u0e1-0 fIiSXl"
+          class="base__StyledIcon-sc-a9u0e1-0 kwHAib"
           color="secondary60"
           fill="currentColor"
           focusable="false"
@@ -367,10 +367,10 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <div
-        class="styled__StyledBox-sc-sj5f1m-0 cITQi styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledFlexItem-sc-1073t7q-4 fYuUQB"
+        class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
       >
         <svg
-          class="base__StyledIcon-sc-a9u0e1-0 dcaOlN"
+          class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
           color="primary30"
           fill="currentColor"
           height="24"
@@ -389,33 +389,33 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <span
-        class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 bodesl"
+        class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 kYSPkb gbMvLN"
         color="secondary70"
       >
         Test Node 3
       </span>
     </div>
     <ul
-      class="styled__StyledUl-sc-6366r7-0 dJzoXA"
+      class="styled__StyledUl-sc-6366r7-0 ePnAUJ"
       role="group"
     >
       <li
         aria-expanded="false"
-        class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+        class="styled__StyledLi-sc-1073t7q-0 ldordH"
         role="treeitem"
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 ftWMUg styled__StyledFlex-sc-1073t7q-3 follZc"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 bIUvrh styled__StyledFlex-sc-1073t7q-3 dKOZZC"
         >
           <div
-            class="styled__StyledGap-sc-1073t7q-5 NiMQL"
+            class="styled__StyledGap-sc-1073t7q-5 jtlobL"
           />
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 cITQi styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledFlexItem-sc-1073t7q-4 fYuUQB"
+            class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
           >
             <svg
-              class="base__StyledIcon-sc-a9u0e1-0 dcaOlN"
+              class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
               color="primary30"
               fill="currentColor"
               height="24"
@@ -434,7 +434,7 @@ exports[`renders simple tree 1`] = `
             </svg>
           </div>
           <span
-            class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 bodesl"
+            class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 kYSPkb gbMvLN"
             color="secondary70"
           >
             Test Node 7
@@ -445,18 +445,18 @@ exports[`renders simple tree 1`] = `
   </li>
   <li
     aria-expanded="false"
-    class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+    class="styled__StyledLi-sc-1073t7q-0 ldordH"
     role="treeitem"
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 ftWMUg styled__StyledFlex-sc-1073t7q-3 follZc"
+      class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 bIUvrh styled__StyledFlex-sc-1073t7q-3 dKOZZC"
     >
       <div
-        class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledArrowWrapper-sc-1073t7q-1 eFYBMc"
+        class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledArrowWrapper-sc-1073t7q-1 halJjp"
       >
         <svg
-          class="base__StyledIcon-sc-a9u0e1-0 fIiSXl"
+          class="base__StyledIcon-sc-a9u0e1-0 kwHAib"
           color="secondary60"
           fill="currentColor"
           focusable="false"
@@ -476,10 +476,10 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <div
-        class="styled__StyledBox-sc-sj5f1m-0 cITQi styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledFlexItem-sc-1073t7q-4 fYuUQB"
+        class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
       >
         <svg
-          class="base__StyledIcon-sc-a9u0e1-0 dcaOlN"
+          class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
           color="primary30"
           fill="currentColor"
           height="24"
@@ -498,33 +498,33 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <span
-        class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 bodesl"
+        class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 kYSPkb gbMvLN"
         color="secondary70"
       >
         Test Node 4
       </span>
     </div>
     <ul
-      class="styled__StyledUl-sc-6366r7-0 dJzoXA"
+      class="styled__StyledUl-sc-6366r7-0 ePnAUJ"
       role="group"
     >
       <li
         aria-expanded="false"
-        class="styled__StyledLi-sc-1073t7q-0 bXJWhx"
+        class="styled__StyledLi-sc-1073t7q-0 ldordH"
         role="treeitem"
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 ftWMUg styled__StyledFlex-sc-1073t7q-3 follZc"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 bIUvrh styled__StyledFlex-sc-1073t7q-3 dKOZZC"
         >
           <div
-            class="styled__StyledGap-sc-1073t7q-5 NiMQL"
+            class="styled__StyledGap-sc-1073t7q-5 jtlobL"
           />
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 cITQi styled__StyledFlexItem-sc-smjqtt-0 fAByWD styled__StyledFlexItem-sc-1073t7q-4 fYuUQB"
+            class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
           >
             <svg
-              class="base__StyledIcon-sc-a9u0e1-0 dcaOlN"
+              class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
               color="primary30"
               fill="currentColor"
               height="24"
@@ -543,7 +543,7 @@ exports[`renders simple tree 1`] = `
             </svg>
           </div>
           <span
-            class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 bodesl"
+            class="styled__StyledText-sc-tqnj75-5 styled__StyledText-sc-1073t7q-6 kYSPkb gbMvLN"
             color="secondary70"
           >
             Test Node 8

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -2,36 +2,36 @@
 
 exports[`renders worksheet 1`] = `
 <table
-  class="styled__Table-sc-16rzzpq-0 eWZhUt"
+  class="styled__Table-sc-16rzzpq-0 cDOfjs"
   tabindex="0"
 >
   <thead>
     <tr>
       <td
-        class="styled__Status-sc-1aacki0-0 dQfqjh"
+        class="styled__Status-sc-1aacki0-0 iuSuXw"
       />
       <th
-        class="styled__Header-sc-16rzzpq-1 hiiNAX"
+        class="styled__Header-sc-16rzzpq-1 eBiVIc"
       >
         Product name
       </th>
       <th
-        class="styled__Header-sc-16rzzpq-1 hiiNAX"
+        class="styled__Header-sc-16rzzpq-1 eBiVIc"
       >
         Visible on storefront
       </th>
       <th
-        class="styled__Header-sc-16rzzpq-1 hiiNAX"
+        class="styled__Header-sc-16rzzpq-1 eBiVIc"
       >
         Other field
       </th>
       <th
-        class="styled__Header-sc-16rzzpq-1 hiiNAX"
+        class="styled__Header-sc-16rzzpq-1 eBiVIc"
       >
         Other field
       </th>
       <th
-        class="styled__Header-sc-16rzzpq-1 hohMQL"
+        class="styled__Header-sc-16rzzpq-1 exsIhv"
       >
         Number field
       </th>
@@ -40,14 +40,14 @@ exports[`renders worksheet 1`] = `
   <tbody>
     <tr>
       <td
-        class="styled__Status-sc-1aacki0-0 dQfqjh"
+        class="styled__Status-sc-1aacki0-0 iuSuXw"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Shoes Name Three"
         >
@@ -55,30 +55,30 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
+        class="styled__StyledCell-sc-1bt06ph-0 eDezrx"
         type="checkbox"
       >
         <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 giEcli"
+          class="styled__CheckboxWrapper-sc-1pcspgo-0 jgSEVL"
         >
           <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 hoGZVm"
+            class="styled__CheckboxContainer-sc-s1u0st-1 jwTjuz"
           >
             <input
               aria-checked="true"
               aria-labelledby="bd-checkbox_label-2"
               checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 HiMTa"
+              class="styled__HiddenCheckbox-sc-s1u0st-2 fesOYn"
               id="bd-checkbox-1"
               type="checkbox"
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 hlxaln"
+              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
               for="bd-checkbox-1"
             >
               <svg
-                class="base__StyledIcon-sc-a9u0e1-0 jcsFSA"
+                class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -96,11 +96,11 @@ exports[`renders worksheet 1`] = `
               </svg>
             </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fsVjMt"
+              class="styled__CheckboxLabelContainer-sc-s1u0st-0 dqYAfq"
             >
               <label
                 aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
+                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 kCTRAh gFPgdf"
                 for="bd-checkbox-1"
                 hidden=""
                 id="bd-checkbox_label-2"
@@ -112,11 +112,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Text"
         >
@@ -124,17 +124,17 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 lcivPq"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 dhhewn"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 eBGMhc styled__StyledFlexItem-sc-smjqtt-0 cEtHzl styled__StyledFlexItem-sc-zoq9bz-1 jhNRVE"
+            class="styled__StyledBox-sc-sj5f1m-0 fbjIpR styled__StyledFlexItem-sc-smjqtt-0 dYiLXE styled__StyledFlexItem-sc-zoq9bz-1 enfxxd"
           >
             <p
-              class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+              class="styled__StyledSmall-sc-tqnj75-6 buphHb"
               color="secondary70"
               title="1"
             >
@@ -142,10 +142,10 @@ exports[`renders worksheet 1`] = `
             </p>
           </div>
           <button
-            class="styled__StyledButton-sc-3yq204-0 kQwjGx styled__StyledButton-sc-zoq9bz-0 cfGbfD"
+            class="styled__StyledButton-sc-3yq204-0 bqyczY styled__StyledButton-sc-zoq9bz-0 gjuKcK"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cUnSLq"
+              class="styled__ContentWrapper-sc-3yq204-1 bBtdZJ"
             >
               Edit
             </span>
@@ -153,11 +153,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
+        class="styled__StyledCell-sc-1bt06ph-0 gdfHlK"
         type="number"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="$50.00"
         >
@@ -167,14 +167,14 @@ exports[`renders worksheet 1`] = `
     </tr>
     <tr>
       <td
-        class="styled__Status-sc-1aacki0-0 dQfqjh"
+        class="styled__Status-sc-1aacki0-0 iuSuXw"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Shoes Name Two"
         >
@@ -182,30 +182,30 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
+        class="styled__StyledCell-sc-1bt06ph-0 eDezrx"
         type="checkbox"
       >
         <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 giEcli"
+          class="styled__CheckboxWrapper-sc-1pcspgo-0 jgSEVL"
         >
           <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 hoGZVm"
+            class="styled__CheckboxContainer-sc-s1u0st-1 jwTjuz"
           >
             <input
               aria-checked="true"
               aria-labelledby="bd-checkbox_label-5"
               checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 HiMTa"
+              class="styled__HiddenCheckbox-sc-s1u0st-2 fesOYn"
               id="bd-checkbox-4"
               type="checkbox"
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 hlxaln"
+              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
               for="bd-checkbox-4"
             >
               <svg
-                class="base__StyledIcon-sc-a9u0e1-0 jcsFSA"
+                class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -223,11 +223,11 @@ exports[`renders worksheet 1`] = `
               </svg>
             </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fsVjMt"
+              class="styled__CheckboxLabelContainer-sc-s1u0st-0 dqYAfq"
             >
               <label
                 aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
+                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 kCTRAh gFPgdf"
                 for="bd-checkbox-4"
                 hidden=""
                 id="bd-checkbox_label-5"
@@ -239,11 +239,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Text"
         >
@@ -251,17 +251,17 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 lcivPq"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 dhhewn"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 eBGMhc styled__StyledFlexItem-sc-smjqtt-0 cEtHzl styled__StyledFlexItem-sc-zoq9bz-1 jhNRVE"
+            class="styled__StyledBox-sc-sj5f1m-0 fbjIpR styled__StyledFlexItem-sc-smjqtt-0 dYiLXE styled__StyledFlexItem-sc-zoq9bz-1 enfxxd"
           >
             <p
-              class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+              class="styled__StyledSmall-sc-tqnj75-6 buphHb"
               color="secondary70"
               title="2"
             >
@@ -269,10 +269,10 @@ exports[`renders worksheet 1`] = `
             </p>
           </div>
           <button
-            class="styled__StyledButton-sc-3yq204-0 kQwjGx styled__StyledButton-sc-zoq9bz-0 cfGbfD"
+            class="styled__StyledButton-sc-3yq204-0 bqyczY styled__StyledButton-sc-zoq9bz-0 gjuKcK"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cUnSLq"
+              class="styled__ContentWrapper-sc-3yq204-1 bBtdZJ"
             >
               Edit
             </span>
@@ -280,11 +280,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
+        class="styled__StyledCell-sc-1bt06ph-0 gdfHlK"
         type="number"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="$50.00"
         >
@@ -294,14 +294,14 @@ exports[`renders worksheet 1`] = `
     </tr>
     <tr>
       <td
-        class="styled__Status-sc-1aacki0-0 dQfqjh"
+        class="styled__Status-sc-1aacki0-0 iuSuXw"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Shoes Name One"
         >
@@ -309,29 +309,29 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
+        class="styled__StyledCell-sc-1bt06ph-0 eDezrx"
         type="checkbox"
       >
         <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 giEcli"
+          class="styled__CheckboxWrapper-sc-1pcspgo-0 jgSEVL"
         >
           <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 hoGZVm"
+            class="styled__CheckboxContainer-sc-s1u0st-1 jwTjuz"
           >
             <input
               aria-checked="false"
               aria-labelledby="bd-checkbox_label-8"
-              class="styled__HiddenCheckbox-sc-s1u0st-2 HiMTa"
+              class="styled__HiddenCheckbox-sc-s1u0st-2 fesOYn"
               id="bd-checkbox-7"
               type="checkbox"
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 BOTgh"
+              class="styled__StyledCheckbox-sc-s1u0st-3 bXFgcu"
               for="bd-checkbox-7"
             >
               <svg
-                class="base__StyledIcon-sc-a9u0e1-0 jcsFSA"
+                class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -349,11 +349,11 @@ exports[`renders worksheet 1`] = `
               </svg>
             </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fsVjMt"
+              class="styled__CheckboxLabelContainer-sc-s1u0st-0 dqYAfq"
             >
               <label
                 aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
+                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 kCTRAh gFPgdf"
                 for="bd-checkbox-7"
                 hidden=""
                 id="bd-checkbox_label-8"
@@ -365,11 +365,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Text"
         >
@@ -377,17 +377,17 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 lcivPq"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 dhhewn"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 eBGMhc styled__StyledFlexItem-sc-smjqtt-0 cEtHzl styled__StyledFlexItem-sc-zoq9bz-1 jhNRVE"
+            class="styled__StyledBox-sc-sj5f1m-0 fbjIpR styled__StyledFlexItem-sc-smjqtt-0 dYiLXE styled__StyledFlexItem-sc-zoq9bz-1 enfxxd"
           >
             <p
-              class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+              class="styled__StyledSmall-sc-tqnj75-6 buphHb"
               color="secondary70"
               title="3"
             >
@@ -395,10 +395,10 @@ exports[`renders worksheet 1`] = `
             </p>
           </div>
           <button
-            class="styled__StyledButton-sc-3yq204-0 kQwjGx styled__StyledButton-sc-zoq9bz-0 cfGbfD"
+            class="styled__StyledButton-sc-3yq204-0 bqyczY styled__StyledButton-sc-zoq9bz-0 gjuKcK"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cUnSLq"
+              class="styled__ContentWrapper-sc-3yq204-1 bBtdZJ"
             >
               Edit
             </span>
@@ -406,11 +406,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
+        class="styled__StyledCell-sc-1bt06ph-0 gdfHlK"
         type="number"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="$50.00"
         >
@@ -420,14 +420,14 @@ exports[`renders worksheet 1`] = `
     </tr>
     <tr>
       <td
-        class="styled__Status-sc-1aacki0-0 dQfqjh"
+        class="styled__Status-sc-1aacki0-0 iuSuXw"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Variant"
         >
@@ -435,30 +435,30 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
+        class="styled__StyledCell-sc-1bt06ph-0 eDezrx"
         type="checkbox"
       >
         <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 giEcli"
+          class="styled__CheckboxWrapper-sc-1pcspgo-0 jgSEVL"
         >
           <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 hoGZVm"
+            class="styled__CheckboxContainer-sc-s1u0st-1 jwTjuz"
           >
             <input
               aria-checked="true"
               aria-labelledby="bd-checkbox_label-11"
               checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 HiMTa"
+              class="styled__HiddenCheckbox-sc-s1u0st-2 fesOYn"
               id="bd-checkbox-10"
               type="checkbox"
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 hlxaln"
+              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
               for="bd-checkbox-10"
             >
               <svg
-                class="base__StyledIcon-sc-a9u0e1-0 jcsFSA"
+                class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -476,11 +476,11 @@ exports[`renders worksheet 1`] = `
               </svg>
             </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fsVjMt"
+              class="styled__CheckboxLabelContainer-sc-s1u0st-0 dqYAfq"
             >
               <label
                 aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
+                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 kCTRAh gFPgdf"
                 for="bd-checkbox-10"
                 hidden=""
                 id="bd-checkbox_label-11"
@@ -492,11 +492,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Text"
         >
@@ -504,17 +504,17 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 lcivPq"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 dhhewn"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 eBGMhc styled__StyledFlexItem-sc-smjqtt-0 cEtHzl styled__StyledFlexItem-sc-zoq9bz-1 jhNRVE"
+            class="styled__StyledBox-sc-sj5f1m-0 fbjIpR styled__StyledFlexItem-sc-smjqtt-0 dYiLXE styled__StyledFlexItem-sc-zoq9bz-1 enfxxd"
           >
             <p
-              class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+              class="styled__StyledSmall-sc-tqnj75-6 buphHb"
               color="secondary70"
               title="4"
             >
@@ -522,10 +522,10 @@ exports[`renders worksheet 1`] = `
             </p>
           </div>
           <button
-            class="styled__StyledButton-sc-3yq204-0 kQwjGx styled__StyledButton-sc-zoq9bz-0 cfGbfD"
+            class="styled__StyledButton-sc-3yq204-0 bqyczY styled__StyledButton-sc-zoq9bz-0 gjuKcK"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cUnSLq"
+              class="styled__ContentWrapper-sc-3yq204-1 bBtdZJ"
             >
               Edit
             </span>
@@ -533,11 +533,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
+        class="styled__StyledCell-sc-1bt06ph-0 gdfHlK"
         type="number"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="$50.00"
         >
@@ -547,43 +547,43 @@ exports[`renders worksheet 1`] = `
     </tr>
     <tr>
       <td
-        class="styled__Status-sc-1aacki0-0 jpxEqg"
+        class="styled__Status-sc-1aacki0-0 bogBHW"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 iLwcsN"
+        class="styled__StyledCell-sc-1bt06ph-0 kfcbVP"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title=""
         />
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
+        class="styled__StyledCell-sc-1bt06ph-0 eDezrx"
         type="checkbox"
       >
         <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 giEcli"
+          class="styled__CheckboxWrapper-sc-1pcspgo-0 jgSEVL"
         >
           <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 hoGZVm"
+            class="styled__CheckboxContainer-sc-s1u0st-1 jwTjuz"
           >
             <input
               aria-checked="true"
               aria-labelledby="bd-checkbox_label-14"
               checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 HiMTa"
+              class="styled__HiddenCheckbox-sc-s1u0st-2 fesOYn"
               id="bd-checkbox-13"
               type="checkbox"
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 hlxaln"
+              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
               for="bd-checkbox-13"
             >
               <svg
-                class="base__StyledIcon-sc-a9u0e1-0 jcsFSA"
+                class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -601,11 +601,11 @@ exports[`renders worksheet 1`] = `
               </svg>
             </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fsVjMt"
+              class="styled__CheckboxLabelContainer-sc-s1u0st-0 dqYAfq"
             >
               <label
                 aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
+                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 kCTRAh gFPgdf"
                 for="bd-checkbox-13"
                 hidden=""
                 id="bd-checkbox_label-14"
@@ -617,11 +617,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Text"
         >
@@ -629,17 +629,17 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 lcivPq"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 dhhewn"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 eBGMhc styled__StyledFlexItem-sc-smjqtt-0 cEtHzl styled__StyledFlexItem-sc-zoq9bz-1 jhNRVE"
+            class="styled__StyledBox-sc-sj5f1m-0 fbjIpR styled__StyledFlexItem-sc-smjqtt-0 dYiLXE styled__StyledFlexItem-sc-zoq9bz-1 enfxxd"
           >
             <p
-              class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+              class="styled__StyledSmall-sc-tqnj75-6 buphHb"
               color="secondary70"
               title="5"
             >
@@ -647,10 +647,10 @@ exports[`renders worksheet 1`] = `
             </p>
           </div>
           <button
-            class="styled__StyledButton-sc-3yq204-0 kQwjGx styled__StyledButton-sc-zoq9bz-0 cfGbfD"
+            class="styled__StyledButton-sc-3yq204-0 bqyczY styled__StyledButton-sc-zoq9bz-0 gjuKcK"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cUnSLq"
+              class="styled__ContentWrapper-sc-3yq204-1 bBtdZJ"
             >
               Edit
             </span>
@@ -658,11 +658,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
+        class="styled__StyledCell-sc-1bt06ph-0 gdfHlK"
         type="number"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="$50.00"
         >
@@ -672,14 +672,14 @@ exports[`renders worksheet 1`] = `
     </tr>
     <tr>
       <td
-        class="styled__Status-sc-1aacki0-0 dQfqjh"
+        class="styled__Status-sc-1aacki0-0 iuSuXw"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Variant"
         >
@@ -687,30 +687,30 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
+        class="styled__StyledCell-sc-1bt06ph-0 eDezrx"
         type="checkbox"
       >
         <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 giEcli"
+          class="styled__CheckboxWrapper-sc-1pcspgo-0 jgSEVL"
         >
           <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 hoGZVm"
+            class="styled__CheckboxContainer-sc-s1u0st-1 jwTjuz"
           >
             <input
               aria-checked="true"
               aria-labelledby="bd-checkbox_label-17"
               checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 HiMTa"
+              class="styled__HiddenCheckbox-sc-s1u0st-2 fesOYn"
               id="bd-checkbox-16"
               type="checkbox"
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 hlxaln"
+              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
               for="bd-checkbox-16"
             >
               <svg
-                class="base__StyledIcon-sc-a9u0e1-0 jcsFSA"
+                class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -728,11 +728,11 @@ exports[`renders worksheet 1`] = `
               </svg>
             </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fsVjMt"
+              class="styled__CheckboxLabelContainer-sc-s1u0st-0 dqYAfq"
             >
               <label
                 aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
+                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 kCTRAh gFPgdf"
                 for="bd-checkbox-16"
                 hidden=""
                 id="bd-checkbox_label-17"
@@ -744,11 +744,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Text"
         >
@@ -756,17 +756,17 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 lcivPq"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 dhhewn"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 eBGMhc styled__StyledFlexItem-sc-smjqtt-0 cEtHzl styled__StyledFlexItem-sc-zoq9bz-1 jhNRVE"
+            class="styled__StyledBox-sc-sj5f1m-0 fbjIpR styled__StyledFlexItem-sc-smjqtt-0 dYiLXE styled__StyledFlexItem-sc-zoq9bz-1 enfxxd"
           >
             <p
-              class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+              class="styled__StyledSmall-sc-tqnj75-6 buphHb"
               color="secondary70"
               title="6"
             >
@@ -774,10 +774,10 @@ exports[`renders worksheet 1`] = `
             </p>
           </div>
           <button
-            class="styled__StyledButton-sc-3yq204-0 kQwjGx styled__StyledButton-sc-zoq9bz-0 cfGbfD"
+            class="styled__StyledButton-sc-3yq204-0 bqyczY styled__StyledButton-sc-zoq9bz-0 gjuKcK"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cUnSLq"
+              class="styled__ContentWrapper-sc-3yq204-1 bBtdZJ"
             >
               Edit
             </span>
@@ -785,11 +785,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
+        class="styled__StyledCell-sc-1bt06ph-0 gdfHlK"
         type="number"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="$50.00"
         >
@@ -799,14 +799,14 @@ exports[`renders worksheet 1`] = `
     </tr>
     <tr>
       <td
-        class="styled__Status-sc-1aacki0-0 jpxEqg"
+        class="styled__Status-sc-1aacki0-0 bogBHW"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Variant"
         >
@@ -814,29 +814,29 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
+        class="styled__StyledCell-sc-1bt06ph-0 eDezrx"
         type="checkbox"
       >
         <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 giEcli"
+          class="styled__CheckboxWrapper-sc-1pcspgo-0 jgSEVL"
         >
           <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 hoGZVm"
+            class="styled__CheckboxContainer-sc-s1u0st-1 jwTjuz"
           >
             <input
               aria-checked="false"
               aria-labelledby="bd-checkbox_label-20"
-              class="styled__HiddenCheckbox-sc-s1u0st-2 HiMTa"
+              class="styled__HiddenCheckbox-sc-s1u0st-2 fesOYn"
               id="bd-checkbox-19"
               type="checkbox"
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 BOTgh"
+              class="styled__StyledCheckbox-sc-s1u0st-3 bXFgcu"
               for="bd-checkbox-19"
             >
               <svg
-                class="base__StyledIcon-sc-a9u0e1-0 jcsFSA"
+                class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -854,11 +854,11 @@ exports[`renders worksheet 1`] = `
               </svg>
             </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fsVjMt"
+              class="styled__CheckboxLabelContainer-sc-s1u0st-0 dqYAfq"
             >
               <label
                 aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
+                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 kCTRAh gFPgdf"
                 for="bd-checkbox-19"
                 hidden=""
                 id="bd-checkbox_label-20"
@@ -870,11 +870,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Text"
         >
@@ -882,17 +882,17 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 lcivPq"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 dhhewn"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 eBGMhc styled__StyledFlexItem-sc-smjqtt-0 cEtHzl styled__StyledFlexItem-sc-zoq9bz-1 jhNRVE"
+            class="styled__StyledBox-sc-sj5f1m-0 fbjIpR styled__StyledFlexItem-sc-smjqtt-0 dYiLXE styled__StyledFlexItem-sc-zoq9bz-1 enfxxd"
           >
             <p
-              class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+              class="styled__StyledSmall-sc-tqnj75-6 buphHb"
               color="secondary70"
               title="7"
             >
@@ -900,10 +900,10 @@ exports[`renders worksheet 1`] = `
             </p>
           </div>
           <button
-            class="styled__StyledButton-sc-3yq204-0 kQwjGx styled__StyledButton-sc-zoq9bz-0 cfGbfD"
+            class="styled__StyledButton-sc-3yq204-0 bqyczY styled__StyledButton-sc-zoq9bz-0 gjuKcK"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cUnSLq"
+              class="styled__ContentWrapper-sc-3yq204-1 bBtdZJ"
             >
               Edit
             </span>
@@ -911,11 +911,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 itFNTF"
+        class="styled__StyledCell-sc-1bt06ph-0 bnHyzk"
         type="number"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="$49.00"
         >
@@ -925,14 +925,14 @@ exports[`renders worksheet 1`] = `
     </tr>
     <tr>
       <td
-        class="styled__Status-sc-1aacki0-0 dQfqjh"
+        class="styled__Status-sc-1aacki0-0 iuSuXw"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Dress Name One"
         >
@@ -940,30 +940,30 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
+        class="styled__StyledCell-sc-1bt06ph-0 eDezrx"
         type="checkbox"
       >
         <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 giEcli"
+          class="styled__CheckboxWrapper-sc-1pcspgo-0 jgSEVL"
         >
           <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 hoGZVm"
+            class="styled__CheckboxContainer-sc-s1u0st-1 jwTjuz"
           >
             <input
               aria-checked="true"
               aria-labelledby="bd-checkbox_label-23"
               checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 HiMTa"
+              class="styled__HiddenCheckbox-sc-s1u0st-2 fesOYn"
               id="bd-checkbox-22"
               type="checkbox"
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 hlxaln"
+              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
               for="bd-checkbox-22"
             >
               <svg
-                class="base__StyledIcon-sc-a9u0e1-0 jcsFSA"
+                class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -981,11 +981,11 @@ exports[`renders worksheet 1`] = `
               </svg>
             </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fsVjMt"
+              class="styled__CheckboxLabelContainer-sc-s1u0st-0 dqYAfq"
             >
               <label
                 aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
+                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 kCTRAh gFPgdf"
                 for="bd-checkbox-22"
                 hidden=""
                 id="bd-checkbox_label-23"
@@ -997,11 +997,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Text"
         >
@@ -1009,17 +1009,17 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 lcivPq"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 dhhewn"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 eBGMhc styled__StyledFlexItem-sc-smjqtt-0 cEtHzl styled__StyledFlexItem-sc-zoq9bz-1 jhNRVE"
+            class="styled__StyledBox-sc-sj5f1m-0 fbjIpR styled__StyledFlexItem-sc-smjqtt-0 dYiLXE styled__StyledFlexItem-sc-zoq9bz-1 enfxxd"
           >
             <p
-              class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+              class="styled__StyledSmall-sc-tqnj75-6 buphHb"
               color="secondary70"
               title="8"
             >
@@ -1027,10 +1027,10 @@ exports[`renders worksheet 1`] = `
             </p>
           </div>
           <button
-            class="styled__StyledButton-sc-3yq204-0 kQwjGx styled__StyledButton-sc-zoq9bz-0 cfGbfD"
+            class="styled__StyledButton-sc-3yq204-0 bqyczY styled__StyledButton-sc-zoq9bz-0 gjuKcK"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cUnSLq"
+              class="styled__ContentWrapper-sc-3yq204-1 bBtdZJ"
             >
               Edit
             </span>
@@ -1038,11 +1038,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
+        class="styled__StyledCell-sc-1bt06ph-0 gdfHlK"
         type="number"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="$50.00"
         >
@@ -1052,14 +1052,14 @@ exports[`renders worksheet 1`] = `
     </tr>
     <tr>
       <td
-        class="styled__Status-sc-1aacki0-0 dQfqjh"
+        class="styled__Status-sc-1aacki0-0 iuSuXw"
       />
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Fans Name One"
         >
@@ -1067,30 +1067,30 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 eanDzN"
+        class="styled__StyledCell-sc-1bt06ph-0 eDezrx"
         type="checkbox"
       >
         <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 giEcli"
+          class="styled__CheckboxWrapper-sc-1pcspgo-0 jgSEVL"
         >
           <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 hoGZVm"
+            class="styled__CheckboxContainer-sc-s1u0st-1 jwTjuz"
           >
             <input
               aria-checked="true"
               aria-labelledby="bd-checkbox_label-26"
               checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 HiMTa"
+              class="styled__HiddenCheckbox-sc-s1u0st-2 fesOYn"
               id="bd-checkbox-25"
               type="checkbox"
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 hlxaln"
+              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
               for="bd-checkbox-25"
             >
               <svg
-                class="base__StyledIcon-sc-a9u0e1-0 jcsFSA"
+                class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -1108,11 +1108,11 @@ exports[`renders worksheet 1`] = `
               </svg>
             </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fsVjMt"
+              class="styled__CheckboxLabelContainer-sc-s1u0st-0 dqYAfq"
             >
               <label
                 aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 fxhvEG"
+                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 kCTRAh gFPgdf"
                 for="bd-checkbox-25"
                 hidden=""
                 id="bd-checkbox_label-26"
@@ -1124,11 +1124,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="text"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="Text"
         >
@@ -1136,17 +1136,17 @@ exports[`renders worksheet 1`] = `
         </p>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 hDVFqs"
+        class="styled__StyledCell-sc-1bt06ph-0 dIPfoJ"
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 bVyIus styled__StyledFlex-sc-hcvk8l-0 lcivPq"
+          class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlex-sc-hcvk8l-0 dhhewn"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 eBGMhc styled__StyledFlexItem-sc-smjqtt-0 cEtHzl styled__StyledFlexItem-sc-zoq9bz-1 jhNRVE"
+            class="styled__StyledBox-sc-sj5f1m-0 fbjIpR styled__StyledFlexItem-sc-smjqtt-0 dYiLXE styled__StyledFlexItem-sc-zoq9bz-1 enfxxd"
           >
             <p
-              class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+              class="styled__StyledSmall-sc-tqnj75-6 buphHb"
               color="secondary70"
               title="9"
             >
@@ -1154,10 +1154,10 @@ exports[`renders worksheet 1`] = `
             </p>
           </div>
           <button
-            class="styled__StyledButton-sc-3yq204-0 kQwjGx styled__StyledButton-sc-zoq9bz-0 cfGbfD"
+            class="styled__StyledButton-sc-3yq204-0 bqyczY styled__StyledButton-sc-zoq9bz-0 gjuKcK"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cUnSLq"
+              class="styled__ContentWrapper-sc-3yq204-1 bBtdZJ"
             >
               Edit
             </span>
@@ -1165,11 +1165,11 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 bRpSFs"
+        class="styled__StyledCell-sc-1bt06ph-0 gdfHlK"
         type="number"
       >
         <p
-          class="styled__StyledSmall-sc-tqnj75-6 coOZF"
+          class="styled__StyledSmall-sc-tqnj75-6 buphHb"
           color="secondary70"
           title="$50.00"
         >

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^17.0.1",
     "react-live": "^2.2.3",
     "react-uid": "^2.3.1",
-    "styled-components": "^4.3.0"
+    "styled-components": "^5.3.0"
   },
   "devDependencies": {
     "@bigcommerce/configs": "^0.15.0-alpha.0",
@@ -43,8 +43,8 @@
     "@types/prettier": "^2.0.1",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",
-    "@types/styled-components": "^4.1.12",
-    "babel-plugin-styled-components": "^1.10.6",
+    "@types/styled-components": "^5.1.11",
+    "babel-plugin-styled-components": "^1.13.2",
     "jsx-to-string-loader": "^1.2.0",
     "next": "^10.0.7",
     "push-dir": "^0.4.1",

--- a/packages/docs/pages/GettingStarted/GettingStartedPage.tsx
+++ b/packages/docs/pages/GettingStarted/GettingStartedPage.tsx
@@ -78,16 +78,26 @@ const GettingStartedPage = () => {
       <Panel header="Getting started">
         <Text>Add BigDesign and styled-components to your project:</Text>
         <CodeSnippet showControls={false} language="bash">
-          npm install @bigcommerce/big-design styled-components@4
+          npm install @bigcommerce/big-design styled-components@5
+        </CodeSnippet>
+
+        <Text>
+          Add the font as a<Code>&lt;link&gt;</Code> in your <Code>index.html</Code>/<Code>&lt;head&gt;</Code> element.
+        </Text>
+
+        <CodeSnippet>
+          {`
+          <head>
+            <link rel="preconnect" href="https://fonts.googleapis.com" />
+            <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600&display=swap" rel="stylesheet" />
+          </head>
+          `}
         </CodeSnippet>
 
         <Text>
           Import the <Code>GlobalStyles</Code> component and use it once in your app. This will set a few styles
-          globally, including a base font family,{' '}
-          <Link href="https://fonts.google.com/specimen/Source+Sans+Pro" target="_blank">
-            Source Sans Pro
-          </Link>{' '}
-          and{' '}
+          globally and add{' '}
           <Link href="https://github.com/necolas/normalize.css/" target="_blank">
             normalize.css
           </Link>

--- a/packages/docs/pages/_app.tsx
+++ b/packages/docs/pages/_app.tsx
@@ -38,11 +38,15 @@ export default class MyApp extends App {
           <link rel="icon" type="image/svg+xml" href={`${process.env.URL_PREFIX}/favicon.svg`} />
           <title>BigDesign</title>
           <meta property="og:image" content={`${process.env.URL_PREFIX}/og-image.png`} />
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600&display=swap"
+            rel="stylesheet"
+          />
         </Head>
         <style jsx global>
           {`
-            @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600');
-
             html,
             body,
             #__next {

--- a/packages/examples/index.html
+++ b/packages/examples/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BigDesign Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -13,14 +13,14 @@
     "formik": "^2.0.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "styled-components": "^4.3.0",
+    "styled-components": "^5.3.0",
     "yup": "^0.28.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.2",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",
-    "@types/styled-components": "^4.1.12",
+    "@types/styled-components": "^5.1.11",
     "@types/yup": "^0.26.24",
     "parcel": "^2.0.0-beta.2",
     "postcss": "^8.2.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,7 +1013,7 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.14.8", "@babel/traverse@^7.2.3":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.14.8", "@babel/traverse@^7.2.3", "@babel/traverse@^7.4.5":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.8.tgz#c0253f02677c5de1a8ff9df6b0aacbec7da1a8ce"
   integrity sha512-kexHhzCljJcFNn1KYAQ6A5wxMRzq9ebYpEDV4+WdNyr3i7O44tanbDOR/xjiG2F3sllan+LgwK+7OMk0EmydHg==
@@ -1200,22 +1200,27 @@
   resolved "https://registry.yarnpkg.com/@emmetio/extract-abbreviation/-/extract-abbreviation-0.1.6.tgz#e4a9856c1057f0aff7d443b8536477c243abe28c"
   integrity sha512-Ce3xE2JvTSEbASFbRbA1gAIcMcZWdS2yUYRaQbeM0nbOzaZrUYfa3ePtcriYRZOZmr+CkKA+zbjhvTpIOAYVcw==
 
-"@emotion/is-prop-valid@^0.8.1":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.5.tgz#2dda0791f0eafa12b7a0a5b39858405cc7bde983"
-  integrity sha512-6ZODuZSFofbxSbcxwsFz+6ioPjb0ISJRRPLZ+WIbjcU2IMU0Io+RGQjjaTgOvNQl007KICBm7zXQaYQEC1r6Bg==
+"@emotion/is-prop-valid@^0.8.8":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
   dependencies:
-    "@emotion/memoize" "0.7.3"
+    "@emotion/memoize" "0.7.4"
 
-"@emotion/memoize@0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
-  integrity sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==
-
-"@emotion/unitless@^0.7.0":
+"@emotion/memoize@0.7.4":
   version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
-  integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/stylis@^0.8.4":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+
+"@emotion/unitless@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@hapi/accept@5.0.2":
   version "5.0.2"
@@ -3328,13 +3333,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-native@*":
-  version "0.61.21"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.61.21.tgz#7b698d1a1a1b9f108af2573b931f3d57e66e8479"
-  integrity sha512-wdA3owsYZ0/eSBji12uh4rqRYfRWlQ3PNI1D5+cmpTfr5/+mdH1WXfFAcM+ncD+zUQW6EmyizHmjT+S31EmjNg==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-redux@^7.1.16":
   version "7.1.16"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.16.tgz#0fbd04c2500c12105494c83d4a3e45c084e3cb21"
@@ -3371,15 +3369,14 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/styled-components@^4.1.12":
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.4.3.tgz#74dd00ad760845a98890a8539361d8afc32059de"
-  integrity sha512-U0udeNOZBfUkJycmGJwmzun0FBt11rZy08weVQmE2xfUNAbX8AGOEWxWna2d+qAUKxKgMlcG+TZT0+K2FfDcnQ==
+"@types/styled-components@^5.1.11":
+  version "5.1.11"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.11.tgz#a3a1bc0f2cdad7318d8ce219ee507e6b353503b5"
+  integrity sha512-u8g3bSw9KUiZY+S++gh+LlURGraqBe3MC5I5dygrNjGDHWWQfsmZZRTJ9K9oHU2CqWtxChWmJkDI/gp+TZPQMw==
   dependencies:
     "@types/hoist-non-react-statics" "*"
     "@types/react" "*"
-    "@types/react-native" "*"
-    csstype "^2.2.0"
+    csstype "^3.0.2"
 
 "@types/testing-library__dom@*", "@types/testing-library__dom@^6.12.1":
   version "6.14.0"
@@ -3981,7 +3978,7 @@ babel-plugin-polyfill-regenerator@^0.2.2:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.2.2"
 
-"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.10.6:
+"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^1.13.2:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.13.2.tgz#ebe0e6deff51d7f93fceda1819e9b96aeb88278d"
   integrity sha512-Vb1R3d4g+MUfPQPVDMCGjm3cDocJEUTR7Xq7QS95JWWeksN1wdFRYpD2kulDgI3Huuaf1CZd+NK4KQmqUFh5dA==
@@ -5167,14 +5164,14 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-to-react-native@^2.2.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.2.tgz#e75e2f8f7aa385b4c3611c52b074b70a002f2e7d"
-  integrity sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==
+css-to-react-native@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
+  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
   dependencies:
     camelize "^1.0.0"
     css-color-keywords "^1.0.0"
-    postcss-value-parser "^3.3.0"
+    postcss-value-parser "^4.0.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -5201,16 +5198,6 @@ css.escape@1.5.1, css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
-
-css@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
-  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
-  dependencies:
-    inherits "^2.0.3"
-    source-map "^0.6.1"
-    source-map-resolve "^0.5.2"
-    urix "^0.1.0"
 
 css@^3.0.0:
   version "3.0.0"
@@ -5343,11 +5330,6 @@ cssstyle@^2.0.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
-
-csstype@^2.2.0:
-  version "2.6.13"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
-  integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
 csstype@^3.0.2:
   version "3.0.8"
@@ -7086,7 +7068,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7881,11 +7863,6 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-what@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.3.1.tgz#79502181f40226e2d8c09226999db90ef7c1bcbe"
-  integrity sha512-seFn10yAXy+yJlTRO+8VfiafC+0QJanGLMPTBWLrJm/QPauuchy0UXh8B6H5o9VA8BAzk0iYievt6mNp6gfaqA==
-
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -8293,12 +8270,12 @@ jest-snapshot@^25.5.1:
     pretty-format "^25.5.0"
     semver "^6.3.0"
 
-jest-styled-components@^6.3.1:
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-6.3.4.tgz#64de9c0ceae14f311248734c79dcc66b447f90f1"
-  integrity sha512-dc32l0/6n3FtsILODpvKNz6SLg50OmbJ/3r3oRh9jc2VIPPGZT5jWv7BKIcNCYH7E38ZK7uejNl3zJsCOIenng==
+jest-styled-components@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-7.0.5.tgz#6da3f1a1c8bd98bccc6bcf9aabfdefdcd88fd92c"
+  integrity sha512-ZR/r3IKNkgaaVIOThn0Qis4sNQtA352qHjhbxSHeLS3FDIvHSUSJoI2b3kzk+bHHQ1VOeV630usERtnyhyZh4A==
   dependencies:
-    css "^2.2.4"
+    css "^3.0.0"
 
 jest-util@^25.5.0:
   version "25.5.0"
@@ -9024,7 +9001,7 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-memoize-one@^5.0.0, memoize-one@^5.1.1:
+memoize-one@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
@@ -9061,13 +9038,6 @@ meow@^8.0.0:
     trim-newlines "^3.0.0"
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
-
-merge-anything@^2.2.4:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.4.1.tgz#e9bccaec1e49ec6cb5f77ca78c5770d1a35315e6"
-  integrity sha512-dYOIAl9GFCJNctSIHWOj9OJtarCjsD16P8ObCl6oxrujAG+kOvlwJuOD9/O9iYZ9aTi1RGpGTG9q9etIvuUikQ==
-  dependencies:
-    is-what "^3.3.1"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -10746,7 +10716,7 @@ postcss-unique-selectors@^4.0.1:
     postcss "^7.0.0"
     uniqs "^2.0.0"
 
-postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0:
+postcss-value-parser@^3.0.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
@@ -10932,7 +10902,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@15.7.2, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -11121,7 +11091,7 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-is@16.13.1, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@16.13.1, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -11891,6 +11861,11 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -12069,7 +12044,7 @@ source-map-js@^0.6.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
+source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
@@ -12492,23 +12467,20 @@ strong-log-transformer@^2.1.0:
     minimist "^1.2.0"
     through "^2.3.4"
 
-styled-components@^4.3.0:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
-  integrity sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==
+styled-components@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.0.tgz#e47c3d3e9ddfff539f118a3dd0fd4f8f4fb25727"
+  integrity sha512-bPJKwZCHjJPf/hwTJl6TbkSZg/3evha+XPEizrZUGb535jLImwDUdjTNxXqjjaASt2M4qO4AVfoHJNe3XB/tpQ==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    "@emotion/is-prop-valid" "^0.8.1"
-    "@emotion/unitless" "^0.7.0"
-    babel-plugin-styled-components ">= 1"
-    css-to-react-native "^2.2.2"
-    memoize-one "^5.0.0"
-    merge-anything "^2.2.4"
-    prop-types "^15.5.4"
-    react-is "^16.6.0"
-    stylis "^3.5.0"
-    stylis-rule-sheet "^0.0.10"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^0.8.8"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1.12.0"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
 styled-jsx@3.3.2:
@@ -12534,12 +12506,12 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
-stylis-rule-sheet@0.0.10, stylis-rule-sheet@^0.0.10:
+stylis-rule-sheet@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
   integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
 
-stylis@3.5.4, stylis@^3.5.0:
+stylis@3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==


### PR DESCRIPTION
## What?

Upgrade to styled-components v5.

### Note:
```
BREAKING CHANGE:
You will need to update to styled-components v5. In addition,
you will need to import the base fonts in your <head> element.
See the "Getting Started" page or README.md for an example.
```

## Why?

It's been on the backburner for quite some time. We were hoping the `styled-components` team would fix the [SSR Memory Leak issue](https://github.com/styled-components/styled-components/issues/2913) using `@import` in `createGlobalStyle`, but no luck. It also seems on their v6 roadmap they don't have intentions of fixing it either. We might as well upgrade and get it over with.

ping @bigcommerce/frontend