### PR TITLE
fix(icons): add aria-hidden=true if an icon doesn't have a title 

### DIFF
--- a/packages/big-design-icons/scripts/svgr-flags.config.js
+++ b/packages/big-design-icons/scripts/svgr-flags.config.js
@@ -31,7 +31,7 @@ module.exports = {
     };
 
     BREAK
-    const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => <FlagIcon {...iconProps} svgRef={ref} />);
+    const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />);
 
     BREAK
     export const COMPONENT_NAME = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/scripts/svgr.config.js
+++ b/packages/big-design-icons/scripts/svgr.config.js
@@ -33,7 +33,7 @@ module.exports = {
     };
 
     BREAK
-    const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => <Icon {...iconProps} svgRef={ref} />);
+    const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />);
 
     BREAK
     export const COMPONENT_NAME = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AddCircleOutlineIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/AddIcon.tsx
+++ b/packages/big-design-icons/src/components/AddIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AddIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ArrowBackIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowBackIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ArrowBackIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ArrowDownwardIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ArrowDropDownIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ArrowForwardIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ArrowUpwardIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/AssignmentIcon.tsx
+++ b/packages/big-design-icons/src/components/AssignmentIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AssignmentIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
+++ b/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BaselineHelpIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/BrushIcon.tsx
+++ b/packages/big-design-icons/src/components/BrushIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BrushIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/CheckCircleIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckCircleIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CheckCircleIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/CheckIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CheckIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ChevronLeftIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ChevronRightIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronRightIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ChevronRightIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/CloseIcon.tsx
+++ b/packages/big-design-icons/src/components/CloseIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CloseIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/CloudUploadIcon.tsx
+++ b/packages/big-design-icons/src/components/CloudUploadIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CloudUploadIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/CodeIcon.tsx
+++ b/packages/big-design-icons/src/components/CodeIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CodeIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ContentCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/ContentCopyIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ContentCopyIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/DeleteIcon.tsx
+++ b/packages/big-design-icons/src/components/DeleteIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const DeleteIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
+++ b/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const DragIndicatorIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/EditIcon.tsx
+++ b/packages/big-design-icons/src/components/EditIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const EditIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ErrorIcon.tsx
+++ b/packages/big-design-icons/src/components/ErrorIcon.tsx
@@ -29,7 +29,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ErrorIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ExpandLessIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandLessIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ExpandLessIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ExpandMoreIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/FileCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/FileCopyIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const FileCopyIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/FilterListIcon.tsx
+++ b/packages/big-design-icons/src/components/FilterListIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const FilterListIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/FolderIcon.tsx
+++ b/packages/big-design-icons/src/components/FolderIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const FolderIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/GetAppIcon.tsx
+++ b/packages/big-design-icons/src/components/GetAppIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GetAppIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/HomeIcon.tsx
+++ b/packages/big-design-icons/src/components/HomeIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const HomeIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/InfoIcon.tsx
+++ b/packages/big-design-icons/src/components/InfoIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const InfoIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/InsertDriveFileIcon.tsx
+++ b/packages/big-design-icons/src/components/InsertDriveFileIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const InsertDriveFileIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/InvertColorsIcon.tsx
+++ b/packages/big-design-icons/src/components/InvertColorsIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const InvertColorsIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/KeyboardDoubleArrowLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/KeyboardDoubleArrowLeftIcon.tsx
@@ -34,7 +34,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KeyboardDoubleArrowLeftIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/LanguageIcon.tsx
+++ b/packages/big-design-icons/src/components/LanguageIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LanguageIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/MenuIcon.tsx
+++ b/packages/big-design-icons/src/components/MenuIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MenuIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/MoreHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/MoreHorizIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MoreHorizIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/NotificationsIcon.tsx
+++ b/packages/big-design-icons/src/components/NotificationsIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NotificationsIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/OpenInNewIcon.tsx
+++ b/packages/big-design-icons/src/components/OpenInNewIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const OpenInNewIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/PublicIcon.tsx
+++ b/packages/big-design-icons/src/components/PublicIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PublicIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ReceiptIcon.tsx
+++ b/packages/big-design-icons/src/components/ReceiptIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ReceiptIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const RemoveCircleOutlineIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/RemoveIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const RemoveIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/RestoreIcon.tsx
+++ b/packages/big-design-icons/src/components/RestoreIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const RestoreIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/SearchIcon.tsx
+++ b/packages/big-design-icons/src/components/SearchIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SearchIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/SettingsIcon.tsx
+++ b/packages/big-design-icons/src/components/SettingsIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SettingsIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/StarBorderIcon.tsx
+++ b/packages/big-design-icons/src/components/StarBorderIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const StarBorderIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/StarHalfIcon.tsx
+++ b/packages/big-design-icons/src/components/StarHalfIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const StarHalfIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/StarIcon.tsx
+++ b/packages/big-design-icons/src/components/StarIcon.tsx
@@ -29,7 +29,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const StarIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/StoreIcon.tsx
+++ b/packages/big-design-icons/src/components/StoreIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const StoreIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/SwapHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/SwapHorizIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SwapHorizIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/VisibilityIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const VisibilityIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
@@ -30,7 +30,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const VisibilityOffIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/WarningIcon.tsx
+++ b/packages/big-design-icons/src/components/WarningIcon.tsx
@@ -29,7 +29,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon {...iconProps} svgRef={ref} />
+  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const WarningIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/flags/components/ADFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ADFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#d0103a" d="M0 0h640v480H0z" />
       <path fill="#fedf00" d="M0 0h435.2v480H0z" />
@@ -307,7 +313,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ADFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AEFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AFFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path d="M0 0h640v480H0z" />
@@ -133,7 +139,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AGFlagIcon.tsx
@@ -34,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AIFlagIcon.tsx
@@ -796,7 +796,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ALFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ALFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#e41e20" d="M0 0h640v480H0z" />
       <path
@@ -25,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ALFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AMFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AOFlagIcon.tsx
@@ -54,7 +54,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AQFlagIcon.tsx
@@ -28,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AQFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ARFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ARFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#74acdf" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 160h640v160H0z" />
@@ -83,7 +89,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ARFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ASFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ASFlagIcon.tsx
@@ -121,7 +121,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ASFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ATFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ATFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ATFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AUFlagIcon.tsx
@@ -36,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AWFlagIcon.tsx
@@ -208,7 +208,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AXFlagIcon.tsx
@@ -35,7 +35,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AXFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AZFlagIcon.tsx
@@ -28,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const AZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BAFlagIcon.tsx
@@ -32,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BBFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#00267f" d="M0 0h640v480H0z" />
       <path fill="#ffc726" d="M213.3 0h213.4v480H213.3z" />
@@ -26,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BBFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BDFlagIcon.tsx
@@ -21,7 +21,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BEFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BFFlagIcon.tsx
@@ -27,7 +27,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BGFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BHFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BIFlagIcon.tsx
@@ -37,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BJFlagIcon.tsx
@@ -31,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BJFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BLFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BMFlagIcon.tsx
@@ -441,7 +441,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BNFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#f7e017" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 33.3v213.4l640 100V233.3z" />
@@ -53,7 +59,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BOFlagIcon.tsx
@@ -2812,7 +2812,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BQFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BQFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BRFlagIcon.tsx
@@ -136,7 +136,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BSFlagIcon.tsx
@@ -30,7 +30,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BTFlagIcon.tsx
@@ -123,7 +123,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BVFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BWFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BYFlagIcon.tsx
@@ -37,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BZFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <radialGradient id="BZFlagIcon__a">
@@ -380,7 +386,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const BZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CAFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CCFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <path
@@ -50,7 +56,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CDFlagIcon.tsx
@@ -25,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CFFlagIcon.tsx
@@ -35,7 +35,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CGFlagIcon.tsx
@@ -29,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CHFlagIcon.tsx
@@ -26,7 +26,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CIFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CKFlagIcon.tsx
@@ -36,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CLFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CMFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#007a5e" d="M0 0h213.3v480H0z" />
       <path fill="#ce1126" d="M213.3 0h213.4v480H213.3z" />
@@ -32,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CNFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <path id="CNFlagIcon__a" fill="#ffde00" d="M-.6.8L0-1 .6.8-1-.3h2z" />
@@ -48,7 +54,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/COFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/COFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const COFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CRFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CUFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CVFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CWFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="CWFlagIcon__a">
@@ -31,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CXFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#0021ad" d="M0 0h640v480H0z" />
       <path fill="#1c8a42" d="M0 0h640v480z" />
@@ -41,7 +47,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CXFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CYFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <path
@@ -30,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CZFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const CZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DEFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const DEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DJFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const DJFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DKFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const DKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DMFlagIcon.tsx
@@ -503,7 +503,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const DMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DOFlagIcon.tsx
@@ -6848,7 +6848,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const DOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DZFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const DZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ECFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ECFlagIcon.tsx
@@ -714,7 +714,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ECFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/EEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EEFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const EEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/EGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EGFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path d="M0 320h640v160H0z" />
       <path fill="#fff" d="M0 160h640v160H0z" />
@@ -98,7 +104,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const EGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/EHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EHFlagIcon.tsx
@@ -38,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const EHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ERFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ERFlagIcon.tsx
@@ -28,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ERFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ESCTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESCTFlagIcon.tsx
@@ -26,7 +26,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ESCTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ESFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESFlagIcon.tsx
@@ -1761,7 +1761,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ESFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ESGAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESGAFlagIcon.tsx
@@ -779,7 +779,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ESGAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ETFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ETFlagIcon.tsx
@@ -34,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ETFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/EUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EUFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <g id="EUFlagIcon__d">
@@ -45,7 +51,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const EUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FIFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const FIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FJFlagIcon.tsx
@@ -248,7 +248,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const FJFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FKFlagIcon.tsx
@@ -12,13 +12,15 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
-        <linearGradient id="FKFlagIcon__a">
-          <stop offset={0} stopColor="#a43907" />
-          <stop offset={1} stopColor="#fff" />
-        </linearGradient>
         <linearGradient
           id="FKFlagIcon__c"
           x1={444.4}
@@ -26,6 +28,16 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
           y1={592.2}
           y2={577.1}
           gradientTransform="matrix(-1.08448 0 0 1.26674 909.5 -414.7)"
+          gradientUnits="userSpaceOnUse"
+          xlinkHref="#FKFlagIcon__a"
+        />
+        <linearGradient
+          id="FKFlagIcon__g"
+          x1={851.8}
+          x2={646.2}
+          y1={369.9}
+          y2={369.9}
+          gradientTransform="matrix(.85733 0 0 .9624 -161.5 .3)"
           gradientUnits="userSpaceOnUse"
           xlinkHref="#FKFlagIcon__a"
         />
@@ -59,16 +71,10 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
           gradientUnits="userSpaceOnUse"
           xlinkHref="#FKFlagIcon__a"
         />
-        <linearGradient
-          id="FKFlagIcon__g"
-          x1={851.8}
-          x2={646.2}
-          y1={369.9}
-          y2={369.9}
-          gradientTransform="matrix(.85733 0 0 .9624 -161.5 .3)"
-          gradientUnits="userSpaceOnUse"
-          xlinkHref="#FKFlagIcon__a"
-        />
+        <linearGradient id="FKFlagIcon__a">
+          <stop offset={0} stopColor="#a43907" />
+          <stop offset={1} stopColor="#fff" />
+        </linearGradient>
         <linearGradient
           id="FKFlagIcon__h"
           x1={388.5}
@@ -520,7 +526,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const FKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FMFlagIcon.tsx
@@ -31,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const FMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FOFlagIcon.tsx
@@ -29,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const FOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FRFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const FRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GAFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GBENGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBENGFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GBENGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBFlagIcon.tsx
@@ -27,7 +27,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GBFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GBNIRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBNIRFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <rect fill="#fff" fillRule="evenodd" rx={0} ry={0} />
@@ -611,7 +617,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GBNIRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GBSCTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBSCTFlagIcon.tsx
@@ -21,7 +21,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GBSCTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GBWLSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBWLSFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GBWLSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GDFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <g id="GDFlagIcon__c">
@@ -53,7 +59,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GEFlagIcon.tsx
@@ -30,7 +30,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GFFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GGFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <path fill="#e8112d" d="M256 0h128v480H256z" />
@@ -26,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GHFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GIFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#da000c" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 0h640v321.6H0z" />
@@ -58,7 +64,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GLFlagIcon.tsx
@@ -21,7 +21,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GMFlagIcon.tsx
@@ -31,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GNFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GPFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GPFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GQFlagIcon.tsx
@@ -67,7 +67,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GQFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GRFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GSFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <linearGradient id="GSFlagIcon__b">
@@ -978,7 +984,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GTFlagIcon.tsx
@@ -12,17 +12,27 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
-        <radialGradient id="GTFlagIcon__m" cx={477.9} cy={215.3} r={0.3} gradientUnits="userSpaceOnUse">
-          <stop offset={0.3} stopColor="#a50a0a" />
-          <stop offset={1} stopColor="#4c0505" />
-        </radialGradient>
         <radialGradient id="GTFlagIcon__a">
           <stop offset={0.2} stopColor="#f9f0aa" />
           <stop offset={1} stopColor="#b07e09" />
         </radialGradient>
+        <radialGradient
+          id="GTFlagIcon__d"
+          cx={447.4}
+          cy={308.3}
+          r={16.5}
+          gradientUnits="userSpaceOnUse"
+          xlinkHref="#GTFlagIcon__a"
+        />
         <radialGradient
           id="GTFlagIcon__e"
           cx={451.6}
@@ -55,14 +65,10 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
           gradientUnits="userSpaceOnUse"
           xlinkHref="#GTFlagIcon__a"
         />
-        <radialGradient
-          id="GTFlagIcon__d"
-          cx={447.4}
-          cy={308.3}
-          r={16.5}
-          gradientUnits="userSpaceOnUse"
-          xlinkHref="#GTFlagIcon__a"
-        />
+        <radialGradient id="GTFlagIcon__m" cx={477.9} cy={215.3} r={0.3} gradientUnits="userSpaceOnUse">
+          <stop offset={0.3} stopColor="#a50a0a" />
+          <stop offset={1} stopColor="#4c0505" />
+        </radialGradient>
         <radialGradient
           id="GTFlagIcon__n"
           cx={489.1}
@@ -393,7 +399,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GUFlagIcon.tsx
@@ -156,7 +156,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GWFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#ce1126" d="M0 0h220v480H0z" />
       <path fill="#fcd116" d="M220 0h420v240H220z" />
@@ -30,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GYFlagIcon.tsx
@@ -26,7 +26,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const GYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HKFlagIcon.tsx
@@ -87,7 +87,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const HKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HMFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const HMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HNFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#0073cf" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 160h640v160H0z" />
@@ -35,7 +41,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const HNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HRFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#171796" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 0h640v320H0z" />
@@ -107,7 +113,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const HRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HTFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#d21034" d="M0 0h640v480H0z" />
       <path fill="#00209f" d="M0 0h640v240H0z" />
@@ -231,7 +237,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const HTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HUFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const HUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IDFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const IDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IEFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const IEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ILFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ILFlagIcon.tsx
@@ -37,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ILFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IMFlagIcon.tsx
@@ -163,7 +163,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const IMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/INFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/INFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#f93" d="M0 0h640v160H0z" />
       <path fill="#fff" d="M0 160h640v160H0z" />
@@ -42,7 +48,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const INFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IOFlagIcon.tsx
@@ -820,7 +820,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const IOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IQFlagIcon.tsx
@@ -27,7 +27,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const IQFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IRFlagIcon.tsx
@@ -242,7 +242,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const IRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ISFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ISFlagIcon.tsx
@@ -29,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ISFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ITFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ITFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ITFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/JEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JEFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 30 22.5" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 30 22.5"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="JEFlagIcon__a">
@@ -72,7 +78,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const JEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/JMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JMFlagIcon.tsx
@@ -25,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const JMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/JOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JOFlagIcon.tsx
@@ -36,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const JOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/JPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JPFlagIcon.tsx
@@ -28,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const JPFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KEFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <path
@@ -47,7 +53,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KGFlagIcon.tsx
@@ -38,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KHFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#032ea1" d="M0 0h640v480H0z" />
       <path fill="#e00025" d="M0 120h640v240H0z" />
@@ -96,7 +102,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KIFlagIcon.tsx
@@ -200,7 +200,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KMFlagIcon.tsx
@@ -39,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KNFlagIcon.tsx
@@ -34,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KPFlagIcon.tsx
@@ -38,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KPFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KRFlagIcon.tsx
@@ -47,7 +47,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KWFlagIcon.tsx
@@ -30,7 +30,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KYFlagIcon.tsx
@@ -308,7 +308,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KZFlagIcon.tsx
@@ -40,7 +40,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const KZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LAFlagIcon.tsx
@@ -29,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LBFlagIcon.tsx
@@ -43,7 +43,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LBFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LCFlagIcon.tsx
@@ -25,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LIFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#002b7f" d="M0 0h640v240H0z" />
       <path fill="#ce1126" d="M0 240h640v240H0z" />
@@ -84,7 +90,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LKFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#ffb700" d="M0 0h640v480H0z" />
       <path fill="#ff5b00" d="M26.7 240l88-213.3h88v426.6h-88z" />
@@ -51,7 +57,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LRFlagIcon.tsx
@@ -37,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LSFlagIcon.tsx
@@ -37,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LTFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LUFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LVFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LYFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const LYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MAFlagIcon.tsx
@@ -21,7 +21,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MCFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MDFlagIcon.tsx
@@ -320,7 +320,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MEFlagIcon.tsx
@@ -334,7 +334,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MFFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MGFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MHFlagIcon.tsx
@@ -27,7 +27,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MKFlagIcon.tsx
@@ -25,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MLFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MMFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <path id="MMFlagIcon__a" fill="#fff" d="M0-.5l.2.5h-.4z" transform="scale(8.844)" />
@@ -33,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MNFlagIcon.tsx
@@ -37,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MOFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#00785e" d="M0 0h640v480H0z" />
       <path fill="#fbd116" d="M295 108.7l40.5 29.5L320 90.5l-15.5 47.7 40.6-29.5z" />
@@ -32,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MPFlagIcon.tsx
@@ -397,7 +397,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MPFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MQFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MQFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MRFlagIcon.tsx
@@ -30,7 +30,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MSFlagIcon.tsx
@@ -98,7 +98,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MTFlagIcon.tsx
@@ -179,7 +179,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MUFlagIcon.tsx
@@ -25,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MVFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MWFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MXFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <radialGradient
@@ -1339,7 +1345,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MXFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MYFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#cc0001" d="M0 0h640v480H0z" />
       <path id="MYFlagIcon__a" fill="#fff" d="M0 445.8h640V480H0z" />
@@ -32,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MZFlagIcon.tsx
@@ -71,7 +71,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const MZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NAFlagIcon.tsx
@@ -39,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NCFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#009543" d="M0 0h640v480H0z" />
       <path fill="#ed4135" d="M0 0h640v320H0z" />
@@ -31,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NEFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NFFlagIcon.tsx
@@ -46,7 +46,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NGFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NIFlagIcon.tsx
@@ -12,22 +12,23 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
-        <linearGradient
-          id="NIFlagIcon__r"
-          x1={444.5}
-          x2={634.4}
-          y1={317.5}
-          y2={317.5}
-          gradientUnits="userSpaceOnUse"
-          xlinkHref="#NIFlagIcon__a"
-        />
         <linearGradient id="NIFlagIcon__f" x1={498.7} x2={500.6} y1={289.1} y2={283.4} gradientUnits="userSpaceOnUse">
           <stop offset={0} stopColor="#510000" />
           <stop offset={0.3} stopColor="#8a0000" />
           <stop offset={1} stopColor="#a00" />
+        </linearGradient>
+        <linearGradient id="NIFlagIcon__g" x1={501.4} x2={502.9} y1={291.4} y2={287.4} gradientUnits="userSpaceOnUse">
+          <stop offset={0} stopColor="#ff2a2a" />
+          <stop offset={1} stopColor="red" />
         </linearGradient>
         <linearGradient id="NIFlagIcon__b" x1={484.8} x2={484.8} y1={311.7} y2={317.6} gradientUnits="userSpaceOnUse">
           <stop offset={0} stopColor="#F5F549" />
@@ -83,10 +84,15 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
           gradientUnits="userSpaceOnUse"
           xlinkHref="#NIFlagIcon__a"
         />
-        <linearGradient id="NIFlagIcon__g" x1={501.4} x2={502.9} y1={291.4} y2={287.4} gradientUnits="userSpaceOnUse">
-          <stop offset={0} stopColor="#ff2a2a" />
-          <stop offset={1} stopColor="red" />
-        </linearGradient>
+        <linearGradient
+          id="NIFlagIcon__r"
+          x1={444.5}
+          x2={634.4}
+          y1={317.5}
+          y2={317.5}
+          gradientUnits="userSpaceOnUse"
+          xlinkHref="#NIFlagIcon__a"
+        />
         <linearGradient
           id="NIFlagIcon__u"
           x1={484.8}
@@ -361,7 +367,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NLFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NOFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NPFlagIcon.tsx
@@ -39,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NPFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NRFlagIcon.tsx
@@ -32,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NUFlagIcon.tsx
@@ -52,7 +52,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NZFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="NZFlagIcon__c">
@@ -155,7 +161,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const NZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/OMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/OMFlagIcon.tsx
@@ -483,7 +483,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const OMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PAFlagIcon.tsx
@@ -39,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PEFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#d91023" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M213.3 0h213.4v480H213.3z" />
@@ -632,7 +638,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PFFlagIcon.tsx
@@ -79,7 +79,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PGFlagIcon.tsx
@@ -43,7 +43,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PHFlagIcon.tsx
@@ -25,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PKFlagIcon.tsx
@@ -32,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PLFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PMFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PNFlagIcon.tsx
@@ -237,7 +237,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PRFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PSFlagIcon.tsx
@@ -32,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PTFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="red" d="M256 0h384v480H256z" />
       <path fill="#060" d="M0 0h256v480H0z" />
@@ -90,7 +96,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PWFlagIcon.tsx
@@ -28,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PYFlagIcon.tsx
@@ -179,7 +179,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const PYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/QAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/QAFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const QAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/REFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/REFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const REFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ROFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ROFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ROFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/RSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RSFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="RSFlagIcon__a">
@@ -943,7 +949,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const RSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/RUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RUFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const RUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/RWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RWFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#20603d" d="M0 0h640v480H0z" />
       <path fill="#fad201" d="M0 0h640v360H0z" />
@@ -34,7 +40,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const RWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SAFlagIcon.tsx
@@ -88,7 +88,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SBFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SBFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SCFlagIcon.tsx
@@ -31,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SDFlagIcon.tsx
@@ -30,7 +30,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SEFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SGFlagIcon.tsx
@@ -36,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SHFlagIcon.tsx
@@ -310,7 +310,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SIFlagIcon.tsx
@@ -53,7 +53,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SJFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SJFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SKFlagIcon.tsx
@@ -38,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SLFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SMFlagIcon.tsx
@@ -361,7 +361,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SNFlagIcon.tsx
@@ -28,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SOFlagIcon.tsx
@@ -31,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SRFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SSFlagIcon.tsx
@@ -25,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/STFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/STFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#12ad2b" d="M0 0h640v480H0z" />
       <path fill="#ffce00" d="M0 137.1h640V343H0z" />
@@ -33,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const STFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SVFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#0f47af" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 160h640v160H0z" />
@@ -1364,7 +1370,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SXFlagIcon.tsx
@@ -232,7 +232,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SXFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SYFlagIcon.tsx
@@ -27,7 +27,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SZFlagIcon.tsx
@@ -171,7 +171,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const SZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TCFlagIcon.tsx
@@ -326,7 +326,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TDFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TFFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <path id="TFFlagIcon__a" fill="#fff" d="M0-21l12.3 38L-20-6.5h40L-12.3 17z" />
@@ -35,7 +41,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TGFlagIcon.tsx
@@ -34,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/THFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/THFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const THFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TJFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#060" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 0h640v342.9H0z" />
@@ -51,7 +57,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TJFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TKFlagIcon.tsx
@@ -28,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TLFlagIcon.tsx
@@ -33,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TMFlagIcon.tsx
@@ -624,7 +624,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TNFlagIcon.tsx
@@ -36,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TOFlagIcon.tsx
@@ -27,7 +27,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TRFlagIcon.tsx
@@ -34,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TTFlagIcon.tsx
@@ -22,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TVFlagIcon.tsx
@@ -36,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TWFlagIcon.tsx
@@ -51,7 +51,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TZFlagIcon.tsx
@@ -30,7 +30,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const TZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UAFlagIcon.tsx
@@ -23,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const UAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UGFlagIcon.tsx
@@ -128,7 +128,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const UGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UMFlagIcon.tsx
@@ -41,7 +41,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const UMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UNFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#4b92db" fillRule="evenodd" d="M0 0h640v480H0z" />
       <g transform="matrix(.6 0 0 .6 -40.6 0)">
@@ -58,7 +64,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const UNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/USFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/USFlagIcon.tsx
@@ -36,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const USFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UYFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <path fill="#0038a8" d="M266 53.3h374v53.4H266zm0 106.7h374v53.3H266zM0 266.7h640V320H0zm0 106.6h640v53.4H0z" />
@@ -51,7 +57,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const UYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UZFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#1eb53a" d="M0 320h640v160H0z" />
       <path fill="#0099b5" d="M0 0h640v160H0z" />
@@ -47,7 +53,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const UZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VAFlagIcon.tsx
@@ -2167,7 +2167,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const VAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VCFlagIcon.tsx
@@ -28,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const VCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VEFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <g id="VEFlagIcon__d" transform="translate(0 -36)">
@@ -43,7 +49,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const VEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VGFlagIcon.tsx
@@ -12,23 +12,29 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
-        <linearGradient
-          id="VGFlagIcon__i"
-          x1={103.1}
-          x2={92.5}
-          y1={111.3}
-          y2={107.8}
-          gradientTransform="matrix(.64274 0 0 1.4534 -98 33.7)"
-          gradientUnits="userSpaceOnUse"
-          xlinkHref="#VGFlagIcon__a"
-        />
         <linearGradient id="VGFlagIcon__a">
           <stop offset={0} stopColor="red" />
           <stop offset={1} stopColor="#ff0" />
         </linearGradient>
+        <linearGradient
+          id="VGFlagIcon__c"
+          x1={103.1}
+          x2={92.5}
+          y1={111.3}
+          y2={107.8}
+          gradientTransform="matrix(.64274 0 0 1.4534 -94.7 29.2)"
+          gradientUnits="userSpaceOnUse"
+          xlinkHref="#VGFlagIcon__a"
+        />
         <linearGradient
           id="VGFlagIcon__d"
           x1={103.1}
@@ -80,12 +86,12 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
           xlinkHref="#VGFlagIcon__a"
         />
         <linearGradient
-          id="VGFlagIcon__c"
+          id="VGFlagIcon__i"
           x1={103.1}
           x2={92.5}
           y1={111.3}
           y2={107.8}
-          gradientTransform="matrix(.64274 0 0 1.4534 -94.7 29.2)"
+          gradientTransform="matrix(.64274 0 0 1.4534 -98 33.7)"
           gradientUnits="userSpaceOnUse"
           xlinkHref="#VGFlagIcon__a"
         />
@@ -624,7 +630,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const VGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VIFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <path
@@ -120,7 +126,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const VIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VNFlagIcon.tsx
@@ -31,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const VNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VUFlagIcon.tsx
@@ -44,7 +44,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const VUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/WFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/WFFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const WFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/WSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/WSFlagIcon.tsx
@@ -27,7 +27,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const WSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/XKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/XKFlagIcon.tsx
@@ -31,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const XKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/YEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/YEFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const YEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/YTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/YTFlagIcon.tsx
@@ -24,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const YTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ZAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZAFlagIcon.tsx
@@ -37,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ZAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ZMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZMFlagIcon.tsx
@@ -85,7 +85,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ZMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ZWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZWFlagIcon.tsx
@@ -12,7 +12,13 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 640 480"
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="ZWFlagIcon__a">
@@ -44,7 +50,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon {...iconProps} svgRef={ref} />
+  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
 ));
 
 export const ZWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-theme/package.json
+++ b/packages/big-design-theme/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.1",
-    "polished": "^3.0.3"
+    "polished": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -39,7 +39,7 @@
     "@types/react-datepicker": "^3.1.5",
     "downshift": "6.1.0",
     "focus-trap": "^5.1.0",
-    "polished": "^3.0.3",
+    "polished": "^4.0.0",
     "react-beautiful-dnd": "^13.1.0",
     "react-datepicker": "^3.6.0",
     "react-popper": "^2.2.4",

--- a/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
@@ -71,6 +71,7 @@ exports[`render default (success) Alert 1`] = `
     class="c0 c3"
   >
     <svg
+      aria-hidden="true"
       class="c4"
       color="success"
       fill="currentColor"
@@ -177,6 +178,7 @@ exports[`render error Alert 1`] = `
     class="c0 c3"
   >
     <svg
+      aria-hidden="true"
       class="c4"
       color="danger"
       fill="currentColor"
@@ -279,6 +281,7 @@ exports[`render info Alert 1`] = `
     class="c0 c3"
   >
     <svg
+      aria-hidden="true"
       class="c4"
       color="primary60"
       fill="currentColor"
@@ -385,6 +388,7 @@ exports[`render warning Alert 1`] = `
     class="c0 c3"
   >
     <svg
+      aria-hidden="true"
       class="c4"
       color="warning50"
       fill="currentColor"
@@ -624,6 +628,7 @@ exports[`renders close button 1`] = `
     class="c0 c3"
   >
     <svg
+      aria-hidden="true"
       class="c4"
       color="success"
       fill="currentColor"
@@ -666,6 +671,7 @@ exports[`renders close button 1`] = `
         class="c10"
       >
         <svg
+          aria-hidden="true"
           class="c11"
           fill="currentColor"
           height="24"
@@ -773,6 +779,7 @@ exports[`renders header 1`] = `
     class="c0 c3"
   >
     <svg
+      aria-hidden="true"
       class="c4"
       color="success"
       fill="currentColor"
@@ -931,6 +938,7 @@ exports[`renders with external link 1`] = `
     class="c0 c3"
   >
     <svg
+      aria-hidden="true"
       class="c4"
       color="success"
       fill="currentColor"
@@ -970,6 +978,7 @@ exports[`renders with external link 1`] = `
           Link
         </span>
         <svg
+          aria-hidden="true"
           class="c10"
           fill="currentColor"
           height="24"
@@ -1089,6 +1098,7 @@ exports[`renders with link 1`] = `
     class="c0 c3"
   >
     <svg
+      aria-hidden="true"
       class="c4"
       color="success"
       fill="currentColor"

--- a/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
@@ -596,6 +596,7 @@ exports[`render icon left and right button 1`] = `
     class="c1"
   >
     <svg
+      aria-hidden="true"
       class="c2"
       fill="currentColor"
       height="24"
@@ -614,6 +615,7 @@ exports[`render icon left and right button 1`] = `
     </svg>
     Button
     <svg
+      aria-hidden="true"
       class="c2"
       fill="currentColor"
       height="24"
@@ -755,6 +757,7 @@ exports[`render icon left button 1`] = `
     class="c1"
   >
     <svg
+      aria-hidden="true"
       class="c2"
       fill="currentColor"
       height="24"
@@ -897,6 +900,7 @@ exports[`render icon only button 1`] = `
     class="c1"
   >
     <svg
+      aria-hidden="true"
       class="c2"
       fill="currentColor"
       height="24"
@@ -1039,6 +1043,7 @@ exports[`render icon right button 1`] = `
   >
     Button
     <svg
+      aria-hidden="true"
       class="c2"
       fill="currentColor"
       height="24"

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -111,6 +111,7 @@ exports[`render Checkbox checked 1`] = `
     for="bd-checkbox-1"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       fill="currentColor"
       height="24"
@@ -255,6 +256,7 @@ exports[`render Checkbox disabled checked 1`] = `
     for="bd-checkbox-1"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       fill="currentColor"
       height="24"
@@ -399,6 +401,7 @@ exports[`render Checkbox disabled indeterminate 1`] = `
     for="bd-checkbox-1"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       fill="currentColor"
       height="24"
@@ -544,6 +547,7 @@ exports[`render Checkbox disabled unchecked 1`] = `
     for="bd-checkbox-1"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       fill="currentColor"
       height="24"
@@ -686,6 +690,7 @@ exports[`render Checkbox indeterminate 1`] = `
     for="bd-checkbox-1"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       fill="currentColor"
       height="24"
@@ -827,6 +832,7 @@ exports[`render Checkbox unchecked 1`] = `
     for="bd-checkbox-1"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       fill="currentColor"
       height="24"
@@ -1008,6 +1014,7 @@ exports[`render Checkbox with description object 1`] = `
     for="bd-checkbox-1"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       fill="currentColor"
       height="24"
@@ -1177,6 +1184,7 @@ exports[`render Checkbox with description string 1`] = `
     for="bd-checkbox-1"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       fill="currentColor"
       height="24"

--- a/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
@@ -69,6 +69,7 @@ exports[`render default (success) InlineMessage 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"
@@ -173,6 +174,7 @@ exports[`render error InlineMessage 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="danger"
       fill="currentColor"
@@ -273,6 +275,7 @@ exports[`render info InlineMessage 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="primary60"
       fill="currentColor"
@@ -377,6 +380,7 @@ exports[`render warning InlineMessage 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="warning50"
       fill="currentColor"
@@ -624,6 +628,7 @@ exports[`renders actions 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"
@@ -887,6 +892,7 @@ exports[`renders close button 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"
@@ -1041,6 +1047,7 @@ exports[`renders header 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"
@@ -1197,6 +1204,7 @@ exports[`renders with external link 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"
@@ -1236,6 +1244,7 @@ exports[`renders with external link 1`] = `
           Link
         </span>
         <svg
+          aria-hidden="true"
           class="c11"
           fill="currentColor"
           height="24"
@@ -1353,6 +1362,7 @@ exports[`renders with link 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -197,6 +197,7 @@ exports[`renders all together 1`] = `
       class="c4"
     >
       <svg
+        aria-hidden="true"
         class="c5"
         data-testid="icon-left"
         fill="currentColor"
@@ -227,6 +228,7 @@ exports[`renders all together 1`] = `
       class="c8"
     >
       <svg
+        aria-hidden="true"
         class="c5"
         data-testid="icon-right"
         fill="currentColor"

--- a/packages/big-design/src/components/Link/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Link/__snapshots__/spec.tsx.snap
@@ -82,6 +82,7 @@ exports[`renders with external icon 1`] = `
     Link
   </span>
   <svg
+    aria-hidden="true"
     class="c1"
     fill="currentColor"
     height="24"

--- a/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
@@ -68,6 +68,7 @@ exports[`render default (success) Message 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"
@@ -171,6 +172,7 @@ exports[`render error Message 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="danger"
       fill="currentColor"
@@ -270,6 +272,7 @@ exports[`render info Message 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="primary60"
       fill="currentColor"
@@ -373,6 +376,7 @@ exports[`render warning Message 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="warning50"
       fill="currentColor"
@@ -619,6 +623,7 @@ exports[`renders actions 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"
@@ -881,6 +886,7 @@ exports[`renders close button 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"
@@ -1033,6 +1039,7 @@ exports[`renders header 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"
@@ -1188,6 +1195,7 @@ exports[`renders with external link 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"
@@ -1227,6 +1235,7 @@ exports[`renders with external link 1`] = `
           Link
         </span>
         <svg
+          aria-hidden="true"
           class="c11"
           fill="currentColor"
           height="24"
@@ -1343,6 +1352,7 @@ exports[`renders with link 1`] = `
     class="c3 c4"
   >
     <svg
+      aria-hidden="true"
       class="c5"
       color="success"
       fill="currentColor"

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -312,6 +312,7 @@ exports[`render pagination component 1`] = `
         >
           1 - 3 of 10
           <svg
+            aria-hidden="true"
             class="c7"
             fill="currentColor"
             height="24"
@@ -726,6 +727,7 @@ exports[`render pagination component with invalid page info 1`] = `
         >
           -8 - -6 of 10
           <svg
+            aria-hidden="true"
             class="c7"
             fill="currentColor"
             height="24"
@@ -1140,6 +1142,7 @@ exports[`render pagination component with invalid range info 1`] = `
         >
           1 - -5 of 10
           <svg
+            aria-hidden="true"
             class="c7"
             fill="currentColor"
             height="24"
@@ -1555,6 +1558,7 @@ exports[`render pagination component with no items 1`] = `
         >
           0 of 0
           <svg
+            aria-hidden="true"
             class="c7"
             fill="currentColor"
             height="24"

--- a/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`render completed determinant progress circle 1`] = `
 
 <div>
   <svg
+    aria-hidden="true"
     aria-valuemax="100"
     aria-valuemin="0"
     aria-valuenow="100"
@@ -110,6 +111,7 @@ exports[`render error determinant progress circle 1`] = `
 
 <div>
   <svg
+    aria-hidden="true"
     aria-valuemax="100"
     aria-valuemin="0"
     aria-valuenow="0"

--- a/packages/big-design/src/components/Stepper/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Stepper/__snapshots__/spec.tsx.snap
@@ -362,6 +362,7 @@ exports[`renders Stepper 1`] = `
       class="c5 c6 c7"
     >
       <svg
+        aria-hidden="true"
         class="c8"
         color="white"
         fill="currentColor"

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -362,6 +362,7 @@ exports[`renders a pagination component 1`] = `
             >
               1 - 3 of 5
               <svg
+                aria-hidden="true"
                 class="c10"
                 fill="currentColor"
                 height="24"
@@ -934,6 +935,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
           for="bd-checkbox-2"
         >
           <svg
+            aria-hidden="true"
             class="c10"
             fill="currentColor"
             height="24"

--- a/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
@@ -20,6 +20,7 @@ exports[`renders simple tree 1`] = `
         class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledArrowWrapper-sc-1073t7q-1 halJjp"
       >
         <svg
+          aria-hidden="true"
           class="base__StyledIcon-sc-a9u0e1-0 kwHAib"
           color="secondary60"
           fill="currentColor"
@@ -43,6 +44,7 @@ exports[`renders simple tree 1`] = `
         class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
       >
         <svg
+          aria-hidden="true"
           class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
           color="primary30"
           fill="currentColor"
@@ -85,6 +87,7 @@ exports[`renders simple tree 1`] = `
             class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledArrowWrapper-sc-1073t7q-1 halJjp"
           >
             <svg
+              aria-hidden="true"
               class="base__StyledIcon-sc-a9u0e1-0 kwHAib"
               color="secondary60"
               fill="currentColor"
@@ -108,6 +111,7 @@ exports[`renders simple tree 1`] = `
             class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
           >
             <svg
+              aria-hidden="true"
               class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
               color="primary30"
               fill="currentColor"
@@ -153,6 +157,7 @@ exports[`renders simple tree 1`] = `
                 class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
               >
                 <svg
+                  aria-hidden="true"
                   class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
                   color="primary30"
                   fill="currentColor"
@@ -196,6 +201,7 @@ exports[`renders simple tree 1`] = `
         class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledArrowWrapper-sc-1073t7q-1 halJjp"
       >
         <svg
+          aria-hidden="true"
           class="base__StyledIcon-sc-a9u0e1-0 kwHAib"
           color="secondary60"
           fill="currentColor"
@@ -219,6 +225,7 @@ exports[`renders simple tree 1`] = `
         class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
       >
         <svg
+          aria-hidden="true"
           class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
           color="primary30"
           fill="currentColor"
@@ -264,6 +271,7 @@ exports[`renders simple tree 1`] = `
             class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
           >
             <svg
+              aria-hidden="true"
               class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
               color="primary30"
               fill="currentColor"
@@ -308,6 +316,7 @@ exports[`renders simple tree 1`] = `
         class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
       >
         <svg
+          aria-hidden="true"
           class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
           color="primary30"
           fill="currentColor"
@@ -347,6 +356,7 @@ exports[`renders simple tree 1`] = `
         class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledArrowWrapper-sc-1073t7q-1 halJjp"
       >
         <svg
+          aria-hidden="true"
           class="base__StyledIcon-sc-a9u0e1-0 kwHAib"
           color="secondary60"
           fill="currentColor"
@@ -370,6 +380,7 @@ exports[`renders simple tree 1`] = `
         class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
       >
         <svg
+          aria-hidden="true"
           class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
           color="primary30"
           fill="currentColor"
@@ -415,6 +426,7 @@ exports[`renders simple tree 1`] = `
             class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
           >
             <svg
+              aria-hidden="true"
               class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
               color="primary30"
               fill="currentColor"
@@ -456,6 +468,7 @@ exports[`renders simple tree 1`] = `
         class="styled__StyledBox-sc-sj5f1m-0 fLCmGm styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledArrowWrapper-sc-1073t7q-1 halJjp"
       >
         <svg
+          aria-hidden="true"
           class="base__StyledIcon-sc-a9u0e1-0 kwHAib"
           color="secondary60"
           fill="currentColor"
@@ -479,6 +492,7 @@ exports[`renders simple tree 1`] = `
         class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
       >
         <svg
+          aria-hidden="true"
           class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
           color="primary30"
           fill="currentColor"
@@ -524,6 +538,7 @@ exports[`renders simple tree 1`] = `
             class="styled__StyledBox-sc-sj5f1m-0 iFpEPs styled__StyledFlexItem-sc-smjqtt-0 loqtGZ styled__StyledFlexItem-sc-1073t7q-4 ggSTVk"
           >
             <svg
+              aria-hidden="true"
               class="base__StyledIcon-sc-a9u0e1-0 kmepXM"
               color="primary30"
               fill="currentColor"

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -80,6 +80,7 @@ exports[`renders worksheet 1`] = `
               for="bd-checkbox-1"
             >
               <svg
+                aria-hidden="true"
                 class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
@@ -209,6 +210,7 @@ exports[`renders worksheet 1`] = `
               for="bd-checkbox-4"
             >
               <svg
+                aria-hidden="true"
                 class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
@@ -337,6 +339,7 @@ exports[`renders worksheet 1`] = `
               for="bd-checkbox-7"
             >
               <svg
+                aria-hidden="true"
                 class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
@@ -466,6 +469,7 @@ exports[`renders worksheet 1`] = `
               for="bd-checkbox-10"
             >
               <svg
+                aria-hidden="true"
                 class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
@@ -593,6 +597,7 @@ exports[`renders worksheet 1`] = `
               for="bd-checkbox-13"
             >
               <svg
+                aria-hidden="true"
                 class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
@@ -722,6 +727,7 @@ exports[`renders worksheet 1`] = `
               for="bd-checkbox-16"
             >
               <svg
+                aria-hidden="true"
                 class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
@@ -850,6 +856,7 @@ exports[`renders worksheet 1`] = `
               for="bd-checkbox-19"
             >
               <svg
+                aria-hidden="true"
                 class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
@@ -979,6 +986,7 @@ exports[`renders worksheet 1`] = `
               for="bd-checkbox-22"
             >
               <svg
+                aria-hidden="true"
                 class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"
@@ -1108,6 +1116,7 @@ exports[`renders worksheet 1`] = `
               for="bd-checkbox-25"
             >
               <svg
+                aria-hidden="true"
                 class="base__StyledIcon-sc-a9u0e1-0 kiXDsL"
                 fill="currentColor"
                 height="24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -997,6 +997,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.14.0":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/standalone@^7.12.4":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.14.8.tgz#4fbb0be8161dbdb30e68d903595fb6479ecf9209"
@@ -10377,12 +10384,12 @@ pnp-webpack-plugin@1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
-polished@^3.0.3:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-3.7.2.tgz#ec5ddc17a7d322a574d5e10ddd2a6f01d3e767d1"
-  integrity sha512-pQKtpZGmsZrW8UUpQMAnR7s3ppHeMQVNyMDKtUyKwuvDmklzcEyM5Kllb3JyE/sE/x7arDmyd35i+4vp99H6sQ==
+polished@^4.0.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.3.tgz#7a3abf2972364e7d97770b827eec9a9e64002cfc"
+  integrity sha512-ocPAcVBUOryJEKe0z2KLd1l9EBa1r5mSwlKpExmrLzsnIzJo4axsoU9O2BjOTkDGDT4mZ0WFE5XKTlR3nLnZOA==
   dependencies:
-    "@babel/runtime" "^7.12.5"
+    "@babel/runtime" "^7.14.0"
 
 popper.js@^1.14.1, popper.js@^1.14.4:
   version "1.16.1"


### PR DESCRIPTION
## What?
Update to `polished@4`. 3.7 shows a lot of warnings.
Add `aria-hidden=true` if an icon doesn't have a title

## Why?

Icons without a title are likely just decoration and should always have
aria-hidden="true"

## Screenshots/Screen Recordings

<table>
<tr>
	<td>Without Title
	<td>With Title
<tr>
	<td><img width="728" alt="image" src="https://user-images.githubusercontent.com/4542735/132791991-9565c682-59eb-47f8-aea9-b9e7cd6fa187.png">
	<td><img width="728" alt="image" src="https://user-images.githubusercontent.com/4542735/132791890-8044b276-2ed4-4340-96ca-46ac585d5ee3.png">
</table>

## Testing/Proof
Tested this in Chrome/Firefox

