### PR TITLE
fix(component): fix PillTab margin

### DIFF
--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -114,7 +114,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
             variant="subtle"
             isActive={activePills.includes(item.id)}
             onClick={() => onPillClick(item.id)}
-            marginRight="xLarge"
+            marginRight="xSmall"
           >
             {item.title}
           </StyledPillTab>

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -110,7 +110,7 @@ exports[`dropdown is not visible if items fit 1`] = `
 }
 
 .c4.c4 {
-  margin-right: 1.5rem;
+  margin-right: 0.5rem;
 }
 
 .c4:focus {
@@ -488,7 +488,7 @@ exports[`it renders the given tabs 1`] = `
 }
 
 .c4.c4 {
-  margin-right: 1.5rem;
+  margin-right: 0.5rem;
 }
 
 .c4:focus {
@@ -866,7 +866,7 @@ exports[`only the pills that fit are visible 1`] = `
 }
 
 .c4.c4 {
-  margin-right: 1.5rem;
+  margin-right: 0.5rem;
 }
 
 .c4:focus {
@@ -1276,7 +1276,7 @@ exports[`only the pills that fit are visible 2 1`] = `
 }
 
 .c4.c4 {
-  margin-right: 1.5rem;
+  margin-right: 0.5rem;
 }
 
 .c4:focus {
@@ -1685,7 +1685,7 @@ exports[`renders all the filters if they fit 1`] = `
 }
 
 .c4.c4 {
-  margin-right: 1.5rem;
+  margin-right: 0.5rem;
 }
 
 .c4:focus {
@@ -2093,7 +2093,7 @@ exports[`renders dropdown if items do not fit 1`] = `
 }
 
 .c5.c5 {
-  margin-right: 1.5rem;
+  margin-right: 0.5rem;
 }
 
 .c5:focus {


### PR DESCRIPTION
## What?

Change right margin of the PillTab from xLarge/24px/1.5rem to xSmall/8px/0.5rem

## Why?

According to BigDesign figma.
https://www.figma.com/file/duwtpbP2tnLLQQmAkwtrNC/BigDesign-Lib?node-id=6093%3A16205
![image](https://user-images.githubusercontent.com/7959201/135306387-c58da975-6de2-45ce-9238-f52a3e6dc5af.png)

## Screenshots/Screen Recordings

![image](https://user-images.githubusercontent.com/7959201/135306700-f1a230e0-1f07-45c6-95de-5ca4e03e3e66.png)

## Testing/Proof

Manually tested. Functionality shouldn't have changed.
