### PR TITLE
fix: tiny-async-pool api changes

### DIFF
--- a/packages/big-design-icons/scripts/build-flags.js
+++ b/packages/big-design-icons/scripts/build-flags.js
@@ -42,9 +42,7 @@ async function convertToReactComponent(filePath, iconName) {
   return outputFile(destPath, code);
 }
 
-async function generateFlags() {
-  const iconFiles = await glob(SOURCE);
-
+function convertWithConcurrencyPool(iconFiles) {
   return asyncPool(cpus().length, iconFiles, (iconFilePath) => {
     const filename = basename(iconFilePath, '.svg');
     const name = `${filename.replace('-', '').toUpperCase()}FlagIcon`;
@@ -56,6 +54,13 @@ async function generateFlags() {
 
     return convertToReactComponent(iconFilePath, name);
   });
+}
+
+async function generateFlags() {
+  const iconFiles = await glob(SOURCE);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _result of convertWithConcurrencyPool(iconFiles));
 }
 
 function cleanDestDirectory() {

--- a/packages/big-design-icons/scripts/build.js
+++ b/packages/big-design-icons/scripts/build.js
@@ -24,9 +24,7 @@ async function convertToReactComponent(filePath, iconName) {
   return outputFile(destPath, code);
 }
 
-async function generateIcons() {
-  const iconFiles = await glob(SOURCE);
-
+function convertWithConcurrencyPool(iconFiles) {
   return asyncPool(cpus().length, iconFiles, (iconFilePath) => {
     const filename = basename(iconFilePath, '.svg');
     const name = `${camelcase(filename, { pascalCase: true })}Icon`;
@@ -38,6 +36,13 @@ async function generateIcons() {
 
     return convertToReactComponent(iconFilePath, name);
   });
+}
+
+async function generateIcons() {
+  const iconFiles = await glob(SOURCE);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _result of convertWithConcurrencyPool(iconFiles));
 }
 
 function cleanDestDirectory() {


### PR DESCRIPTION
## What?

Changes how we use `tiny-async-pool`. They updated their library to use an iterator approach so we needed to adjust that logic.

## Testing/Proof

See CI.