### PR TITLE
fix(component): change flex-reversed to flex-reverse

### DIFF
--- a/packages/big-design/src/components/Flex/types.ts
+++ b/packages/big-design/src/components/Flex/types.ts
@@ -27,7 +27,7 @@ type AlignSelf = ResponsiveProp<
 
 type FlexDirection = ResponsiveProp<'row' | 'column' | 'row-reverse' | 'column-reverse'>;
 
-type FlexWrap = ResponsiveProp<'nowrap' | 'wrap' | 'wrap-reversed'>;
+type FlexWrap = ResponsiveProp<'nowrap' | 'wrap' | 'wrap-reverse'>;
 
 type JustifyContent = ResponsiveProp<
   | 'normal'

--- a/packages/docs/PropTables/FlexPropTable.tsx
+++ b/packages/docs/PropTables/FlexPropTable.tsx
@@ -59,7 +59,7 @@ const flexProps: Prop[] = [
   },
   {
     name: 'flexWrap',
-    types: ['nowrap', 'wrap', 'wrap-reversed'],
+    types: ['nowrap', 'wrap', 'wrap-reverse'],
     defaultValue: 'nowrap',
     description: (
       <>


### PR DESCRIPTION
## What?

Fixes [https://github.com/bigcommerce/big-design/issues/661](url)

## Why?

Flex component has type `wrap-reversed` but the correct value is `wrap-reverse`

## Screenshots/Screen Recordings

<img width="1319" alt="Screen Shot 2022-02-16 at 4 11 46 PM" src="https://user-images.githubusercontent.com/99345561/154370502-d84e1514-df70-4b79-9c48-50230743691b.png">

## Testing/Proof

Inspected Flex component example and verified correct property is being applied. 
