### PR TITLE
chore(configs): add eslint rule for curly braces presence

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     '@typescript-eslint/no-use-before-define': 'off',
     'no-console': 'warn',
     'react/display-name': 'off',
+    'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never', propElementValues: 'always' }],
     'react/prop-types': 'off',
     'react/no-unescaped-entities': [
       'error',


### PR DESCRIPTION
## What?

Add eslint rule for curly braces presence.
Reference: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md

## Why?
Prevent using curly braces when adding a string as a value in a prop.

## Screenshots/Screen Recordings
<img width="1032" alt="Screen Shot 2022-05-03 at 2 01 12 PM" src="https://user-images.githubusercontent.com/39739180/166524015-a307aafe-82e2-4c61-8d91-44c10ea34f01.png">
