### PR TITLE
feat(component): add margin props to Form component

### DIFF
--- a/packages/big-design/src/components/Form/Form.tsx
+++ b/packages/big-design/src/components/Form/Form.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, Ref } from 'react';
 
+import { MarginProps } from '../../mixins';
 import { typedMemo } from '../../utils';
 
 import { StyledForm } from './styled';
@@ -8,9 +9,10 @@ interface PrivateProps {
   forwardedRef: Ref<HTMLFormElement>;
 }
 
-export type FormProps = React.FormHTMLAttributes<HTMLFormElement> & {
-  fullWidth?: boolean;
-};
+export type FormProps = React.FormHTMLAttributes<HTMLFormElement> &
+  MarginProps & {
+    fullWidth?: boolean;
+  };
 
 const StyleableForm: React.FC<PrivateProps & FormProps> = ({ forwardedRef, ...props }) => (
   <StyledForm {...props} ref={forwardedRef} />

--- a/packages/big-design/src/components/Form/spec.tsx
+++ b/packages/big-design/src/components/Form/spec.tsx
@@ -55,3 +55,13 @@ test('simple form render', () => {
 
   expect(container.firstChild).toMatchSnapshot();
 });
+
+test('has margin props', () => {
+  const { container, rerender } = render(<Form />);
+
+  expect(container.firstChild).not.toHaveStyle('margin: 1rem');
+
+  rerender(<Form margin="medium" />);
+
+  expect(container.firstChild).toHaveStyle('margin: 1rem');
+});

--- a/packages/big-design/src/components/Form/styled.tsx
+++ b/packages/big-design/src/components/Form/styled.tsx
@@ -1,12 +1,15 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
+import { withMargins } from '../../mixins';
 import { StyledInputWrapper } from '../Input/styled';
 import { StyledTextareaWrapper } from '../Textarea/styled';
 
 import { FormProps } from './Form';
 
 export const StyledForm = styled.form<FormProps>`
+  ${withMargins()}
+
   ${({ theme }) => theme.breakpoints.tablet} {
     ${StyledInputWrapper},
     ${StyledTextareaWrapper} {

--- a/packages/docs/pages/Form/FormPage.tsx
+++ b/packages/docs/pages/Form/FormPage.tsx
@@ -23,6 +23,7 @@ import {
   FormGroupPropTable,
   FormLabelPropTable,
   FormPropTable,
+  MarginPropTable,
 } from '../../PropTables';
 
 const FormPage = () => {
@@ -199,7 +200,7 @@ const FormPage = () => {
       title: 'Props',
       render: () => (
         <>
-          <FormPropTable />
+          <FormPropTable inheritedProps={<MarginPropTable collapsible />} />
           <FormErrorPropTable id="error" />
           <FormLabelPropTable id="label" />
           <FormDescriptionPropTable id="label" />


### PR DESCRIPTION
## What?

Adds `margin` props to the `Form` component.

## Why?

I noticed a ton of cases where people need to add margin to a `Form`, for example in a `Modal`. Most cases looked like this:
```tsx
<Box marginBottom="medium">
  <Form>
    {...}
  </Form>
</Box>
```

This aims to make the DX better, so we can do this:
```tsx
<Form marginBottom="medium" />
```

## Screenshots/Screen Recordings

<img width="1008" alt="Screen Shot 2021-07-30 at 10 08 08" src="https://user-images.githubusercontent.com/10539418/127674969-9b746c15-0b62-4ab3-b404-a58d86379586.png">