### PR TITLE
fix(docs): dependency is an expression

### DIFF
--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -14,12 +14,20 @@ module.exports = {
     BD_VERSION: bdPkg.version,
   },
   webpack: (config) => {
-    config.module.rules.push({
-      test: /\.(ts|tsx)$/,
-      use: [require.resolve('jsx-to-string-loader')],
-    });
-
-    return config;
+    return {
+      ...config,
+      module: {
+        ...config.module,
+        rules: [
+          ...config.module.rules,
+          {
+            test: /\.(ts|tsx)$/,
+            use: [require.resolve('jsx-to-string-loader')],
+          },
+        ],
+        noParse: /@babel\/standalone/,
+      },
+    };
   },
   exportPathMap: () => ({
     '/': { page: '/GettingStarted/GettingStartedPage' },


### PR DESCRIPTION
## What & Why?

Fixes the logs happening on the `docs` package.
```
Critical dependency: the request of a dependency is an expression
```

![image](https://user-images.githubusercontent.com/2752665/133156838-0ef21dff-5fe9-4370-8330-1ce06833af7b.png)


This PR makes webpack not parse `@babel/standalone`.
