### PR TITLE
feat(docs): update breakpoints page to use new layout

### DIFF
--- a/packages/docs/components/Code/styled.tsx
+++ b/packages/docs/components/Code/styled.tsx
@@ -10,7 +10,7 @@ export const StyledCode = styled.code<CodeProps>`
     highlight &&
     !primary &&
     css`
-      background-color: ${theme.colors.warning10};
+      background-color: ${theme.colors.warning20};
       padding: ${theme.spacing.xxSmall};
     `};
 

--- a/packages/docs/pages/breakpoints.tsx
+++ b/packages/docs/pages/breakpoints.tsx
@@ -1,63 +1,133 @@
-import { Box, H1, Panel, Text } from '@bigcommerce/big-design';
+import { BoxProps, Box as Container, H1, Message, Panel, Text } from '@bigcommerce/big-design';
 import { breakpointValues } from '@bigcommerce/big-design-theme';
 import React from 'react';
 import styled from 'styled-components';
 
-import { Code, CodePreview } from '../components';
+import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable } from '../components';
+
+const Box: React.FC<BoxProps> = ({ children, ...props }) => (
+  <Container backgroundColor="secondary10" border="box" {...props}>
+    {children}
+  </Container>
+);
 
 const BreakpointsPage = () => (
   <>
     <H1>Breakpoints</H1>
 
-    <Panel>
+    <Panel header="Overview" headerId="overview">
       <Text>
-        We provide access to our breakpoints' <Code>@media</Code> queries. Our breakpoints include{' '}
-        <Code primary>mobile</Code>, <Code primary>tablet</Code> and <Code primary>desktop</Code> . Values for each
-        breakpoint are <Code>{breakpointValues.mobile}</Code>, <Code>{breakpointValues.tablet}</Code>, and{' '}
+        BigDesign exposes a set of <Code primary>breakpoints</Code> and <Code primary>breakpointValues</Code> that can
+        be used to create responsive layouts and components. Our breakpoints include <Code primary>mobile</Code>,{' '}
+        <Code primary>tablet</Code> and <Code primary>desktop</Code>. For each breakpoint, the breakpoint values are{' '}
+        <Code>{breakpointValues.mobile}</Code>, <Code>{breakpointValues.tablet}</Code>, and{' '}
         <Code>{breakpointValues.desktop}</Code> respectively.
       </Text>
-      <CodePreview>
-        {/* jsx-to-string:start */}
-        {function Example() {
-          const StyledBox = styled(Box)`
-            height: ${({ theme }) => theme.spacing.xxxLarge};
-            width: 100%;
-
-            ${({ theme }) => theme.breakpoints.tablet} {
-              width: 60%;
-            }
-
-            ${({ theme }) => theme.breakpoints.desktop} {
-              width: 30%;
-            }
-          `;
-
-          return <StyledBox backgroundColor="secondary20" />;
-        }}
-        {/* jsx-to-string:end */}
-      </CodePreview>
     </Panel>
-    <Panel header="Breakpoint values">
-      <Text>
-        We also expose the <Code primary>breakpointValues</Code> for each breakpoint.
-      </Text>
 
-      <CodePreview>
-        {/* jsx-to-string:start */}
-        {function Example() {
-          const StyledBox = styled(Box)`
-            height: ${({ theme }) => theme.spacing.xxxLarge};
-            width: 100%;
+    <Panel header="Implementation" headerId="implementation">
+      <ContentRoutingTabs
+        id="implementation"
+        routes={[
+          {
+            id: 'basic',
+            title: 'Basic',
+            render: () => (
+              <>
+                <Text>
+                  Most utility components contain responsive props. You can pass in an object with{' '}
+                  <Code primary>breakpoints</Code> as keys to provide values at each breakpoint. BigDesign is
+                  mobile-first in nature, so bigger screen size values will override smaller ones.
+                </Text>
 
-            ${({ theme }) => theme.breakpoints.desktop} {
-              width: ${({ theme }) => theme.breakpointValues.tablet};
-            }
-          `;
+                <CodePreview scope={{ Box }}>
+                  {/* jsx-to-string:start */}
+                  <Box padding={{ mobile: 'none', tablet: 'small', desktop: 'xLarge' }}>
+                    This box has responsive props!
+                  </Box>
+                  {/* jsx-to-string:end */}
+                </CodePreview>
+              </>
+            ),
+          },
+          {
+            id: 'extending',
+            title: 'Extending',
+            render: () => (
+              <>
+                <Message
+                  messages={[
+                    { text: 'Before extending a component, if possible, use one of BigDesigns core components.' },
+                  ]}
+                  type="warning"
+                  marginVertical="medium"
+                />
+                <Text>
+                  If you need a customized wrapper you can extend one of our utility components (
+                  <Code primary>Box</Code>, <Code primary>Flex</Code>, or <Code primary>Grid</Code>) using{' '}
+                  <Code>styled-components</Code>. Exposed on the <Code primary>theme</Code> object is the{' '}
+                  <Code primary>breakpoints</Code> key. The values returned are <Code>@media</Code> queries ready for
+                  consumtion.
+                </Text>
 
-          return <StyledBox backgroundColor="secondary20" />;
-        }}
-        {/* jsx-to-string:end */}
-      </CodePreview>
+                <CodePreview scope={{ Box }}>
+                  {/* jsx-to-string:start */}
+                  {function Example() {
+                    const StyledBox = styled(Box)`
+                      height: ${({ theme }) => theme.spacing.xxxLarge};
+                      width: 100%;
+
+                      ${({ theme }) => theme.breakpoints.tablet} {
+                        width: 60%;
+                      }
+
+                      ${({ theme }) => theme.breakpoints.desktop} {
+                        width: 30%;
+                      }
+                    `;
+
+                    return <StyledBox />;
+                  }}
+                  {/* jsx-to-string:end */}
+                </CodePreview>
+              </>
+            ),
+          },
+          {
+            id: 'breakpoint-values',
+            title: 'Breakpoint Values',
+            render: () => (
+              <>
+                <Text>
+                  <Code primary>breakpointValues</Code> are also exposed on the <Code primary>theme</Code> object. Each
+                  value is the <Code>px</Code> value of each breakpoint.
+                </Text>
+
+                <CodePreview scope={{ Box }}>
+                  {/* jsx-to-string:start */}
+                  {function Example() {
+                    const StyledBox = styled(Box)`
+                      height: ${({ theme }) => theme.spacing.xxxLarge};
+                      width: 100%;
+
+                      ${({ theme }) => theme.breakpoints.desktop} {
+                        width: ${({ theme }) => theme.breakpointValues.tablet};
+                      }
+                    `;
+
+                    return <StyledBox />;
+                  }}
+                  {/* jsx-to-string:end */}
+                </CodePreview>
+              </>
+            ),
+          },
+        ]}
+      />
+    </Panel>
+
+    <Panel header="Do's and Don'ts" headerId="guidelines">
+      <GuidelinesTable recommended={['Use built in responsive props, where applicable.']} discouraged={[]} />
     </Panel>
   </>
 );


### PR DESCRIPTION
## What?
Update Breakpoints page to use new layout.

## Screenshots/Screen Recordings
![screencapture-localhost-3000-breakpoints-2022-01-14-11_38_36](https://user-images.githubusercontent.com/10539418/149560463-ee46b7ef-c07e-4320-bd27-81d7d52509b5.png)
<img width="843" alt="Screen Shot 2022-01-14 at 11 38 50" src="https://user-images.githubusercontent.com/10539418/149560356-53b8e51d-05e5-468c-b686-4e167179d7fc.png">
<img width="843" alt="Screen Shot 2022-01-14 at 11 39 04" src="https://user-images.githubusercontent.com/10539418/149560358-c76f12c5-70c7-4c0a-a7b8-17080f4677db.png">



## Testing/Proof

N/A
