### PR TITLE
chore(docs): convert List to FC

### DIFF
--- a/packages/docs/components/List/List.tsx
+++ b/packages/docs/components/List/List.tsx
@@ -1,28 +1,32 @@
-import React, { PureComponent } from 'react';
+import React, { CSSProperties, ReactElement, ReactNode } from 'react';
 
 import { ListItem } from './Item';
 import { StyledOrderedList, StyledUnorderedList } from './styled';
 
 export interface ListProps {
+  as?: 'ul' | 'ol';
+  children: ReactNode;
   columnCount?: number;
   columnGap?: number | string;
-  ordered?: boolean;
-  bulleted?: boolean;
+  reset?: boolean;
+  style?: CSSProperties;
+  className?: string;
 }
 
-export class List extends PureComponent<ListProps> {
-  static defaultProps = {
-    columnCount: 1,
-    columnGap: 'normal',
-    ordered: false,
-    bulleted: true,
-  };
-  static Item = ListItem;
+export const List = ({
+  columnCount = 1,
+  columnGap = 'normal',
+  as = 'ul',
+  children,
+  ...props
+}: ListProps): ReactElement<ListProps> => {
+  const ElementType = as === 'ol' ? StyledOrderedList : StyledUnorderedList;
 
-  render() {
-    const { children, ordered } = this.props;
-    const ElementType = ordered ? StyledOrderedList : StyledUnorderedList;
+  return (
+    <ElementType columnCount={columnCount} columnGap={columnGap} {...props}>
+      {children}
+    </ElementType>
+  );
+};
 
-    return <ElementType {...this.props}>{children}</ElementType>;
-  }
-}
+List.Item = ListItem;

--- a/packages/docs/components/List/styled.tsx
+++ b/packages/docs/components/List/styled.tsx
@@ -13,14 +13,18 @@ const SharedListStyles = css<ListProps>`
     column-count: ${({ columnCount }) => columnCount};
     column-gap: ${({ columnGap }) => columnGap};
   }
+
+  ${({ reset, theme }) =>
+    reset &&
+    css`
+      ${theme.helpers.listReset};
+    `}
 `;
 
 export const StyledOrderedList = styled.ol<ListProps>`
   ${SharedListStyles};
-  list-style-type: ${({ bulleted }) => `${bulleted ? 'decimal' : 'none'}`};
 `;
 
 export const StyledUnorderedList = styled.ul<ListProps>`
   ${SharedListStyles}
-  list-style-type: ${({ bulleted }) => `${bulleted ? 'disc' : 'none'}`}
 `;

--- a/packages/docs/components/MethodList/MethodList.tsx
+++ b/packages/docs/components/MethodList/MethodList.tsx
@@ -37,7 +37,7 @@ export const MethodList: React.FC<MethodListProps> = ({ name, intro, usage, para
         <>
           <MethodBadge label="Parameters" />
 
-          <List bulleted={false}>
+          <List style={{ listStyleType: 'none' }}>
             {parameterList.map(({ param, description, required }, index) => (
               <List.Item key={index}>
                 <Text>

--- a/packages/docs/components/SideNav/SideNavGroup/SideNavGroup.tsx
+++ b/packages/docs/components/SideNav/SideNavGroup/SideNavGroup.tsx
@@ -1,19 +1,13 @@
 import { Box, H4 } from '@bigcommerce/big-design';
 import React from 'react';
-import styled from 'styled-components';
 
 import { List } from '../../List';
-
-const StyledList = styled(List)`
-  margin: ${({ theme }) => theme.spacing.none};
-  padding: ${({ theme }) => theme.spacing.none};
-`;
 
 export const SideNavGroup: React.FC<{ title: string }> = (props) => {
   return (
     <Box marginTop={{ mobile: 'xxSmall', tablet: 'xLarge' }} marginHorizontal={{ mobile: 'medium', tablet: 'none' }}>
       <H4>{props.title}</H4>
-      <StyledList bulleted={false}>{props.children}</StyledList>
+      <List reset>{props.children}</List>
     </Box>
   );
 };


### PR DESCRIPTION
## What?

Converts the local documentation `List` over to a Functional Component.

## Why?

To remove the need for `Pure/ClassComponents`.

## Screenshots/Screen Recordings
Used the `Alert` page, since the side nav + the alert manager functions used the `List` component.

![screencapture-localhost-3000-alert-2022-05-10-17_15_51](https://user-images.githubusercontent.com/10539418/167730677-fd8c8acb-2be7-4c52-b77a-726845730362.png)

## Testing/Proof

See screenshot.