### PR TITLE
fix(icons): Ensure aira-hidden is correctly set in flags

### DIFF
--- a/packages/big-design-icons/scripts/svgr-flags.config.js
+++ b/packages/big-design-icons/scripts/svgr-flags.config.js
@@ -5,6 +5,9 @@ module.exports = {
   ref: true,
   ext: 'tsx',
   plugins: ['@svgr/plugin-svgo', '@svgr/plugin-jsx', '@svgr/plugin-prettier'],
+  svgProps: {
+    'aria-hidden': '{ariaHidden}',
+  },
   template({ template }, _, { componentName, jsx }) {
     const flagName = componentName.name.replace('FlagIcon', '');
 
@@ -23,6 +26,7 @@ module.exports = {
     const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = '${flagName} flag', theme, ...props }) => {
       const uniqueTitleId = useUniqueId('icon');
       const titleId = title ? props.titleId || uniqueTitleId : undefined;
+      const ariaHidden = titleId ? undefined : true;
 
       BREAK
       return (
@@ -31,7 +35,7 @@ module.exports = {
     };
 
     BREAK
-    const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />);
+    const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => <FlagIcon {...iconProps} svgRef={ref} />);
 
     BREAK
     export const COMPONENT_NAME = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/scripts/svgr.config.js
+++ b/packages/big-design-icons/scripts/svgr.config.js
@@ -8,6 +8,7 @@ module.exports = {
     stroke: 'currentColor',
     fill: 'currentColor',
     strokeWidth: '0',
+    'aria-hidden': '{ariaHidden}',
   },
   plugins: ['@svgr/plugin-svgo', '@svgr/plugin-jsx', '@svgr/plugin-prettier'],
   template({ template }, _, { componentName, jsx }) {
@@ -25,6 +26,7 @@ module.exports = {
     const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
       const uniqueTitleId = useUniqueId('icon');
       const titleId = title ? props.titleId || uniqueTitleId : undefined;
+      const ariaHidden = titleId ? undefined : true;
 
       BREAK
       return (
@@ -33,7 +35,7 @@ module.exports = {
     };
 
     BREAK
-    const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />);
+    const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => <Icon {...iconProps} svgRef={ref} />);
 
     BREAK
     export const COMPONENT_NAME = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const AddCircleOutlineIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/AddIcon.tsx
+++ b/packages/big-design-icons/src/components/AddIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const AddIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ArrowBackIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowBackIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ArrowBackIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ArrowDownwardIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ArrowDropDownIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ArrowForwardIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ArrowUpwardIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/AssignmentIcon.tsx
+++ b/packages/big-design-icons/src/components/AssignmentIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const AssignmentIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
+++ b/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const BaselineHelpIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/BrushIcon.tsx
+++ b/packages/big-design-icons/src/components/BrushIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const BrushIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/CheckCircleIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckCircleIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const CheckCircleIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/CheckIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const CheckIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ChevronLeftIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ChevronRightIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronRightIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ChevronRightIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/CloseIcon.tsx
+++ b/packages/big-design-icons/src/components/CloseIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const CloseIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/CloudUploadIcon.tsx
+++ b/packages/big-design-icons/src/components/CloudUploadIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const CloudUploadIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/CodeIcon.tsx
+++ b/packages/big-design-icons/src/components/CodeIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const CodeIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ContentCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/ContentCopyIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ContentCopyIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/DeleteIcon.tsx
+++ b/packages/big-design-icons/src/components/DeleteIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const DeleteIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
+++ b/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const DragIndicatorIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/EditIcon.tsx
+++ b/packages/big-design-icons/src/components/EditIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const EditIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ErrorIcon.tsx
+++ b/packages/big-design-icons/src/components/ErrorIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -29,7 +31,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ErrorIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ExpandLessIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandLessIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ExpandLessIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ExpandMoreIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/FileCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/FileCopyIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const FileCopyIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/FilterListIcon.tsx
+++ b/packages/big-design-icons/src/components/FilterListIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const FilterListIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/FolderIcon.tsx
+++ b/packages/big-design-icons/src/components/FolderIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const FolderIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/GetAppIcon.tsx
+++ b/packages/big-design-icons/src/components/GetAppIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const GetAppIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/HomeIcon.tsx
+++ b/packages/big-design-icons/src/components/HomeIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const HomeIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/InfoIcon.tsx
+++ b/packages/big-design-icons/src/components/InfoIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const InfoIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/InsertDriveFileIcon.tsx
+++ b/packages/big-design-icons/src/components/InsertDriveFileIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const InsertDriveFileIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/InvertColorsIcon.tsx
+++ b/packages/big-design-icons/src/components/InvertColorsIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const InvertColorsIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/KeyboardDoubleArrowLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/KeyboardDoubleArrowLeftIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -34,7 +36,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const KeyboardDoubleArrowLeftIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/LanguageIcon.tsx
+++ b/packages/big-design-icons/src/components/LanguageIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const LanguageIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/MenuIcon.tsx
+++ b/packages/big-design-icons/src/components/MenuIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const MenuIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/MoreHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/MoreHorizIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const MoreHorizIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/NotificationsIcon.tsx
+++ b/packages/big-design-icons/src/components/NotificationsIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const NotificationsIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/OpenInNewIcon.tsx
+++ b/packages/big-design-icons/src/components/OpenInNewIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const OpenInNewIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/PublicIcon.tsx
+++ b/packages/big-design-icons/src/components/PublicIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const PublicIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/ReceiptIcon.tsx
+++ b/packages/big-design-icons/src/components/ReceiptIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const ReceiptIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const RemoveCircleOutlineIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/RemoveIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const RemoveIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/RestoreIcon.tsx
+++ b/packages/big-design-icons/src/components/RestoreIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const RestoreIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/SearchIcon.tsx
+++ b/packages/big-design-icons/src/components/SearchIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const SearchIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/SettingsIcon.tsx
+++ b/packages/big-design-icons/src/components/SettingsIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const SettingsIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/StarBorderIcon.tsx
+++ b/packages/big-design-icons/src/components/StarBorderIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const StarBorderIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/StarHalfIcon.tsx
+++ b/packages/big-design-icons/src/components/StarHalfIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const StarHalfIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/StarIcon.tsx
+++ b/packages/big-design-icons/src/components/StarIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -29,7 +31,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const StarIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/StoreIcon.tsx
+++ b/packages/big-design-icons/src/components/StoreIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const StoreIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/SwapHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/SwapHorizIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const SwapHorizIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/VisibilityIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const VisibilityIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -30,7 +32,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const VisibilityOffIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/components/WarningIcon.tsx
+++ b/packages/big-design-icons/src/components/WarningIcon.tsx
@@ -9,6 +9,7 @@ import { useUniqueId } from '../utils';
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
@@ -18,6 +19,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
       stroke="currentColor"
       fill="currentColor"
       strokeWidth="0"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -29,7 +31,7 @@ const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ..
 };
 
 const IconWithForwardedRef = forwardRef<SVGSVGElement, IconProps>((iconProps, ref) => (
-  <Icon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <Icon {...iconProps} svgRef={ref} />
 ));
 
 export const WarningIcon = memo(createStyledIcon(IconWithForwardedRef as React.FC<IconProps>));

--- a/packages/big-design-icons/src/flags/components/ADFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ADFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AD flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -313,7 +315,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ADFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AEFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#00732f" d="M0 0h640v160H0z" />
       <path fill="#fff" d="M0 160h640v160H0z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AFFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AF flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -139,7 +141,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="AGFlagIcon__a">
@@ -34,7 +35,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AIFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AI flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#012169" d="M0 0h640v480H0z" />
       <path fill="#49497d" d="M484.3 180.4l2 2z" />
@@ -796,7 +797,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ALFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ALFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AL flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -31,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ALFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="red" d="M0 0h640v160H0z" />
       <path fill="#00f" d="M0 160h640v160H0z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AOFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="red" d="M0 0h640v243.6H0z" />
@@ -54,7 +55,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AQFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AQ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#072B5F" d="M0 0h640v480H0z" />
       <path
@@ -28,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AQFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ARFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ARFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -89,7 +91,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ARFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ASFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ASFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="ASFlagIcon__a">
@@ -121,7 +122,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ASFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ATFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ATFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#fff" d="M640 480H0V0h640z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ATFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AUFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AU flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#006" d="M0 0h640v480H0z" />
       <path
@@ -36,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AWFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AW flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="AWFlagIcon__a">
@@ -208,7 +209,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AXFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AX flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="AXFlagIcon__a">
@@ -35,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AXFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/AZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AZFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'AZ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#3f9c35" d="M.1 0h640v480H.1z" />
       <path fill="#ed2939" d="M.1 0h640v320H.1z" />
@@ -28,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const AZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="BAFlagIcon__a">
@@ -32,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BBFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BB flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -32,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BBFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BDFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BD flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#006a4e" d="M0 0h640v480H0z" />
       <circle cx={280} cy={240} r={160} fill="#f42a41" />
@@ -21,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BEFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path d="M0 0h213.3v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BFFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BF flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#de0000" d="M640 479.6H.4V0H640z" />
@@ -27,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#d62612" d="M0 320h640v160H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BHFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BH flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0" />
       <path
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BIFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BI flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="BIFlagIcon__a">
@@ -37,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BJFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BJ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="BJFlagIcon__a">
@@ -31,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BJFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BLFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BL flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#cf142b" d="M0 0h640v480H0z" />
       <path fill="#00247d" d="M0 0h320v160H0z" />
@@ -441,7 +442,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BNFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -59,7 +61,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BOFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#007934" d="M0 0h640v480H0z" />
       <path fill="#ffe000" d="M0 0h640v320H0z" />
@@ -2812,7 +2813,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BQFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BQ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#21468b" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 0h640v320H0z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BQFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g strokeWidth="1pt">
         <path fill="#229e45" fillRule="evenodd" d="M0 0h640v480H0z" />
@@ -136,7 +137,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BSFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="BSFlagIcon__a">
@@ -30,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BTFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#ffd520" d="M.1 0h640.1v480H.1z" />
       <path fill="#ff4e12" d="M.1 480h640.1V0z" />
@@ -123,7 +124,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BVFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BV flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="BVFlagIcon__a">
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BWFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BW flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#00cbff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BYFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BY flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="BYFlagIcon__a">
@@ -37,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/BZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BZFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'BZ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -386,7 +388,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const BZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M150.131 0h339.656v480H150.132z" />
       <path
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CCFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CC flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -56,7 +58,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CDFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CD flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#007fff" d="M0 0h640v480H0z" />
       <path
@@ -25,7 +26,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CFFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CF flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="CFFlagIcon__a">
@@ -35,7 +36,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="CGFlagIcon__a">
@@ -29,7 +30,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CHFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CH flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#d52b1e" d="M0 0h640v480H0z" />
@@ -26,7 +27,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CIFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CI flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#00cd00" d="M426.8 0H640v480H426.8z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CKFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CK flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#006" d="M0 0h640v480H0z" />
       <path
@@ -36,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CLFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CL flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="CLFlagIcon__a">
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CMFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -38,7 +40,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CNFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -54,7 +56,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/COFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/COFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#ffe800" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const COFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#0000b4" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CUFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CU flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="CUFlagIcon__a">
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CVFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CV flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="CVFlagIcon__a">
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CWFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CW flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -37,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CXFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CX flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -47,7 +49,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CXFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CYFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CY flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -36,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/CZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CZFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'CZ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v240H0z" />
       <path fill="#d7141a" d="M0 240h640v240H0z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const CZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DEFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'DE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#ffce00" d="M0 320h640v160H0z" />
       <path d="M0 0h640v160H0z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const DEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DJFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'DJ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="DJFlagIcon__a">
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const DJFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DKFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'DK flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#c8102e" d="M0 0h640.1v480H0z" />
       <path fill="#fff" d="M205.7 0h68.6v480h-68.6z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const DKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'DM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="DMFlagIcon__a">
@@ -503,7 +504,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const DMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DOFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'DO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="DOFlagIcon__a">
@@ -6848,7 +6849,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const DOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/DZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DZFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'DZ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M320 0h320v480H320z" />
       <path fill="#006233" d="M0 0h320v480H0z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const DZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ECFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ECFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'EC flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#ffe800" d="M0 0h640v480H0z" />
@@ -714,7 +715,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ECFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/EEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EEFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'EE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <rect width={640} height={477.9} rx={0} ry={0} />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const EEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/EGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EGFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'EG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -104,7 +106,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const EGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/EHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EHFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'EH flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="EHFlagIcon__a">
@@ -38,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const EHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ERFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ERFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ER flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#be0027" d="M0 0h640v480H0z" />
@@ -28,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ERFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ESCTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESCTFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ESCT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fcdd09" d="M0 0h640v480H0z" />
       <path
@@ -26,7 +27,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ESCTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ESFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ES flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#AA151B" d="M0 0h640v480H0z" />
       <path fill="#F1BF00" d="M0 120h640v240H0z" />
@@ -1761,7 +1762,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ESFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ESGAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESGAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ESGA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fontSize={12}>
         <path fill="#fff" fillRule="evenodd" d="M0-.09h640.002v480.04H0z" />
@@ -779,7 +780,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ESGAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ETFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ETFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ET flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="ETFlagIcon__a">
@@ -34,7 +35,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ETFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/EUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EUFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'EU flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -51,7 +53,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const EUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FIFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'FI flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <path fill="#003580" d="M0 174.5h640v131H0z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const FIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FJFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'FJ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#68bfe5" d="M0 0v480h640V0H0z" />
       <g strokeMiterlimit={4.8}>
@@ -248,7 +249,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const FJFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FKFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'FK flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -526,7 +528,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const FKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'FM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="FMFlagIcon__a">
@@ -31,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const FMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FOFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'FO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="FOFlagIcon__a">
@@ -29,7 +30,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const FOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/FRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'FR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const FRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#ffe700" d="M640 480H0V0h640z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GBENGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBENGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GBENG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <path fill="#ce1124" d="M281.6 0h76.8v480h-76.8z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GBENGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GB flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#012169" d="M0 0h640v480H0z" />
       <path fill="#FFF" d="M75 0l244 181L562 0h78v62L400 241l240 178v61h-80L320 301 81 480H0v-60l239-178L0 64V0h75z" />
@@ -27,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GBFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GBNIRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBNIRFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GBNIR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -617,7 +619,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GBNIRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GBSCTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBSCTFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GBSCT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#0065bd" d="M0 0h640v480H0z" />
       <path stroke="#fff" strokeWidth={0.6} d="M0 0l5 3M0 3l5-3" transform="scale(128 160)" />
@@ -21,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GBSCTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GBWLSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBWLSFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GBWLS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#00ab39" d="M0 240h640v240H0z" />
       <path fill="#fff" d="M0 0h640v240H0z" />
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GBWLSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GDFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GD flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -59,7 +61,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GEFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <path fill="red" d="M272 0h96v480h-96z" />
@@ -30,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GFFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GF flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GGFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -32,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GHFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GH flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#006b3f" d="M0 0h640v480H0z" />
       <path fill="#fcd116" d="M0 0h640v320H0z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GIFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GI flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -64,7 +66,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GLFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GL flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <path fill="#d00c33" d="M0 240h640v240H0zm80 0a160 160 0 10320 0 160 160 0 00-320 0" />
@@ -21,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="GMFlagIcon__a">
@@ -31,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GNFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="red" d="M0 0h213.3v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GPFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GP flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GPFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GQFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GQ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#e32118" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 0h640v320H0z" />
@@ -67,7 +68,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GQFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#005bae" fillRule="evenodd" d="M0 0h640v53.3H0z" />
       <path fill="#fff" fillRule="evenodd" d="M0 53.3h640v53.4H0z" />
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GSFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -984,7 +986,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GTFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -399,7 +401,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GUFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GU flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#be0027" fillRule="evenodd" d="M0 0h640v480H0z" />
       <path fill="#3b5aa3" fillRule="evenodd" d="M25.6 27.3h589.5v428.4H25.6z" />
@@ -156,7 +157,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GWFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GW flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -36,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/GYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GYFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'GY flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#399408" d="M2.4 0H640v480H2.4z" />
@@ -26,7 +27,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const GYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HKFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'HK flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="HKFlagIcon__a">
@@ -87,7 +88,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const HKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'HM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g strokeWidth="1pt">
         <path fill="#006" d="M0 0h640v480H0z" />
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const HMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HNFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'HN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -41,7 +43,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const HNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HRFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'HR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -113,7 +115,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const HRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HTFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'HT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -237,7 +239,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const HTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/HUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HUFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'HU flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#fff" d="M640 480H0V0h640z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const HUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IDFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ID flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#e70011" d="M0 0h640v249H0z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const IDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IEFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'IE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const IEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ILFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ILFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'IL flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="ILFlagIcon__a">
@@ -37,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ILFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'IM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="IMFlagIcon__a">
@@ -163,7 +164,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const IMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/INFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/INFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'IN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -48,7 +50,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const INFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IOFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'IO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="IOFlagIcon__a">
@@ -820,7 +821,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const IOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IQFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'IQ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 160h640v160H0z" />
       <path fill="#ce1126" d="M0 0h640v160H0z" />
@@ -27,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const IQFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/IRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'IR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="IRFlagIcon__a">
@@ -242,7 +243,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const IRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ISFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ISFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'IS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="ISFlagIcon__a">
@@ -29,7 +30,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ISFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ITFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ITFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'IT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ITFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/JEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JEFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'JE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 30 22.5"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -78,7 +80,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const JEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/JMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'JM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path d="M0 0l320 240L0 480zm640 0L320 240l320 240z" />
@@ -25,7 +26,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const JMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/JOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JOFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'JO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="JOFlagIcon__a">
@@ -36,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const JOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/JPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JPFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'JP flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="JPFlagIcon__a">
@@ -28,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const JPFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KEFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -53,7 +55,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="KGFlagIcon__a">
@@ -38,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KHFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KH flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -102,7 +104,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KIFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KI flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="KIFlagIcon__a">
@@ -200,7 +201,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="KMFlagIcon__a">
@@ -39,7 +40,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KNFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="KNFlagIcon__a">
@@ -34,7 +35,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KPFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KP flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="KPFlagIcon__a">
@@ -38,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KPFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="KRFlagIcon__a">
@@ -47,7 +48,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KWFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KW flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="KWFlagIcon__a">
@@ -30,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KYFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KY flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#006" d="M0 0h640v480H0z" />
       <path fill="#006" fillRule="evenodd" d="M0 0h400v200H0z" />
@@ -308,7 +309,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/KZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KZFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'KZ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#6fdcff" d="M0 0h640v480H0z" />
@@ -40,7 +41,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const KZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="LAFlagIcon__a">
@@ -29,7 +30,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LBFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LB flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="LBFlagIcon__a">
@@ -43,7 +44,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LBFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LCFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LC flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#65cfff" d="M0 0h640v480H0z" />
@@ -25,7 +26,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LIFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LI flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -90,7 +92,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LKFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LK flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -57,7 +59,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="LRFlagIcon__a">
@@ -37,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LSFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <path fill="#009543" d="M0 336h640v144H0z" />
@@ -37,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LTFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt" transform="scale(.64143 .96773)">
         <rect width={1063} height={708.7} fill="#006a44" rx={0} ry={0} transform="scale(.93865 .69686)" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LUFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LU flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#00a1de" d="M0 240h640v240H0z" />
       <path fill="#ed2939" d="M0 0h640v240H0z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LVFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LV flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/LYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LYFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'LY flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="LYFlagIcon__a">
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const LYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#c1272d" d="M640 0H0v480h640z" />
       <path fill="none" stroke="#006233" strokeWidth={11.7} d="M320 179.4L284.4 289l93.2-67.6H262.4l93.2 67.6z" />
@@ -21,7 +22,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MCFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MC flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#f31830" d="M0 0h640v240H0z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MDFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MD flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#00319c" d="M0 0h213.3v480H0z" />
@@ -320,7 +321,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MEFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ME flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#d3ae3b" d="M0 0h640v480H0z" />
       <path fill="#c40308" d="M24 24h592v432H24z" />
@@ -334,7 +335,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MFFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MF flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#ff3319" d="M213.3 0H640v240H213.3z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MHFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MH flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#3b5aa3" d="M0 0h639.9v480H0z" />
@@ -27,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MKFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MK flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#d20000" d="M0 0h640v480H0z" />
       <path
@@ -25,7 +26,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MLFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ML flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="red" d="M425.8 0H640v480H425.7z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MMFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -39,7 +41,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MNFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#c4272f" d="M0 0h640v480H0z" />
       <path fill="#015197" d="M213.3 0h213.4v480H213.3z" />
@@ -37,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MOFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -38,7 +40,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MPFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MP flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="MPFlagIcon__a">
@@ -397,7 +398,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MPFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MQFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MQ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MQFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#cd2a3e" d="M0 0h640v480H0z" />
       <path fill="#006233" d="M0 72h640v336H0z" />
@@ -30,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MSFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#012169" d="M0 0h640v480H0z" />
       <path
@@ -98,7 +99,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MTFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#ce0000" d="M320 0h320v480H320z" />
@@ -179,7 +180,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MUFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MU flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#00a04d" d="M0 360h640v120H0z" />
@@ -25,7 +26,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MVFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MV flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#d21034" d="M0 0h640v480H0z" />
       <path fill="#007e3a" d="M120 120h400v240H120z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MWFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MW flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#f41408" d="M0 0h640v480H0z" />
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MXFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MX flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -1345,7 +1347,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MXFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MYFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MY flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -38,7 +40,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/MZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MZFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'MZ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="MZFlagIcon__a">
@@ -71,7 +72,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const MZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="NAFlagIcon__a">
@@ -39,7 +40,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NCFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NC flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -37,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NEFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#0db02b" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 0h640v320H0z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NFFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NF flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#fff" d="M194.8 0h250.4v480H194.8z" />
@@ -46,7 +47,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NIFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NI flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -367,7 +369,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NLFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NL flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#21468b" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M0 0h640v320H0z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NOFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#ed2939" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M180 0h120v480H180z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NPFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NP flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="NPFlagIcon__a">
@@ -39,7 +40,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NPFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="NRFlagIcon__a">
@@ -32,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NUFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NU flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="NUFlagIcon__a">
@@ -52,7 +53,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/NZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NZFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'NZ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -161,7 +163,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const NZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/OMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/OMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'OM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="OMFlagIcon__a">
@@ -483,7 +484,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const OMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="PAFlagIcon__a">
@@ -39,7 +40,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PEFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -638,7 +640,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PFFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PF flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="PFFlagIcon__a">
@@ -79,7 +80,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path d="M1.6 0l-.5 480h640L1.6 0z" />
@@ -43,7 +44,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PHFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PH flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#0038a8" d="M0 0h640v240H0z" />
       <path fill="#ce1126" d="M0 240h640v240H0z" />
@@ -25,7 +26,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PKFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PK flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="PKFlagIcon__a">
@@ -32,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PLFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PL flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#fff" d="M640 480H0V0h640z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PNFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="PNFlagIcon__a">
@@ -237,7 +238,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="PRFlagIcon__a">
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PSFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="PSFlagIcon__a">
@@ -32,7 +33,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PTFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -96,7 +98,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PWFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PW flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="PWFlagIcon__a">
@@ -28,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/PYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PYFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'PY flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#0038a8" d="M0 319.7h640V480H0z" />
       <path fill="#fff" d="M0 160h640v160H0z" />
@@ -179,7 +180,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const PYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/QAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/QAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'QA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#8d1b3d" d="M0 0h640v480H0z" />
       <path
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const QAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/REFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/REFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'RE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const REFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ROFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ROFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'RO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#00319c" d="M0 0h213.3v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ROFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/RSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RSFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'RS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -949,7 +951,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const RSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/RUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RUFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'RU flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const RUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/RWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RWFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'RW flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -40,7 +42,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const RWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="SAFlagIcon__a">
@@ -88,7 +89,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SBFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SB flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="SBFlagIcon__a">
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SBFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SCFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SC flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="SCFlagIcon__a">
@@ -31,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SDFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SD flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="SDFlagIcon__a">
@@ -30,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SEFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#066aa7" d="M0 0h640v480H0z" />
       <path fill="#fecc00" d="M0 192h640v96H0z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="SGFlagIcon__a">
@@ -36,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SHFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SH flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#006" d="M640 480V0H0v480h640z" />
       <path
@@ -310,7 +311,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SHFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SIFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SI flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="SIFlagIcon__a">
@@ -53,7 +54,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SJFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SJ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#ef2b2d" d="M0 0h640v480H0z" />
       <path fill="#fff" d="M180 0h120v480H180z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SJFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SKFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SK flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#ee1c25" d="M0 0h640v480H0z" />
       <path fill="#0b4ea2" d="M0 0h640v320H0z" />
@@ -38,7 +39,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SLFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SL flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#0000cd" d="M0 320.3h640V480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#19b6ef" d="M0 240h640v240H0z" />
@@ -361,7 +362,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SNFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#0b7226" d="M0 0h213.3v480H0z" />
@@ -28,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SOFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="SOFlagIcon__a">
@@ -31,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#377e3f" d="M.1 0h640v480H.1z" />
       <path fill="#fff" d="M.1 96h640v288H.1z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SSFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#078930" d="M0 336h640v144H0z" />
       <path fill="#fff" d="M0 144h640v192H0z" />
@@ -25,7 +26,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/STFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/STFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ST flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -39,7 +41,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const STFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SVFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SV flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -1370,7 +1372,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SXFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SX flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="SXFlagIcon__a">
@@ -232,7 +233,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SXFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SYFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SY flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <rect width={640} height={160} y={160} fill="#fff" fillRule="evenodd" rx={0} ry={0} />
       <rect width={640} height={160} y={320} fillRule="evenodd" rx={0} ry={0} />
@@ -27,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/SZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SZFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'SZ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="SZFlagIcon__a">
@@ -171,7 +172,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const SZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TCFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TC flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#006" d="M640 480V0H0v480h640z" />
       <path fill="#006" fillRule="evenodd" d="M0 0h373.7v232.2H0z" />
@@ -326,7 +327,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TDFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TD flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#000067" d="M0 0h214v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TDFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TFFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TF flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -41,7 +43,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="TGFlagIcon__a">
@@ -34,7 +35,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/THFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/THFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TH flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#f4f5f8" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const THFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TJFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TJ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -57,7 +59,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TJFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TKFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TK flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#00247d" d="M0 0h640v480H0z" />
       <path
@@ -28,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TLFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TL flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="TLFlagIcon__a">
@@ -33,7 +34,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TLFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="TMFlagIcon__a">
@@ -624,7 +625,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TNFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="TNFlagIcon__a">
@@ -36,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TOFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TO flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#c10000" d="M0 0h640v480H0z" />
@@ -27,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TOFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TRFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TR flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#e30a17" d="M0 0h640v480H0z" />
@@ -34,7 +35,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TRFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TTFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#fff" d="M0 0h640v480H0z" />
       <path fill="#e00000" fillRule="evenodd" d="M463.7 480L0 1v478.8l463.7.2zM176.3 0L640 479V.2L176.3 0z" />
@@ -22,7 +23,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TVFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TV flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#009fca" d="M0 0h640v480H0z" />
       <path
@@ -36,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TVFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TWFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TW flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <clipPath id="TWFlagIcon__a">
         <path d="M0 0h640v480H0z" />
@@ -51,7 +52,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/TZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TZFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'TZ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="TZFlagIcon__a">
@@ -30,7 +31,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const TZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'UA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#ffd500" d="M0 0h640v480H0z" />
@@ -23,7 +24,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const UAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UGFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'UG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="UGFlagIcon__a">
@@ -128,7 +129,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const UGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'UM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="UMFlagIcon__a">
@@ -41,7 +42,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const UMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UNFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'UN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -64,7 +66,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const UNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/USFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/USFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'US flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <g strokeWidth="1pt">
@@ -36,7 +37,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const USFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UYFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'UY flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -57,7 +59,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const UYFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/UZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UZFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'UZ flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -53,7 +55,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const UZFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'VA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#fff" d="M320 0h320v480H320z" />
@@ -2167,7 +2168,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const VAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VCFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'VC flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd">
         <path fill="#f4f100" d="M0 0h640v480H0z" />
@@ -28,7 +29,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const VCFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VEFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'VE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -49,7 +51,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const VEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VGFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'VG flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -630,7 +632,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const VGFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VIFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'VI flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -126,7 +128,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const VIFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VNFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'VN flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="VNFlagIcon__a">
@@ -31,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const VNFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/VUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VUFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'VU flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="VUFlagIcon__a">
@@ -44,7 +45,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const VUFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/WFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/WFFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'WF flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const WFFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/WSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/WSFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'WS flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#ce1126" d="M0 0h640v480H0z" />
@@ -27,7 +28,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const WSFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/XKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/XKFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'XK flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <path fill="#244AA5" d="M0 0h640v480H0z" />
       <path
@@ -31,7 +32,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const XKFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/YEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/YEFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'YE flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v472.8H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const YEFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/YTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/YTFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'YT flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <g fillRule="evenodd" strokeWidth="1pt">
         <path fill="#fff" d="M0 0h640v480H0z" />
@@ -24,7 +25,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const YTFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ZAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZAFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ZA flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="ZAFlagIcon__a">
@@ -37,7 +38,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ZAFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ZMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZMFlagIcon.tsx
@@ -10,9 +10,10 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ZM flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
-    <svg viewBox="0 0 640 480" ref={svgRef} aria-labelledby={titleId} {...props}>
+    <svg viewBox="0 0 640 480" aria-hidden={ariaHidden} ref={svgRef} aria-labelledby={titleId} {...props}>
       {title ? <title id={titleId}>{title}</title> : null}
       <defs>
         <clipPath id="ZMFlagIcon__a">
@@ -85,7 +86,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ZMFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));

--- a/packages/big-design-icons/src/flags/components/ZWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZWFlagIcon.tsx
@@ -10,11 +10,13 @@ import { createStyledFlagIcon, FlagIconProps } from '../base';
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 'ZW flag', theme, ...props }) => {
   const uniqueTitleId = useUniqueId('icon');
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
+  const ariaHidden = titleId ? undefined : true;
 
   return (
     <svg
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 640 480"
+      aria-hidden={ariaHidden}
       ref={svgRef}
       aria-labelledby={titleId}
       {...props}
@@ -50,7 +52,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = 
 };
 
 const FlagIconWithForwardedRef = forwardRef<SVGSVGElement, FlagIconProps>((iconProps, ref) => (
-  <FlagIcon aria-hidden={iconProps.title ? undefined : true} {...iconProps} svgRef={ref} />
+  <FlagIcon {...iconProps} svgRef={ref} />
 ));
 
 export const ZWFlagIcon = memo(createStyledFlagIcon(FlagIconWithForwardedRef as React.FC<FlagIconProps>));


### PR DESCRIPTION
## What?
Ensure aria-hidden is set correctly in icons.

## Why?
Because of the way we added the aria-hidden attribute, flags with default
title will still be set as `aria-hidden="true"`. This change ensures any
icon with a title is not set as hidden.

## Screenshots/Screen Recordings

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="671" alt="image" src="https://user-images.githubusercontent.com/4542735/133201805-a4329e2f-1537-4107-8c11-73c6e0e9b1e1.png">
	<td><img width="671" alt="image" src="https://user-images.githubusercontent.com/4542735/133201100-391b6a1f-627a-4563-93d4-4b2cef69d2af.png">
<tr>
  <td>n/a
	<td><img width="671" alt="image" src="https://user-images.githubusercontent.com/4542735/133201193-1e905251-7f60-4cbb-ad67-cf69c56913e6.png">
<tr>
  <td>n/a
	<td><img width="671" alt="image" src="https://user-images.githubusercontent.com/4542735/133201273-56625586-e038-4589-a09e-9f9e37f3463c.png">
</table>

## Testing/Proof

Manually tested it in the documentation preview.