### PR TITLE
feat(component): table row with expandable details

### DIFF
--- a/packages/big-design/src/components/Table/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/Table/DataCell/DataCell.tsx
@@ -6,6 +6,7 @@ import { StyledTableDataCell, StyledTableDataCheckbox } from './styled';
 
 export interface DataCellProps extends TableHTMLAttributes<HTMLTableCellElement>, TableColumnDisplayProps {
   align?: 'left' | 'center' | 'right';
+  colSpan?: number;
   isCheckbox?: boolean;
   verticalAlign?: 'top' | 'middle';
   width?: number | string;
@@ -17,6 +18,7 @@ export const DataCell: React.FC<DataCellProps> = memo(
   ({
     align,
     children,
+    colSpan,
     display,
     isCheckbox,
     verticalAlign,
@@ -31,6 +33,7 @@ export const DataCell: React.FC<DataCellProps> = memo(
     ) : (
       <StyledTableDataCell
         align={align}
+        colSpan={colSpan}
         display={display}
         verticalAlign={verticalAlign}
         width={width}

--- a/packages/big-design/src/components/Table/Row/Row.tsx
+++ b/packages/big-design/src/components/Table/Row/Row.tsx
@@ -1,14 +1,16 @@
-import { DragIndicatorIcon } from '@bigcommerce/big-design-icons';
-import React, { forwardRef, TableHTMLAttributes } from 'react';
+import { ChevronRightIcon, DragIndicatorIcon, ExpandMoreIcon } from '@bigcommerce/big-design-icons';
+import React, { forwardRef, TableHTMLAttributes, useEffect, useState } from 'react';
 
 import { typedMemo } from '../../../utils';
+import { Button } from '../../Button';
 import { Checkbox } from '../../Checkbox';
 import { DataCell } from '../DataCell';
 import { TableColumn, TableItem } from '../types';
 
-import { StyledTableRow } from './styled';
+import { StyledDataCell, StyledTableRow } from './styled';
 
 export interface RowProps<T> extends TableHTMLAttributes<HTMLTableRowElement> {
+  isExpandable?: boolean;
   isDragging?: boolean;
   isSelected?: boolean;
   isSelectable?: boolean;
@@ -25,6 +27,7 @@ interface PrivateProps {
 const InternalRow = <T extends TableItem>({
   columns,
   forwardedRef,
+  isExpandable = false,
   isDragging = false,
   isSelectable = false,
   isSelected = false,
@@ -40,35 +43,68 @@ const InternalRow = <T extends TableItem>({
   };
 
   const label = isSelected ? `Selected` : `Unselected`;
+  const [isExpanded, setIsExpanded] = useState(false);
+  const itemHasChild = Boolean(item.expandableContent);
+  const colSpan = columns.length + Number(showDragIcon) + Number(isSelectable);
+
+  const toggleExpanded = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  useEffect(() => {
+    if (isDragging && isExpanded) {
+      setIsExpanded(false);
+    }
+  }, [isDragging, isExpanded]);
 
   return (
-    <StyledTableRow isSelected={isSelected} ref={forwardedRef} isDragging={isDragging} {...rest}>
-      {showDragIcon && (
-        <DataCell>
-          <DragIndicatorIcon />
-        </DataCell>
+    <>
+      <StyledTableRow isSelected={isSelected} ref={forwardedRef} isDragging={isDragging} {...rest}>
+        {isExpandable && (
+          <DataCell withPadding={false}>
+            {itemHasChild && (
+              <Button
+                variant="subtle"
+                onClick={toggleExpanded}
+                iconOnly={isExpanded ? <ExpandMoreIcon color="gray" /> : <ChevronRightIcon color="gray" />}
+              />
+            )}
+          </DataCell>
+        )}
+        {showDragIcon && (
+          <DataCell>
+            <DragIndicatorIcon />
+          </DataCell>
+        )}
+        {isSelectable && (
+          <DataCell key="data-checkbox" isCheckbox={true}>
+            <Checkbox checked={isSelected} hiddenLabel label={label} onChange={onChange} />
+          </DataCell>
+        )}
+        {columns.map(
+          ({ render: CellContent, align, display, verticalAlign, width, withPadding = true }, columnIndex) => (
+            <DataCell
+              key={columnIndex}
+              align={align}
+              display={display}
+              verticalAlign={verticalAlign}
+              width={width}
+              withPadding={withPadding}
+            >
+              {/*
+              // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
+              <CellContent {...item} />
+            </DataCell>
+          ),
+        )}
+      </StyledTableRow>
+      {isExpanded && (
+        <StyledTableRow isSelected={false} isDragging={false}>
+          <StyledDataCell withPadding={false} />
+          <StyledDataCell colSpan={colSpan}>{item.expandableContent}</StyledDataCell>
+        </StyledTableRow>
       )}
-      {isSelectable && (
-        <DataCell key="data-checkbox" isCheckbox={true}>
-          <Checkbox checked={isSelected} hiddenLabel label={label} onChange={onChange} />
-        </DataCell>
-      )}
-
-      {columns.map(({ render: CellContent, align, display, verticalAlign, width, withPadding = true }, columnIndex) => (
-        <DataCell
-          key={columnIndex}
-          align={align}
-          display={display}
-          verticalAlign={verticalAlign}
-          width={width}
-          withPadding={withPadding}
-        >
-          {/*
-          // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
-          <CellContent {...item} />
-        </DataCell>
-      ))}
-    </StyledTableRow>
+    </>
   );
 };
 

--- a/packages/big-design/src/components/Table/Row/styled.tsx
+++ b/packages/big-design/src/components/Table/Row/styled.tsx
@@ -22,7 +22,12 @@ export const StyledTableRow = styled.tr<StyledTableRowProps>`
 
 export const StyledDataCell = styled(StyledTableDataCell)`
   background-color: ${({ theme }) => theme.colors.secondary10};
-  padding: ${({ theme }) => theme.spacing.small};
+  padding: ${({ theme }) => theme.spacing.xLarge};
+  padding-left: ${({ theme }) => theme.spacing.small};
+
+  &:last-of-type {
+    padding-right: ${({ theme }) => theme.spacing.xLarge};
+  }
 `;
 
 StyledTableRow.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Table/Row/styled.tsx
+++ b/packages/big-design/src/components/Table/Row/styled.tsx
@@ -2,6 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withTransition } from '../../../mixins/transitions';
+import { StyledTableDataCell } from '../DataCell/styled';
 
 interface StyledTableRowProps {
   isDragging: boolean;
@@ -17,6 +18,11 @@ export const StyledTableRow = styled.tr<StyledTableRowProps>`
   &:hover {
     background-color: ${({ theme }) => theme.colors.secondary10};
   }
+`;
+
+export const StyledDataCell = styled(StyledTableDataCell)`
+  background-color: ${({ theme }) => theme.colors.secondary10};
+  padding: ${({ theme }) => theme.spacing.small};
 `;
 
 StyledTableRow.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -111,9 +111,15 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
     return index;
   };
 
+  const hasExpandableContent = items.some((item: T) => item.expandableContent);
+  const emptyHeaderCell = (
+    <HeaderCell actionsRef={actionsRef} column={{ hash: '', header: '', render: () => '', width: 0 }} />
+  );
+
   const renderHeaders = () => (
     <Head hidden={headerless}>
       <tr>
+        {hasExpandableContent && emptyHeaderCell}
         {typeof onRowDrop === 'function' && <DragIconHeaderCell actionsRef={actionsRef} />}
         {isSelectable && <HeaderCheckboxCell stickyHeader={stickyHeader} actionsRef={actionsRef} />}
 
@@ -154,6 +160,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
               <Draggable key={key} draggableId={String(key)} index={index}>
                 {(provided, snapshot) => (
                   <Row
+                    isExpandable={hasExpandableContent}
                     isDragging={snapshot.isDragging}
                     {...provided.dragHandleProps}
                     {...provided.draggableProps}
@@ -186,6 +193,7 @@ const InternalTable = <T extends TableItem>(props: TableProps<T>): React.ReactEl
 
           return (
             <Row
+              isExpandable={hasExpandableContent}
               columns={columns}
               isSelectable={isSelectable}
               isSelected={isSelected}

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -21,6 +21,7 @@ export interface TableSortable<T> {
 export interface TableItem {
   id?: string | number;
   [key: string]: any;
+  expandableContent?: ReactNode;
 }
 
 export interface TableColumn<T> extends TableColumnDisplayProps {


### PR DESCRIPTION
## What?
Table row with expandable details

## Why?
To add a possibility to pass additional expandable content to specific table rows

## Screenshots/Screen Recordings
![image](https://user-images.githubusercontent.com/94108505/150352873-c5357d15-a632-4bae-a55a-fd0a0af6c994.png)
![image](https://user-images.githubusercontent.com/94108505/150352926-87a722d3-5a45-4ba3-a002-6d44ced737ea.png)


## Testing/Proof
Manually tested on chrome 95.0.4638.69
