### PR TITLE
fix(component): hide close buttons in MultiSelect

### DIFF
--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -364,7 +364,7 @@ export const MultiSelect = typedMemo(
             })}
             chips={selectedOptions.map((option: SelectOption<T>) => ({
               label: option.content,
-              onDelete: () => removeItem(option),
+              onDelete: disabled ? undefined : () => removeItem(option),
             }))}
             iconRight={renderToggle}
             readOnly={!filterable}

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -105,6 +105,28 @@ const MultiSelectWithOptionsDescriptions = (
   />
 );
 
+const DisabledMultiSelectMock = (
+  <MultiSelect
+    action={{
+      actionType: 'destructive',
+      content: 'Remove Country',
+      icon: <DeleteIcon />,
+      onActionClick,
+    }}
+    data-testid="multi-select"
+    disabled
+    error="Required"
+    label="Countries"
+    onClose={onClose}
+    onOpen={onOpen}
+    onOptionsChange={onChange}
+    options={mockOptions}
+    placeholder="Choose country"
+    required
+    value={['us', 'mx']}
+  />
+);
+
 test('renders select combobox', async () => {
   render(MultiSelectMock);
 
@@ -812,6 +834,36 @@ test('chips should be rendered', async () => {
 
   expect((await screen.findAllByText('United States')).length).toEqual(1);
   expect((await screen.findAllByText('Mexico')).length).toEqual(1);
+
+  expect(
+    await screen.getByRole('button', {
+      name: /remove united states/i,
+    }),
+  ).toBeDefined();
+  expect(
+    await screen.getByRole('button', {
+      name: /remove mexico/i,
+    }),
+  ).toBeDefined();
+});
+
+test('chips should be rendered without close button when MultiSelect is disabled', async () => {
+  render(DisabledMultiSelectMock);
+
+  await screen.findAllByText('United States');
+  await screen.findAllByText('Mexico');
+
+  expect(
+    await screen.queryByRole('button', {
+      name: /remove united states/i,
+    }),
+  ).toBeNull();
+
+  expect(
+    await screen.queryByRole('button', {
+      name: /remove mexico/i,
+    }),
+  ).toBeNull();
 });
 
 test('options should allow icons', async () => {


### PR DESCRIPTION
## What?

Hides pills close buttons in `MultiSelect` when it is disabled.

## Why?

We don't want these to be modified when the select is disabled.

## Screenshots/Screen Recordings

<img width="486" alt="Screen Shot 2021-09-15 at 12 08 29 PM" src="https://user-images.githubusercontent.com/196129/133478365-00c5b4bc-4216-4c0b-a161-3b5f28824b68.png">

## Testing/Proof

Added unit tests for this.

Fixes #587.
