### PR TITLE
chore(ci): split ci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,38 +2,196 @@ version: 2.1
 orbs:
   node: circleci/node@4.7.0
 
-jobs:
-  build:
-    executor:
-      name: node/default
-      tag: '14.16'
+#################################################################################
+# Aliases
+#################################################################################
+default_executor: &default_executor
+  executor:
+    name: node/default
+    tag: '14.16'
+
+filter_branch: &filter_branch
+  filters:
+    branches:
+      ignore: gh-pages
+
+#################################################################################
+# Commands
+#################################################################################
+commands:
+  yarn-install:
+    parameters:
+      cache-version:
+        type: string
+        default: v4
+        description: Change the cache version if you need to clear the cache for any reason.
 
     steps:
+      - restore_cache:
+          keys:
+            - node-deps-<<parameters.cache-version>>-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+            - node-deps-<<parameters.cache-version>>-{{ checksum "package.json" }}
+            - node-deps-<<parameters.cache-version>>
+
+      - run:
+          name: yarn install
+          command: |
+              CKSUM_BEFORE=$(cksum yarn.lock)
+              yarn install
+              CKSUM_AFTER=$(cksum yarn.lock)
+            
+              if [[ $CKSUM_BEFORE != $CKSUM_AFTER ]]; then
+                echo "yarn.lock was modified unexpectedly - terminating"
+                exit 1
+              fi
+      
+      - save_cache:
+          key: node-deps-<<parameters.cache-version>>-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+            - packages/big-design/node_modules
+            - packages/big-design-theme/node_modules
+            - packages/big-design-icons/node_modules
+            - packages/configs/node_modules
+            - packages/docs/node_modules
+            - packages/examples/node_modules
+  
+  pre-setup:
+    steps:
       - checkout
-
       - node/install-yarn:
-          version: 1.22.10
+          version: 1.22.15
+      - yarn-install
 
-      - node/install-packages:
-          with-cache: true
-          cache-version: v3
-          include-branch-in-cache-key: false
-          pkg-manager: yarn
+  attach-built-icons:
+    steps:
+      - attach_workspace:
+          at: .
 
-      - run:
-          command: yarn run ci
-          environment:
-            NEXT_TELEMETRY_DISABLED: '1'
+#################################################################################
+# Jobs
+#################################################################################
+jobs:
+  build-icons:
+    <<: *default_executor
 
-      - run:
-          command: yarn run lint
+    steps:
+      - pre-setup
+      - run: yarn workspace @bigcommerce/big-design-icons run build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - packages/big-design-icons/dist
 
+  build-theme:
+    <<: *default_executor
 
+    steps:
+      - pre-setup
+      - run: yarn workspace @bigcommerce/big-design-theme run build
+
+  build-big-design:
+    <<: *default_executor
+
+    steps:
+      - pre-setup
+      - attach-built-icons
+      - run: yarn workspace @bigcommerce/big-design run build
+
+  build-examples:
+    <<: *default_executor
+
+    steps:
+      - pre-setup
+      - attach-built-icons
+      - run: yarn workspace @bigcommerce/examples run build
+
+  build-docs:
+    <<: *default_executor
+
+    parameters:
+      cache-version:
+        type: string
+        default: v1
+        description: Change the next.js cache version if you need to clear the cache for any reason.
+
+    steps:
+      - pre-setup
+      - attach-built-icons
+      - restore_cache:
+          keys:
+            - nextjs-<<parameters.cache-version>>-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+            - nextjs-<<parameters.cache-version>>-{{ checksum "package.json" }}
+            - nextjs-<<parameters.cache-version>>
+      - run: yarn workspace @bigcommerce/docs run build
+      - save_cache:
+          key: nextjs-<<parameters.cache-version>>-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+          paths:
+            - packages/docs/.next
+
+  typeCheck:
+    <<: *default_executor
+
+    steps:
+      - pre-setup
+      - attach-built-icons
+      - run: yarn run ci:typeCheck
+
+  lint:
+    <<: *default_executor
+
+    steps:
+      - pre-setup
+      - attach-built-icons
+      - run: yarn run lint
+
+  test:
+    <<: *default_executor
+
+    steps:
+      - pre-setup
+      - attach-built-icons
+      - run: yarn run ci:test
+
+#################################################################################
+# Workflows
+#################################################################################
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - build:
-        filters:
-          branches:
-            ignore: gh-pages
+      - build-icons:
+          <<: *filter_branch
+
+      - build-theme:
+          <<: *filter_branch
+
+      - build-big-design:
+          <<: *filter_branch
+          requires:
+            - build-icons
+
+      - build-examples:
+          <<: *filter_branch
+          requires:
+            - build-icons
+
+      - build-docs:
+          <<: *filter_branch
+          requires:
+            - build-icons
+
+      - typeCheck:
+          <<: *filter_branch
+          requires:
+            - build-icons
+
+      - lint:
+          <<: *filter_branch
+          requires:
+            - build-icons
+
+      - test:
+          <<: *filter_branch
+          requires:
+            - build-icons

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "lerna run build --stream",
     "build:icons": "yarn workspace @bigcommerce/big-design-icons run build",
-    "ci": "lerna run ci --stream",
+    "ci:typeCheck": "lerna run typeCheck --stream",
+    "ci:test": "lerna run test --stream -- --maxWorkers=2 --coverage",
+    "ci:build": "lerna run build --stream",
     "diff": "lerna diff",
     "lint": "eslint . --ext .ts,.tsx,.js",
     "start": "yarn workspace @bigcommerce/docs run start",

--- a/packages/big-design-icons/package.json
+++ b/packages/big-design-icons/package.json
@@ -20,10 +20,8 @@
     "build:icons": "node scripts/build.js",
     "build:flags": "node scripts/build-flags.js",
     "download": "node scripts/downloader.js",
-    "ci": "yarn run lint && yarn run build",
-    "lint": "yarn run lint:tsc",
-    "lint:tsc": "tsc --noEmit",
-    "prepublishOnly": "rimraf dist && yarn run ci"
+    "prepublishOnly": "rimraf dist && yarn run typeCheck && yarn run build",
+    "typeCheck": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/packages/big-design-theme/package.json
+++ b/packages/big-design-theme/package.json
@@ -15,14 +15,12 @@
     "build:cjs": "NODE_ENV=production BABEL_ENV=cjs babel --extensions \".ts,.tsx\" ./src --out-dir ./dist/cjs",
     "build:es": "NODE_ENV=production BABEL_ENV=es babel --extensions \".ts,.tsx\" ./src --out-dir ./dist/es",
     "build:dt": "tsc --emitDeclarationOnly",
-    "ci": "yarn run lint && yarn run test --maxWorkers=2 --coverage && yarn run build",
-    "lint": "yarn run lint:tsc",
-    "lint:tsc": "tsc --noEmit",
-    "prepublishOnly": "rimraf dist && yarn run ci",
+    "prepublishOnly": "rimraf dist && yarn run typeCheck && yarn run test && yarn run build",
     "prepack": "big-design-prepack",
     "postpack": "big-design-postpack",
     "test": "BABEL_ENV=test jest",
-    "test:watch": "yarn run test --watch"
+    "test:watch": "yarn run test --watch",
+    "typeCheck": "tsc --noEmit"
   },
   "files": [
     "dist"

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -18,14 +18,12 @@
     "build:cjs": "NODE_ENV=production BABEL_ENV=cjs babel --extensions \".ts,.tsx\" ./src --out-dir ./dist/cjs",
     "build:es": "NODE_ENV=production BABEL_ENV=es babel --extensions \".ts,.tsx\" ./src --out-dir ./dist/es",
     "build:dt": "tsc -p tsconfig.declarations.json --emitDeclarationOnly",
-    "ci": "yarn run lint && yarn run test --maxWorkers=2 --coverage && yarn run build",
-    "lint": "yarn run lint:tsc",
-    "lint:tsc": "tsc --noEmit",
     "test": "BABEL_ENV=test jest",
     "test:watch": "yarn run test --watch",
-    "prepublishOnly": "rimraf dist && yarn run ci",
+    "prepublishOnly": "rimraf dist && yarn run typeCheck && yarn run test --maxWorkers=2 && yarn run build",
     "prepack": "big-design-prepack",
-    "postpack": "big-design-postpack"
+    "postpack": "big-design-postpack",
+    "typeCheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -11,12 +11,10 @@
     "directory": "packages/docs"
   },
   "scripts": {
-    "build-static": "next build && next export",
-    "deploy": "yarn run build-static && touch out/.nojekyll && push-dir --dir=out --branch=gh-pages --verbose",
+    "build": "next build && next export",
+    "deploy": "yarn run build && touch out/.nojekyll && push-dir --dir=out --branch=gh-pages --verbose",
     "start": "next",
-    "ci": "yarn run lint && yarn run build-static",
-    "lint": "yarn run lint:tsc",
-    "lint:tsc": "tsc --noEmit"
+    "typeCheck": "tsc --noEmit"
   },
   "dependencies": {
     "@babel/core": "^7.15.5",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -3,8 +3,9 @@
   "private": true,
   "version": "0.17.2",
   "scripts": {
+    "build": "vite build",
     "start": "vite",
-    "ci": "tsc && vite build"
+    "typeCheck": "tsc --noEmit"
   },
   "dependencies": {
     "@bigcommerce/big-design": "^0.30.2",


### PR DESCRIPTION
First pass, this brings down the workflow from 7-10min, to 3-5min (hot/cold cache).

- Split npm `ci` script into multiple scripts
- Split CI jobs
- Cache `node_modules` + `<package>/node_modules`
- Cache `.next` dir for docs.