### PR TITLE
feat(docs): update progress bar page to use new layout

### DIFF
--- a/packages/docs/pages/progress-bar.tsx
+++ b/packages/docs/pages/progress-bar.tsx
@@ -1,59 +1,99 @@
 import { Box, H1, Panel, ProgressBar, Text } from '@bigcommerce/big-design';
-import React from 'react';
+import React, { Fragment } from 'react';
 
-import { Code, CodePreview, PageNavigation } from '../components';
+import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
 import { ProgressBarPropTable } from '../PropTables';
 
 const ProgressBarPage = () => {
-  const items = [
-    {
-      id: 'examples',
-      title: 'Examples',
-      render: () => (
-        <>
-          <Panel header="Determinant">
-            <Text>
-              Determinant Progress represents a known amount of time or completeness for a task. A{' '}
-              <Code primary>percent</Code> prop needs to be passed to render a determinate progress.
-            </Text>
-
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Box marginVertical="large">
-                <ProgressBar percent={50} />
-              </Box>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-          <Panel header="Indeterminant">
-            <Text>
-              Indeterminant Progress represents an unknown amount of time for a task to complete. Component will render
-              an indeterminant progress when missing a <Code primary>percent</Code> prop.
-            </Text>
-
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Box marginVertical="large">
-                <ProgressBar />
-              </Box>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-        </>
-      ),
-    },
-    {
-      id: 'props',
-      title: 'Props',
-      render: () => <ProgressBarPropTable />,
-    },
-  ];
-
   return (
     <>
       <H1>ProgressBar</H1>
 
-      <PageNavigation items={items} />
+      <Panel header="Overview" headerId="overview">
+        <Text>
+          Progress indicators give the user system visibility when a front end action triggers a need from the back end.
+        </Text>
+        <Text bold>When to use:</Text>
+        <List>
+          <List.Item>Progress indicators can be combined with additional status feedback.</List.Item>
+          <List.Item>Use when there is a greater than one second waiting time.</List.Item>
+        </List>
+        <Text>Linear progress</Text>
+        <List>
+          <List.Item>Often used to reflect import/export actions.</List.Item>
+          <List.Item>
+            Use the indeterminant linear progress, where there is an unknown amount of time for a task to complete.
+          </List.Item>
+          <List.Item>
+            Use the determinant linear progress, where there is a known amount of time for a task to complete.
+          </List.Item>
+        </List>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'determinant',
+              title: 'Determinant',
+              render: () => (
+                <Fragment key="determinant">
+                  <Text>
+                    Determinant Progress represents a known amount of time or completeness for a task. A{' '}
+                    <Code primary>percent</Code> prop needs to be passed to render a determinate progress.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Box marginVertical="large">
+                      <ProgressBar percent={50} />
+                    </Box>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'indeterminant',
+              title: 'Indeterminant',
+              render: () => (
+                <Fragment key="indeterminant">
+                  <Text>
+                    Indeterminant Progress represents an unknown amount of time for a task to complete. Component will
+                    render an indeterminant progress when missing a <Code primary>percent</Code> prop.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Box marginVertical="large">
+                      <ProgressBar />
+                    </Box>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <ProgressBarPropTable renderPanel={false} />
+      </Panel>
+
+      <Panel header="Do's and Don'ts" headerId="guidelines">
+        <GuidelinesTable
+          recommended={[
+            <>Status feedback should be clear and direct. Limit verbiage and information.</>,
+            <>If progress is determinate, use a percentage or copy to reflect the completeness of the action.</>,
+          ]}
+          discouraged={[
+            <>Don’t use if an action is not triggering a back end action.</>,
+            <>Don’t use to indicate the completeness of a user-dependent task.</>,
+          ]}
+        />
+      </Panel>
     </>
   );
 };


### PR DESCRIPTION
## What?
Update Progress bar page to use new layout

## Why?
Provide better experience to the user when reading the docs.

## Screenshots/Screen Recordings
<img width="605" alt="Screen Shot 2022-02-21 at 11 13 44 AM" src="https://user-images.githubusercontent.com/39739180/155000864-a2a7a592-aab3-4f0c-9878-160c9abfd973.png">


