### PR TITLE
feat(docs): update page navigation for Badge documentation

### DIFF
--- a/packages/docs/components/ContentRoutingTabs/ContentRoutingTabs.tsx
+++ b/packages/docs/components/ContentRoutingTabs/ContentRoutingTabs.tsx
@@ -1,0 +1,24 @@
+import { Box, PillTabs } from '@bigcommerce/big-design';
+import React from 'react';
+
+import { ContentRoutingTabsProps } from './types';
+import { useContentRoutingTabs } from './useContentRoutingTabs';
+
+const RawContentRoutingTabs: React.FC<ContentRoutingTabsProps> = ({ routes, id }) => {
+  const { activeContent, activePills, pills, handlePillClick } = useContentRoutingTabs(routes, id);
+
+  return (
+    <>
+      <PillTabs activePills={activePills} items={pills} onPillClick={handlePillClick} />
+      <Box marginTop="xSmall">{activeContent?.render()}</Box>
+    </>
+  );
+};
+
+export const ContentRoutingTabs: React.FC<ContentRoutingTabsProps> = (props) => {
+  if (props.routes.length === 0) {
+    return null;
+  }
+
+  return <RawContentRoutingTabs {...props} />;
+};

--- a/packages/docs/components/ContentRoutingTabs/index.ts
+++ b/packages/docs/components/ContentRoutingTabs/index.ts
@@ -1,0 +1,1 @@
+export * from './ContentRoutingTabs';

--- a/packages/docs/components/ContentRoutingTabs/types.ts
+++ b/packages/docs/components/ContentRoutingTabs/types.ts
@@ -1,0 +1,10 @@
+import { PillTabItem } from '@bigcommerce/big-design';
+
+export interface Route extends PillTabItem {
+  render(): JSX.Element;
+}
+
+export interface ContentRoutingTabsProps {
+  routes: Route[];
+  id: string;
+}

--- a/packages/docs/components/ContentRoutingTabs/useContentRoutingTabs.ts
+++ b/packages/docs/components/ContentRoutingTabs/useContentRoutingTabs.ts
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/router';
+
+import { Route } from './types';
+
+export const useContentRoutingTabs = (routes: Route[], id: string) => {
+  const { query, push } = useRouter();
+  const pills = routes.map(({ render, ...pill }) => pill);
+  const queryValue = query[id];
+  const activePill = queryValue && !Array.isArray(queryValue) ? queryValue : routes[0].id;
+  const activeContent = routes.find((content) => content.id === activePill);
+
+  const handlePillClick = (pillId: string) => {
+    push({ query: { ...query, [id]: pillId } }, undefined, { shallow: true });
+  };
+
+  return {
+    activeContent,
+    activePills: activePill ? [activePill] : [],
+    pills,
+    handlePillClick,
+  };
+};

--- a/packages/docs/components/PropTable/PropTable.tsx
+++ b/packages/docs/components/PropTable/PropTable.tsx
@@ -23,18 +23,23 @@ export interface PropTableProps {
   nativeElement?: [string, 'most' | 'all'];
   propList: Prop[];
   title: string;
+  /**
+   * @deprecated Used to migrate to new documentation stucture
+   */
+  renderPanel?: boolean;
 }
 
 export type PropTableWrapper = Partial<PropTableProps>;
 
 export const PropTable: FC<PropTableProps> = (props) => {
-  const { collapsible, id, propList: items, title, inheritedProps, nativeElement } = props;
+  const { collapsible, id, propList: items, title, inheritedProps, nativeElement, renderPanel = true } = props;
 
   const renderTable = () => {
     if (items.length > 0) {
       return (
         <TableFigure marginBottom={collapsible || inheritedProps ? 'xLarge' : 'none'}>
           <Table
+            id={id}
             columns={[
               {
                 header: 'Prop name',
@@ -88,11 +93,9 @@ export const PropTable: FC<PropTableProps> = (props) => {
     return null;
   };
 
-  return collapsible ? (
-    <Collapsible title={`${title} Props`}>{renderTable()}</Collapsible>
-  ) : (
-    <>
-      <Panel header={title} headerId={id}>
+  const renderContent = () => {
+    return (
+      <>
         {renderNativeElement()}
         {renderTable()}
         {inheritedProps ? (
@@ -101,9 +104,19 @@ export const PropTable: FC<PropTableProps> = (props) => {
             <Flex flexDirection="column">{inheritedProps}</Flex>
           </>
         ) : null}
-      </Panel>
-    </>
-  );
+      </>
+    );
+  };
+
+  if (collapsible) {
+    return <Collapsible title={`${title} Props`}>{renderTable()}</Collapsible>;
+  }
+
+  if (renderPanel) {
+    return <Panel header={title}>{renderContent()}</Panel>;
+  }
+
+  return renderContent();
 };
 
 const TypesData: React.FC<TypesDataProps> = (props): any => {

--- a/packages/docs/components/index.tsx
+++ b/packages/docs/components/index.tsx
@@ -3,6 +3,7 @@ export * from './Code';
 export * from './CodePreview';
 export * from './CodeSnippet';
 export * from './Collapsible';
+export * from './ContentRoutingTabs';
 export * from './List';
 export * from './MethodBadge';
 export * from './MethodList';

--- a/packages/docs/pages/badge.tsx
+++ b/packages/docs/pages/badge.tsx
@@ -1,61 +1,75 @@
 import { Badge, Grid, H1, Panel, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
-import { Code, CodePreview, PageNavigation } from '../components';
+import { Code, CodePreview, ContentRoutingTabs, List } from '../components';
 import { BadgePropTable, MarginPropTable } from '../PropTables';
 
 const BadgePage = () => {
-  const items = [
-    {
-      id: 'examples',
-      title: 'Examples',
-      render: () => (
-        <>
-          <Panel>
-            <Text>
-              Badges are used to quickly indicate status or information to a user visually. Each variant correlates to a
-              specific status or value.
-            </Text>
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Badge label="active" variant="success" />
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-          <Panel header="Variants">
-            <Text>
-              There are five types of variants to choose from: <Code>success</Code>, <Code>secondary</Code>,{' '}
-              <Code>warning</Code>, <Code>danger</Code>, and <Code>primary</Code>. You can determine what type by using
-              the <Code primary>variant</Code> prop.
-            </Text>
-
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Grid gridColumns="repeat(5, min-content)">
-                <Badge variant="secondary" label="secondary" />
-                <Badge variant="success" label="success" />
-                <Badge variant="warning" label="warning" />
-                <Badge variant="danger" label="danger" />
-                <Badge variant="primary" label="primary" />
-              </Grid>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-        </>
-      ),
-    },
-    {
-      id: 'props',
-      title: 'Props',
-      render: () => <BadgePropTable inheritedProps={<MarginPropTable collapsible />} />,
-    },
-  ];
-
   return (
     <>
       <H1>Badge</H1>
 
-      <PageNavigation items={items} />
+      <Panel header="Overview" headerId="overview">
+        <Text>Badges are labels that indicate the status of an object on the page.</Text>
+        <Text bold>When to use it:</Text>
+        <List>
+          <List.Item>
+            Use badges to indicate the connection status of a 3rd party integration (e.g. payment method, a channel
+            connection)
+          </List.Item>
+          <List.Item>
+            You can also use badges to call attention to new features (e.g. “new”) or recommended integrations.
+          </List.Item>
+        </List>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <CodePreview>
+                  {/* jsx-to-string:start */}
+                  <Badge label="active" variant="success" />
+                  {/* jsx-to-string:end */}
+                </CodePreview>
+              ),
+            },
+            {
+              id: 'variants',
+              title: 'Variants',
+              render: () => (
+                <>
+                  <Text>
+                    There are five types of variants to choose from: <Code>success</Code>, <Code>secondary</Code>,{' '}
+                    <Code>warning</Code>, <Code>danger</Code>, and <Code>primary</Code>. You can determine what type by
+                    using the <Code primary>variant</Code> prop.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Grid gridColumns="repeat(5, min-content)">
+                      <Badge variant="secondary" label="secondary" />
+                      <Badge variant="success" label="success" />
+                      <Badge variant="warning" label="warning" />
+                      <Badge variant="danger" label="danger" />
+                      <Badge variant="primary" label="primary" />
+                    </Grid>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </>
+              ),
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <BadgePropTable inheritedProps={<MarginPropTable collapsible />} renderPanel={false} />
+      </Panel>
     </>
   );
 };


### PR DESCRIPTION
## What?

- Adds `ContentRoutingTabs` component. (Let me know if you have a better suggestion for the name)
- Uses new layout for the `Badge` page.

## Why?

We wanted to tackle some of the feedback we received when we updated the documentation site in version `0.30.0`.

## Screenshots/Screen Recordings

**Full page:**

![screencapture-localhost-3000-badge-2021-09-30-16_02_16](https://user-images.githubusercontent.com/10539418/135529742-d6db6cf3-b090-4cd1-a318-e6b7d24b812d.png)

**New component with usage:**

https://user-images.githubusercontent.com/10539418/135528437-651a3837-d28d-475c-be93-19ca8115d78c.mov
