### PR TITLE
fix(component): remove TreeNode focus

### DIFF
--- a/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, ChevronRightIcon, FolderIcon } from '@bigcommerce/big-design-icons';
-import React, { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useContext, useMemo, useRef } from 'react';
 
 import { typedMemo } from '../../../utils';
 import { StyledCheckbox } from '../../Checkbox/private';
@@ -38,16 +38,6 @@ const InternalTreeNode = <T,>({
   const isDisabled = disabledNodes?.includes(id);
   const isSelectable = value !== undefined && selectable?.type !== undefined && !isDisabled;
   const selectedChildrenCount = useSelectedChildrenCount({ selectedNodes: selectable?.selectedNodes, children });
-
-  useEffect(() => {
-    if (
-      focusable.focusedNode === id &&
-      nodeRef.current !== document.activeElement &&
-      document.activeElement !== document.body
-    ) {
-      nodeRef.current?.focus();
-    }
-  }, [focusable, id]);
 
   // Could be multiple elements in which are clicked.
   // Typing to generic Element type since all other elements extend from it.


### PR DESCRIPTION
## What?
Remove focus for TreeNode 

## Why?
With the current implementation, TreeNode will snatch the focus of the entire page and it's not possible to use it with other inputs on the page.

## Screenshots/Screen Recordings
Before:
https://user-images.githubusercontent.com/22089936/165676627-a1580774-b60d-44fd-9595-b7dc49a4dea7.mov

After:
https://user-images.githubusercontent.com/22089936/165676636-852cd1a3-5164-4e1a-8472-4209971fa01f.mov

## Testing/Proof
Attached screen recording
