### PR TITLE
fix(component): Error locale must match

### DIFF
--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -37,7 +37,7 @@
     "@bigcommerce/big-design-theme": "^0.13.1",
     "@popperjs/core": "^2.5.4",
     "@types/react-datepicker": "^3.1.5",
-    "date-fns": "^2.24.0",
+    "date-fns": "2.22.1",
     "downshift": "6.1.0",
     "focus-trap": "^5.1.0",
     "polished": "^4.0.0",

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -37,6 +37,7 @@
     "@bigcommerce/big-design-theme": "^0.13.1",
     "@popperjs/core": "^2.5.4",
     "@types/react-datepicker": "^3.1.5",
+    "date-fns": "^2.23.0",
     "downshift": "6.1.0",
     "focus-trap": "^5.1.0",
     "polished": "^4.0.0",

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -37,7 +37,7 @@
     "@bigcommerce/big-design-theme": "^0.13.1",
     "@popperjs/core": "^2.5.4",
     "@types/react-datepicker": "^3.1.5",
-    "date-fns": "^2.23.0",
+    "date-fns": "^2.24.0",
     "downshift": "6.1.0",
     "focus-trap": "^5.1.0",
     "polished": "^4.0.0",

--- a/packages/big-design/src/components/Datepicker/Datepicker.tsx
+++ b/packages/big-design/src/components/Datepicker/Datepicker.tsx
@@ -40,7 +40,7 @@ const RawDatepicker: React.FC<DatepickerProps & PrivateProps> = ({
   const localization = createLocalizationProvider(locale);
 
   registerLocale(locale, localization);
-  const updateDate = (value: Date) => onDateChange(value.toISOString());
+  const updateDate = (value: Date) => onDateChange(value ? value.toISOString() : value);
 
   useEffect(() => {
     if (typeof value === 'string') {

--- a/packages/big-design/src/components/Datepicker/spec.tsx
+++ b/packages/big-design/src/components/Datepicker/spec.tsx
@@ -78,6 +78,23 @@ test('calls onDateChange function when a date cell is clicked', () => {
   expect(changeFunction).toHaveBeenCalled();
 });
 
+test('no error when input date value manually', () => {
+  const changeFunction = jest.fn();
+  const { container } = render(<Datepicker onDateChange={changeFunction} />);
+
+  const dateString = 'Wed, 03 June, 2020';
+  const input = container.querySelector('input');
+
+  fireEvent.input(input as HTMLInputElement, {
+    target: {
+      value: dateString,
+    },
+  });
+
+  expect(changeFunction).not.toBeCalled();
+  expect(input?.getAttribute('value')).toEqual(dateString);
+});
+
 test('renders an error if one is provided', () => {
   const { getByText } = render(
     <FormGroup>

--- a/packages/big-design/src/utils/localizationProvider/localizationProvider.ts
+++ b/packages/big-design/src/utils/localizationProvider/localizationProvider.ts
@@ -1,3 +1,5 @@
+import { enUS as defaultLocale } from 'date-fns/locale';
+
 interface LocalizationProviderInterface {
   code?: string;
   localize?: {
@@ -6,6 +8,7 @@ interface LocalizationProviderInterface {
   };
   monthsLong?: string[];
   formatLong?: Record<string, unknown>;
+  match?: Record<string, unknown>;
   formatTime(date: Date): string;
 }
 
@@ -48,8 +51,8 @@ export const createLocalizationProvider = (locale: string) => {
       day: (n: number) => daysShort[n],
     },
     monthsLong,
-    // Required by datepicker.
-    formatLong: {},
+    formatLong: defaultLocale.formatLong,
+    match: defaultLocale.match,
     formatTime: timeFormatter.format,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4920,10 +4920,10 @@ date-fns@^2.0.1, date-fns@^2.16.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
   integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
-date-fns@^2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
-  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
+date-fns@^2.24.0:
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.25.0.tgz#8c5c8f1d958be3809a9a03f4b742eba894fc5680"
+  integrity sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==
 
 dateformat@^3.0.0:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4920,6 +4920,11 @@ date-fns@^2.0.1, date-fns@^2.16.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
   integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
+date-fns@^2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
+  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4910,20 +4910,15 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^1.27.2:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
-  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
-
-date-fns@^2.0.1, date-fns@^2.16.1:
+date-fns@2.22.1, date-fns@^2.0.1, date-fns@^2.16.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
   integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
-date-fns@^2.24.0:
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.25.0.tgz#8c5c8f1d958be3809a9a03f4b742eba894fc5680"
-  integrity sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==
+date-fns@^1.27.2:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 dateformat@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
## What?

Fix `Uncaught RangeError: locale must contain match property` in issue #525  by using `match` from `date-fns`


## Why?

There is a missing property `match` 

## Screenshots/Screen Recordings

demo: https://take.ms/DCJRv

## Testing/Proof

The change is covered with unit-test to make sure the component still working as expected
