### PR TITLE
chore(docs): rename spacing values tab

### DIFF
--- a/packages/docs/pages/Spacing/SpacingPage.tsx
+++ b/packages/docs/pages/Spacing/SpacingPage.tsx
@@ -67,8 +67,8 @@ const SpacingPage = () => {
       ),
     },
     {
-      id: 'props',
-      title: 'Props',
+      id: 'spacing',
+      title: 'Spacing values',
       render: () => (
         <Panel header="Spacing values">
           <Flex justifyContent="space-around">


### PR DESCRIPTION
## What?

Rename "Props" tab on "Spacing" page to "Spacing values".

## Why?

"Spacing values" name better reflects the content of the tab.

## Screenshots/Screen Recordings

![image](https://user-images.githubusercontent.com/7959201/135316725-86c7fc67-e497-45f1-938e-df57725729e0.png)

## Testing/Proof

Manually tested. Functionality shouldn't have changed.
