### PR TITLE
chore(docs): change assetPath to basePath for links

### DIFF
--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -9,7 +9,7 @@ const URL_PREFIX = '/big-design';
 const examplesVersion = pkg.devDependencies['@bigcommerce/examples'].replace('^', '');
 
 module.exports = withTM({
-  assetPrefix: isProduction ? URL_PREFIX : '',
+  basePath: isProduction ? URL_PREFIX : '',
   env: {
     CODE_SANDBOX_URL: `https://codesandbox.io/s/github/bigcommerce/big-design/tree/%40bigcommerce/examples%40${examplesVersion}/packages/examples`,
     URL_PREFIX: isProduction ? URL_PREFIX : '',


### PR DESCRIPTION
## What?

Changes `assetPath` to `basePath` for links.

## Why?

<img width="701" alt="Screen Shot 2022-05-11 at 16 35 33" src="https://user-images.githubusercontent.com/10539418/167951974-a2d1283d-71fb-4547-bef3-f677187e50cb.png">

## Testing/Proof

Tested locally by providing `/big-design` on dev* mode.

<img width="2119" alt="Screen Shot 2022-05-11 at 16 40 35" src="https://user-images.githubusercontent.com/10539418/167952495-c4fbdc28-0819-44e5-bd17-d56718aff65b.png">

