### PR TITLE
feat(docs): fix code editor bug part 2

### DIFF
--- a/packages/docs/pages/counter.tsx
+++ b/packages/docs/pages/counter.tsx
@@ -1,5 +1,5 @@
 import { Counter, Form, FormGroup, H1, Panel, Text } from '@bigcommerce/big-design';
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 
 import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
 import { CounterPropTable } from '../PropTables';
@@ -34,7 +34,7 @@ const CounterPage = () => {
               id: 'basic',
               title: 'Basic',
               render: () => (
-                <>
+                <Fragment key="basic">
                   <Text>
                     <Code primary>Counters</Code> are stylized numerical form controls with the ability to control
                     validation.
@@ -64,14 +64,14 @@ const CounterPage = () => {
                     }}
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'error-states',
               title: 'Error states',
               render: () => (
-                <>
+                <Fragment key="error-states">
                   <Text>
                     <Code primary>Counters</Code> allow you to pass in an <Code primary>error</Code> message that will
                     control the styles of a <Code primary>Counter</Code>. The logic on the counter can be controlled
@@ -110,7 +110,7 @@ const CounterPage = () => {
                     }}
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
           ]}

--- a/packages/docs/pages/datepicker.tsx
+++ b/packages/docs/pages/datepicker.tsx
@@ -1,5 +1,5 @@
 import { Datepicker, Form, FormGroup, H1, Panel, Text } from '@bigcommerce/big-design';
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 
 import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
 import { DatepickerPropTable } from '../PropTables';
@@ -31,7 +31,7 @@ const DatepickerPage = () => {
               id: 'basic',
               title: 'Basic',
               render: () => (
-                <>
+                <Fragment key="basic">
                   <Text>Use to select a single date from the calendar.</Text>
 
                   <CodePreview>
@@ -56,14 +56,14 @@ const DatepickerPage = () => {
                     }}
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'error-states',
               title: 'Error states',
               render: () => (
-                <>
+                <Fragment key="error-state">
                   <Text>
                     <Code primary>Datepicker</Code> allows you to pass in an <Code primary>error</Code> message that
                     will control the styles of a counter. The logic on the <Code primary>Datepicker</Code> can be
@@ -103,7 +103,7 @@ const DatepickerPage = () => {
                     }}
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
           ]}

--- a/packages/docs/pages/form.tsx
+++ b/packages/docs/pages/form.tsx
@@ -65,7 +65,7 @@ const FormPage = () => {
               id: 'basic',
               title: 'Basic',
               render: () => (
-                <>
+                <Fragment key="basic">
                   <Text>
                     Form fields are essential to any website or web application. Unique <Code>id</Code>'s' will be
                     auto-generated for the form fields and labels <Code>for</Code> attribute, unless manually specified.
@@ -91,7 +91,7 @@ const FormPage = () => {
                     </Form>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
@@ -177,7 +177,7 @@ const FormPage = () => {
               id: 'layout',
               title: 'Layout',
               render: () => (
-                <>
+                <Fragment key="layout">
                   <Text>
                     You can up to 3 <Code>Input</Code> components in row to add more dimension to a{' '}
                     <Code>FormGroup</Code>. <Code>Radio</Code> and <Code>Checkbox</Code> components will never display
@@ -209,14 +209,14 @@ const FormPage = () => {
                     </Form>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'validation',
               title: 'Validation',
               render: () => (
-                <>
+                <Fragment key="validation">
                   <Text>
                     All form controls are tied to <Code primary>onChange</Code> or equivalent event handlers. Validation
                     messages can be passed through the <Code>error</Code> prop. All input errors in an{' '}
@@ -277,7 +277,7 @@ const FormPage = () => {
                     }}
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
           ]}

--- a/packages/docs/pages/inline-message.tsx
+++ b/packages/docs/pages/inline-message.tsx
@@ -1,5 +1,5 @@
 import { H1, InlineMessage, Panel, Text } from '@bigcommerce/big-design';
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List, NextLink } from '../components';
 import { InlineMessagePropTable } from '../PropTables';
@@ -31,7 +31,7 @@ const InlineMessagePage = () => {
               id: 'basic',
               title: 'Basic',
               render: () => (
-                <>
+                <Fragment key="basic">
                   <Text>
                     An inline message, mostly used for displaying alerts within <Code primary>Modals</Code>. Is a
                     condensed version of the <NextLink href="/message">Message</NextLink> component.
@@ -54,14 +54,14 @@ const InlineMessagePage = () => {
                     />
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'types',
               title: 'Types',
               render: () => (
-                <>
+                <Fragment key="types">
                   <Text>
                     There are four types of <Code primary>InlineMessages</Code> based on the level of message you want
                     to display.
@@ -93,14 +93,14 @@ const InlineMessagePage = () => {
                     </>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'header',
               title: 'Header',
               render: () => (
-                <>
+                <Fragment key="header">
                   <Text>
                     <Code primary>InlineMessages</Code> allow you to pass an optional <Code primary>header</Code> prop.
                   </Text>
@@ -122,14 +122,14 @@ const InlineMessagePage = () => {
                     </>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
-              id: 'onclose',
+              id: 'onClose',
               title: 'onClose',
               render: () => (
-                <>
+                <Fragment key="on-close">
                   <Text>Toggles the visibility of the close button, and provides an on click callback.</Text>
 
                   <CodePreview>
@@ -149,14 +149,14 @@ const InlineMessagePage = () => {
                     </>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'actions',
               title: 'Actions',
               render: () => (
-                <>
+                <Fragment key="actions">
                   <Text>
                     <Code primary>InlineMessages</Code> allow you to pass an optional <Code primary>actions</Code> prop.
                   </Text>
@@ -183,7 +183,7 @@ const InlineMessagePage = () => {
                     </>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
           ]}

--- a/packages/docs/pages/inline-message.tsx
+++ b/packages/docs/pages/inline-message.tsx
@@ -126,10 +126,10 @@ const InlineMessagePage = () => {
               ),
             },
             {
-              id: 'onClose',
+              id: 'onclose',
               title: 'onClose',
               render: () => (
-                <Fragment key="on-close">
+                <Fragment key="onclose">
                   <Text>Toggles the visibility of the close button, and provides an on click callback.</Text>
 
                   <CodePreview>

--- a/packages/docs/pages/textarea.tsx
+++ b/packages/docs/pages/textarea.tsx
@@ -1,5 +1,5 @@
 import { Form, FormGroup, H1, Panel, Text, Textarea } from '@bigcommerce/big-design';
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 
 import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
 import { TextareaPropTable } from '../PropTables';
@@ -30,7 +30,7 @@ const TextAreaPage = () => {
               id: 'basic',
               title: 'Basic',
               render: () => (
-                <CodePreview>
+                <CodePreview key="basic">
                   {/* jsx-to-string:start */}
                   {function Example() {
                     const [value, setValue] = useState('');
@@ -61,7 +61,7 @@ const TextAreaPage = () => {
               id: 'error-state',
               title: 'Error state',
               render: () => (
-                <>
+                <Fragment key="error-state">
                   <Text>
                     <Code primary>Textareas</Code> allow you to pass in an <Code primary>error</Code> message that will
                     control the styles of an input. The logic on the input can be controlled with the{' '}
@@ -84,14 +84,14 @@ const TextAreaPage = () => {
                     </Form>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'controlling-rows',
               title: 'Controlling rows',
               render: () => (
-                <>
+                <Fragment key="controlling-rows">
                   <Text>
                     By default, a <Code primary>Textarea</Code> displays with <Code>3</Code> rows. In order to set the
                     intial amount of rows, pass in the <Code>rows</Code> prop. There can only be a maximum of{' '}
@@ -112,14 +112,14 @@ const TextAreaPage = () => {
                     </Form>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'resizable',
               title: 'Resizable',
               render: () => (
-                <>
+                <Fragment key="resizable">
                   <Text>
                     You can also control whether <Code primary>Textarea</Code> components are resizeable. Resizing is
                     only available on the vertical axis.
@@ -134,7 +134,7 @@ const TextAreaPage = () => {
                     </Form>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
           ]}


### PR DESCRIPTION
## What?
Code editor wasn't rendering the corresponding code when switching between tabs inside the implementation section of a documentation page.

**For additional context:** https://github.com/bigcommerce/big-design/pull/746

**Note:** I'm gonna open additional PRs to make it easier to review.

## Why?
To display the corresponding code when users switch between the tabs.

## Screenshots/Screen Recordings
https://user-images.githubusercontent.com/39739180/156409195-fc4b8fcd-c1b1-4834-8a14-c2f8700c0f14.mp4