### PR TITLE
fix(component): add missing aria roles to tabs

### DIFF
--- a/packages/big-design/src/components/Tabs/Tabs.tsx
+++ b/packages/big-design/src/components/Tabs/Tabs.tsx
@@ -3,6 +3,7 @@ import React, { HTMLAttributes, memo } from 'react';
 import { StyledTab, StyledTabs } from './styled';
 
 export interface TabItem {
+  ariaControls?: string;
   id: string;
   title: string;
   disabled?: boolean;
@@ -29,11 +30,11 @@ export const Tabs: React.FC<TabsProps> = memo(
     return (
       <>
         <StyledTabs {...props} flexDirection="row" role="tablist">
-          {items.map(({ id, title, disabled }) => (
+          {items.map(({ ariaControls, id, title, disabled }) => (
             <StyledTab
               activeTab={activeTab}
               aria-expanded={id === activeTab ? 'true' : 'false'}
-              aria-controls={`${id}-content`}
+              aria-controls={ariaControls || `${id}-content`}
               id={id}
               key={id}
               onClick={handleOnTabClick}

--- a/packages/big-design/src/components/Tabs/Tabs.tsx
+++ b/packages/big-design/src/components/Tabs/Tabs.tsx
@@ -32,6 +32,8 @@ export const Tabs: React.FC<TabsProps> = memo(
           {items.map(({ id, title, disabled }) => (
             <StyledTab
               activeTab={activeTab}
+              aria-expanded={id === activeTab ? 'true' : 'false'}
+              aria-controls={`${id}-content`}
               id={id}
               key={id}
               onClick={handleOnTabClick}

--- a/packages/big-design/src/components/Tabs/Tabs.tsx
+++ b/packages/big-design/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,7 @@
 import React, { HTMLAttributes, memo } from 'react';
 
+import { warning } from '../../utils';
+
 import { StyledTab, StyledTabs } from './styled';
 
 export interface TabItem {
@@ -26,6 +28,17 @@ export const Tabs: React.FC<TabsProps> = memo(
         onTabClick(tabId);
       }
     };
+
+    const activeItem = activeTab && items[Number(activeTab)];
+    const missingAriaControls = items.some((item) => !item.ariaControls);
+    const missingFallback =
+      activeItem && !document.getElementById(activeItem.ariaControls || `${activeItem.id}-content`);
+
+    if (missingAriaControls || missingFallback) {
+      warning(
+        'TabItems must have an ariaControls field, otherwise, an element with fallback ID "{tab.id}-content" must exist in the DOM',
+      );
+    }
 
     return (
       <>

--- a/packages/big-design/src/components/Tabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tabs/__snapshots__/spec.tsx.snap
@@ -154,6 +154,8 @@ exports[`render Tabs 1`] = `
   role="tablist"
 >
   <button
+    aria-controls="tab1-content"
+    aria-expanded="false"
     class="c3 c4"
     id="tab1"
     role="tab"
@@ -166,6 +168,8 @@ exports[`render Tabs 1`] = `
     </span>
   </button>
   <button
+    aria-controls="tab2-content"
+    aria-expanded="false"
     class="c3 c4"
     id="tab2"
     role="tab"
@@ -334,6 +338,8 @@ exports[`render Tabs with disabled item 1`] = `
   role="tablist"
 >
   <button
+    aria-controls="tab1-content"
+    aria-expanded="false"
     class="c3 c4"
     id="tab1"
     role="tab"
@@ -346,6 +352,8 @@ exports[`render Tabs with disabled item 1`] = `
     </span>
   </button>
   <button
+    aria-controls="tab2-content"
+    aria-expanded="false"
     class="c3 c4"
     id="tab2"
     role="tab"
@@ -358,6 +366,8 @@ exports[`render Tabs with disabled item 1`] = `
     </span>
   </button>
   <button
+    aria-controls="tab3-content"
+    aria-expanded="false"
     class="c3 c4"
     disabled=""
     id="tab3"

--- a/packages/big-design/src/components/Tabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tabs/__snapshots__/spec.tsx.snap
@@ -154,7 +154,7 @@ exports[`render Tabs 1`] = `
   role="tablist"
 >
   <button
-    aria-controls="tab1-content"
+    aria-controls="content1"
     aria-expanded="false"
     class="c3 c4"
     id="tab1"
@@ -168,7 +168,7 @@ exports[`render Tabs 1`] = `
     </span>
   </button>
   <button
-    aria-controls="tab2-content"
+    aria-controls="content2"
     aria-expanded="false"
     class="c3 c4"
     id="tab2"
@@ -338,7 +338,7 @@ exports[`render Tabs with disabled item 1`] = `
   role="tablist"
 >
   <button
-    aria-controls="tab1-content"
+    aria-controls="content1"
     aria-expanded="false"
     class="c3 c4"
     id="tab1"
@@ -352,7 +352,7 @@ exports[`render Tabs with disabled item 1`] = `
     </span>
   </button>
   <button
-    aria-controls="tab2-content"
+    aria-controls="content2"
     aria-expanded="false"
     class="c3 c4"
     id="tab2"

--- a/packages/big-design/src/components/Tabs/spec.tsx
+++ b/packages/big-design/src/components/Tabs/spec.tsx
@@ -5,12 +5,19 @@ import { render, screen } from '@test/utils';
 
 import 'jest-styled-components';
 
+import { warning } from '../../utils';
+
 import { TabItem, Tabs } from './Tabs';
 
 const items: TabItem[] = [
   { ariaControls: 'content1', id: 'tab1', title: 'Tab 1' },
   { ariaControls: 'content2', id: 'tab2', title: 'Tab 2' },
 ];
+
+jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
+  warning: jest.fn(),
+}));
 
 test('render Tabs', () => {
   const { container } = render(<Tabs items={items} />);
@@ -120,4 +127,43 @@ test('active tab has aria-expanded', () => {
 
   expect(tabs[0].getAttribute('aria-expanded')).toBe('true');
   expect(tabs[1].getAttribute('aria-expanded')).toBe('false');
+});
+
+test('shows a warning if ariaControls is missing or fallback id does not exist', () => {
+  const warningSpy = jest.fn();
+
+  jest.mocked(warning).mockImplementation(warningSpy);
+
+  const incompleteItems: TabItem[] = [
+    { id: 'tab1', title: 'Tab 1' },
+    { id: 'tab2', title: 'Tab 2' },
+  ];
+  render(<Tabs activeTab="tab1" items={incompleteItems} />);
+
+  expect(warningSpy).toHaveBeenCalled();
+});
+
+test('does not warn if ariaControls is present', () => {
+  const warningSpy = jest.fn();
+
+  jest.mocked(warning).mockImplementation(warningSpy);
+
+  render(<Tabs activeTab="tab1" items={items} />);
+
+  expect(warningSpy).not.toHaveBeenCalled();
+});
+
+test('does not warn if fallback id is valid', () => {
+  const warningSpy = jest.fn();
+
+  jest.mocked(warning).mockImplementation(warningSpy);
+
+  render(
+    <>
+      <Tabs activeTab="tab1" items={items} />
+      <div id="tab1-content">Hello world</div>
+    </>,
+  );
+
+  expect(warningSpy).not.toHaveBeenCalled();
 });

--- a/packages/big-design/src/components/Tabs/spec.tsx
+++ b/packages/big-design/src/components/Tabs/spec.tsx
@@ -1,14 +1,15 @@
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { fireEvent, render } from '@test/utils';
+import { render, screen } from '@test/utils';
 
 import 'jest-styled-components';
 
 import { TabItem, Tabs } from './Tabs';
 
 const items: TabItem[] = [
-  { id: 'tab1', title: 'Tab 1' },
-  { id: 'tab2', title: 'Tab 2' },
+  { ariaControls: 'content1', id: 'tab1', title: 'Tab 1' },
+  { ariaControls: 'content2', id: 'tab2', title: 'Tab 2' },
 ];
 
 test('render Tabs', () => {
@@ -25,22 +26,22 @@ test('render Tabs with disabled item', () => {
 });
 
 test('Tabs has a role', () => {
-  const { getByRole } = render(<Tabs items={items} />);
+  render(<Tabs items={items} />);
 
-  expect(getByRole('tablist')).toBeInTheDocument();
+  expect(screen.getByRole('tablist')).toBeInTheDocument();
 });
 
 test('Tab items have a role', () => {
-  const { getAllByRole } = render(<Tabs items={items} />);
+  render(<Tabs items={items} />);
 
-  expect(getAllByRole('tab').length).toBe(2);
+  expect(screen.getAllByRole('tab').length).toBe(2);
 });
 
 test('active tab has a tabindex', () => {
   const activeTab = 'tab2';
-  const { getAllByRole } = render(<Tabs activeTab={activeTab} items={items} />);
+  render(<Tabs activeTab={activeTab} items={items} />);
 
-  const tabs = getAllByRole('tab');
+  const tabs = screen.getAllByRole('tab');
 
   tabs.forEach((tab) => {
     if (tab.id === activeTab) {
@@ -53,10 +54,10 @@ test('active tab has a tabindex', () => {
 
 test('onTabClick is called', () => {
   const onClick = jest.fn();
-  const { getByText } = render(<Tabs items={items} onTabClick={onClick} />);
-  const trigger = getByText('Tab 2');
+  render(<Tabs items={items} onTabClick={onClick} />);
+  const trigger = screen.getByText('Tab 2');
 
-  fireEvent.click(trigger);
+  userEvent.click(trigger);
 
   expect(onClick).toHaveBeenCalled();
 });
@@ -64,19 +65,19 @@ test('onTabClick is called', () => {
 test('active tab changes on tab click', () => {
   const onClick = jest.fn();
 
-  const { getByText, rerender } = render(<Tabs items={items} onTabClick={onClick} />);
+  const { rerender } = render(<Tabs items={items} onTabClick={onClick} />);
 
-  let trigger = getByText('Tab 2');
+  let trigger = screen.getByText('Tab 2');
 
-  fireEvent.click(trigger);
+  userEvent.click(trigger);
 
   expect(onClick).toHaveBeenCalled();
 
   rerender(<Tabs items={items} onTabClick={onClick} />);
 
-  trigger = getByText('Tab 1');
+  trigger = screen.getByText('Tab 1');
 
-  fireEvent.click(trigger);
+  userEvent.click(trigger);
 
   expect(onClick).toHaveBeenCalled();
 });
@@ -86,11 +87,11 @@ test("clicking a disabled tab doesn't set the active tab", () => {
   const disabledItems: TabItem[] = [...items, { id: 'tab3', title: 'Tab 3', disabled: true }];
   const setActiveTab = jest.fn((tabId: string) => (activeTab = tabId));
 
-  const { getByText } = render(<Tabs activeTab={activeTab} items={disabledItems} onTabClick={setActiveTab} />);
+  render(<Tabs activeTab={activeTab} items={disabledItems} onTabClick={setActiveTab} />);
 
-  const trigger = getByText('Tab 3');
+  const trigger = screen.getByText('Tab 3');
 
-  fireEvent.click(trigger);
+  userEvent.click(trigger);
 
   expect(setActiveTab).not.toHaveBeenCalled();
   expect(activeTab).toBe('tab1');
@@ -101,4 +102,22 @@ test('does not forward styles', () => {
 
   expect(container.getElementsByClassName('test').length).toBe(0);
   expect(container.firstChild).not.toHaveStyle('background: red');
+});
+
+test('passes the ariaControls prop to the tabs', () => {
+  render(<Tabs className="test" items={items} />);
+
+  const tabs = screen.getAllByRole('tab');
+
+  expect(tabs[0].getAttribute('aria-controls')).toBe('content1');
+  expect(tabs[1].getAttribute('aria-controls')).toBe('content2');
+});
+
+test('active tab has aria-expanded', () => {
+  render(<Tabs activeTab="tab1" items={items} />);
+
+  const tabs = screen.getAllByRole('tab');
+
+  expect(tabs[0].getAttribute('aria-expanded')).toBe('true');
+  expect(tabs[1].getAttribute('aria-expanded')).toBe('false');
 });

--- a/packages/docs/PropTables/TabsPropTable.tsx
+++ b/packages/docs/PropTables/TabsPropTable.tsx
@@ -30,6 +30,12 @@ export const TabsPropTable: React.FC<PropTableWrapper> = (props) => (
 
 const tabItemProps: Prop[] = [
   {
+    name: 'ariaControls',
+    types: 'string',
+    description: 'An ID corresponding to the HTML element where your content will be.',
+    required: false,
+  },
+  {
     name: 'id',
     types: 'string',
     description: 'Tab identifier, must be unique.',

--- a/packages/docs/pages/tabs.tsx
+++ b/packages/docs/pages/tabs.tsx
@@ -38,12 +38,18 @@ const TabsPage = () => {
 
             return (
               <>
-                <Tabs activeTab={activeTab} items={items} onTabClick={setActiveTab} />
+                <Tabs
+                  aria-label="Example Tab Content"
+                  activeTab={activeTab}
+                  items={items}
+                  id="tab-example"
+                  onTabClick={setActiveTab}
+                />
                 <Box marginTop="large">
-                  {activeTab === 'tab1' && <Text>Content 1</Text>}
-                  {activeTab === 'tab2' && <Text>Content 2</Text>}
-                  {activeTab === 'tab3' && <Text>Content 3</Text>}
-                  {activeTab === 'tab4' && <Text>Content 4</Text>}
+                  {activeTab === 'tab1' && <Text id="tab1-content">Content 1</Text>}
+                  {activeTab === 'tab2' && <Text id="tab2-content">Content 2</Text>}
+                  {activeTab === 'tab3' && <Text id="tab3-content">Content 3</Text>}
+                  {activeTab === 'tab4' && <Text id="tab4-content">Content 4</Text>}
                 </Box>
               </>
             );

--- a/packages/docs/pages/tabs.tsx
+++ b/packages/docs/pages/tabs.tsx
@@ -30,10 +30,10 @@ const TabsPage = () => {
             const [activeTab, setActiveTab] = useState('tab1');
 
             const items = [
-              { id: 'tab1', title: 'Example 1' },
-              { id: 'tab2', title: 'Example 2' },
-              { id: 'tab3', title: 'Example 3' },
-              { id: 'tab4', title: 'Example 4', disabled: true },
+              { ariaControls: 'content1', id: 'tab1', title: 'Example 1' },
+              { ariaControls: 'content2', id: 'tab2', title: 'Example 2' },
+              { ariaControls: 'content3', id: 'tab3', title: 'Example 3' },
+              { ariaControls: 'content4', id: 'tab4', title: 'Example 4', disabled: true },
             ];
 
             return (
@@ -46,10 +46,10 @@ const TabsPage = () => {
                   onTabClick={setActiveTab}
                 />
                 <Box marginTop="large">
-                  {activeTab === 'tab1' && <Text id="tab1-content">Content 1</Text>}
-                  {activeTab === 'tab2' && <Text id="tab2-content">Content 2</Text>}
-                  {activeTab === 'tab3' && <Text id="tab3-content">Content 3</Text>}
-                  {activeTab === 'tab4' && <Text id="tab4-content">Content 4</Text>}
+                  {activeTab === 'tab1' && <Text id="content1">Content 1</Text>}
+                  {activeTab === 'tab2' && <Text id="content2">Content 2</Text>}
+                  {activeTab === 'tab3' && <Text id="content3">Content 3</Text>}
+                  {activeTab === 'tab4' && <Text id="content4">Content 4</Text>}
                 </Box>
               </>
             );
@@ -92,6 +92,10 @@ const TabsPage = () => {
             </>,
             <>
               Use <Code primary>Tabs</Code> to switch between related content.
+            </>,
+            <>
+              Use the <Code primary>ariaControls</Code> prop to match your content with the <Code primary>TabItem</Code>{' '}
+              that displays it.
             </>,
           ]}
           discouraged={[


### PR DESCRIPTION
## What?
Add aria roles to the Tabs component

## Why?
Missing aria roles in a few places:

- Each tab must have an `aria-expanded` role that is set to `true` or `false` if it is active
- Each tab must have an `aria-controls` role that points to the content it displays (this relies on the developer adding the right IDs, so I've updated the example to reflect this)

[Aria rules Source](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role#description)

**Because we don't have access to the tab panel content, I have assumed IDs of the form `${id}-content`. Open to feedback here, not super reliable, but I don't see another option (short of adding a completely new `TabItem` which opens up its own can of worms)**

## Testing/Proof

<img width="1768" alt="aria tabs 2" src="https://user-images.githubusercontent.com/6025510/158470818-9743de10-0653-442e-84bd-85a2c32171ba.png">


