### PR TITLE
feat(docs): fix code editor bug part 4

### DIFF
--- a/packages/docs/pages/badge.tsx
+++ b/packages/docs/pages/badge.tsx
@@ -1,5 +1,5 @@
 import { Badge, Grid, H1, Panel, Text } from '@bigcommerce/big-design';
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { Code, CodePreview, ContentRoutingTabs, List } from '../components';
 import { GuidelinesTable } from '../components/GuidelinesTable';
@@ -35,7 +35,7 @@ const BadgePage = () => {
               id: 'basic',
               title: 'Basic',
               render: () => (
-                <CodePreview>
+                <CodePreview key="basic">
                   {/* jsx-to-string:start */}
                   <Badge label="active" variant="success" />
                   {/* jsx-to-string:end */}
@@ -46,7 +46,7 @@ const BadgePage = () => {
               id: 'variants',
               title: 'Variants',
               render: () => (
-                <>
+                <Fragment key="variants">
                   <Text>
                     There are five types of variants to choose from: <Code>success</Code>, <Code>secondary</Code>,{' '}
                     <Code>warning</Code>, <Code>danger</Code>, and <Code>primary</Code>. You can determine what type by
@@ -64,7 +64,7 @@ const BadgePage = () => {
                     </Grid>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
           ]}

--- a/packages/docs/pages/breakpoints.tsx
+++ b/packages/docs/pages/breakpoints.tsx
@@ -1,6 +1,6 @@
 import { BoxProps, Box as Container, H1, Message, Panel, Text } from '@bigcommerce/big-design';
 import { breakpointValues } from '@bigcommerce/big-design-theme';
-import React from 'react';
+import React, { Fragment } from 'react';
 import styled from 'styled-components';
 
 import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable } from '../components';
@@ -33,7 +33,7 @@ const BreakpointsPage = () => (
             id: 'basic',
             title: 'Basic',
             render: () => (
-              <>
+              <Fragment key="basic">
                 <Text>
                   Most utility components contain responsive props. You can pass in an object with{' '}
                   <Code primary>breakpoints</Code> as keys to provide values at each breakpoint. BigDesign is
@@ -47,14 +47,14 @@ const BreakpointsPage = () => (
                   </Box>
                   {/* jsx-to-string:end */}
                 </CodePreview>
-              </>
+              </Fragment>
             ),
           },
           {
             id: 'extending',
             title: 'Extending',
             render: () => (
-              <>
+              <Fragment key="extending">
                 <Message
                   messages={[
                     { text: 'Before extending a component, if possible, use one of BigDesigns core components.' },
@@ -90,14 +90,14 @@ const BreakpointsPage = () => (
                   }}
                   {/* jsx-to-string:end */}
                 </CodePreview>
-              </>
+              </Fragment>
             ),
           },
           {
             id: 'breakpoint-values',
             title: 'Breakpoint Values',
             render: () => (
-              <>
+              <Fragment key="breakpoint-values">
                 <Text>
                   <Code primary>breakpointValues</Code> are also exposed on the <Code primary>theme</Code> object. Each
                   value is the <Code>px</Code> value of each breakpoint.
@@ -119,7 +119,7 @@ const BreakpointsPage = () => (
                   }}
                   {/* jsx-to-string:end */}
                 </CodePreview>
-              </>
+              </Fragment>
             ),
           },
         ]}

--- a/packages/docs/pages/grid.tsx
+++ b/packages/docs/pages/grid.tsx
@@ -1,5 +1,5 @@
 import { Box, Grid, GridItem, H1, Link, Panel, Text } from '@bigcommerce/big-design';
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List, NextLink } from '../components';
 import {
@@ -51,7 +51,7 @@ const GridPage = () => {
               id: 'basic',
               title: 'Basic',
               render: () => (
-                <>
+                <Fragment key="basic">
                   <Text>
                     The <Code primary>Grid</Code> component is useful for creating intrinsically responsive layouts.
                   </Text>
@@ -74,14 +74,14 @@ const GridPage = () => {
                     </Grid>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'custom-layout',
               title: 'Custom layout',
               render: () => (
-                <>
+                <Fragment key="custom-layout">
                   <Text>
                     <Code primary>Grid</Code> allows you to create custom layouts using combinations of{' '}
                     <Code>gridTemplate</Code> and <Code>gridArea</Code> props.
@@ -116,14 +116,14 @@ const GridPage = () => {
                     }}
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'column-layout',
               title: 'Column layout',
               render: () => (
-                <>
+                <Fragment key="column-layout">
                   <Text>
                     You can use the <Code>gridColumns</Code> prop to create columned layouts.
                   </Text>
@@ -158,7 +158,7 @@ const GridPage = () => {
                     </Grid>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
           ]}

--- a/packages/docs/pages/typography.tsx
+++ b/packages/docs/pages/typography.tsx
@@ -1,5 +1,5 @@
 import { Box, H0, H1, H2, H3, H4, HR, Panel, Small, Text } from '@bigcommerce/big-design';
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { Code, CodePreview, ContentRoutingTabs, List, NextLink } from '../components';
 import { HeadingPropTable, HRPropTable, MarginPropTable, TextPropTable, TypographyPropTable } from '../PropTables';
@@ -33,7 +33,7 @@ const TypographyPage = () => {
               id: 'heading',
               title: 'Heading',
               render: () => (
-                <CodePreview>
+                <CodePreview key="heading">
                   {/* jsx-to-string:start */}
                   <>
                     <H0>Hero header - h0</H0>
@@ -50,7 +50,7 @@ const TypographyPage = () => {
               id: 'text',
               title: 'Text',
               render: () => (
-                <CodePreview>
+                <CodePreview key="text">
                   {/* jsx-to-string:start */}
                   <>
                     <Text>Text - p</Text>
@@ -64,7 +64,7 @@ const TypographyPage = () => {
               id: 'hr',
               title: 'HR',
               render: () => (
-                <CodePreview>
+                <CodePreview key="hr">
                   {/* jsx-to-string:start */}
                   <HR marginVertical="large" />
                   {/* jsx-to-string:end */}
@@ -75,7 +75,7 @@ const TypographyPage = () => {
               id: 'color',
               title: 'Color',
               render: () => (
-                <>
+                <Fragment key="color">
                   <Text>
                     Choose any color from our <NextLink href="/colors">color pallete</NextLink> to style your text
                     color.
@@ -90,14 +90,14 @@ const TypographyPage = () => {
                     </>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'text-modifiers',
               title: 'Text modifiers',
               render: () => (
-                <CodePreview>
+                <CodePreview key="text-modifiers">
                   {/* jsx-to-string:start */}
                   <>
                     <Text bold>This text is bold.</Text>
@@ -119,7 +119,7 @@ const TypographyPage = () => {
               id: 'overflow',
               title: 'Overflow',
               render: () => (
-                <>
+                <Fragment key="overflow">
                   <Text>
                     Setting the <Code>ellipsis</Code> prop, will allow text to overflow nicely.
                   </Text>
@@ -131,14 +131,14 @@ const TypographyPage = () => {
                     </Box>
                     {/* jsx-to-string:end */}
                   </CodePreview>
-                </>
+                </Fragment>
               ),
             },
             {
               id: 'different-tag',
               title: 'As a different tag',
               render: () => (
-                <CodePreview>
+                <CodePreview key="different-tag">
                   {/* jsx-to-string:start */}
                   <Text as="span">This is a span.</Text>
                   {/* jsx-to-string:end */}


### PR DESCRIPTION
## What?
Code editor wasn't rendering the corresponding code when switching between tabs inside the implementation section of a documentation page.

**For additional context:** https://github.com/bigcommerce/big-design/pull/746

## Why?
To display the corresponding code when users switch between the tabs.

## Screenshots
https://user-images.githubusercontent.com/39739180/156409195-fc4b8fcd-c1b1-4834-8a14-c2f8700c0f14.mp4
