### PR TITLE
feat(docs): update display page to use new layout

### DIFF
--- a/packages/docs/pages/display.tsx
+++ b/packages/docs/pages/display.tsx
@@ -1,72 +1,105 @@
-import { Box, H1, Panel, Text } from '@bigcommerce/big-design';
+import { Box, H1, Link, Panel, Text } from '@bigcommerce/big-design';
 import React from 'react';
 
-import { Code, CodePreview, NextLink, PageNavigation } from '../components';
+import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, NextLink } from '../components';
 import { DisplayPropTable } from '../PropTables';
 
 const DisplayPage = () => {
-  const items = [
-    {
-      id: 'examples',
-      title: 'Examples',
-      render: () => (
-        <>
-          <Panel>
-            <Text>
-              A few of our components expose a <Code primary>display</Code> prop in order to change the CSS display
-              property.
-            </Text>
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Box display="inline-block" backgroundColor="secondary20" border="box" padding="medium">
-                Boxed content
-              </Box>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-          <Panel header="Responsive breakpoints">
-            <Text>
-              It's also possible to use the prop with responsive <NextLink href="/breakpoints">breakpoints</NextLink>:
-            </Text>
-
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <>
-                <Box
-                  display={{ mobile: 'none', tablet: 'inline-block' }}
-                  backgroundColor="secondary20"
-                  border="box"
-                  padding="medium"
-                >
-                  Boxed content hidden on mobile.
-                </Box>
-                <Box
-                  display={{ mobile: 'block', tablet: 'none' }}
-                  backgroundColor="primary10"
-                  border="box"
-                  padding="medium"
-                >
-                  Boxed content hidden on tablet.
-                </Box>
-              </>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-        </>
-      ),
-    },
-    {
-      id: 'props',
-      title: 'Props',
-      render: () => <DisplayPropTable />,
-    },
-  ];
-
   return (
     <>
       <H1>Display</H1>
 
-      <PageNavigation items={items} />
+      <Panel header="Overview" headerId="overview">
+        <Text>
+          The <Code primary>display</Code> is a dynamic and responsive{' '}
+          <Link
+            href="https://developer.mozilla.org/en-US/docs/Web/CSS/display"
+            external
+            target="_blank"
+            rel="external nofollow noreferrer"
+          >
+            CSS display
+          </Link>{' '}
+          property.
+        </Text>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <>
+                  <Text>
+                    A few of our components expose a <Code primary>display</Code> prop in order to change the CSS
+                    display property. See a components prop table to see if this prop exists.
+                  </Text>
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Box display="inline-block" backgroundColor="secondary20" border="box" padding="medium">
+                      Boxed content
+                    </Box>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </>
+              ),
+            },
+            {
+              id: 'responsive',
+              title: 'Responsive',
+              render: () => (
+                <>
+                  <Text>
+                    It's also possible to use the prop with responsive{' '}
+                    <NextLink href="/breakpoints">breakpoints</NextLink>:
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <>
+                      <Box
+                        display={{ mobile: 'none', tablet: 'inline-block' }}
+                        backgroundColor="secondary20"
+                        border="box"
+                        padding="medium"
+                      >
+                        Boxed content hidden on mobile.
+                      </Box>
+                      <Box
+                        display={{ mobile: 'block', tablet: 'none' }}
+                        backgroundColor="primary10"
+                        border="box"
+                        padding="medium"
+                      >
+                        Boxed content hidden on tablet.
+                      </Box>
+                    </>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </>
+              ),
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <DisplayPropTable renderPanel={false} />
+      </Panel>
+
+      <Panel header="Do's and Don'ts" headerId="guidelines">
+        <GuidelinesTable
+          recommended={['Use the display prop for responsiveness']}
+          discouraged={[
+            <>
+              Don't use <Code>display="none"</Code> directly on a component, instead don't render the it.
+            </>,
+          ]}
+        />
+      </Panel>
     </>
   );
 };

--- a/packages/docs/pages/display.tsx
+++ b/packages/docs/pages/display.tsx
@@ -92,7 +92,7 @@ const DisplayPage = () => {
 
       <Panel header="Do's and Don'ts" headerId="guidelines">
         <GuidelinesTable
-          recommended={['Use the display prop for responsiveness']}
+          recommended={['Use the display prop for responsiveness.']}
           discouraged={[
             <>
               Don't use <Code>display="none"</Code> directly on a component, instead don't render the it.


### PR DESCRIPTION
## What?

Updates the `Display` page to use new documentation layout.

## Screenshots/Screen Recordings

![screencapture-localhost-3000-display-2022-01-20-12_12_27](https://user-images.githubusercontent.com/10539418/150397105-399e5e70-21d4-402c-b612-97bcc890a8e9.png)
