### PR TITLE
chore: update documentation codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @bigcommerce/frontend @bigcommerce/product-design
-packages/docs @bigcommerce/dev-docs-team
+packages/docs @bigcommerce/dev-docs-team @bigcommerce/frontend @bigcommerce/product-design


### PR DESCRIPTION
## What/Why?

Noticed that when opening a PR in the `packages/docs` repo that the other codeowners didn't get added. This should fix that.
