### PR TITLE
fix(docs): scope not being reinitialized on rerender

### DIFF
--- a/packages/docs/components/CodePreview/CodePreview.tsx
+++ b/packages/docs/components/CodePreview/CodePreview.tsx
@@ -66,7 +66,11 @@ export const CodePreview: React.FC<CodePreviewProps> = (props) => {
 
   const initialCode = getInitialCode(children, language);
   const [code, setCode] = useState(initialCode);
-  const scope = { ...defaultScope, ...props.scope };
+  const [scope, setScope] = useState({ ...defaultScope, ...props.scope });
+
+  useEffect(() => {
+    setScope({ ...defaultScope, ...props.scope });
+  }, [props.scope, setScope]);
 
   useEffect(() => {
     setCode(getInitialCode(children, language));


### PR DESCRIPTION
## What?

`scope` was not being reinitialized when `CodePreview` component was being rerendered.

## Why?

Rerendering CodePreview components would cause react errors due to certain variables not being passed into the scope.
