### PR TITLE
fix(component): alert autoDismiss firing when not visible

### DIFF
--- a/packages/big-design/src/managers/alerts/types.ts
+++ b/packages/big-design/src/managers/alerts/types.ts
@@ -3,4 +3,4 @@ import { MessagingType } from '../../utils';
 
 export type TypeMap = { [key in MessagingType]: number };
 
-export type Subscriber = (alert: AlertProps) => void;
+export type Subscriber = (alert: AlertProps | null) => void;

--- a/packages/big-design/src/utils/messagingHelpers.tsx
+++ b/packages/big-design/src/utils/messagingHelpers.tsx
@@ -17,8 +17,6 @@ export interface SharedMessagingProps extends HTMLAttributes<HTMLDivElement> {
 
 export type MessagingType = 'success' | 'error' | 'warning' | 'info';
 
-export type MessagingVariant = 'alert' | 'message' | 'inline';
-
 export interface MessageItem {
   text: string;
   link?: MessageLinkItem;


### PR DESCRIPTION
## What?

Fixes the alert manager auto-dismissing hidden alerts.

## Why?

The `setTimeout` was being invoked as soon as the alert was created, which meant that the alert was already counting down to 0 before you even saw it.

## Screenshots/Screen Recordings

https://user-images.githubusercontent.com/10539418/129981438-ece33b9a-a859-4ea5-8346-4bf1bfd95bfb.mov

## Testing/Proof

Added additional test for it.

shoutout to @jordan-massingill for catching this
