### PR TITLE
test(component): refactor collapse component tests

### DIFF
--- a/packages/big-design/src/components/Collapse/spec.tsx
+++ b/packages/big-design/src/components/Collapse/spec.tsx
@@ -1,7 +1,9 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { render } from '@test/utils';
 
 import { Text } from '../Typography';
 
@@ -21,150 +23,159 @@ const CollapseWithVisiblePanelMock = (
 );
 
 test('renders with title button', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
+  render(CollapseWithStaticTitleMock);
 
-  expect(getByRole('button')).toBeInTheDocument();
+  expect(screen.getByRole('button')).toBeInTheDocument();
 });
 
 test('renders with provided title', () => {
-  const { queryAllByText } = render(CollapseWithStaticTitleMock);
+  render(CollapseWithStaticTitleMock);
 
-  expect(queryAllByText('title').length).toBe(2);
+  expect(screen.getAllByText('title')).toHaveLength(2);
 });
 
 test('renders with panel', () => {
-  const { getByRole } = render(CollapseWithVisiblePanelMock);
+  render(CollapseWithVisiblePanelMock);
 
-  expect(getByRole('region')).toBeInTheDocument();
+  expect(screen.getByRole('region')).toBeInTheDocument();
 });
 
 test('title button has id', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
+  render(CollapseWithStaticTitleMock);
 
-  expect(getByRole('button').id).toBeDefined();
+  expect(screen.getByRole('button').id).toBeDefined();
 });
 
 test('title button has aria-controls', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const button = getByRole('button');
-  const panel = getByRole('region', { hidden: true });
+  render(CollapseWithStaticTitleMock);
 
-  fireEvent.focus(button);
+  const button = screen.getByRole('button');
+  const panelId = screen.getByRole('region', { hidden: true }).id;
 
-  expect(button.getAttribute('aria-controls')).toBe(panel.id);
+  expect(button.getAttribute('aria-controls')).toBe(panelId);
 });
 
 test('title button has icon', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const trigger = getByRole('button');
-  const icon = trigger.querySelector('svg');
+  render(CollapseWithStaticTitleMock);
+
+  const icon = screen.getByRole('button').querySelector('svg');
 
   expect(icon).toBeInTheDocument();
 });
 
 test('title button icon in initially collapsed state', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const trigger = getByRole('button');
-  const icon = trigger.querySelector('svg');
+  render(CollapseWithStaticTitleMock);
+
+  const icon = screen.getByRole('button').querySelector('svg');
 
   expect(icon).not.toHaveStyle('transform: rotate(-180deg)');
 });
 
 test('title button icon in initially expanded state', () => {
-  const { getByRole } = render(CollapseWithVisiblePanelMock);
-  const trigger = getByRole('button');
-  const icon = trigger.querySelector('svg');
+  render(CollapseWithVisiblePanelMock);
+
+  const icon = screen.getByRole('button').querySelector('svg');
 
   expect(icon).toHaveStyle('transform: rotate(-180deg)');
 });
 
 test('title button icon toggles on title click', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const trigger = getByRole('button');
+  render(CollapseWithStaticTitleMock);
+
+  const trigger = screen.getByRole('button');
   const icon = trigger.querySelector('svg');
 
-  fireEvent.click(trigger);
+  userEvent.click(trigger);
 
   expect(icon).toHaveStyle('transform: rotate(-180deg)');
 
-  fireEvent.click(trigger);
+  userEvent.click(trigger);
 
   expect(icon).not.toHaveStyle('transform: rotate(-180deg)');
 });
 
 test('panel has id', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const panel = getByRole('region', { hidden: true });
+  render(CollapseWithStaticTitleMock);
 
-  expect(panel.id).toBeDefined();
+  const panelId = screen.getByRole('region', { hidden: true }).id;
+
+  expect(panelId).toBeDefined();
 });
 
 test('panel has aria-labelledby attribute', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const panel = getByRole('region', { hidden: true });
+  render(CollapseWithStaticTitleMock);
+
+  const panel = screen.getByRole('region', { hidden: true });
 
   expect(panel.getAttribute('aria-labelledby')).toBeDefined();
 });
 
 test('panel has role attribute', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const panel = getByRole('region', { hidden: true });
+  render(CollapseWithStaticTitleMock);
+
+  const panel = screen.getByRole('region', { hidden: true });
 
   expect(panel).toBeInTheDocument();
 });
 
 test('panel is hidden', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const panel = getByRole('region', { hidden: true });
+  render(CollapseWithStaticTitleMock);
+
+  const panel = screen.getByRole('region', { hidden: true });
 
   expect(panel).not.toBeVisible();
 });
 
 test('panel is visible', () => {
-  const { getByRole } = render(CollapseWithVisiblePanelMock);
-  const panel = getByRole('region', { hidden: true });
+  render(CollapseWithVisiblePanelMock);
+
+  const panel = screen.getByRole('region', { hidden: true });
 
   expect(panel).toBeVisible();
 });
 
 test('hidden panel becomes visible on title click', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const trigger = getByRole('button') as HTMLButtonElement;
-  const panel = getByRole('region', { hidden: true });
+  render(CollapseWithStaticTitleMock);
 
-  fireEvent.click(trigger);
+  const trigger = screen.getByRole<HTMLButtonElement>('button');
+  const panel = screen.getByRole('region', { hidden: true });
+
+  userEvent.click(trigger);
 
   expect(panel).toBeVisible();
 });
 
 test('visible panel becomes hidden on title click', () => {
-  const { getByRole } = render(CollapseWithVisiblePanelMock);
-  const trigger = getByRole('button') as HTMLButtonElement;
-  const panel = getByRole('region', { hidden: true });
+  render(CollapseWithVisiblePanelMock);
 
-  fireEvent.click(trigger);
+  const trigger = screen.getByRole<HTMLButtonElement>('button');
+  const panel = screen.getByRole('region', { hidden: true });
+
+  userEvent.click(trigger);
 
   expect(panel).not.toBeVisible();
 });
 
 test('click on title toggles aria-expanded attribute on title button', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const trigger = getByRole('button') as HTMLButtonElement;
+  render(CollapseWithStaticTitleMock);
 
-  fireEvent.click(trigger);
+  const trigger = screen.getByRole<HTMLButtonElement>('button');
+
+  userEvent.click(trigger);
 
   expect(trigger.getAttribute('aria-expanded')).toBe('true');
 
-  fireEvent.click(trigger);
+  userEvent.click(trigger);
 
   expect(trigger.getAttribute('aria-expanded')).toBe('false');
 });
 
 test('onCollapseChange is called', () => {
-  const { getByRole } = render(CollapseWithStaticTitleMock);
-  const trigger = getByRole('button') as HTMLButtonElement;
+  render(CollapseWithStaticTitleMock);
 
-  fireEvent.click(trigger);
+  const trigger = screen.getByRole<HTMLButtonElement>('button');
+
+  userEvent.click(trigger);
 
   expect(handleChange).toHaveBeenCalled();
 });


### PR DESCRIPTION
## What?

This PR is aimed to refactor Collapse component's tests according to best practices. We take into account recommendations from  Kent C. Dodds [article](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-container-to-query-for-elements). For instance, using `container` for  `query`-ing elements has been removed. Instead,  we replace it with `screen`. 

**NOTE**: userEvent package has been added for switching over fireEvent.

## Why?
the changes are based on GitHub [issue](https://github.com/bigcommerce/big-design/issues/635) and PRs will be open for each component separately.

## Testing/Proof

The tests have been successfully run locally.