### PR TITLE
feat(docs): update margin and padding pages to use new layout

### DIFF
--- a/packages/docs/PropTables/MarginPropTable.tsx
+++ b/packages/docs/PropTables/MarginPropTable.tsx
@@ -5,37 +5,37 @@ import { NextLink, Prop, PropTable, PropTableWrapper } from '../components';
 const marginProps: Prop[] = [
   {
     name: 'margin',
-    types: <NextLink href="/margin">Margin</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the margin to be applied.',
   },
   {
     name: 'marginTop',
-    types: <NextLink href="/margin">Margin</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the top margin to be applied.',
   },
   {
     name: 'marginRight',
-    types: <NextLink href="/margin">Margin</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the right margin to be applied.',
   },
   {
     name: 'marginBottom',
-    types: <NextLink href="/margin">Margin</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the bottom margin to be applied.',
   },
   {
     name: 'marginLeft',
-    types: <NextLink href="/margin">Margin</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the left margin to be applied.',
   },
   {
     name: 'marginVertical',
-    types: <NextLink href="/margin">Margin</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the top and bottom margin to be applied.',
   },
   {
     name: 'marginHorizontal',
-    types: <NextLink href="/margin">Margin</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the left and right margin to be applied.',
   },
 ];

--- a/packages/docs/PropTables/PaddingPropTable.tsx
+++ b/packages/docs/PropTables/PaddingPropTable.tsx
@@ -5,39 +5,39 @@ import { NextLink, Prop, PropTable, PropTableWrapper } from '../components';
 const paddingProps: Prop[] = [
   {
     name: 'padding',
-    types: <NextLink href="/padding">Padding</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the padding to be applied.',
   },
   {
     name: 'paddingTop',
-    types: <NextLink href="/padding">Padding</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the top padding to be applied.',
   },
   {
     name: 'paddingRight',
-    types: <NextLink href="/padding">Padding</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the right padding to be applied.',
   },
   {
     name: 'paddingBottom',
-    types: <NextLink href="/padding">Padding</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
     description: 'Determines the bottom padding to be applied.',
   },
   {
     name: 'paddingLeft',
-    types: <NextLink href="/padding">Padding</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
 
     description: 'Determines the left padding to be applied.',
   },
   {
     name: 'paddingVertical',
-    types: <NextLink href="/padding">Padding</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
 
     description: 'Determines the top and bottom padding to be applied.',
   },
   {
     name: 'paddingHorizontal',
-    types: <NextLink href="/padding">Padding</NextLink>,
+    types: <NextLink href="/spacing">Spacing</NextLink>,
 
     description: 'Determines the left and right padding to be applied.',
   },

--- a/packages/docs/pages/margin.tsx
+++ b/packages/docs/pages/margin.tsx
@@ -1,55 +1,67 @@
 import { Button, H1, Panel, Text } from '@bigcommerce/big-design';
-import React from 'react';
+import React, { Fragment } from 'react';
 
-import { CodePreview, NextLink, PageNavigation } from '../components';
+import { Code, CodePreview, ContentRoutingTabs, NextLink } from '../components';
 import { MarginPropTable } from '../PropTables';
 
 const MarginPage = () => {
-  const items = [
-    {
-      id: 'examples',
-      title: 'Examples',
-      render: () => (
-        <>
-          <Panel>
-            <Text>
-              Some of our components expose a simple way to modify their margin. The following example showcases the
-              simples way to use the margin prop by giving it a <NextLink href="/spacing">Spacing</NextLink> value.
-            </Text>
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Button margin="medium">Example</Button>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-          <Panel header="Responsive breakpoints">
-            <Text>
-              You can also specify margins with an object to handle different margins with different{' '}
-              <NextLink href="/breakpoints">breakpoints</NextLink>. All values must be of{' '}
-              <NextLink href="/spacing">Spacing</NextLink> type.
-            </Text>
-
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Button margin={{ mobile: 'none', tablet: 'medium', desktop: 'xLarge' }}>Example</Button>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-        </>
-      ),
-    },
-    {
-      id: 'props',
-      title: 'Props',
-      render: () => <MarginPropTable />,
-    },
-  ];
-
   return (
     <>
       <H1>Margin</H1>
 
-      <PageNavigation items={items} />
+      <Panel header="Overview" headerId="overview">
+        <Text>
+          BigDesign provides the <Code primary>margin</Code> prop which can be used in some of our components.
+        </Text>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <Fragment key="basic">
+                  <Text>
+                    The following example showcases the simplest way to use the <Code primary>margin</Code> prop by
+                    giving it a <NextLink href="/spacing">Spacing</NextLink> value.
+                  </Text>
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Button margin="medium">Example</Button>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'responsive-breakpoints',
+              title: 'Responsive breakpoints',
+              render: () => (
+                <Fragment>
+                  <Text>
+                    You can also specify margins with an object to handle different margins with different{' '}
+                    <NextLink href="/breakpoints">breakpoints</NextLink>. All values must be of{' '}
+                    <NextLink href="/spacing">Spacing</NextLink> type.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Button margin={{ mobile: 'none', tablet: 'medium', desktop: 'xLarge' }}>Example</Button>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <MarginPropTable renderPanel={false} />
+      </Panel>
     </>
   );
 };

--- a/packages/docs/pages/padding.tsx
+++ b/packages/docs/pages/padding.tsx
@@ -1,59 +1,74 @@
 import { Box, H1, Panel, Text } from '@bigcommerce/big-design';
-import React from 'react';
+import React, { Fragment } from 'react';
 
-import { CodePreview, NextLink, PageNavigation } from '../components';
+import { Code, CodePreview, ContentRoutingTabs, NextLink } from '../components';
 import { PaddingPropTable } from '../PropTables';
 
 const PaddingPage = () => {
-  const items = [
-    {
-      id: 'examples',
-      title: 'Examples',
-      render: () => (
-        <>
-          <Panel>
-            <Text>
-              Some of our components expose a simple way to modify their padding. The following example showcases the
-              simples way to use the padding prop by giving it a <NextLink href="/spacing">Spacing</NextLink> value.
-            </Text>
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Box padding="medium" backgroundColor="secondary20">
-                Example
-              </Box>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-          <Panel header="Responsive breakpoints">
-            <Text>
-              You can also specify paddings with an object to handle different paddings with different{' '}
-              <NextLink href="/breakpoints">breakpoints</NextLink>. All values must be of{' '}
-              <NextLink href="/spacing">Spacing</NextLink> type.
-            </Text>
-
-            <CodePreview>
-              {/* jsx-to-string:start */}
-              <Box padding={{ mobile: 'none', tablet: 'medium', desktop: 'xLarge' }} backgroundColor="secondary20">
-                Example
-              </Box>
-              {/* jsx-to-string:end */}
-            </CodePreview>
-          </Panel>
-        </>
-      ),
-    },
-    {
-      id: 'props',
-      title: 'Props',
-      render: () => <PaddingPropTable />,
-    },
-  ];
-
   return (
     <>
       <H1>Padding</H1>
 
-      <PageNavigation items={items} />
+      <Panel header="Overview" headerId="overview">
+        <Text>
+          BigDesign provides the <Code primary>padding</Code> prop which can be used in some of our components.
+        </Text>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <Fragment key="basic">
+                  <Text>
+                    The following example showcases the simplest way to use the <Code primary>padding</Code> prop by
+                    giving it a <NextLink href="/spacing">Spacing</NextLink> value.
+                  </Text>
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Box padding="medium" backgroundColor="secondary20">
+                      Example
+                    </Box>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'responsive-breakpoints',
+              title: 'Responsive breakpoints',
+              render: () => (
+                <Fragment key="responsive-breakpoints">
+                  <Text>
+                    You can also specify paddings with an object to handle different paddings with different{' '}
+                    <NextLink href="/breakpoints">breakpoints</NextLink>. All values must be of{' '}
+                    <NextLink href="/spacing">Spacing</NextLink> type.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Box
+                      padding={{ mobile: 'none', tablet: 'medium', desktop: 'xLarge' }}
+                      backgroundColor="secondary20"
+                    >
+                      Example
+                    </Box>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <PaddingPropTable renderPanel={false} />
+      </Panel>
     </>
   );
 };


### PR DESCRIPTION
## What?
Update Margin and Padding pages to use new layout.

## Why?
Provide better experience to the user when reading the docs.

## Screenshots/Screen Recordings
<img width="793" alt="Screen Shot 2022-03-10 at 3 54 09 PM" src="https://user-images.githubusercontent.com/39739180/157761053-11a2a1eb-7f5f-41fb-a7f8-671cc37e2c62.png">

<img width="778" alt="Screen Shot 2022-03-10 at 3 54 41 PM" src="https://user-images.githubusercontent.com/39739180/157761118-fecacb78-389e-4dde-92db-7aa568d7f8a8.png">

