### PR TITLE
feat(theme): add listReset helper

### DIFF
--- a/packages/big-design-theme/src/helpers/helpers.spec.ts
+++ b/packages/big-design-theme/src/helpers/helpers.spec.ts
@@ -1,6 +1,6 @@
 import { themeOptions } from '../options';
 
-import { addValues, createRGBA, emCalc, remCalc } from './helpers';
+import { addValues, createRGBA, emCalc, listReset, remCalc } from './helpers';
 
 describe('addValues', () => {
   test('adds px', () => {
@@ -94,4 +94,10 @@ describe('emCal', () => {
 
     expect(result).toEqual(expected);
   });
+});
+
+test('listReset returns reset css', () => {
+  const expected = ['list-style-type:none;margin:0;padding:0;'];
+
+  expect(listReset).toEqual(expected);
 });

--- a/packages/big-design-theme/src/helpers/helpers.ts
+++ b/packages/big-design-theme/src/helpers/helpers.ts
@@ -1,4 +1,5 @@
 import { em, math, rem, transparentize } from 'polished';
+import { css, FlattenSimpleInterpolation } from 'styled-components';
 
 import { themeOptions } from '../options';
 
@@ -7,6 +8,7 @@ export interface Helpers {
   createRGBA(color: string, alpha: number): string;
   remCalc(value: string | number): string;
   emCalc(value: string | number): string;
+  listReset: FlattenSimpleInterpolation;
 }
 
 export const addValues = (first: string, second: string) => {
@@ -35,3 +37,9 @@ export const emCalc = (value: string | number) => {
 
   return em(value, htmlFontSize);
 };
+
+export const listReset = css`
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+`;

--- a/packages/big-design-theme/src/helpers/index.ts
+++ b/packages/big-design-theme/src/helpers/index.ts
@@ -1,9 +1,10 @@
-import { addValues, createRGBA, emCalc, remCalc } from './helpers';
+import { addValues, createRGBA, emCalc, listReset, remCalc } from './helpers';
 
 export * from './helpers';
 export const createHelpers = () => ({
   addValues,
   createRGBA,
   emCalc,
+  listReset,
   remCalc,
 });


### PR DESCRIPTION
## What?

Provides a `listReset` helper on the theme.

## Why?

There have been a few use-cases where we want to build a list of components. In order to do that semantically you need a `ul/ol` with reset styles. This utility should help prevent writing the following repeatedly:
```tsx
const StyledUl = styled.ul`
  list-style-type: none;
  margin: 0;
  padding: 0;
`;
```

Now you can writing it like so:
```tsx
const StyledUl = styled.ul`
  $({ theme } => theme.helpers.listReset);
`;
```

## Screenshots/Screen Recordings

<img width="698" alt="Screen Shot 2021-07-30 at 10 38 34" src="https://user-images.githubusercontent.com/10539418/127678540-567653ec-3f9c-49d8-953b-d2ddec5a1873.png">
