### PR TITLE
[DRAFT]fix(component): change position of selection icon on Select component

### DIFF
--- a/packages/big-design/src/components/List/Item/Content.tsx
+++ b/packages/big-design/src/components/List/Item/Content.tsx
@@ -6,14 +6,15 @@ import { SelectAction, SelectOption } from '../../Select';
 import { Tooltip } from '../../Tooltip';
 import { Small } from '../../Typography';
 
-import { StyledLink } from './styled';
+import { StyledLabel, StyledLink } from './styled';
 
 interface ContentProps {
   item: DropdownItem | DropdownLinkItem | SelectOption<any> | SelectAction;
   isHighlighted: boolean;
+  isSelected: boolean;
 }
 
-export const Content = memo(({ item, isHighlighted }: ContentProps) => {
+export const Content = memo(({ item, isHighlighted, isSelected }: ContentProps) => {
   const iconColor = useMemo(() => {
     if (item.disabled) {
       return 'secondary40';
@@ -84,7 +85,9 @@ export const Content = memo(({ item, isHighlighted }: ContentProps) => {
             <Small color={descriptionColor(disabled)}>{description}</Small>
           </FlexItem>
         ) : (
-          content
+          <StyledLabel content={content} isSelected={isSelected}>
+            {content}
+          </StyledLabel>
         )}
       </Flex>
     );
@@ -93,7 +96,7 @@ export const Content = memo(({ item, isHighlighted }: ContentProps) => {
       'type' in item && item.type === 'link' && !disabled ? wrapInLink(item, baseContent) : baseContent;
 
     return disabled && 'tooltip' in item && item.tooltip ? wrapInTooltip(item.tooltip, finalContent) : finalContent;
-  }, [descriptionColor, item, renderIcon, wrapInLink, wrapInTooltip]);
+  }, [descriptionColor, item, renderIcon, wrapInLink, wrapInTooltip, isSelected]);
 
   return getContent;
 });

--- a/packages/big-design/src/components/List/Item/Item.tsx
+++ b/packages/big-design/src/components/List/Item/Item.tsx
@@ -100,7 +100,7 @@ const StyleableListItem = typedMemo(
         isHighlighted={isHighlighted}
         isSelected={isSelected}
       >
-        {<Content item={item} isHighlighted={isHighlighted} />}
+        {<Content item={item} isHighlighted={isHighlighted} isSelected={isSelected} />}
         {isSelected && <CheckIcon color="primary" size="large" />}
       </StyledListItem>
     ),

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -69,6 +69,19 @@ export const StyledListItem = styled.li<ListItemProps<unknown>>`
   }
 `;
 
+export const StyledLabel = styled.span<any>`
+  margin-right: ${({ theme, isSelected }) => (isSelected ? theme.helpers.remCalc(8) : theme.helpers.remCalc(28))};
+
+  &:after {
+    display: block;
+    content: attr(content);
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
+    font-weight: 700;
+  }
+`;
+
 export const StyledLink = styled.a`
   ${withTransition(['background-color', 'color'])}
 
@@ -86,3 +99,4 @@ export const StyledLink = styled.a`
 
 StyledListItem.defaultProps = { theme: defaultTheme };
 StyledLink.defaultProps = { theme: defaultTheme };
+StyledLabel.defaultProps = { theme: defaultTheme };


### PR DESCRIPTION
## What?

This PR updates position of check icon in select list. ([BIGDESIGN-207](https://jira.bigcommerce.com/browse/BIGDESIGN-207))

## Why?

According to design check icon should be located 8px from list item label. Also width of the list should be static and not changed after any item selection.

## Screenshots/Screen Recordings

BEFORE
<img width="929" alt="init-icon2" src="https://user-images.githubusercontent.com/66325265/139291333-cc71dbe5-7061-411f-b420-47dd40399286.png">
<img width="929" alt="init-icon" src="https://user-images.githubusercontent.com/66325265/139291412-a2ff62c5-89d9-41f3-b618-50393353061c.png">
AFTER
<img width="1189" alt="updated-icon" src="https://user-images.githubusercontent.com/66325265/140800657-06ca7844-fc9a-4549-918d-a235e3d429b5.png">
<img width="1189" alt="updated-icon2" src="https://user-images.githubusercontent.com/66325265/140800686-59c7d9b7-1021-41ae-9cf9-142548dc305c.png">