### PR TITLE
fix(component): use aria-selected for tabs

### DIFF
--- a/packages/big-design/src/components/Tabs/Tabs.tsx
+++ b/packages/big-design/src/components/Tabs/Tabs.tsx
@@ -46,7 +46,7 @@ export const Tabs: React.FC<TabsProps> = memo(
           {items.map(({ ariaControls, id, title, disabled }) => (
             <StyledTab
               activeTab={activeTab}
-              aria-expanded={id === activeTab ? 'true' : 'false'}
+              aria-selected={id === activeTab ? 'true' : 'false'}
               aria-controls={ariaControls || `${id}-content`}
               id={id}
               key={id}

--- a/packages/big-design/src/components/Tabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tabs/__snapshots__/spec.tsx.snap
@@ -155,7 +155,7 @@ exports[`render Tabs 1`] = `
 >
   <button
     aria-controls="content1"
-    aria-expanded="false"
+    aria-selected="false"
     class="c3 c4"
     id="tab1"
     role="tab"
@@ -169,7 +169,7 @@ exports[`render Tabs 1`] = `
   </button>
   <button
     aria-controls="content2"
-    aria-expanded="false"
+    aria-selected="false"
     class="c3 c4"
     id="tab2"
     role="tab"
@@ -339,7 +339,7 @@ exports[`render Tabs with disabled item 1`] = `
 >
   <button
     aria-controls="content1"
-    aria-expanded="false"
+    aria-selected="false"
     class="c3 c4"
     id="tab1"
     role="tab"
@@ -353,7 +353,7 @@ exports[`render Tabs with disabled item 1`] = `
   </button>
   <button
     aria-controls="content2"
-    aria-expanded="false"
+    aria-selected="false"
     class="c3 c4"
     id="tab2"
     role="tab"
@@ -367,7 +367,7 @@ exports[`render Tabs with disabled item 1`] = `
   </button>
   <button
     aria-controls="tab3-content"
-    aria-expanded="false"
+    aria-selected="false"
     class="c3 c4"
     disabled=""
     id="tab3"

--- a/packages/big-design/src/components/Tabs/spec.tsx
+++ b/packages/big-design/src/components/Tabs/spec.tsx
@@ -120,13 +120,13 @@ test('passes the ariaControls prop to the tabs', () => {
   expect(tabs[1].getAttribute('aria-controls')).toBe('content2');
 });
 
-test('active tab has aria-expanded', () => {
+test('active tab has aria-selected', () => {
   render(<Tabs activeTab="tab1" items={items} />);
 
   const tabs = screen.getAllByRole('tab');
 
-  expect(tabs[0].getAttribute('aria-expanded')).toBe('true');
-  expect(tabs[1].getAttribute('aria-expanded')).toBe('false');
+  expect(tabs[0].getAttribute('aria-selected')).toBe('true');
+  expect(tabs[1].getAttribute('aria-selected')).toBe('false');
 });
 
 test('shows a warning if ariaControls is missing or fallback id does not exist', () => {


### PR DESCRIPTION
## What?
Swap `aria-expanded` to `aria-selected` for Tabs

## Why?

It looks like it should be `selected`, not `expanded`, based on the w3 guidelines. MDN has inconsistent information on their site (one page says `aria-expanded` and the other says `aria-selected`).

So we're going to side with the w3 on this one. Smells like typo on MDN


