### PR TITLE
chore(icons): Process icons based on the number of available CPUs

### DIFF
--- a/packages/big-design-icons/package.json
+++ b/packages/big-design-icons/package.json
@@ -77,6 +77,7 @@
     "react-dom": "^17.0.1",
     "rimraf": "^3.0.2",
     "styled-components": "^5.3.0",
+    "tiny-async-pool": "^1.2.0",
     "typescript": "^4.4.3",
     "typescript-styled-plugin": "^0.18.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13368,6 +13368,14 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-async-pool@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-async-pool/-/tiny-async-pool-1.2.0.tgz#22132957e18f8b6020a94b390d07718fd519cc71"
+  integrity sha512-PY/OiSenYGBU3c1nTuP1HLKRkhKFDXsAibYI5GeHbHw2WVpt6OFzAPIRP94dGnS66Jhrkheim2CHAXUNI4XwMg==
+  dependencies:
+    semver "^5.5.0"
+    yaassertion "^1.0.0"
+
 tiny-invariant@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
@@ -14263,6 +14271,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yaassertion@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/yaassertion/-/yaassertion-1.0.2.tgz#f1a90166e1cc4ad44dbb71487009ebca017e9874"
+  integrity sha512-sBoJBg5vTr3lOpRX0yFD+tz7wv/l2UPMFthag4HGTMPrypBRKerjjS8jiEnNMjcAEtPXjbHiKE0UwRR1W1GXBg==
 
 yallist@^3.0.0, yallist@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## What?

Really simple promise pool for icon processing.

## Why?
The previous solution will throw all icons at once, this makes the log print the list of icons and then hang for 11s until they are all processed. This commit just implements a really simple promise-pool to process them based on the number of available cpus.

## Screenshots/Screen Recordings

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><video src="https://user-images.githubusercontent.com/4542735/133357407-8cd31bef-a212-4d66-a721-ec1ff3a5ed4b.mov" />
	<td><video src="https://user-images.githubusercontent.com/4542735/133357409-f3cacde3-5286-4bc2-a6e6-ee79835fbc9a.mov" />
</table>

## Testing/Proof

I ran the command locally and it works correctly.