### PR TITLE
fix(component): change table paddding

### DIFF
--- a/packages/big-design/src/components/Table/Actions/styled.tsx
+++ b/packages/big-design/src/components/Table/Actions/styled.tsx
@@ -9,7 +9,7 @@ export const StyledFlex = styled.div<FlexProps & { stickyHeader?: boolean }>`
 
   background-color: ${({ theme }) => theme.colors.white};
   display: flex;
-  padding: ${({ theme }) => theme.spacing.small};
+  padding: ${({ theme }) => `${theme.spacing.small} ${theme.spacing.xLarge}`};
 
   ${({ theme, stickyHeader }) =>
     stickyHeader &&

--- a/packages/big-design/src/components/Table/DataCell/styled.tsx
+++ b/packages/big-design/src/components/Table/DataCell/styled.tsx
@@ -14,6 +14,14 @@ export const StyledTableDataCell = styled.td<DataCellProps>`
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   padding: ${({ theme, withPadding }) => (withPadding ? theme.spacing.small : 0)};
 
+  &:first-of-type {
+    padding-left: ${({ theme, withPadding }) => (withPadding ? theme.spacing.xLarge : 0)};
+  }
+
+  &:last-of-type {
+    padding-right: ${({ theme, withPadding }) => (withPadding ? theme.spacing.xLarge : 0)};
+  }
+
   ${({ theme, withBorder }) =>
     withBorder &&
     css`
@@ -44,6 +52,14 @@ export const StyledTableDataCheckbox = styled(StyledTableDataCell)`
 
   background-color: ${({ theme }) => theme.colors.white};
   padding: ${({ theme }) => `0 ${theme.spacing.small}`};
+
+  &:first-of-type {
+    padding-left: ${({ theme }) => theme.spacing.xLarge};
+  }
+
+  &:last-of-type {
+    padding-right: ${({ theme }) => theme.spacing.xLarge};
+  }
 
   ${(props) =>
     props.isCheckbox &&

--- a/packages/big-design/src/components/Table/HeaderCell/styled.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/styled.tsx
@@ -29,6 +29,14 @@ export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
   padding: ${({ theme }) => theme.spacing.small};
   white-space: nowrap;
 
+  &:first-of-type {
+    padding-left: ${({ theme }) => theme.spacing.xLarge};
+  }
+
+  &:last-of-type {
+    padding-right: ${({ theme }) => theme.spacing.xLarge};
+  }
+
   ${({ isSortable }) =>
     isSortable &&
     css`

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -303,7 +303,7 @@ exports[`renders a pagination component 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0.75rem;
+  padding: 0.75rem 1.5rem;
 }
 
 @media (min-width:720px) {
@@ -507,6 +507,14 @@ exports[`renders a simple table 1`] = `
   white-space: nowrap;
 }
 
+.c1:first-of-type {
+  padding-left: 1.5rem;
+}
+
+.c1:last-of-type {
+  padding-right: 1.5rem;
+}
+
 .c4 {
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
@@ -521,6 +529,14 @@ exports[`renders a simple table 1`] = `
   font-size: 1rem;
   padding: 0.75rem;
   border-bottom: 1px solid #D9DCE9;
+}
+
+.c6:first-of-type {
+  padding-left: 1.5rem;
+}
+
+.c6:last-of-type {
+  padding-right: 1.5rem;
 }
 
 .c5 {
@@ -906,7 +922,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0.75rem;
+  padding: 0.75rem 1.5rem;
 }
 
 <div

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -178,7 +178,7 @@ test('tweaks column styles with props', () => {
 
   expect(nameTd).toHaveStyle(`
     width: 100px;
-    padding: 0;
+    padding: 0 0 0 0;
   `);
 });
 


### PR DESCRIPTION
## What?
- Change `padding-left` from `small(12px)` to `xLarge(24px)` for the first `th/td`;
- Change `padding-right` from `small(12px)` to `xLarge(24px)` for the last `th/td`;
- Change `horizontal padding` from `small(12px)` to `xLarge(24px)` for the `Actions` wrapper.

## Why?
According to guidelines 👍 (screenshots below).
<img width="326" alt="Screenshot 2021-10-18 at 13 44 46" src="https://user-images.githubusercontent.com/9980803/137716984-72f6561a-76cd-46d8-80e3-6b5423f17e4d.png">
<img width="272" alt="Screenshot 2021-10-18 at 13 44 56" src="https://user-images.githubusercontent.com/9980803/137716988-b387037b-4980-4643-a6dc-c6e9c80e0212.png">

## Screenshots/Screen Recordings
<img width="782" alt="Screenshot 2021-10-18 at 13 06 05" src="https://user-images.githubusercontent.com/9980803/137717037-b570eb33-0e8b-4764-b862-b85b2ef878f7.png">
<img width="778" alt="Screenshot 2021-10-18 at 13 06 18" src="https://user-images.githubusercontent.com/9980803/137717042-64ffddf3-8308-4a08-b8a6-63f53c7a6ff6.png">
<img width="779" alt="Screenshot 2021-10-18 at 13 06 34" src="https://user-images.githubusercontent.com/9980803/137717045-65f79044-4bf4-4c0b-b122-5dc2505cf9e2.png">
<img width="777" alt="Screenshot 2021-10-18 at 13 07 08" src="https://user-images.githubusercontent.com/9980803/137717052-116e28d1-51ee-4f68-a6b0-855c66bca1c9.png">

## Testing/Proof
Locally + existing unit tests.
