### PR TITLE
fix(component): fix Worksheet onChange typings

### DIFF
--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -10,7 +10,7 @@ export interface WorksheetProps<Item extends WorksheetItem> {
   columns: Array<WorksheetColumn<Item>>;
   items: Item[];
   expandableRows?: ExpandableRows;
-  onChange(items: Array<Cell<Item>>): void;
+  onChange(items: Array<Item>): void;
   onErrors?(items: WorksheetError<Item>[]): void;
 }
 


### PR DESCRIPTION
## What?

Fix Worksheet onChange typings.

## Why?
Since the actual accepted items for `onChnage` has the `Array<Item>` interface, but not the `Array<Cell<Item>>`
## Screenshots/Screen Recordings
As we can see from the logs in the console. The changes have the same interface as the `items`.
<img width="1219" alt="Screenshot 2022-06-07 at 14 30 02" src="https://user-images.githubusercontent.com/84462142/172368997-d195ee77-5bd4-4742-8211-219e7f7382b6.png">


## Testing/Proof

Locally.
