### PR TITLE
chore(icons): run icon's main build files through prettier

### DIFF
--- a/packages/big-design-icons/scripts/build-flags.js
+++ b/packages/big-design-icons/scripts/build-flags.js
@@ -5,6 +5,7 @@ const { basename, join } = require('path');
 const rimraf = require('rimraf');
 const { promisify } = require('util');
 
+const { format } = require('./format');
 const config = require('./svgr-flags.config');
 
 const SOURCE = join(__dirname, '..', '..', '..', 'node_modules', '@jorgemoya/flag-icon-css', 'flags', '4x3', '*.svg');
@@ -68,7 +69,11 @@ function cleanDestDirectory() {
 
   const indexFile = Array.from(componentNames).map((name) => `export * from './${name}';`);
 
-  await outputFile(join(DEST_PATH, 'index.ts'), indexFile.join('\n'));
+  const destFile = join(DEST_PATH, 'index.ts');
+
+  await outputFile(destFile, indexFile.join('\n'));
+
+  await format(destFile);
 
   // eslint-disable-next-line no-console
   console.log('Done!');

--- a/packages/big-design-icons/scripts/build.js
+++ b/packages/big-design-icons/scripts/build.js
@@ -6,6 +6,7 @@ const { basename, join } = require('path');
 const rimraf = require('rimraf');
 const { promisify } = require('util');
 
+const { format } = require('./format');
 const config = require('./svgr.config');
 
 const SOURCE = join(__dirname, '..', 'svgs', '*', '*.svg');
@@ -50,7 +51,11 @@ function cleanDestDirectory() {
 
   const indexFile = Array.from(componentNames).map((name) => `export * from './${name}';`);
 
-  await outputFile(join(DEST_PATH, 'index.ts'), indexFile.join('\n'));
+  const destFile = join(DEST_PATH, 'index.ts');
+
+  await outputFile(destFile, indexFile.join('\n'));
+
+  await format(destFile);
 
   // eslint-disable-next-line no-console
   console.log('Done!');

--- a/packages/big-design-icons/scripts/format.js
+++ b/packages/big-design-icons/scripts/format.js
@@ -1,0 +1,15 @@
+const { outputFile, readFile } = require('fs-extra');
+const prettier = require('prettier');
+
+const format = async (filepath) => {
+  const fileContent = await readFile(filepath, { encoding: 'utf-8' });
+
+  const prettierConfig = await prettier.resolveConfig(filepath);
+  const formattedOutput = prettier.format(fileContent, { ...prettierConfig, filepath });
+
+  return outputFile(filepath, formattedOutput);
+};
+
+module.exports = {
+  format,
+};


### PR DESCRIPTION
## What / Why?
I don't know why, but the output of the icons/flags build was missing a new line at the end of the file. This commit makes the output of the script run through prettier.

## Screenshots/Screen Recordings
n/a

## Testing/Proof

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="348" alt="image" src="https://user-images.githubusercontent.com/4542735/132809602-08b7b397-1573-443d-b87e-b026ef988753.png">
	<td><img width="348" alt="image" src="https://user-images.githubusercontent.com/4542735/132809545-690fc178-afdc-47e0-908d-82147681558a.png">
</table>