### PR TITLE
fix(component): fix checkbox alignment to label

### DIFF
--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -75,6 +75,8 @@ exports[`render Checkbox checked 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-bottom: 0.0625rem;
+  margin-top: 0.0625rem;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -219,6 +221,8 @@ exports[`render Checkbox disabled checked 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-bottom: 0.0625rem;
+  margin-top: 0.0625rem;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -366,6 +370,8 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-bottom: 0.0625rem;
+  margin-top: 0.0625rem;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -511,6 +517,8 @@ exports[`render Checkbox disabled unchecked 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-bottom: 0.0625rem;
+  margin-top: 0.0625rem;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -656,6 +664,8 @@ exports[`render Checkbox indeterminate 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-bottom: 0.0625rem;
+  margin-top: 0.0625rem;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -797,6 +807,8 @@ exports[`render Checkbox unchecked 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-bottom: 0.0625rem;
+  margin-top: 0.0625rem;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -978,6 +990,8 @@ exports[`render Checkbox with description object 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-bottom: 0.0625rem;
+  margin-top: 0.0625rem;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1148,6 +1162,8 @@ exports[`render Checkbox with description string 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-bottom: 0.0625rem;
+  margin-top: 0.0625rem;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -43,6 +43,8 @@ export const StyledCheckbox = styled.label<StyledCheckboxProps>`
   display: inline-flex;
   height: ${({ theme }) => theme.spacing.large};
   justify-content: center;
+  margin-bottom: ${({ theme }) => theme.helpers.remCalc(1)};
+  margin-top: ${({ theme }) => theme.helpers.remCalc(1)};
   user-select: none;
   width: ${({ theme }) => theme.spacing.large};
 

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -886,6 +886,8 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-bottom: 0.0625rem;
+  margin-top: 0.0625rem;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -76,7 +76,7 @@ exports[`renders worksheet 1`] = `
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
+              class="styled__StyledCheckbox-sc-s1u0st-3 hMHbNJ"
               for="bd-checkbox-1"
             >
               <svg
@@ -206,7 +206,7 @@ exports[`renders worksheet 1`] = `
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
+              class="styled__StyledCheckbox-sc-s1u0st-3 hMHbNJ"
               for="bd-checkbox-4"
             >
               <svg
@@ -335,7 +335,7 @@ exports[`renders worksheet 1`] = `
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 bXFgcu"
+              class="styled__StyledCheckbox-sc-s1u0st-3 ijngYq"
               for="bd-checkbox-7"
             >
               <svg
@@ -465,7 +465,7 @@ exports[`renders worksheet 1`] = `
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
+              class="styled__StyledCheckbox-sc-s1u0st-3 hMHbNJ"
               for="bd-checkbox-10"
             >
               <svg
@@ -593,7 +593,7 @@ exports[`renders worksheet 1`] = `
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
+              class="styled__StyledCheckbox-sc-s1u0st-3 hMHbNJ"
               for="bd-checkbox-13"
             >
               <svg
@@ -723,7 +723,7 @@ exports[`renders worksheet 1`] = `
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
+              class="styled__StyledCheckbox-sc-s1u0st-3 hMHbNJ"
               for="bd-checkbox-16"
             >
               <svg
@@ -852,7 +852,7 @@ exports[`renders worksheet 1`] = `
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 bXFgcu"
+              class="styled__StyledCheckbox-sc-s1u0st-3 ijngYq"
               for="bd-checkbox-19"
             >
               <svg
@@ -982,7 +982,7 @@ exports[`renders worksheet 1`] = `
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
+              class="styled__StyledCheckbox-sc-s1u0st-3 hMHbNJ"
               for="bd-checkbox-22"
             >
               <svg
@@ -1112,7 +1112,7 @@ exports[`renders worksheet 1`] = `
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 iTGSWB"
+              class="styled__StyledCheckbox-sc-s1u0st-3 hMHbNJ"
               for="bd-checkbox-25"
             >
               <svg


### PR DESCRIPTION
## What?
Add `margin-top` & `margin-bottom` for `StyledCheckbox` to resolve problem with alignment between `checkbox` and `label`.

## Why?
I faced a problem when the checkbox is not alignments correctly to label.

**Why it happens:**
Reason: the difference between next 2 values.
- Checkbox label has `line-height` which is equal to `1.5rem(24px)`;
- `StyledCheckbox` has `height` and `width` which equal to `1.25rem(22px)`.

**Why I added `margin-bottom` property:**
- We have a case when the checkbox uses without a label so, if I will use only `margin-top`, the `checkbox` will have the wrong view (slight downward displacement), for example in the `Worksheet`, `Table` components and other same cases.

## Screenshots/Screen Recordings

Before | After
--- | ---
<img width="295" alt="Screenshot 2021-10-20 at 11 40 20" src="https://user-images.githubusercontent.com/9980803/138060639-90027566-d7c6-4fcb-8927-251bf26148c6.png"> | <img width="300" alt="Screenshot 2021-10-20 at 11 40 02" src="https://user-images.githubusercontent.com/9980803/138060758-3553d7aa-ccb7-4fe2-8979-7046c5ef68f6.png">
<img width="121" alt="Screenshot 2021-10-20 at 11 38 08" src="https://user-images.githubusercontent.com/9980803/138060677-864c7257-cd81-40bd-b0a0-4915eb550cee.png"> | <img width="127" alt="Screenshot 2021-10-20 at 11 38 25" src="https://user-images.githubusercontent.com/9980803/138060799-f810d647-b14a-45b8-ae00-278a4ea3ac92.png">

## Testing/Proof
Locally + Snapshots
