### PR TITLE
fix(docs): minor page fixes

### DIFF
--- a/packages/docs/pages/icons.tsx
+++ b/packages/docs/pages/icons.tsx
@@ -169,8 +169,8 @@ const IconsPage = () => {
           id="props"
           routes={[
             {
-              id: 'Icon',
-              title: 'icon',
+              id: 'icon',
+              title: 'Icon',
               render: () => (
                 <IconPropTable renderPanel={false}>
                   <CodeSnippet showControls={false} language="bash">
@@ -208,7 +208,7 @@ const IconsPage = () => {
             return (
               <Flex
                 key={iconName}
-                style={{ width: '300px' }}
+                style={{ width: '300px', gap: '1rem' }}
                 flexDirection="column"
                 borderRadius="normal"
                 justifyContent="center"


### PR DESCRIPTION
## What?

- Fix a small typo for the `Icon` tab button
- Add some spacing for the icon names.

## Why?

Cleanup

## Screenshots/Screen Recordings

![screencapture-localhost-3000-icons-2022-05-10-15_47_39](https://user-images.githubusercontent.com/10539418/167719551-6002e196-535e-4e9d-8f33-f3111ba33bab.png)

## Testing/Proof
See screenshot
