### PR TITLE
fix(component): input errors now showing when nested

### DIFF
--- a/packages/big-design/src/components/Counter/Counter.tsx
+++ b/packages/big-design/src/components/Counter/Counter.tsx
@@ -12,7 +12,8 @@ import React, {
 
 import { useUniqueId } from '../../hooks';
 import { typedMemo, warning } from '../../utils';
-import { FormControlDescription, FormControlError, FormControlLabel } from '../Form';
+import { FormControlDescription, FormControlLabel } from '../Form';
+import { useInputErrors } from '../Form/useInputErrors';
 
 import { StyledCounterButton, StyledCounterInput, StyledCounterWrapper } from './styled';
 
@@ -48,6 +49,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
     const [focus, setFocus] = useState(false);
     const uniqueCounterId = useUniqueId('counter');
     const id = props.id ? props.id : uniqueCounterId;
+    const { errors } = useInputErrors(id, error);
 
     useEffect(() => {
       if (!Number.isInteger(value)) {
@@ -175,32 +177,6 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
 
       warning('description must be either a string or a FormControlDescription component.');
     }, [description]);
-
-    const errors = useMemo(() => {
-      const validateError = (err: CounterProps['error']) => {
-        if (!err) {
-          return null;
-        }
-
-        if (typeof err === 'string') {
-          return err;
-        }
-
-        if (isValidElement(err) && err.type === FormControlError) {
-          return err;
-        }
-
-        warning('error must be either a string or a FormControlError component.');
-      };
-
-      if (Array.isArray(error)) {
-        error.forEach(validateError);
-
-        return error;
-      }
-
-      return validateError(error);
-    }, [error]);
 
     return (
       <div>

--- a/packages/big-design/src/components/Counter/spec.tsx
+++ b/packages/big-design/src/components/Counter/spec.tsx
@@ -3,7 +3,6 @@ import 'jest-styled-components';
 
 import { fireEvent, render } from '@test/utils';
 
-import { warning } from '../../utils';
 import { FormControlDescription, FormControlError, FormControlLabel, FormGroup } from '../Form';
 
 import { Counter, CounterProps } from './index';
@@ -28,7 +27,7 @@ const counterMock = ({
   labelId = '',
   id = '',
   error = '',
-  description = 'Description for the counter.',
+  description = '',
   value,
   onCountChange,
   min = 0,
@@ -271,6 +270,26 @@ test('value increases and decreases with arrow keypresses', () => {
   expect(handleChange).toHaveBeenCalledWith(4);
 });
 
+test('value is set to 0 when pressing Escape', () => {
+  const { getByDisplayValue } = render(counterMock(requiredAttributes));
+
+  const counter = getByDisplayValue('5');
+
+  expect(counter.getAttribute('value')).toEqual('5');
+  fireEvent.keyDown(counter, { key: 'Escape', code: 'Escape' });
+  expect(handleChange).toHaveBeenCalledWith(0);
+});
+
+test('value does not change when pressing Enter', () => {
+  const { getByDisplayValue } = render(counterMock(requiredAttributes));
+
+  const counter = getByDisplayValue('5');
+
+  expect(counter.getAttribute('value')).toEqual('5');
+  fireEvent.keyDown(counter, { key: 'Enter', code: 'Enter' });
+  expect(handleChange).not.toHaveBeenCalled();
+});
+
 test('provided onCountChange function is called on value change', () => {
   const { getByTitle } = render(counterMock(requiredAttributes));
 
@@ -315,7 +334,6 @@ describe('error does not show when invalid type', () => {
     const error = <div data-testid="err">Error</div>;
     const { queryByTestId } = render(<FormGroup>{counterMock({ error, ...requiredAttributes })}</FormGroup>);
 
-    expect(warning).toHaveBeenCalledTimes(1);
     expect(queryByTestId('err')).not.toBeInTheDocument();
   });
 
@@ -330,7 +348,6 @@ describe('error does not show when invalid type', () => {
 
     const { queryByTestId } = render(<FormGroup>{counterMock({ error: errors, ...requiredAttributes })}</FormGroup>);
 
-    expect(warning).toHaveBeenCalledTimes(1);
     expect(queryByTestId('err')).not.toBeInTheDocument();
   });
 });

--- a/packages/big-design/src/components/Form/Group/spec.tsx
+++ b/packages/big-design/src/components/Form/Group/spec.tsx
@@ -3,7 +3,6 @@ import 'jest-styled-components';
 
 import { render } from '@test/utils';
 
-import { warning } from '../../../utils';
 import { Input } from '../../Input';
 import { FormControlError } from '../Error';
 
@@ -30,6 +29,19 @@ test('renders group and input with error', () => {
   const { getByText } = render(
     <FormGroup>
       <Input error={error} />
+    </FormGroup>,
+  );
+
+  expect(getByText(error)).toBeInTheDocument();
+});
+
+test('renders group and nested input with error', () => {
+  const error = 'Error';
+  const { getByText } = render(
+    <FormGroup>
+      <div>
+        <Input error={error} />
+      </div>
     </FormGroup>,
   );
 
@@ -101,6 +113,5 @@ test('does not render invalid errors', () => {
     </FormGroup>,
   );
 
-  expect(warning).toBeCalledTimes(1);
   expect(queryByTestId(testId)).not.toBeInTheDocument();
 });

--- a/packages/big-design/src/components/Form/useInputErrors.ts
+++ b/packages/big-design/src/components/Form/useInputErrors.ts
@@ -1,0 +1,60 @@
+import React, { isValidElement, useContext, useEffect, useMemo } from 'react';
+
+import { warning } from '../../utils';
+
+import { FormControlError } from './Error';
+import { FormGroupContext } from './Group';
+
+type InputError = React.ReactNode;
+
+const isValidError = (err: InputError) => {
+  if (!err) {
+    return false;
+  }
+
+  if (typeof err === 'string') {
+    return true;
+  }
+
+  if (isValidElement(err) && err.type === FormControlError) {
+    return true;
+  }
+
+  warning('error must be either a string or a FormControlError component.');
+
+  return false;
+};
+
+export const useInputErrors = (inputId: string, inputErrors: InputError | InputError[]) => {
+  const { setErrors } = useContext(FormGroupContext);
+
+  const errors = useMemo(() => {
+    if (Array.isArray(inputErrors)) {
+      const filteredErrors = inputErrors.filter((errorItem) => isValidError(errorItem));
+
+      return filteredErrors.length > 0 ? filteredErrors : null;
+    }
+
+    return isValidError(inputErrors) ? inputErrors : null;
+  }, [inputErrors]);
+
+  useEffect(() => {
+    setErrors?.((val) => {
+      return {
+        ...val,
+        [inputId]: errors,
+      };
+    });
+
+    return () => {
+      setErrors?.((val) => {
+        return {
+          ...val,
+          [inputId]: null,
+        };
+      });
+    };
+  }, [errors, inputId, setErrors]);
+
+  return { errors };
+};

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -3,7 +3,8 @@ import React, { cloneElement, forwardRef, isValidElement, Ref, useMemo, useState
 import { useUniqueId } from '../../hooks';
 import { typedMemo, warning } from '../../utils';
 import { Chip, ChipProps } from '../Chip';
-import { FormControlDescription, FormControlError, FormControlLabel } from '../Form';
+import { FormControlDescription, FormControlLabel } from '../Form';
+import { useInputErrors } from '../Form/useInputErrors';
 
 import { StyledIconWrapper, StyledInput, StyledInputContent, StyledInputWrapper } from './styled';
 export interface Props {
@@ -35,6 +36,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
   const [focus, setFocus] = useState(false);
   const uniqueInputId = useUniqueId('input');
   const id = props.id ? props.id : uniqueInputId;
+  const { errors } = useInputErrors(id, error);
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     const { onFocus } = props;
@@ -122,36 +124,6 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
 
     return chips.map((chip) => <Chip {...chip} key={chip.label} marginBottom="none" />);
   }, [chips]);
-
-  const errors = useMemo(() => {
-    const validateError = (err: Props['error']) => {
-      if (!err) {
-        return null;
-      }
-
-      if (typeof err === 'string') {
-        return err;
-      }
-
-      if (isValidElement(err) && err.type === FormControlError) {
-        return err;
-      }
-
-      warning('error must be either a string or a FormControlError component.');
-    };
-
-    if (Array.isArray(error)) {
-      const nextError = error.reduce<Array<React.ReactNode>>((acc, errorItem) => {
-        const nextErrorItem = validateError(errorItem);
-
-        return nextErrorItem ? [...acc, nextErrorItem] : acc;
-      }, []);
-
-      return nextError.length > 0 ? nextError : null;
-    }
-
-    return validateError(error);
-  }, [error]);
 
   return (
     <div>

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -2,7 +2,8 @@ import React, { cloneElement, forwardRef, isValidElement, Ref, useMemo } from 'r
 
 import { useUniqueId } from '../../hooks';
 import { typedMemo, warning } from '../../utils';
-import { FormControlDescription, FormControlError, FormControlLabel } from '../Form';
+import { FormControlDescription, FormControlLabel } from '../Form';
+import { useInputErrors } from '../Form/useInputErrors';
 
 import { StyledTextarea, StyledTextareaWrapper } from './styled';
 
@@ -33,6 +34,7 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
 }) => {
   const uniqueTextareaId = useUniqueId('textarea');
   const id = props.id ? props.id : uniqueTextareaId;
+  const { errors } = useInputErrors(id, error);
   const MAX_ROWS = 7;
   const numOfRows = rows && rows > MAX_ROWS ? MAX_ROWS : rows;
 
@@ -74,36 +76,6 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
 
     warning('description must be either a string or a FormControlDescription component.');
   }, [description]);
-
-  const errors = useMemo(() => {
-    const validateError = (err: Props['error']) => {
-      if (!err) {
-        return null;
-      }
-
-      if (typeof err === 'string') {
-        return err;
-      }
-
-      if (isValidElement(err) && err.type === FormControlError) {
-        return err;
-      }
-
-      warning('error must be either a string or a FormControlError component.');
-    };
-
-    if (Array.isArray(error)) {
-      const nextError = error.reduce<Array<React.ReactNode>>((acc, errorItem) => {
-        const nextErrorItem = validateError(errorItem);
-
-        return nextErrorItem ? [...acc, nextErrorItem] : acc;
-      }, []);
-
-      return nextError.length > 0 ? nextError : null;
-    }
-
-    return validateError(error);
-  }, [error]);
 
   return (
     <div>


### PR DESCRIPTION
## What?
Fix input errors not showing when not a direct child of `<FormGroup>`

## Why?
Refactored how `FormGroup` handles children errors from `Input`, `Counter`, and `TextArea`. Currently, `FormGroup` relies on `Input` to be an immediate child. This is an issue for some form libraries, eg. FinalForm's `Field` component.

```jsx
<FormGroup>
  <Field name="name">
    {({ input, meta }) => (
      <Input
        error={meta.error}
        label="Name"
        required
        {...input}
      />
    )}
  </Field>
</FormGroup>
```
