### PR TITLE
feat(components): Add gap prop into Flex component and Grid component

### DIFF
--- a/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`render default (success) Alert 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -120,7 +120,7 @@ exports[`render error Alert 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -223,7 +223,7 @@ exports[`render info Alert 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -330,7 +330,7 @@ exports[`render warning Alert 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -555,7 +555,7 @@ exports[`renders close button 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -705,7 +705,7 @@ exports[`renders header 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -837,7 +837,7 @@ exports[`renders with external link 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -1012,7 +1012,7 @@ exports[`renders with link 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 

--- a/packages/big-design/src/components/Flex/spec.tsx
+++ b/packages/big-design/src/components/Flex/spec.tsx
@@ -17,6 +17,20 @@ test('has display flex', () => {
   expect(container.firstChild).toHaveStyle('display: flex');
 });
 
+test('has gap properties', () => {
+  const { container, rerender } = render(<Flex flexGap="3rem">Flex</Flex>);
+
+  expect(container.firstChild).toHaveStyle('gap: 3rem');
+
+  rerender(
+    <Flex flexRowGap="2rem" flexColumnGap="1rem">
+      Flex
+    </Flex>,
+  );
+
+  expect(container.firstChild).toHaveStyle({ 'row-gap': '2rem', 'column-gap': '1rem' });
+});
+
 test('forwards styles', () => {
   const { container } = render(
     <Flex className="test" style={{ background: 'red' }}>

--- a/packages/big-design/src/components/Flex/types.ts
+++ b/packages/big-design/src/components/Flex/types.ts
@@ -25,7 +25,21 @@ type AlignSelf = ResponsiveProp<
   'auto' | 'normal' | 'self-start' | 'self-end' | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
 >;
 
+type FlexBasis = ResponsiveProp<'auto' | 'fill' | 'min-content' | 'max-content' | 'fit-content' | 'content' | string>;
+
+type FlexColumnGap = ResponsiveProp<string>;
+
 type FlexDirection = ResponsiveProp<'row' | 'column' | 'row-reverse' | 'column-reverse'>;
+
+type FlexGap = ResponsiveProp<string>;
+
+type FlexGrow = ResponsiveProp<number>;
+
+type FlexOrder = ResponsiveProp<number>;
+
+type FlexRowGap = ResponsiveProp<string>;
+
+type FlexShrink = ResponsiveProp<number>;
 
 type FlexWrap = ResponsiveProp<'nowrap' | 'wrap' | 'wrap-reverse'>;
 
@@ -45,18 +59,13 @@ type JustifyContent = ResponsiveProp<
   | 'stretch'
 >;
 
-type FlexBasis = ResponsiveProp<'auto' | 'fill' | 'min-content' | 'max-content' | 'fit-content' | 'content' | string>;
-
-type FlexGrow = ResponsiveProp<number>;
-
-type FlexOrder = ResponsiveProp<number>;
-
-type FlexShrink = ResponsiveProp<number>;
-
 export type FlexedProps = Partial<{
   alignContent: AlignContent;
   alignItems: AlignItems;
+  flexColumnGap: FlexColumnGap;
   flexDirection: FlexDirection;
+  flexGap: FlexGap;
+  flexRowGap: FlexRowGap;
   flexWrap: FlexWrap;
   justifyContent: JustifyContent;
 }>;
@@ -72,7 +81,10 @@ export type FlexedItemProps = Partial<{
 export interface FlexedOverload {
   (flexedProp: AlignContent, theme: ThemeInterface, cssKey: 'align-content'): FlattenSimpleInterpolation;
   (flexedProp: AlignItems, theme: ThemeInterface, cssKey: 'align-items'): FlattenSimpleInterpolation;
+  (flexedProp: FlexColumnGap, theme: ThemeInterface, cssKey: 'column-gap'): FlattenSimpleInterpolation;
   (flexedProp: FlexDirection, theme: ThemeInterface, cssKey: 'flex-direction'): FlattenSimpleInterpolation;
+  (flexedProp: FlexGap, theme: ThemeInterface, cssKey: 'gap'): FlattenSimpleInterpolation;
+  (flexedProp: FlexRowGap, theme: ThemeInterface, cssKey: 'row-gap'): FlattenSimpleInterpolation;
   (flexedProp: FlexWrap, theme: ThemeInterface, cssKey: 'flex-wrap'): FlattenSimpleInterpolation;
   (flexedProp: JustifyContent, theme: ThemeInterface, cssKey: 'justify-content'): FlattenSimpleInterpolation;
   (flexedProp: AlignSelf, theme: ThemeInterface, cssKey: 'align-self'): FlattenSimpleInterpolation;

--- a/packages/big-design/src/components/Flex/withFlex.ts
+++ b/packages/big-design/src/components/Flex/withFlex.ts
@@ -7,6 +7,9 @@ export const withFlexedContainer = () => css<FlexedProps>`
   ${({ alignContent, theme }) => alignContent && getFlexedStyles(alignContent, theme, 'align-content')};
   ${({ alignItems, theme }) => alignItems && getFlexedStyles(alignItems, theme, 'align-items')};
   ${({ flexDirection, theme }) => flexDirection && getFlexedStyles(flexDirection, theme, 'flex-direction')};
+  ${({ flexGap, theme }) => flexGap && getFlexedStyles(flexGap, theme, 'gap')};
+  ${({ flexColumnGap, theme }) => flexColumnGap && getFlexedStyles(flexColumnGap, theme, 'column-gap')};
+  ${({ flexRowGap, theme }) => flexRowGap && getFlexedStyles(flexRowGap, theme, 'row-gap')};
   ${({ flexWrap, theme }) => flexWrap && getFlexedStyles(flexWrap, theme, 'flex-wrap')};
   ${({ justifyContent, theme }) => justifyContent && getFlexedStyles(justifyContent, theme, 'justify-content')};
 `;

--- a/packages/big-design/src/components/Grid/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Grid/__snapshots__/spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`render Grid 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   grid-template: "head head" 80px "nav  main" 1fr "nav  foot" 10% / 120px 1fr;
   display: grid;
 }

--- a/packages/big-design/src/components/Grid/spec.tsx
+++ b/packages/big-design/src/components/Grid/spec.tsx
@@ -33,6 +33,16 @@ test('has display grid', () => {
   expect(container.firstChild).toHaveStyle('display: grid');
 });
 
+test('has gap properties', () => {
+  const { container, rerender } = render(<Grid gridGap="3rem" />);
+
+  expect(container.firstChild).toHaveStyle('gap: 3rem');
+
+  rerender(<Grid gridColumnGap="1rem" gridRowGap="2rem" />);
+
+  expect(container.firstChild).toHaveStyle({ 'row-gap': '2rem', 'column-gap': '1rem' });
+});
+
 test('Grid forwards styles', () => {
   const { container } = render(<Grid className="test" style={{ background: 'red' }} />);
 

--- a/packages/big-design/src/components/Grid/types.ts
+++ b/packages/big-design/src/components/Grid/types.ts
@@ -15,6 +15,8 @@ type GridAutoRows = ResponsiveProp<string>;
 
 type GridColumns = ResponsiveProp<string>;
 
+type GridColumnGap = ResponsiveProp<string>;
+
 type GridGap = ResponsiveProp<string>;
 
 type GridRows = ResponsiveProp<string>;
@@ -33,6 +35,8 @@ type GridRow = ResponsiveProp<string>;
 
 type GridRowEnd = ResponsiveProp<string>;
 
+type GridRowGap = ResponsiveProp<string>;
+
 type GridRowStart = ResponsiveProp<string>;
 
 export type GridedProps = Partial<{
@@ -41,8 +45,10 @@ export type GridedProps = Partial<{
   gridAutoFlow: GridAutoFlow;
   gridAutoRows: GridAutoRows;
   gridColumns: GridColumns;
+  gridColumnGap: GridColumnGap;
   gridGap: GridGap;
   gridRows: GridRows;
+  gridRowGap: GridRowGap;
   gridTemplate: GridTemplate;
 }>;
 
@@ -62,8 +68,10 @@ export interface GridedOverload {
   (gridedProp: GridAutoFlow, theme: ThemeInterface, cssKey: 'grid-auto-flow'): FlattenSimpleInterpolation;
   (gridedProp: GridAutoRows, theme: ThemeInterface, cssKey: 'grid-auto-rows'): FlattenSimpleInterpolation;
   (gridedProp: GridColumns, theme: ThemeInterface, cssKey: 'grid-template-columns'): FlattenSimpleInterpolation;
-  (gridedProp: GridGap, theme: ThemeInterface, cssKey: 'grid-gap'): FlattenSimpleInterpolation;
+  (gridedPopr: GridColumnGap, theme: ThemeInterface, cssKey: 'column-gap'): FlattenSimpleInterpolation;
+  (gridedProp: GridGap, theme: ThemeInterface, cssKey: 'gap'): FlattenSimpleInterpolation;
   (gridedProp: GridRows, theme: ThemeInterface, cssKey: 'grid-template-rows'): FlattenSimpleInterpolation;
+  (gridedProp: GridRowGap, theme: ThemeInterface, cssKey: 'row-gap'): FlattenSimpleInterpolation;
   (gridedProp: GridTemplate, theme: ThemeInterface, cssKey: 'grid-template'): FlattenSimpleInterpolation;
   (gridedProp: GridArea, theme: ThemeInterface, cssKey: 'grid-area'): FlattenSimpleInterpolation;
   (gridedProp: GridColumn, theme: ThemeInterface, cssKey: 'grid-column'): FlattenSimpleInterpolation;

--- a/packages/big-design/src/components/Grid/withGrid.ts
+++ b/packages/big-design/src/components/Grid/withGrid.ts
@@ -9,8 +9,10 @@ export const withGridedContainer = () => css<GridedProps>`
   ${({ gridAutoFlow, theme }) => gridAutoFlow && getGridedStyles(gridAutoFlow, theme, 'grid-auto-flow')};
   ${({ gridAutoRows, theme }) => gridAutoRows && getGridedStyles(gridAutoRows, theme, 'grid-auto-rows')};
   ${({ gridColumns, theme }) => gridColumns && getGridedStyles(gridColumns, theme, 'grid-template-columns')};
-  ${({ gridGap, theme }) => gridGap && getGridedStyles(gridGap, theme, 'grid-gap')};
+  ${({ gridGap, theme }) => gridGap && getGridedStyles(gridGap, theme, 'gap')};
+  ${({ gridColumnGap, theme }) => gridColumnGap && getGridedStyles(gridColumnGap, theme, 'column-gap')};
   ${({ gridRows, theme }) => gridRows && getGridedStyles(gridRows, theme, 'grid-template-rows')};
+  ${({ gridRowGap, theme }) => gridRowGap && getGridedStyles(gridRowGap, theme, 'row-gap')};
   ${({ gridTemplate, theme }) => gridTemplate && getGridedStyles(gridTemplate, theme, 'grid-template')};
 `;
 

--- a/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
@@ -18,7 +18,7 @@ exports[`render default (success) InlineMessage 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -123,7 +123,7 @@ exports[`render error InlineMessage 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -224,7 +224,7 @@ exports[`render info InlineMessage 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -329,7 +329,7 @@ exports[`render warning InlineMessage 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -556,7 +556,7 @@ exports[`renders actions 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -824,7 +824,7 @@ exports[`renders close button 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -977,7 +977,7 @@ exports[`renders header 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -1108,7 +1108,7 @@ exports[`renders with external link 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -1281,7 +1281,7 @@ exports[`renders with link 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 

--- a/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
@@ -18,7 +18,7 @@ exports[`render default (success) Message 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -122,7 +122,7 @@ exports[`render error Message 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -222,7 +222,7 @@ exports[`render info Message 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -326,7 +326,7 @@ exports[`render warning Message 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -552,7 +552,7 @@ exports[`renders actions 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -819,7 +819,7 @@ exports[`renders close button 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -971,7 +971,7 @@ exports[`renders header 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -1100,7 +1100,7 @@ exports[`renders with external link 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
@@ -1272,7 +1272,7 @@ exports[`renders with link 1`] = `
 }
 
 .c1 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 

--- a/packages/big-design/src/components/Stepper/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Stepper/__snapshots__/spec.tsx.snap
@@ -97,12 +97,12 @@ exports[`renders Stepper 1`] = `
 }
 
 .c3 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 
 .c14 {
-  grid-gap: 1rem;
+  gap: 1rem;
   display: grid;
 }
 

--- a/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`renders simple tree 1`] = `
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iWqGEw styled__StyledFlex-sc-1073t7q-3 gKYrlH"
+      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1073t7q-3 gKYrlH"
     >
       <div
         class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 detsCw styled__StyledArrowWrapper-sc-1073t7q-1 gpgdOM"
@@ -81,7 +81,7 @@ exports[`renders simple tree 1`] = `
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iWqGEw styled__StyledFlex-sc-1073t7q-3 gKYrlH"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1073t7q-3 gKYrlH"
         >
           <div
             class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 detsCw styled__StyledArrowWrapper-sc-1073t7q-1 gpgdOM"
@@ -148,7 +148,7 @@ exports[`renders simple tree 1`] = `
             tabindex="-1"
           >
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iWqGEw styled__StyledFlex-sc-1073t7q-3 gKYrlH"
+              class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1073t7q-3 gKYrlH"
             >
               <div
                 class="styled__StyledGap-sc-1073t7q-5 cqwrlW"
@@ -195,7 +195,7 @@ exports[`renders simple tree 1`] = `
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iWqGEw styled__StyledFlex-sc-1073t7q-3 gKYrlH"
+      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1073t7q-3 gKYrlH"
     >
       <div
         class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 detsCw styled__StyledArrowWrapper-sc-1073t7q-1 gpgdOM"
@@ -262,7 +262,7 @@ exports[`renders simple tree 1`] = `
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iWqGEw styled__StyledFlex-sc-1073t7q-3 gKYrlH"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1073t7q-3 gKYrlH"
         >
           <div
             class="styled__StyledGap-sc-1073t7q-5 cqwrlW"
@@ -307,7 +307,7 @@ exports[`renders simple tree 1`] = `
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iWqGEw styled__StyledFlex-sc-1073t7q-3 gKYrlH"
+      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1073t7q-3 gKYrlH"
     >
       <div
         class="styled__StyledGap-sc-1073t7q-5 cqwrlW"
@@ -350,7 +350,7 @@ exports[`renders simple tree 1`] = `
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iWqGEw styled__StyledFlex-sc-1073t7q-3 gKYrlH"
+      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1073t7q-3 gKYrlH"
     >
       <div
         class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 detsCw styled__StyledArrowWrapper-sc-1073t7q-1 gpgdOM"
@@ -417,7 +417,7 @@ exports[`renders simple tree 1`] = `
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iWqGEw styled__StyledFlex-sc-1073t7q-3 gKYrlH"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1073t7q-3 gKYrlH"
         >
           <div
             class="styled__StyledGap-sc-1073t7q-5 cqwrlW"
@@ -462,7 +462,7 @@ exports[`renders simple tree 1`] = `
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iWqGEw styled__StyledFlex-sc-1073t7q-3 gKYrlH"
+      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1073t7q-3 gKYrlH"
     >
       <div
         class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 detsCw styled__StyledArrowWrapper-sc-1073t7q-1 gpgdOM"
@@ -529,7 +529,7 @@ exports[`renders simple tree 1`] = `
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iWqGEw styled__StyledFlex-sc-1073t7q-3 gKYrlH"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1073t7q-3 gKYrlH"
         >
           <div
             class="styled__StyledGap-sc-1073t7q-5 cqwrlW"

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -131,7 +131,7 @@ exports[`renders worksheet 1`] = `
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 jIatQO"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dOfHrm"
         >
           <div
             class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
@@ -261,7 +261,7 @@ exports[`renders worksheet 1`] = `
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 jIatQO"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dOfHrm"
         >
           <div
             class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
@@ -390,7 +390,7 @@ exports[`renders worksheet 1`] = `
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 jIatQO"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dOfHrm"
         >
           <div
             class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
@@ -520,7 +520,7 @@ exports[`renders worksheet 1`] = `
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 jIatQO"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dOfHrm"
         >
           <div
             class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
@@ -648,7 +648,7 @@ exports[`renders worksheet 1`] = `
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 jIatQO"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dOfHrm"
         >
           <div
             class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
@@ -778,7 +778,7 @@ exports[`renders worksheet 1`] = `
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 jIatQO"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dOfHrm"
         >
           <div
             class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
@@ -907,7 +907,7 @@ exports[`renders worksheet 1`] = `
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 jIatQO"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dOfHrm"
         >
           <div
             class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
@@ -1037,7 +1037,7 @@ exports[`renders worksheet 1`] = `
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 jIatQO"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dOfHrm"
         >
           <div
             class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
@@ -1167,7 +1167,7 @@ exports[`renders worksheet 1`] = `
         type="modal"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 jIatQO"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dOfHrm"
         >
           <div
             class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"

--- a/packages/docs/PropTables/FlexPropTable.tsx
+++ b/packages/docs/PropTables/FlexPropTable.tsx
@@ -26,12 +26,40 @@ const flexProps: Prop[] = [
     ),
   },
   {
+    name: 'flexColumnGap',
+    types: 'string',
+    description: (
+      <>
+        Sets the size of the gap between flex columns. Same as the <Code highlight={false}>column-gap</Code> CSS
+        property.
+      </>
+    ),
+  },
+  {
     name: 'flexDirection',
     types: ['row', 'column', 'row-reverse', 'column-reverse'],
     defaultValue: 'row',
     description: (
       <>
         Determines the direction of flex items. Same as the <Code highlight={false}>flex-direction</Code> CSS property.
+      </>
+    ),
+  },
+  {
+    name: 'flexGap',
+    types: 'string',
+    description: (
+      <>
+        Controls the spacing between flex items. Same as the <Code highlight={false}>gap</Code> CSS property.
+      </>
+    ),
+  },
+  {
+    name: 'flexRowGap',
+    types: 'string',
+    description: (
+      <>
+        Sets the size of the gap between flex rows. Same as the <Code highlight={false}>row-gap</Code> CSS property.
       </>
     ),
   },

--- a/packages/docs/PropTables/GridPropTable.tsx
+++ b/packages/docs/PropTables/GridPropTable.tsx
@@ -54,11 +54,21 @@ const gridProps: Prop[] = [
     ),
   },
   {
+    name: 'gridColumnGap',
+    types: 'string',
+    description: (
+      <>
+        Sets the size of the gap between grid columns. Same as the <Code highlight={false}>column-gap</Code> CSS
+        property.
+      </>
+    ),
+  },
+  {
     name: 'gridGap',
     types: 'string',
     description: (
       <>
-        Controls the spacing between grid items. Same as the <Code highlight={false}>grid-gap</Code> CSS property.
+        Controls the spacing between grid items. Same as the <Code highlight={false}>gap</Code> CSS property.
       </>
     ),
   },
@@ -69,6 +79,15 @@ const gridProps: Prop[] = [
       <>
         Defines the rows of the grid with a space-separated list of values. Same as the{' '}
         <Code highlight={false}>grid-template-rows</Code> CSS property.
+      </>
+    ),
+  },
+  {
+    name: 'gridRowGap',
+    types: 'string',
+    description: (
+      <>
+        Sets the size of the gap between grid rows. Same as the <Code highlight={false}>row-gap</Code> CSS property.
       </>
     ),
   },

--- a/packages/docs/pages/grid.tsx
+++ b/packages/docs/pages/grid.tsx
@@ -91,9 +91,9 @@ const GridPage = () => {
                     {/* jsx-to-string:start */}
                     {function Example() {
                       const template = `
-                      "head head" 80px
-                      "nav  main" 200px
-                      "foot  foot" 50px
+                      "head head" 5rem
+                      "nav  main" 12.5rem
+                      "foot  foot" 3.2rem
                       / 1fr 5fr;
                       `;
 


### PR DESCRIPTION
## What?
Expose the [gap](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) prop to Flex / Grid, including row-gap and column-gap. Also, update the corresponding documentation pages to let the users know about this new available props.

Props for Flex component:
- flexGap
- flexRowGap
- flexColumnGap

Props for Grid component:
- gridGap
- gridRowGap
- gridColumnGap

## Why?
This was a reported enhancement(Fixes #800). These new props are gonna help the user to easily apply spacing between items. 

## Screenshots/Screen Recordings
<table>
<tr>
	<td>Grid component
	<td>Flex component
<tr>
<tr>
       <td><video src= "https://user-images.githubusercontent.com/39739180/171470343-79fa321a-caf9-4fc0-8950-f2476f360a16.mp4"/>
	<td><video src= "https://user-images.githubusercontent.com/39739180/171470374-a8c24154-798c-49a4-82dd-87cd60d107ea.mp4" />
<tr>
<tr>
       <td><video src="https://user-images.githubusercontent.com/39739180/171470845-9da43b1c-1c70-4ccb-8f69-993a43f50c75.mp4" />
	<td><video src="https://user-images.githubusercontent.com/39739180/171470867-9117be02-62b9-4e32-94ee-d1096f686704.mp4" />
<tr>
<tr>
	<td><video src="https://user-images.githubusercontent.com/39739180/171471039-108a2fec-2c36-4af4-a5d4-77ff3695ed56.mp4" />
	<td><video src="https://user-images.githubusercontent.com/39739180/171471104-d6535475-264a-4b4c-86ed-32b13ba7e157.mp4" />
<tr>
</table>

## Testing/Proof
Run tests
Test locally
