### PR TITLE
feat(component): Search component improvements.

### DIFF
--- a/packages/big-design/src/components/Search/Search.tsx
+++ b/packages/big-design/src/components/Search/Search.tsx
@@ -14,6 +14,7 @@ export const Search: React.FC<SearchProps> = ({
   onSubmit,
   placeholder = 'Search',
   'aria-label': ariaLabel = 'Search',
+  autoComplete = 'off',
   ...props
 }) => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -32,6 +33,7 @@ export const Search: React.FC<SearchProps> = ({
           <Input
             {...props}
             aria-label={ariaLabel}
+            autoComplete={autoComplete}
             placeholder={placeholder}
             type="search"
             value={value}

--- a/packages/big-design/src/components/Search/Search.tsx
+++ b/packages/big-design/src/components/Search/Search.tsx
@@ -8,7 +8,14 @@ import { Input } from '../Input';
 
 import { SearchProps } from './types';
 
-export const Search: React.FC<SearchProps> = ({ value, onChange, onSubmit }) => {
+export const Search: React.FC<SearchProps> = ({
+  value,
+  onChange,
+  onSubmit,
+  placeholder = 'Search',
+  'aria-label': ariaLabel = 'Search',
+  ...props
+}) => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -23,8 +30,9 @@ export const Search: React.FC<SearchProps> = ({ value, onChange, onSubmit }) => 
       <Flex alignItems="center" backgroundColor="white" flexDirection="row" paddingBottom="xxSmall">
         <FlexItem flexGrow={1} marginRight="small">
           <Input
-            aria-label="Search"
-            placeholder="Search"
+            {...props}
+            aria-label={ariaLabel}
+            placeholder={placeholder}
             type="search"
             value={value}
             onChange={onChange}

--- a/packages/big-design/src/components/Search/spec.tsx
+++ b/packages/big-design/src/components/Search/spec.tsx
@@ -33,3 +33,11 @@ test('call onSubmit when user click to the Search button', () => {
 
   expect(onSubmit).toHaveBeenCalled();
 });
+
+test('Search input has autocomplete=off', async () => {
+  render(<Search value="" onChange={jest.fn()} onSubmit={jest.fn()} />);
+
+  const input = await screen.findByPlaceholderText('Search');
+
+  expect(input.getAttribute('autocomplete')).toBe('off');
+});

--- a/packages/big-design/src/components/Search/types.ts
+++ b/packages/big-design/src/components/Search/types.ts
@@ -1,7 +1,9 @@
+import { InputHTMLAttributes } from 'react';
+
 import { FormProps } from '../Form';
 import { InputProps } from '../Input';
 
-export interface SearchProps {
+export interface SearchProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onSubmit'> {
   value: InputProps['value'];
   onChange: InputProps['onChange'];
   onSubmit: FormProps['onSubmit'];

--- a/packages/docs/PropTables/SearchPropTable.tsx
+++ b/packages/docs/PropTables/SearchPropTable.tsx
@@ -24,5 +24,5 @@ const searchProps: Prop[] = [
 ];
 
 export const SearchPropTable: React.FC<PropTableWrapper> = (props) => (
-  <PropTable title="Search" propList={searchProps} {...props} />
+  <PropTable title="Search" propList={searchProps} nativeElement={['input', 'most']} {...props} />
 );


### PR DESCRIPTION
## What?

- Adds a11y and i18n improvements for `Search` component.
- Adds `autoComplete="off"` as default for `Search` input field. Fixes #580

## Why?

- Enable UI's to be able to translate the `placeholder` and `aria-*` fields.
- Enable developers to add `aria-*` or other `input` related attributes.
- Disable, by default, the `autoComplete` attribute.

## Screenshots/Screen Recordings

<img width="1066" alt="Screen Shot 2022-01-18 at 13 37 38" src="https://user-images.githubusercontent.com/10539418/150006835-6509962a-77b1-40ca-96f5-db596c14766d.png">

<img width="911" alt="Screen Shot 2022-01-18 at 10 07 55" src="https://user-images.githubusercontent.com/10539418/149974241-ecae739e-eeac-4a22-813b-51588e4b58e2.png">

## Testing/Proof

Added tests
