### PR TITLE
chore(docs): remove renderPanel prop for PropTable

### DIFF
--- a/packages/docs/components/PropTable/PropTable.tsx
+++ b/packages/docs/components/PropTable/PropTable.tsx
@@ -1,4 +1,4 @@
-import { Flex, H3, Link, Panel, Small, Table, TableFigure, Text } from '@bigcommerce/big-design';
+import { Flex, H3, Link, Small, Table, TableFigure, Text } from '@bigcommerce/big-design';
 import React, { FC, ReactNode } from 'react';
 
 import { Code } from '../Code';
@@ -23,16 +23,12 @@ export interface PropTableProps {
   nativeElement?: [string, 'most' | 'all'];
   propList: Prop[];
   title: string;
-  /**
-   * @deprecated Used to migrate to new documentation stucture
-   */
-  renderPanel?: boolean;
 }
 
 export type PropTableWrapper = Partial<PropTableProps>;
 
 export const PropTable: FC<PropTableProps> = (props) => {
-  const { collapsible, id, propList: items, title, inheritedProps, nativeElement, renderPanel = true } = props;
+  const { collapsible, id, propList: items, title, inheritedProps, nativeElement } = props;
 
   const renderTable = () => {
     if (items.length > 0) {
@@ -110,10 +106,6 @@ export const PropTable: FC<PropTableProps> = (props) => {
 
   if (collapsible) {
     return <Collapsible title={`${title} Props`}>{renderTable()}</Collapsible>;
-  }
-
-  if (renderPanel) {
-    return <Panel header={title}>{renderContent()}</Panel>;
   }
 
   return renderContent();

--- a/packages/docs/pages/alert.tsx
+++ b/packages/docs/pages/alert.tsx
@@ -73,19 +73,19 @@ const AlertPage = () => {
                     ]}
                     marginBottom="large"
                   />
-                  <AlertPropTable renderPanel={false} />
+                  <AlertPropTable />
                 </>
               ),
             },
             {
               id: 'message-item',
               title: 'MessageItem',
-              render: () => <MessagingItemPropTable renderPanel={false} />,
+              render: () => <MessagingItemPropTable />,
             },
             {
               id: 'message-link-item',
               title: 'MessageLinkItem',
-              render: () => <MessagingLinkItemPropTable renderPanel={false} />,
+              render: () => <MessagingLinkItemPropTable />,
             },
           ]}
         />

--- a/packages/docs/pages/badge.tsx
+++ b/packages/docs/pages/badge.tsx
@@ -72,7 +72,7 @@ const BadgePage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <BadgePropTable inheritedProps={<MarginPropTable collapsible />} renderPanel={false} />
+        <BadgePropTable inheritedProps={<MarginPropTable collapsible />} />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/box.tsx
+++ b/packages/docs/pages/box.tsx
@@ -107,7 +107,6 @@ const BoxPage = () => {
               <PaddingPropTable collapsible />
             </>
           }
-          renderPanel={false}
         />
       </Panel>
 

--- a/packages/docs/pages/button-group.tsx
+++ b/packages/docs/pages/button-group.tsx
@@ -108,7 +108,7 @@ const ButtonGroupPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <ButtonGroupPropTable renderPanel={false} />
+        <ButtonGroupPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/button.tsx
+++ b/packages/docs/pages/button.tsx
@@ -199,7 +199,7 @@ const ButtonPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <ButtonPropTable inheritedProps={<MarginPropTable collapsible />} renderPanel={false} />
+        <ButtonPropTable inheritedProps={<MarginPropTable collapsible />} />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/checkbox.tsx
+++ b/packages/docs/pages/checkbox.tsx
@@ -140,19 +140,17 @@ const CheckboxPage = () => {
             {
               id: 'checkbox',
               title: 'Checkbox',
-              render: () => <CheckboxPropTable renderPanel={false} />,
+              render: () => <CheckboxPropTable />,
             },
             {
               id: 'checkbox-description',
               title: 'CheckboxDescription',
-              render: () => <CheckboxDescriptionPropTable id="checkbox-description-prop-table" renderPanel={false} />,
+              render: () => <CheckboxDescriptionPropTable id="checkbox-description-prop-table" />,
             },
             {
               id: 'checkbox-description-link',
               title: 'CheckboxDescriptionLink',
-              render: () => (
-                <CheckboxDescriptionLinkPropTable id="checkbox-description-link-prop-table" renderPanel={false} />
-              ),
+              render: () => <CheckboxDescriptionLinkPropTable id="checkbox-description-link-prop-table" />,
             },
           ]}
         />

--- a/packages/docs/pages/collapse.tsx
+++ b/packages/docs/pages/collapse.tsx
@@ -48,7 +48,7 @@ const CollapsePage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <CollapsePropTable renderPanel={false} />
+        <CollapsePropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/counter.tsx
+++ b/packages/docs/pages/counter.tsx
@@ -118,7 +118,7 @@ const CounterPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <CounterPropTable renderPanel={false} />
+        <CounterPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/datepicker.tsx
+++ b/packages/docs/pages/datepicker.tsx
@@ -111,7 +111,7 @@ const DatepickerPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <DatepickerPropTable renderPanel={false} />
+        <DatepickerPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/display.tsx
+++ b/packages/docs/pages/display.tsx
@@ -87,7 +87,7 @@ const DisplayPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <DisplayPropTable renderPanel={false} />
+        <DisplayPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/dropdown.tsx
+++ b/packages/docs/pages/dropdown.tsx
@@ -418,22 +418,22 @@ const DropdownPage = () => {
             {
               id: 'dropdown',
               title: 'Dropdown',
-              render: () => <DropdownPropTable renderPanel={false} />,
+              render: () => <DropdownPropTable />,
             },
             {
               id: 'dropdown-item',
               title: 'DropdownItem',
-              render: () => <DropdownItemPropTable renderPanel={false} />,
+              render: () => <DropdownItemPropTable />,
             },
             {
               id: 'dropdown-link-item',
               title: 'DropdownLinkItem',
-              render: () => <DropdownLinkItemPropTable renderPanel={false} />,
+              render: () => <DropdownLinkItemPropTable />,
             },
             {
               id: 'dropdown-item-group',
               title: 'DropdownItemGroup',
-              render: () => <DropdownItemGroupPropTable renderPanel={false} />,
+              render: () => <DropdownItemGroupPropTable />,
             },
           ]}
         />

--- a/packages/docs/pages/flex.tsx
+++ b/packages/docs/pages/flex.tsx
@@ -195,7 +195,6 @@ const FlexPage = () => {
               title: 'Flex',
               render: () => (
                 <FlexPropTable
-                  renderPanel={false}
                   inheritedProps={
                     <>
                       <BoxPropTable collapsible />
@@ -212,7 +211,6 @@ const FlexPage = () => {
               title: 'FlexItem',
               render: () => (
                 <FlexItemPropTable
-                  renderPanel={false}
                   inheritedProps={
                     <>
                       <BoxPropTable collapsible />

--- a/packages/docs/pages/form.tsx
+++ b/packages/docs/pages/form.tsx
@@ -291,32 +291,32 @@ const FormPage = () => {
             {
               id: 'form',
               title: 'Form',
-              render: () => <FormPropTable renderPanel={false} inheritedProps={<MarginPropTable collapsible />} />,
+              render: () => <FormPropTable inheritedProps={<MarginPropTable collapsible />} />,
             },
             {
               id: 'form-group',
               title: 'FormGroup',
-              render: () => <FormGroupPropTable renderPanel={false} />,
+              render: () => <FormGroupPropTable />,
             },
             {
               id: 'form-control-error',
               title: 'FormControlError',
-              render: () => <FormErrorPropTable renderPanel={false} />,
+              render: () => <FormErrorPropTable />,
             },
             {
               id: 'form-control-label',
               title: 'FormControlLabel',
-              render: () => <FormLabelPropTable renderPanel={false} />,
+              render: () => <FormLabelPropTable />,
             },
             {
               id: 'form-control-description',
               title: 'FormControlDescription',
-              render: () => <FormDescriptionPropTable renderPanel={false} />,
+              render: () => <FormDescriptionPropTable />,
             },
             {
               id: 'form-fieldset',
               title: 'Fieldset',
-              render: () => <FormFieldsetPropTable renderPanel={false} />,
+              render: () => <FormFieldsetPropTable />,
             },
           ]}
         />

--- a/packages/docs/pages/grid.tsx
+++ b/packages/docs/pages/grid.tsx
@@ -174,7 +174,6 @@ const GridPage = () => {
               title: 'Grid',
               render: () => (
                 <GridPropTable
-                  renderPanel={false}
                   inheritedProps={
                     <>
                       <BoxPropTable collapsible />
@@ -191,7 +190,6 @@ const GridPage = () => {
               title: 'GridItem',
               render: () => (
                 <GridItemPropTable
-                  renderPanel={false}
                   inheritedProps={
                     <>
                       <BoxPropTable collapsible />

--- a/packages/docs/pages/icons.tsx
+++ b/packages/docs/pages/icons.tsx
@@ -172,7 +172,7 @@ const IconsPage = () => {
               id: 'icon',
               title: 'Icon',
               render: () => (
-                <IconPropTable renderPanel={false}>
+                <IconPropTable>
                   <CodeSnippet showControls={false} language="bash">
                     npm install @bigcommerce/big-design-icons // or yarn add @bigcommerce/big-design-icons
                   </CodeSnippet>
@@ -183,7 +183,7 @@ const IconsPage = () => {
               id: 'flag-icon',
               title: 'Flag icon',
               render: () => (
-                <FlagIconPropTable renderPanel={false}>
+                <FlagIconPropTable>
                   <InlineMessage
                     type="warning"
                     messages={[

--- a/packages/docs/pages/inline-message.tsx
+++ b/packages/docs/pages/inline-message.tsx
@@ -197,17 +197,17 @@ const InlineMessagePage = () => {
             {
               id: 'inline-message',
               title: 'InlineMessage',
-              render: () => <InlineMessagePropTable renderPanel={false} />,
+              render: () => <InlineMessagePropTable />,
             },
             {
               id: 'message-item',
               title: 'MessageItem',
-              render: () => <MessagingItemPropTable id="message-item-prop-table" renderPanel={false} />,
+              render: () => <MessagingItemPropTable id="message-item-prop-table" />,
             },
             {
               id: 'message-link-item',
               title: 'MessageLinkItem',
-              render: () => <MessagingLinkItemPropTable id="message-link-item-prop-table" renderPanel={false} />,
+              render: () => <MessagingLinkItemPropTable id="message-link-item-prop-table" />,
             },
           ]}
         />

--- a/packages/docs/pages/input.tsx
+++ b/packages/docs/pages/input.tsx
@@ -119,7 +119,7 @@ const InputPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <InputPropTable renderPanel={false} />
+        <InputPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/link.tsx
+++ b/packages/docs/pages/link.tsx
@@ -60,11 +60,7 @@ const LinkPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <LinkPropTable
-          inheritedProps={<MarginPropTable collapsible />}
-          renderPanel={false}
-          nativeElement={['a', 'all']}
-        />
+        <LinkPropTable inheritedProps={<MarginPropTable collapsible />} nativeElement={['a', 'all']} />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/margin.tsx
+++ b/packages/docs/pages/margin.tsx
@@ -61,7 +61,7 @@ const MarginPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <MarginPropTable renderPanel={false} />
+        <MarginPropTable />
       </Panel>
     </>
   );

--- a/packages/docs/pages/message.tsx
+++ b/packages/docs/pages/message.tsx
@@ -197,17 +197,17 @@ const MessagePage = () => {
             {
               id: 'inline-message',
               title: 'InlineMessage',
-              render: () => <MessagePropTable inheritedProps={<MarginPropTable collapsible />} renderPanel={false} />,
+              render: () => <MessagePropTable inheritedProps={<MarginPropTable collapsible />} />,
             },
             {
               id: 'message-item',
               title: 'MessageItem',
-              render: () => <MessagingItemPropTable id="message-item-prop-table" renderPanel={false} />,
+              render: () => <MessagingItemPropTable id="message-item-prop-table" />,
             },
             {
               id: 'message-link-item',
               title: 'MessageLinkItem',
-              render: () => <MessagingLinkItemPropTable id="message-link-item-prop-table" renderPanel={false} />,
+              render: () => <MessagingLinkItemPropTable id="message-link-item-prop-table" />,
             },
           ]}
         />

--- a/packages/docs/pages/modal.tsx
+++ b/packages/docs/pages/modal.tsx
@@ -121,7 +121,7 @@ const ModalPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <ModalPropTable renderPanel={false} />
+        <ModalPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="props">

--- a/packages/docs/pages/multi-select.tsx
+++ b/packages/docs/pages/multi-select.tsx
@@ -446,17 +446,17 @@ const MultiSelectPage = () => {
             {
               id: 'multi-select',
               title: 'MultiSelect',
-              render: () => <MultiSelectPropTable renderPanel={false} />,
+              render: () => <MultiSelectPropTable />,
             },
             {
               id: 'select-option',
               title: 'SelectOption',
-              render: () => <SelectOptionPropTable renderPanel={false} />,
+              render: () => <SelectOptionPropTable />,
             },
             {
               id: 'select-action',
               title: 'SelectAction',
-              render: () => <SelectActionPropTable renderPanel={false} />,
+              render: () => <SelectActionPropTable />,
             },
           ]}
         />

--- a/packages/docs/pages/padding.tsx
+++ b/packages/docs/pages/padding.tsx
@@ -68,7 +68,7 @@ const PaddingPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <PaddingPropTable renderPanel={false} />
+        <PaddingPropTable />
       </Panel>
     </>
   );

--- a/packages/docs/pages/pagination.tsx
+++ b/packages/docs/pages/pagination.tsx
@@ -69,7 +69,7 @@ const PaginationPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <PaginationPropTable inheritedProps={<MarginPropTable collapsible />} renderPanel={false} />
+        <PaginationPropTable inheritedProps={<MarginPropTable collapsible />} />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/panel.tsx
+++ b/packages/docs/pages/panel.tsx
@@ -48,7 +48,7 @@ const PanelPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <PanelPropTable inheritedProps={<MarginPropTable collapsible />} renderPanel={false} />
+        <PanelPropTable inheritedProps={<MarginPropTable collapsible />} />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/pill-tabs.tsx
+++ b/packages/docs/pages/pill-tabs.tsx
@@ -100,12 +100,12 @@ const PillTabsPage = () => {
             {
               id: 'pill-tabs',
               title: 'PillTabs',
-              render: () => <PillTabsPropTable renderPanel={false} />,
+              render: () => <PillTabsPropTable />,
             },
             {
               id: 'pill-tab-item',
               title: 'PillTabItem',
-              render: () => <PillTabItemPropTable id="pill-tabs-items-prop-table" renderPanel={false} />,
+              render: () => <PillTabItemPropTable id="pill-tabs-items-prop-table" />,
             },
           ]}
         />

--- a/packages/docs/pages/popover.tsx
+++ b/packages/docs/pages/popover.tsx
@@ -57,7 +57,6 @@ const PopoverPage = () => {
               <PaddingPropTable collapsible />
             </>
           }
-          renderPanel={false}
         />
       </Panel>
 

--- a/packages/docs/pages/progress-bar.tsx
+++ b/packages/docs/pages/progress-bar.tsx
@@ -79,7 +79,7 @@ const ProgressBarPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <ProgressBarPropTable renderPanel={false} />
+        <ProgressBarPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/progress-circle.tsx
+++ b/packages/docs/pages/progress-circle.tsx
@@ -79,7 +79,7 @@ const ProgressCirclePage = () => {
       </Panel>
 
       <Panel header="Props" headerId="pros">
-        <ProgressCirclePropTable renderPanel={false} />
+        <ProgressCirclePropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/radio.tsx
+++ b/packages/docs/pages/radio.tsx
@@ -183,17 +183,17 @@ const RadioPage = () => {
             {
               id: 'radio',
               title: 'Radio',
-              render: () => <RadioPropTable renderPanel={false} />,
+              render: () => <RadioPropTable />,
             },
             {
               id: 'radio-description',
               title: 'RadioDescription',
-              render: () => <RadioDescriptionPropTable renderPanel={false} />,
+              render: () => <RadioDescriptionPropTable />,
             },
             {
               id: 'radio-description-link',
               title: 'RadioDescriptionLink',
-              render: () => <RadioDescriptionLinkPropTable renderPanel={false} />,
+              render: () => <RadioDescriptionLinkPropTable />,
             },
           ]}
         />

--- a/packages/docs/pages/search.tsx
+++ b/packages/docs/pages/search.tsx
@@ -67,7 +67,7 @@ const SearchPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <SearchPropTable renderPanel={false} />
+        <SearchPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/select.tsx
+++ b/packages/docs/pages/select.tsx
@@ -448,22 +448,22 @@ const SelectPage = () => {
             {
               id: 'select',
               title: 'Select',
-              render: () => <SelectPropTable renderPanel={false} />,
+              render: () => <SelectPropTable />,
             },
             {
               id: 'select-option',
               title: 'SelectOption',
-              render: () => <SelectOptionPropTable renderPanel={false} />,
+              render: () => <SelectOptionPropTable />,
             },
             {
               id: 'select-action',
               title: 'SelectAction',
-              render: () => <SelectActionPropTable renderPanel={false} />,
+              render: () => <SelectActionPropTable />,
             },
             {
               id: 'select-group',
               title: 'SelectGroup',
-              render: () => <SelectGroupPropTable renderPanel={false} />,
+              render: () => <SelectGroupPropTable />,
             },
           ]}
         />

--- a/packages/docs/pages/statefulTable.tsx
+++ b/packages/docs/pages/statefulTable.tsx
@@ -288,21 +288,17 @@ const StatefulTablePage = () => {
             {
               id: 'stateful-table',
               title: 'StatefulTable',
-              render: () => <StatefulTablePropTable renderPanel={false} />,
+              render: () => <StatefulTablePropTable />,
             },
             {
               id: 'columns',
               title: 'Columns',
-              render: () => (
-                <StatefulTableColumnsPropTable id="stateful-table-columns-prop-table" renderPanel={false} />
-              ),
+              render: () => <StatefulTableColumnsPropTable id="stateful-table-columns-prop-table" />,
             },
             {
               id: 'filters',
               title: 'Filters',
-              render: () => (
-                <StatefulTableFiltersPropTable id="stateful-table-filters-prop-table" renderPanel={false} />
-              ),
+              render: () => <StatefulTableFiltersPropTable id="stateful-table-filters-prop-table" />,
             },
           ]}
         />

--- a/packages/docs/pages/statefulTree.tsx
+++ b/packages/docs/pages/statefulTree.tsx
@@ -154,12 +154,12 @@ const StatefulTreePage = () => {
             {
               id: 'stateful-tree',
               title: 'StatefulTree',
-              render: () => <StatefulTreePropTable renderPanel={false} />,
+              render: () => <StatefulTreePropTable />,
             },
             {
               id: 'tree-node',
               title: 'TreeNode',
-              render: () => <TreeNodePropTable id="tree-node-prop-table" renderPanel={false} />,
+              render: () => <TreeNodePropTable id="tree-node-prop-table" />,
             },
           ]}
         />

--- a/packages/docs/pages/stepper.tsx
+++ b/packages/docs/pages/stepper.tsx
@@ -48,7 +48,7 @@ const StepperPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <StepperPropTable renderPanel={false} />
+        <StepperPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/switch.tsx
+++ b/packages/docs/pages/switch.tsx
@@ -47,7 +47,7 @@ const SwitchPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <SwitchPropTable renderPanel={false} />
+        <SwitchPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/table.tsx
+++ b/packages/docs/pages/table.tsx
@@ -324,27 +324,27 @@ const TablePage = () => {
             {
               id: 'table',
               title: 'Table',
-              render: () => <TablePropTable renderPanel={false} />,
+              render: () => <TablePropTable />,
             },
             {
               id: 'columns',
               title: 'Columns',
-              render: () => <TableColumnsPropTable id="table-columns-prop-table" renderPanel={false} />,
+              render: () => <TableColumnsPropTable id="table-columns-prop-table" />,
             },
             {
               id: 'selectable',
               title: 'Selectable',
-              render: () => <TableSelectablePropTable id="table-selectable-prop-table" renderPanel={false} />,
+              render: () => <TableSelectablePropTable id="table-selectable-prop-table" />,
             },
             {
               id: 'sortable',
               title: 'Sortable',
-              render: () => <TableSortablePropTable id="table-sortable-prop-table" renderPanel={false} />,
+              render: () => <TableSortablePropTable id="table-sortable-prop-table" />,
             },
             {
               id: 'table-figure',
               title: 'TableFigure',
-              render: () => <TableFigurePropTable renderPanel={false} />,
+              render: () => <TableFigurePropTable />,
             },
           ]}
         />

--- a/packages/docs/pages/tabs.tsx
+++ b/packages/docs/pages/tabs.tsx
@@ -65,12 +65,12 @@ const TabsPage = () => {
             {
               id: 'tabs',
               title: 'Tabs',
-              render: () => <TabsPropTable renderPanel={false} />,
+              render: () => <TabsPropTable />,
             },
             {
               id: 'tab-item',
               title: 'TabItem',
-              render: () => <TabItemPropTable id="tab-item-prop-table" renderPanel={false} />,
+              render: () => <TabItemPropTable id="tab-item-prop-table" />,
             },
           ]}
         />

--- a/packages/docs/pages/textarea.tsx
+++ b/packages/docs/pages/textarea.tsx
@@ -142,7 +142,7 @@ const TextAreaPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <TextareaPropTable renderPanel={false} />
+        <TextareaPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/timepicker.tsx
+++ b/packages/docs/pages/timepicker.tsx
@@ -40,7 +40,7 @@ const TimepickerPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <TimepickerPropTable renderPanel={false} />
+        <TimepickerPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/tooltip.tsx
+++ b/packages/docs/pages/tooltip.tsx
@@ -115,7 +115,7 @@ const TooltipPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <TooltipPropTable renderPanel={false} />
+        <TooltipPropTable />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/typography.tsx
+++ b/packages/docs/pages/typography.tsx
@@ -164,7 +164,6 @@ const TypographyPage = () => {
                       <MarginPropTable collapsible />
                     </>
                   }
-                  renderPanel={false}
                 />
               ),
             },
@@ -179,14 +178,13 @@ const TypographyPage = () => {
                       <MarginPropTable collapsible />
                     </>
                   }
-                  renderPanel={false}
                 />
               ),
             },
             {
               id: 'hr',
               title: 'HR',
-              render: () => <HRPropTable inheritedProps={<MarginPropTable collapsible />} renderPanel={false} />,
+              render: () => <HRPropTable inheritedProps={<MarginPropTable collapsible />} />,
             },
           ]}
         />

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -629,59 +629,47 @@ const WorksheetPage = () => {
             {
               id: 'worksheet',
               title: 'Worksheet',
-              render: () => <WorksheetPropTable renderPanel={false} />,
+              render: () => <WorksheetPropTable />,
             },
             {
               id: 'text-column',
               title: 'TextColumn',
-              render: () => <WorksheetTextColumnPropTable id="worksheet-text-column-prop-table" renderPanel={false} />,
+              render: () => <WorksheetTextColumnPropTable id="worksheet-text-column-prop-table" />,
             },
             {
               id: 'number-column',
               title: 'NumberColumn',
-              render: () => (
-                <WorksheetNumberColumnPropTable id="worksheet-number-column-prop-table" renderPanel={false} />
-              ),
+              render: () => <WorksheetNumberColumnPropTable id="worksheet-number-column-prop-table" />,
             },
             {
               id: 'checkbox-column',
               title: 'CheckboxColumn',
-              render: () => (
-                <WorksheetCheckboxColumnPropTable id="worksheet-checkbox-column-prop-table" renderPanel={false} />
-              ),
+              render: () => <WorksheetCheckboxColumnPropTable id="worksheet-checkbox-column-prop-table" />,
             },
             {
               id: 'selectable-column',
               title: 'SelectableColumn',
-              render: () => (
-                <WorksheetSelectableColumnPropTable id="worksheet-selectable-column-prop-table" renderPanel={false} />
-              ),
+              render: () => <WorksheetSelectableColumnPropTable id="worksheet-selectable-column-prop-table" />,
             },
             {
               id: 'modal-column',
               title: 'ModalColumn',
-              render: () => (
-                <WorksheetModalColumnPropTable id="worksheet-modal-column-prop-table" renderPanel={false} />
-              ),
+              render: () => <WorksheetModalColumnPropTable id="worksheet-modal-column-prop-table" />,
             },
             {
               id: 'selectable-config',
               title: 'SelectableConfig',
-              render: () => (
-                <WorksheetSelectableConfigPropTable id="worksheet-selectable-config-prop-table" renderPanel={false} />
-              ),
+              render: () => <WorksheetSelectableConfigPropTable id="worksheet-selectable-config-prop-table" />,
             },
             {
               id: 'modal-config',
               title: 'ModalConfig',
-              render: () => (
-                <WorksheetModalConfigPropTable id="worksheet-modal-config-prop-table" renderPanel={false} />
-              ),
+              render: () => <WorksheetModalConfigPropTable id="worksheet-modal-config-prop-table" />,
             },
             {
               id: 'error',
               title: 'Error',
-              render: () => <WorksheetErrorPropTable id="worksheet-error-prop-table" renderPanel={false} />,
+              render: () => <WorksheetErrorPropTable id="worksheet-error-prop-table" />,
             },
           ]}
         />


### PR DESCRIPTION
## What/Why?

Removes the `renderPanel` prop for `PropTables`. This is no longer needed since we've converted all the pages necessary to the new layout.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

Went through all the pages an litmus tested that no `Panel` rendered in the prop tables.
