### PR TITLE
feat(docs): update radio page to use new layout

### DIFF
--- a/packages/docs/PropTables/RadioPropTable.tsx
+++ b/packages/docs/PropTables/RadioPropTable.tsx
@@ -11,7 +11,7 @@ const radioProps: Prop[] = [
     required: true,
     description: (
       <>
-        Label to display next to a <Code>Radio</Code> component.
+        Label to display next to a <Code primary>Radio</Code> component.
       </>
     ),
   },
@@ -20,7 +20,11 @@ const radioProps: Prop[] = [
     types: ['string', 'RadioDescription'],
     description: (
       <>
-        See <NextLink href="#radio-description-prop-table">below</NextLink> for usage.
+        See{' '}
+        <NextLink href={{ hash: 'radio-description-prop-table', query: { props: 'radio-description' } }}>
+          RadioDescription
+        </NextLink>{' '}
+        for usage.
       </>
     ),
   },
@@ -33,7 +37,7 @@ const radioDescriptionProps: Prop[] = [
     required: true,
     description: (
       <>
-        Description to display below <Code>Label</Code>
+        Description to display below <Code primary>label</Code>.
       </>
     ),
   },
@@ -42,7 +46,11 @@ const radioDescriptionProps: Prop[] = [
     types: ['RadioDescriptionLink'],
     description: (
       <>
-        See <NextLink href="#radio-description-link-prop-table">below</NextLink> for usage.
+        See{' '}
+        <NextLink href={{ hash: 'radio-description-link-prop-table', query: { props: 'radio-description-link' } }}>
+          RadioDescriptionLink
+        </NextLink>{' '}
+        for usage.
       </>
     ),
   },

--- a/packages/docs/PropTables/shared.tsx
+++ b/packages/docs/PropTables/shared.tsx
@@ -67,7 +67,7 @@ export const messagingLinkItemProps: Prop[] = [
     types: 'boolean',
     description: (
       <>
-        Shows an external icon when the <Code primary>external</Code> flag is set and target="_blank".
+        Shows an external icon when the <Code primary>external</Code> prop is set and target="_blank".
       </>
     ),
   },

--- a/packages/docs/PropTables/shared.tsx
+++ b/packages/docs/PropTables/shared.tsx
@@ -67,7 +67,7 @@ export const messagingLinkItemProps: Prop[] = [
     types: 'boolean',
     description: (
       <>
-        Shows an external icons when the <Code primary>external</Code> flag is set and target="_blank".
+        Shows an external icon when the <Code primary>external</Code> flag is set and target="_blank".
       </>
     ),
   },

--- a/packages/docs/pages/radio.tsx
+++ b/packages/docs/pages/radio.tsx
@@ -10,7 +10,7 @@ const RadioPage = () => {
       <H1>Radio</H1>
 
       <Panel header="Overview" headerId="overview">
-        <Text>Radio buttons let users select an option from a list of two or more.</Text>
+        <Text>Radio buttons let users select an option from a list of two or more items.</Text>
         <Text bold>When to use:</Text>
         <List>
           <List.Item>
@@ -29,7 +29,7 @@ const RadioPage = () => {
               render: () => (
                 <Fragment key="basic">
                   <Text>
-                    <Code primary>Radios</Code> are group of items which a single option can be selected.
+                    A <Code primary>Radio</Code> is a group of items from which a single option can be selected.
                   </Text>
                   <CodePreview>
                     {/* jsx-to-string:start */}
@@ -203,13 +203,13 @@ const RadioPage = () => {
         <GuidelinesTable
           recommended={[
             <>Group related radio buttons under input headings.</>,
-            <>Radio buttons should always have a default selected option.</>,
-            <>Radio buttons should always be laid out vertically.</>,
+            <>Include a default selected option with the radio buttons.</>,
+            <>Lay radio buttons vertically.</>,
           ]}
           discouraged={[
-            <>Don’t use radio buttons for long lists of short items - use a select input instead.</>,
+            <>Don’t use radio buttons for long lists of short items. Use a select input instead.</>,
             <>
-              A set of radio buttons should not have a state of being “unselected” - there must always be a selection.
+              A set of radio buttons should not have a state of being “unselected.” There must always be a selection.
             </>,
           ]}
         />

--- a/packages/docs/pages/radio.tsx
+++ b/packages/docs/pages/radio.tsx
@@ -1,151 +1,219 @@
 import { Fieldset, Form, FormGroup, H1, Panel, Radio, Text } from '@bigcommerce/big-design';
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 
-import { Code, CodePreview, PageNavigation } from '../components';
+import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
 import { RadioDescriptionLinkPropTable, RadioDescriptionPropTable, RadioPropTable } from '../PropTables';
 
 const RadioPage = () => {
-  const items = [
-    {
-      id: 'examples',
-      title: 'Examples',
-      render: () => (
-        <>
-          <Panel>
-            <Text>Radios are group of items which a single option can be selected.</Text>
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              {function Example() {
-                const [selected, setSelected] = useState('');
-
-                const handleChange = (event) => setSelected(event.target.value);
-
-                return (
-                  <Form>
-                    <FormGroup>
-                      <Radio label="On" checked={selected === 'on'} value="on" onChange={handleChange} />
-                      <Radio label="Off" checked={selected === 'off'} value="off" onChange={handleChange} />
-                      <Radio
-                        label="Disabled"
-                        disabled={true}
-                        checked={selected === 'disabled'}
-                        value="disabled"
-                        onChange={handleChange}
-                      />
-                    </FormGroup>
-                  </Form>
-                );
-              }}
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-          <Panel header="Grouping">
-            <Text>
-              In order to group radio controls, use the <Code>Fieldset</Code> component to separate the controls.
-            </Text>
-
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              {function Example() {
-                const [firstRadio, setFirstRadio] = useState('');
-                const [secondRadio, setSecondRadio] = useState('');
-
-                const handleFirstChange = (event) => setFirstRadio(event.target.value);
-                const handleSecondChange = (event) => setSecondRadio(event.target.value);
-
-                return (
-                  <Form>
-                    <Fieldset legend="First Group">
-                      <FormGroup>
-                        <Radio label="On" checked={firstRadio === 'on'} value="on" onChange={handleFirstChange} />
-                        <Radio label="Off" checked={firstRadio === 'off'} value="off" onChange={handleFirstChange} />
-                      </FormGroup>
-                    </Fieldset>
-                    <Fieldset legend="Second Group">
-                      <FormGroup>
-                        <Radio label="On" checked={secondRadio === 'on'} value="on" onChange={handleSecondChange} />
-                        <Radio label="Off" checked={secondRadio === 'off'} value="off" onChange={handleSecondChange} />
-                      </FormGroup>
-                    </Fieldset>
-                  </Form>
-                );
-              }}
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-          <Panel header="Description">
-            <Text>
-              Radio support <Code primary>description</Code> passed as a prop, which contains a text and an optional
-              link.
-            </Text>
-
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              {function Example() {
-                const [selected, setSelected] = useState('');
-
-                const handleChange = (event) => setSelected(event.target.value);
-
-                return (
-                  <Form>
-                    <FormGroup>
-                      <Radio
-                        label="On"
-                        checked={selected === 'on'}
-                        description="Description for on"
-                        value="on"
-                        onChange={handleChange}
-                      />
-                      <Radio
-                        label="Off"
-                        description="Description for off"
-                        checked={selected === 'off'}
-                        value="off"
-                        onChange={handleChange}
-                      />
-                      <Radio
-                        label="Disabled"
-                        disabled={true}
-                        description={{
-                          text: 'Description for disabled.',
-                          link: {
-                            text: 'Learn more',
-                            target: '_blank',
-                            href: 'http://www.bigcommerce.com',
-                          },
-                        }}
-                        checked={selected === 'disabled'}
-                        value="disabled"
-                        onChange={handleChange}
-                      />
-                    </FormGroup>
-                  </Form>
-                );
-              }}
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-        </>
-      ),
-    },
-    {
-      id: 'props',
-      title: 'Props',
-      render: () => (
-        <>
-          <RadioPropTable />
-          <RadioDescriptionPropTable />
-          <RadioDescriptionLinkPropTable />
-        </>
-      ),
-    },
-  ];
-
   return (
     <>
       <H1>Radio</H1>
 
-      <PageNavigation items={items} />
+      <Panel header="Overview" headerId="overview">
+        <Text>Radio buttons let users select an option from a list of two or more.</Text>
+        <Text bold>When to use:</Text>
+        <List>
+          <List.Item>
+            Use radio buttons when a user can only make one, mutually exclusive selection from a list.
+          </List.Item>
+        </List>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <Fragment key="basic">
+                  <Text>
+                    <Code primary>Radios</Code> are group of items which a single option can be selected.
+                  </Text>
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    {function Example() {
+                      const [selected, setSelected] = useState('');
+
+                      const handleChange = (event) => setSelected(event.target.value);
+
+                      return (
+                        <Form>
+                          <FormGroup>
+                            <Radio label="On" checked={selected === 'on'} value="on" onChange={handleChange} />
+                            <Radio label="Off" checked={selected === 'off'} value="off" onChange={handleChange} />
+                            <Radio
+                              label="Disabled"
+                              disabled={true}
+                              checked={selected === 'disabled'}
+                              value="disabled"
+                              onChange={handleChange}
+                            />
+                          </FormGroup>
+                        </Form>
+                      );
+                    }}
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'grouping',
+              title: 'Grouping',
+              render: () => (
+                <Fragment key="grouping">
+                  <Text>
+                    In order to group radio controls, use the <Code>Fieldset</Code> component to separate the controls.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    {function Example() {
+                      const [firstRadio, setFirstRadio] = useState('');
+                      const [secondRadio, setSecondRadio] = useState('');
+
+                      const handleFirstChange = (event) => setFirstRadio(event.target.value);
+                      const handleSecondChange = (event) => setSecondRadio(event.target.value);
+
+                      return (
+                        <Form>
+                          <Fieldset legend="First Group">
+                            <FormGroup>
+                              <Radio label="On" checked={firstRadio === 'on'} value="on" onChange={handleFirstChange} />
+                              <Radio
+                                label="Off"
+                                checked={firstRadio === 'off'}
+                                value="off"
+                                onChange={handleFirstChange}
+                              />
+                            </FormGroup>
+                          </Fieldset>
+                          <Fieldset legend="Second Group">
+                            <FormGroup>
+                              <Radio
+                                label="On"
+                                checked={secondRadio === 'on'}
+                                value="on"
+                                onChange={handleSecondChange}
+                              />
+                              <Radio
+                                label="Off"
+                                checked={secondRadio === 'off'}
+                                value="off"
+                                onChange={handleSecondChange}
+                              />
+                            </FormGroup>
+                          </Fieldset>
+                        </Form>
+                      );
+                    }}
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'description',
+              title: 'Description',
+              render: () => (
+                <Fragment key="description">
+                  <Text>
+                    Radio support <Code primary>description</Code> passed as a prop, which contains a text and an
+                    optional link.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    {function Example() {
+                      const [selected, setSelected] = useState('');
+
+                      const handleChange = (event) => setSelected(event.target.value);
+
+                      return (
+                        <Form>
+                          <FormGroup>
+                            <Radio
+                              label="On"
+                              checked={selected === 'on'}
+                              description="Description for on"
+                              value="on"
+                              onChange={handleChange}
+                            />
+                            <Radio
+                              label="Off"
+                              description="Description for off"
+                              checked={selected === 'off'}
+                              value="off"
+                              onChange={handleChange}
+                            />
+                            <Radio
+                              label="Disabled"
+                              disabled={true}
+                              description={{
+                                text: 'Description for disabled.',
+                                link: {
+                                  text: 'Learn more',
+                                  target: '_blank',
+                                  href: 'http://www.bigcommerce.com',
+                                },
+                              }}
+                              checked={selected === 'disabled'}
+                              value="disabled"
+                              onChange={handleChange}
+                            />
+                          </FormGroup>
+                        </Form>
+                      );
+                    }}
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <ContentRoutingTabs
+          id="props"
+          routes={[
+            {
+              id: 'radio',
+              title: 'Radio',
+              render: () => <RadioPropTable renderPanel={false} />,
+            },
+            {
+              id: 'radio-description',
+              title: 'RadioDescription',
+              render: () => <RadioDescriptionPropTable renderPanel={false} />,
+            },
+            {
+              id: 'radio-description-link',
+              title: 'RadioDescriptionLink',
+              render: () => <RadioDescriptionLinkPropTable renderPanel={false} />,
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Do's and Don'ts" headerId="guidelines">
+        <GuidelinesTable
+          recommended={[
+            <>Group related radio buttons under input headings.</>,
+            <>Radio buttons should always have a default selected option.</>,
+            <>Radio buttons should always be laid out vertically.</>,
+          ]}
+          discouraged={[
+            <>Don’t use radio buttons for long lists of short items - use a select input instead.</>,
+            <>
+              A set of radio buttons should not have a state of being “unselected” - there must always be a selection.
+            </>,
+          ]}
+        />
+      </Panel>
     </>
   );
 };


### PR DESCRIPTION
## What?
Update radio page to use new layout.

## Why?
Provide better experience to the user when reading the docs.

## Screenshots

<img width="485" alt="Screen Shot 2022-02-22 at 1 57 40 PM" src="https://user-images.githubusercontent.com/39739180/155209199-974ffbb7-882a-487a-9f97-a815ad763131.png">


