### PR TITLE
feat(docs): update buttongroup page to use new layout

### DIFF
--- a/packages/docs/pages/button-group.tsx
+++ b/packages/docs/pages/button-group.tsx
@@ -2,83 +2,112 @@ import { Box, ButtonGroup, H1, Panel, Text } from '@bigcommerce/big-design';
 import { CheckIcon, InfoIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
 
-import { Code, CodePreview, PageNavigation } from '../components';
+import { Code, CodePreview, ContentRoutingTabs, List } from '../components';
 import { ButtonGroupPropTable } from '../PropTables';
 
 const ButtonGroupPage = () => {
-  const items = [
-    {
-      id: 'examples',
-      title: 'Examples',
-      render: () => (
-        <>
-          <Panel>
-            <Text>
-              The <Code primary>Button Group</Code> component is used for grouping actions like{' '}
-              <Code primary>Button</Code>. Allows to save space and reduce visual overload when there are multiple
-              actions available for the same entity.
-            </Text>
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Box style={{ width: 400 }}>
-                <ButtonGroup
-                  actions={[
-                    { text: 'Button 1' },
-                    { text: 'Button 2' },
-                    { text: 'Button 3' },
-                    { text: 'Button 4' },
-                    { text: 'Button 5' },
-                  ]}
-                />
-              </Box>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-          <Panel header="Action type destructive">
-            <Text>
-              By default action with <Code>actionsType: 'destructive'</Code> hides under the ellipsis.
-            </Text>
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <ButtonGroup
-                actions={[{ actionType: 'destructive', text: 'Button 1' }, { text: 'Button 2' }, { text: 'Button 3' }]}
-              />
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-          <Panel header="Icon property">
-            <Text>Icon is available only for actions which is hidden under the ellipsis.</Text>
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Box style={{ width: 400 }}>
-                <ButtonGroup
-                  actions={[
-                    { icon: <InfoIcon />, text: 'Button 1' },
-                    { text: 'Button 2' },
-                    { text: 'Button 3' },
-                    { icon: <InfoIcon />, text: 'Button 4' },
-                    { icon: <CheckIcon />, text: 'Button 5' },
-                  ]}
-                />
-              </Box>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-        </>
-      ),
-    },
-    {
-      id: 'props',
-      title: 'Props',
-      render: () => <ButtonGroupPropTable />,
-    },
-  ];
-
   return (
     <>
       <H1>Button Group</H1>
 
-      <PageNavigation items={items} />
+      <Panel header="Overview" headerId="overview">
+        <Text>
+          Allows to save space and reduce visual overload when there are multiple actions available for the same entity.
+        </Text>
+        <Text bold>When to use it:</Text>
+        <List>
+          <List.Item>In tables as a list of bulk actions available for the selected items.</List.Item>
+        </List>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <>
+                  <Text>
+                    The <Code primary>Button Group</Code> component is used for grouping actions like{' '}
+                    <Code primary>Button</Code>. Allows to save space and reduce visual overload when there are multiple
+                    actions available for the same entity.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Box style={{ width: 400 }}>
+                      <ButtonGroup
+                        actions={[
+                          { text: 'Button 1' },
+                          { text: 'Button 2' },
+                          { text: 'Button 3' },
+                          { text: 'Button 4' },
+                          { text: 'Button 5' },
+                        ]}
+                      />
+                    </Box>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </>
+              ),
+            },
+            {
+              id: 'action-type-destructive',
+              title: 'Action type destructive',
+              render: () => (
+                <>
+                  <Text>
+                    By default action with <Code>actionsType: 'destructive'</Code> hides under the ellipsis.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <ButtonGroup
+                      actions={[
+                        { actionType: 'destructive', text: 'Button 1' },
+                        { text: 'Button 2' },
+                        { text: 'Button 3' },
+                      ]}
+                    />
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </>
+              ),
+            },
+            {
+              id: 'icon-property',
+              title: 'Icon property',
+              render: () => (
+                <>
+                  <Text>Icon is available only for actions which is hidden under the ellipsis.</Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Box style={{ width: 400 }}>
+                      <ButtonGroup
+                        actions={[
+                          { icon: <InfoIcon />, text: 'Button 1' },
+                          { text: 'Button 2' },
+                          { text: 'Button 3' },
+                          { icon: <InfoIcon />, text: 'Button 4' },
+                          { icon: <CheckIcon />, text: 'Button 5' },
+                        ]}
+                      />
+                    </Box>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </>
+              ),
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <ButtonGroupPropTable renderPanel={false} />
+      </Panel>
     </>
   );
 };


### PR DESCRIPTION
## What?

Updates buttongroup to use new layout

## Screenshots/Screen Recordings


![buttongroup-page](https://user-images.githubusercontent.com/196129/136277424-a0e65198-f5dc-4028-9e61-7268ee56eacd.png)

## Testing/Proof

Local