### PR TITLE
chore(docs): add dev-docs-team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @bigcommerce/frontend @bigcommerce/product-design
+packages/docs @bigcommerce/dev-docs-team


### PR DESCRIPTION
## What?

Adds the @bigcommerce/dev-docs-team as reviewers to any changes in the docs.

## Why?

To open up visibility to the dev-docs team. This will help gain some visibility into anything we might miss when updating documentation.
