### PR TITLE
feat(docs): Update Link documentation page to use new layout

### DIFF
--- a/packages/docs/pages/button.tsx
+++ b/packages/docs/pages/button.tsx
@@ -43,7 +43,7 @@ const ButtonPage = () => {
               id: 'basic',
               title: 'Basic',
               render: () => (
-                <>
+                <Fragment key="basic">
                   <Text>Buttons are calls to action used throughout the product experience.</Text>
                   <CodePreview>
                     {/* jsx-to-string:start */}
@@ -52,7 +52,7 @@ const ButtonPage = () => {
                     </Button>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
@@ -80,7 +80,7 @@ const ButtonPage = () => {
             },
             {
               id: 'action-types',
-              title: 'Action Types',
+              title: 'Action types',
               render: () => (
                 <Fragment key="action-types">
                   <Text>

--- a/packages/docs/pages/link.tsx
+++ b/packages/docs/pages/link.tsx
@@ -1,52 +1,80 @@
 import { H1, Link, Panel, Text } from '@bigcommerce/big-design';
-import React from 'react';
+import React, { Fragment } from 'react';
 
-import { CodePreview, PageNavigation } from '../components';
+import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
 import { LinkPropTable, MarginPropTable } from '../PropTables';
 
 const LinkPage = () => {
-  const items = [
-    {
-      id: 'examples',
-      title: 'Examples',
-      render: () => (
-        <>
-          <Panel>
-            <Text>
-              A simple wrapper for anchor elements. Use instead of {'<a>'}. Supports all native anchor element
-              attributes.
-            </Text>
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Link href="#">Link Example</Link>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-          <Panel header="External link">
-            <Text>You can also include and external icon.</Text>
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Link href="#" target="_blank" external>
-                Learn More
-              </Link>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-        </>
-      ),
-    },
-    {
-      id: 'props',
-      title: 'Props',
-      render: () => <LinkPropTable inheritedProps={<MarginPropTable collapsible />} />,
-    },
-  ];
-
   return (
     <>
       <H1>Link</H1>
 
-      <PageNavigation items={items} />
+      <Panel header="Overview" headerId="overview">
+        <Text>Provides navigation to another page</Text>
+        <Text bold>When to use:</Text>
+        <List>
+          <List.Item>Navigate to an external webpage</List.Item>
+          <List.Item>Navigate to helpful documentation</List.Item>
+        </List>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <Fragment key="basic">
+                  <Text>
+                    A simple wrapper for anchor elements. Use instead of {'<a>'}. Supports all native anchor element
+                    attributes.
+                  </Text>
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Link href="#">Link Example</Link>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'external-link',
+              title: 'External Link',
+              render: () => (
+                <Fragment key="external-link">
+                  <Text>You can also include an external icon.</Text>
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Link href="#" target="_blank" external>
+                      Learn More
+                    </Link>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <LinkPropTable inheritedProps={<MarginPropTable collapsible />} renderPanel={false} />
+      </Panel>
+
+      <Panel header="Do's and Don'ts" headerId="guidelines">
+        <GuidelinesTable
+          recommended={[
+            <>
+              Use the <Code primary>external</Code> prop when a link navigates away from the control panel
+            </>,
+            <>Usually within a sentance to provide additional guidance or information</>,
+            <>Use descriptive text to set clear expectations of the link destination</>,
+          ]}
+          discouraged={[<>Avoid using links for actions – use a button instead</>]}
+        />
+      </Panel>
     </>
   );
 };

--- a/packages/docs/pages/link.tsx
+++ b/packages/docs/pages/link.tsx
@@ -67,12 +67,12 @@ const LinkPage = () => {
         <GuidelinesTable
           recommended={[
             <>
-              Use the <Code primary>external</Code> prop when a link navigates away from the control panel
+              Use the <Code primary>external</Code> prop when a link navigates away from the control panel.
             </>,
-            <>Usually within a sentance to provide additional guidance or information</>,
-            <>Use descriptive text to set clear expectations of the link destination</>,
+            <>Usually within a sentance to provide additional guidance or information.</>,
+            <>Use descriptive text to set clear expectations of the link destination.</>,
           ]}
-          discouraged={[<>Avoid using links for actions – use a button instead</>]}
+          discouraged={[<>Avoid using links for actions – use a button instead.</>]}
         />
       </Panel>
     </>

--- a/packages/docs/pages/link.tsx
+++ b/packages/docs/pages/link.tsx
@@ -33,7 +33,7 @@ const LinkPage = () => {
                   </Text>
                   <CodePreview>
                     {/* jsx-to-string:start */}
-                    <Link href="#">Link Example</Link>
+                    <Link href="#">Link example</Link>
                     {/* jsx-to-string:end */}
                   </CodePreview>
                 </Fragment>
@@ -41,14 +41,14 @@ const LinkPage = () => {
             },
             {
               id: 'external-link',
-              title: 'External Link',
+              title: 'External link',
               render: () => (
                 <Fragment key="external-link">
                   <Text>You can also include an external icon.</Text>
                   <CodePreview>
                     {/* jsx-to-string:start */}
                     <Link href="#" target="_blank" external>
-                      Learn More
+                      Learn more
                     </Link>
                     {/* jsx-to-string:end */}
                   </CodePreview>
@@ -60,7 +60,11 @@ const LinkPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <LinkPropTable inheritedProps={<MarginPropTable collapsible />} renderPanel={false} />
+        <LinkPropTable
+          inheritedProps={<MarginPropTable collapsible />}
+          renderPanel={false}
+          nativeElement={['a', 'all']}
+        />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">
@@ -69,7 +73,7 @@ const LinkPage = () => {
             <>
               Use the <Code primary>external</Code> prop when a link navigates away from the control panel.
             </>,
-            <>Usually within a sentance to provide additional guidance or information.</>,
+            <>Usually within a sentence to provide additional guidance or information.</>,
             <>Use descriptive text to set clear expectations of the link destination.</>,
           ]}
           discouraged={[<>Avoid using links for actions – use a button instead.</>]}


### PR DESCRIPTION
## What?
Update Link documentation page to use the new layout

## Screenshots/Screen Recordings
<img width="594" alt="Screen Shot 2022-02-09 at 4 21 56 PM" src="https://user-images.githubusercontent.com/39739180/153300162-ec938cd0-202c-49ed-813f-4381addf1d6b.png">



