### PR TITLE
Update Lerna JS project link in README.md to correct website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import { Button, GlobalStyles } from '@bigcommerce/big-design';
 
 ### Monorepo
 
-This is a monorepo that uses [Lerna](https://lernajs.io) and [Yarn Workspaces](https://yarnpkg.com/lang/en/docs/workspaces/).
+This is a monorepo that uses [Lerna](https://lerna.js.org/) and [Yarn Workspaces](https://yarnpkg.com/lang/en/docs/workspaces/).
 
 Workspaces are inside the [packages](https://github.com/bigcommerce/big-design/blob/master/packages) directory.
 


### PR DESCRIPTION
## What?

Updates the link to the Lerna website in the README.md to use https://lerna.js.org (official Lerna website).

## Why?

The existing link in the README.js goes to https://lernajs.io/ which is some kind of spam site.