### PR TITLE
chore(ci): Enabled type assertions lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,6 @@ module.exports = {
       files: ['**/*.ts', '**/*.tsx', '**/*.js'],
       rules: {
         '@bigcommerce/jsx-short-circuit-conditionals': 'off',
-        '@typescript-eslint/consistent-type-assertions': 'off',
         '@typescript-eslint/naming-convention': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',

--- a/packages/big-design/src/components/Alert/styled.ts
+++ b/packages/big-design/src/components/Alert/styled.ts
@@ -1,10 +1,11 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled, { css } from 'styled-components';
+import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
 
 import { getBorderStyle } from '../../utils';
 import { Grid } from '../Grid';
 import { Link } from '../Link';
 import { StyleableH4, StyleableSmall } from '../Typography/private';
+import { TextProps } from '../Typography/types';
 
 import { AlertProps } from './Alert';
 
@@ -41,7 +42,9 @@ export const StyledHeader = styled(StyleableH4)`
   margin-bottom: ${({ theme }) => theme.spacing.xxSmall};
 `;
 
-export const StyledMessageItem = styled(StyleableSmall).attrs({ as: 'span' })`
+export const StyledMessageItem = styled<StyledComponent<'span', DefaultTheme, Partial<TextProps>>>(
+  StyleableSmall,
+).attrs({ as: 'span' })`
   color: ${({ theme }) => theme.colors.secondary70};
   vertical-align: middle;
 `;

--- a/packages/big-design/src/components/Alert/styled.ts
+++ b/packages/big-design/src/components/Alert/styled.ts
@@ -1,10 +1,9 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { getBorderStyle } from '../../utils';
 import { Grid } from '../Grid';
 import { Link } from '../Link';
-import { TextProps } from '../Typography';
 import { StyleableH4, StyleableSmall } from '../Typography/private';
 
 import { AlertProps } from './Alert';
@@ -42,9 +41,7 @@ export const StyledHeader = styled(StyleableH4)`
   margin-bottom: ${({ theme }) => theme.spacing.xxSmall};
 `;
 
-export const StyledMessageItem: StyledComponent<'span', DefaultTheme, TextProps> = styled(
-  StyleableSmall,
-).attrs({ as: 'span' })`
+export const StyledMessageItem = styled(StyleableSmall).attrs({ as: 'span' })`
   color: ${({ theme }) => theme.colors.secondary70};
   vertical-align: middle;
 `;

--- a/packages/big-design/src/components/Alert/styled.ts
+++ b/packages/big-design/src/components/Alert/styled.ts
@@ -42,10 +42,12 @@ export const StyledHeader = styled(StyleableH4)`
   margin-bottom: ${({ theme }) => theme.spacing.xxSmall};
 `;
 
-export const StyledMessageItem = styled(StyleableSmall).attrs({ as: 'span' })`
+export const StyledMessageItem: StyledComponent<'span', DefaultTheme, TextProps> = styled(
+  StyleableSmall,
+).attrs({ as: 'span' })`
   color: ${({ theme }) => theme.colors.secondary70};
   vertical-align: middle;
-` as StyledComponent<'span', DefaultTheme, TextProps>;
+`;
 
 export const StyledLink = styled(Link)`
   font-size: ${({ theme }) => theme.typography.fontSize.small};

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -68,6 +68,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
 
     if (isValidElement(label) && label.type === CheckboxLabel) {
       return cloneElement(
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
         {
           hidden: hiddenLabel,
@@ -113,7 +114,8 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
               // RefObject.current is readonly in DefinitelyTyped
               // but in practice you can still write to it.
               // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
-              (forwardedRef as React.MutableRefObject<HTMLInputElement | null>).current = checkbox;
+              // @ts-expect-error Can still write
+              forwardedRef.current = checkbox;
             }
           }
         }}

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -67,15 +67,11 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
     }
 
     if (isValidElement(label) && label.type === CheckboxLabel) {
-      return cloneElement(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
-        {
-          hidden: hiddenLabel,
-          htmlFor: id,
-          id: labelId,
-        },
-      );
+      return cloneElement<React.LabelHTMLAttributes<HTMLLabelElement>>(label, {
+        hidden: hiddenLabel,
+        htmlFor: id,
+        id: labelId,
+      });
     }
 
     warning('label must be either a string or a CheckboxLabel component.');
@@ -114,7 +110,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
               // RefObject.current is readonly in DefinitelyTyped
               // but in practice you can still write to it.
               // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
-              // @ts-expect-error Can still write
+              // @ts-expect-error TODO look into useImperativeHandle
               forwardedRef.current = checkbox;
             }
           }

--- a/packages/big-design/src/components/Checkbox/Label/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/Label/styled.tsx
@@ -9,6 +9,7 @@ export interface StyledLabelProps extends React.LabelHTMLAttributes<HTMLLabelEle
   disabled?: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export const StyledLabel = styled(StyleableText).attrs({
   as: 'label',
 })<StyledLabelProps>`

--- a/packages/big-design/src/components/Checkbox/Label/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/Label/styled.tsx
@@ -3,14 +3,16 @@ import { hideVisually } from 'polished';
 import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
 
 import { StyleableText } from '../../Typography/private';
+import { TextProps } from '../../Typography/types';
 
 export interface StyledLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
   hidden?: boolean;
   disabled?: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-export const StyledLabel = styled(StyleableText).attrs({
+export const StyledLabel = styled<
+  StyledComponent<'label' | 'p', DefaultTheme, Partial<TextProps>> & StyledLabelProps
+>(StyleableText).attrs({
   as: 'label',
 })<StyledLabelProps>`
   cursor: pointer;
@@ -22,6 +24,6 @@ export const StyledLabel = styled(StyleableText).attrs({
     `}
 
   ${({ hidden }) => hidden && hideVisually()}
-` as StyledComponent<'label', DefaultTheme, StyledLabelProps>;
+`;
 
 StyledLabel.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Checkbox/spec.tsx
+++ b/packages/big-design/src/components/Checkbox/spec.tsx
@@ -1,7 +1,7 @@
 import React, { createRef } from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { warning } from '../../utils';
 
@@ -92,26 +92,24 @@ describe('render Checkbox', () => {
   });
 });
 
-test('has correct value for checked', () => {
-  const { getByTestId } = render(
-    <Checkbox checked={true} data-testid="checkbox" label="Checked" onChange={() => null} />,
-  );
-  const input = getByTestId('checkbox') as HTMLInputElement;
+test('has correct value for checked', async () => {
+  render(<Checkbox checked={true} data-testid="checkbox" label="Checked" onChange={() => null} />);
+
+  const input = await screen.findByTestId<HTMLInputElement>('checkbox');
 
   expect(input.checked).toBe(true);
 });
 
-test('has correct value for unchecked', () => {
-  const { getByTestId } = render(
-    <Checkbox checked={false} data-testid="checkbox" label="Checked" onChange={() => null} />,
-  );
-  const input = getByTestId('checkbox') as HTMLInputElement;
+test('has correct value for unchecked', async () => {
+  render(<Checkbox checked={false} data-testid="checkbox" label="Checked" onChange={() => null} />);
+
+  const input = await screen.findByTestId<HTMLInputElement>('checkbox');
 
   expect(input.checked).toBe(false);
 });
 
-test('has correct value for indeterminate', () => {
-  const { getByTestId } = render(
+test('has correct value for indeterminate', async () => {
+  render(
     <Checkbox
       checked={false}
       data-testid="checkbox"
@@ -120,17 +118,18 @@ test('has correct value for indeterminate', () => {
       onChange={() => null}
     />,
   );
-  const input = getByTestId('checkbox') as HTMLInputElement;
+
+  const input = await screen.findByTestId<HTMLInputElement>('checkbox');
 
   expect(input.checked).toBe(false);
 });
 
-test('triggers onChange when clicking the checkbox', () => {
+test('triggers onChange when clicking the checkbox', async () => {
   const onChange = jest.fn();
-  const { getByTestId } = render(
-    <Checkbox checked={true} data-testid="checkbox" label="Checked" onChange={onChange} />,
-  );
-  const checkbox = getByTestId('checkbox') as HTMLInputElement;
+
+  render(<Checkbox checked={true} data-testid="checkbox" label="Checked" onChange={onChange} />);
+
+  const checkbox = await screen.findByTestId<HTMLInputElement>('checkbox');
 
   fireEvent.click(checkbox);
 

--- a/packages/big-design/src/components/Counter/Counter.tsx
+++ b/packages/big-design/src/components/Counter/Counter.tsx
@@ -160,14 +160,10 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
       }
 
       if (isValidElement(label) && label.type === FormControlLabel) {
-        return cloneElement(
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
-          {
-            id: labelId,
-            htmlFor: id,
-          },
-        );
+        return cloneElement<React.LabelHTMLAttributes<HTMLLabelElement>>(label, {
+          id: labelId,
+          htmlFor: id,
+        });
       }
 
       warning('label must be either a string or a FormControlLabel component.');

--- a/packages/big-design/src/components/Counter/Counter.tsx
+++ b/packages/big-design/src/components/Counter/Counter.tsx
@@ -161,6 +161,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
 
       if (isValidElement(label) && label.type === FormControlLabel) {
         return cloneElement(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
           {
             id: labelId,

--- a/packages/big-design/src/components/Counter/spec.tsx
+++ b/packages/big-design/src/components/Counter/spec.tsx
@@ -1,7 +1,7 @@
 import React, { createRef, Ref } from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { FormControlDescription, FormControlError, FormControlLabel, FormGroup } from '../Form';
 
@@ -70,45 +70,41 @@ test('renders a counter with matched label', () => {
   expect(queryByLabelText('Test Label')).toBeInTheDocument();
 });
 
-test('create unique ids if not provided', () => {
-  const { queryByTestId } = render(
+test('create unique ids if not provided', async () => {
+  render(
     <>
       {counterMock({ dataTestId: 'item1', label: 'Test Label', ...requiredAttributes })}
       {counterMock({ dataTestId: 'item2', label: 'Test Label', ...requiredAttributes })}
     </>,
   );
 
-  const item1 = queryByTestId('item1') as HTMLInputElement;
-  const item2 = queryByTestId('item2') as HTMLInputElement;
+  const [item1, item2] = await screen.findAllByLabelText<HTMLInputElement>('Test Label');
 
   expect(item1).toBeDefined();
   expect(item2).toBeDefined();
   expect(item1.id).not.toBe(item2.id);
 });
 
-test('respects provided id', () => {
-  const { container } = render(
-    counterMock({ id: 'test', label: 'Test Label', ...requiredAttributes }),
-  );
-  const counter = container.querySelector('#test') as HTMLInputElement;
+test('respects provided id', async () => {
+  render(counterMock({ id: 'test', label: 'Test Label', ...requiredAttributes }));
+
+  const counter = await screen.findByLabelText('Test Label');
 
   expect(counter.id).toBe('test');
 });
 
-test('matches label htmlFor with id provided', () => {
-  const { container } = render(
-    counterMock({ id: 'test', label: 'Test Label', ...requiredAttributes }),
-  );
-  const label = container.querySelector('label') as HTMLLabelElement;
+test('matches label htmlFor with id provided', async () => {
+  render(counterMock({ id: 'test', label: 'Test Label', ...requiredAttributes }));
+
+  const label = await screen.findByText<HTMLLabelElement>('Test Label');
 
   expect(label.htmlFor).toBe('test');
 });
 
-test('respects provided labelId', () => {
-  const { container } = render(
-    counterMock({ label: 'Test Label', labelId: 'test', ...requiredAttributes }),
-  );
-  const label = container.querySelector('#test') as HTMLLabelElement;
+test('respects provided labelId', async () => {
+  render(counterMock({ label: 'Test Label', labelId: 'test', ...requiredAttributes }));
+
+  const label = await screen.findByText<HTMLLabelElement>('Test Label');
 
   expect(label.id).toBe('test');
 });
@@ -261,10 +257,10 @@ test('value prop only accepts whole numbers', () => {
   expect(handleChange).toHaveBeenCalledWith(2);
 });
 
-test('value increases when increase or decrease icons are clicked', () => {
-  const { getByDisplayValue, container } = render(counterMock(requiredAttributes));
+test('value increases when increase or decrease icons are clicked', async () => {
+  const { container } = render(counterMock(requiredAttributes));
 
-  const counter = getByDisplayValue('5') as HTMLInputElement;
+  const counter = await screen.findByDisplayValue<HTMLInputElement>('5');
 
   const icons = container.getElementsByTagName('svg');
 
@@ -280,9 +276,9 @@ test('value increases when increase or decrease icons are clicked', () => {
 });
 
 test('value increases and decreases with arrow keypresses', () => {
-  const { getByDisplayValue } = render(counterMock(requiredAttributes));
+  render(counterMock(requiredAttributes));
 
-  const counter = getByDisplayValue('5') as HTMLInputElement;
+  const counter = screen.getByDisplayValue<HTMLInputElement>('5');
 
   counter.focus();
 

--- a/packages/big-design/src/components/Datepicker/spec.tsx
+++ b/packages/big-design/src/components/Datepicker/spec.tsx
@@ -3,7 +3,6 @@ import 'jest-styled-components';
 import userEvent from '@testing-library/user-event';
 import React, { createRef } from 'react';
 import type { ReactDatePicker } from 'react-datepicker';
-import { act } from 'react-dom/test-utils';
 
 import { fireEvent, render, screen, waitFor } from '@test/utils';
 
@@ -44,11 +43,7 @@ test('calls onDateChange function when a date cell is clicked', async () => {
 
   const cell = await screen.findByRole('option', { current: 'date' });
 
-  await act(async () => {
-    if (cell) {
-      await waitFor(() => fireEvent.click(cell));
-    }
-  });
+  await userEvent.click(cell);
 
   expect(changeFunction).toHaveBeenCalled();
 });

--- a/packages/big-design/src/components/Datepicker/spec.tsx
+++ b/packages/big-design/src/components/Datepicker/spec.tsx
@@ -4,25 +4,27 @@ import React, { createRef } from 'react';
 import type { ReactDatePicker } from 'react-datepicker';
 import { act } from 'react-dom/test-utils';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, waitFor } from '@test/utils';
 
 import { FormGroup } from '..';
 
 import { Datepicker } from './index';
 
-test('should use the passed in ref object if provided', () => {
+test('should use the passed in ref object if provided', async () => {
   const ref = createRef<ReactDatePicker>();
   const { container } = render(<Datepicker onDateChange={jest.fn()} ref={ref} />);
 
   const input = container.querySelector('input');
 
-  fireEvent.click(input as HTMLInputElement);
+  if (input) {
+    await waitFor(() => fireEvent.click(input));
+  }
 
   const datepicker = container.querySelector('.react-datepicker');
+  const refClassname =
+    ref.current && ref.current.props.calendarClassName ? ref.current.props.calendarClassName : '';
 
-  expect(
-    datepicker?.className.includes(ref.current?.props.calendarClassName as string),
-  ).toBeTruthy();
+  expect(datepicker?.className.includes(refClassname)).toBeTruthy();
 });
 
 test('renders select label', () => {
@@ -33,36 +35,44 @@ test('renders select label', () => {
   expect(getByText('test')).toBeInTheDocument();
 });
 
-test('calls onDateChange function when a date cell is clicked', () => {
+test('calls onDateChange function when a date cell is clicked', async () => {
   const changeFunction = jest.fn();
   const { container } = render(<Datepicker onDateChange={changeFunction} />);
 
   const input = container.querySelector('input');
 
-  fireEvent.click(input as HTMLInputElement);
+  if (input) {
+    await waitFor(() => fireEvent.click(input));
+  }
 
   const datepicker = container.querySelector('.react-datepicker');
 
   const cell = datepicker?.querySelector('.react-datepicker__day--today');
 
-  act(() => {
-    fireEvent.click(cell as HTMLElement);
+  await act(async () => {
+    if (cell) {
+      await waitFor(() => fireEvent.click(cell));
+    }
   });
 
   expect(changeFunction).toHaveBeenCalled();
 });
 
-test('no error when input date value manually', () => {
+test('no error when input date value manually', async () => {
   const changeFunction = jest.fn();
   const { container } = render(<Datepicker onDateChange={changeFunction} />);
 
   const dateString = 'Wed, 03 June, 2020';
   const input = container.querySelector('input');
 
-  fireEvent.input(input as HTMLInputElement, {
-    target: {
-      value: dateString,
-    },
+  await waitFor(() => {
+    if (input) {
+      fireEvent.input(input, {
+        target: {
+          value: dateString,
+        },
+      });
+    }
   });
 
   expect(changeFunction).not.toHaveBeenCalled();
@@ -86,7 +96,7 @@ test('appends (optional) text to label if select is not required', () => {
   expect(label).toHaveStyleRule('content', "' (optional)'", { modifier: '::after' });
 });
 
-test('dates before minimum date passed are disabled', () => {
+test('dates before minimum date passed are disabled', async () => {
   const selectedDate = '2020/1/5';
   const minimumDate = '2020/1/4';
   const { container } = render(
@@ -94,14 +104,16 @@ test('dates before minimum date passed are disabled', () => {
   );
   const input = container.querySelector('input');
 
-  fireEvent.click(input as HTMLInputElement);
+  if (input) {
+    await waitFor(() => fireEvent.click(input));
+  }
 
   const disabledDate = container.querySelector('.react-datepicker__day--003');
 
   expect(disabledDate?.classList.contains('react-datepicker__day--disabled')).toBe(true);
 });
 
-test('dates after max date passed are disabled', () => {
+test('dates after max date passed are disabled', async () => {
   const selectedDate = '2020/1/5';
   const maximumDate = '2020/1/10';
   const { container } = render(
@@ -109,7 +121,9 @@ test('dates after max date passed are disabled', () => {
   );
   const input = container.querySelector('input');
 
-  fireEvent.click(input as HTMLInputElement);
+  if (input) {
+    await waitFor(() => fireEvent.click(input));
+  }
 
   const disabledDate = container.querySelector('.react-datepicker__day--011');
 

--- a/packages/big-design/src/components/Datepicker/spec.tsx
+++ b/packages/big-design/src/components/Datepicker/spec.tsx
@@ -35,15 +35,14 @@ test('renders select label', () => {
 
 test('calls onDateChange function when a date cell is clicked', async () => {
   const changeFunction = jest.fn();
-  const { container } = render(<Datepicker onDateChange={changeFunction} />);
+
+  render(<Datepicker onDateChange={changeFunction} />);
 
   const input = await screen.findByRole('textbox');
 
   await userEvent.click(input);
 
-  const datepicker = container.querySelector('.react-datepicker');
-
-  const cell = datepicker?.querySelector('.react-datepicker__day--today');
+  const cell = await screen.findByRole('option', { current: 'date' });
 
   await act(async () => {
     if (cell) {

--- a/packages/big-design/src/components/Datepicker/spec.tsx
+++ b/packages/big-design/src/components/Datepicker/spec.tsx
@@ -1,10 +1,11 @@
 import 'jest-styled-components';
 
+import userEvent from '@testing-library/user-event';
 import React, { createRef } from 'react';
 import type { ReactDatePicker } from 'react-datepicker';
 import { act } from 'react-dom/test-utils';
 
-import { fireEvent, render, waitFor } from '@test/utils';
+import { fireEvent, render, screen, waitFor } from '@test/utils';
 
 import { FormGroup } from '..';
 
@@ -14,15 +15,12 @@ test('should use the passed in ref object if provided', async () => {
   const ref = createRef<ReactDatePicker>();
   const { container } = render(<Datepicker onDateChange={jest.fn()} ref={ref} />);
 
-  const input = container.querySelector('input');
+  const input = await screen.findByRole('textbox');
 
-  if (input) {
-    await waitFor(() => fireEvent.click(input));
-  }
+  await userEvent.click(input);
 
   const datepicker = container.querySelector('.react-datepicker');
-  const refClassname =
-    ref.current && ref.current.props.calendarClassName ? ref.current.props.calendarClassName : '';
+  const refClassname = ref?.current?.props?.calendarClassName ?? '';
 
   expect(datepicker?.className.includes(refClassname)).toBeTruthy();
 });
@@ -39,11 +37,9 @@ test('calls onDateChange function when a date cell is clicked', async () => {
   const changeFunction = jest.fn();
   const { container } = render(<Datepicker onDateChange={changeFunction} />);
 
-  const input = container.querySelector('input');
+  const input = await screen.findByRole('textbox');
 
-  if (input) {
-    await waitFor(() => fireEvent.click(input));
-  }
+  await userEvent.click(input);
 
   const datepicker = container.querySelector('.react-datepicker');
 
@@ -60,19 +56,19 @@ test('calls onDateChange function when a date cell is clicked', async () => {
 
 test('no error when input date value manually', async () => {
   const changeFunction = jest.fn();
-  const { container } = render(<Datepicker onDateChange={changeFunction} />);
+
+  render(<Datepicker onDateChange={changeFunction} />);
 
   const dateString = 'Wed, 03 June, 2020';
-  const input = container.querySelector('input');
+
+  const input = await screen.findByRole('textbox');
 
   await waitFor(() => {
-    if (input) {
-      fireEvent.input(input, {
-        target: {
-          value: dateString,
-        },
-      });
-    }
+    fireEvent.input(input, {
+      target: {
+        value: dateString,
+      },
+    });
   });
 
   expect(changeFunction).not.toHaveBeenCalled();
@@ -102,11 +98,9 @@ test('dates before minimum date passed are disabled', async () => {
   const { container } = render(
     <Datepicker label="label" min={minimumDate} onDateChange={jest.fn()} value={selectedDate} />,
   );
-  const input = container.querySelector('input');
+  const input = await screen.findByRole('textbox');
 
-  if (input) {
-    await waitFor(() => fireEvent.click(input));
-  }
+  await userEvent.click(input);
 
   const disabledDate = container.querySelector('.react-datepicker__day--003');
 
@@ -119,11 +113,9 @@ test('dates after max date passed are disabled', async () => {
   const { container } = render(
     <Datepicker label="label" max={maximumDate} onDateChange={jest.fn()} value={selectedDate} />,
   );
-  const input = container.querySelector('input');
+  const input = await screen.findByRole('textbox');
 
-  if (input) {
-    await waitFor(() => fireEvent.click(input));
-  }
+  await userEvent.click(input);
 
   const disabledDate = container.querySelector('.react-datepicker__day--011');
 

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -645,7 +645,11 @@ test('rendered line separators cannot be focused on', async () => {
   const list = await screen.findByRole('listbox');
   const hrListItems = list.querySelectorAll('hr');
 
-  fireEvent.mouseOver(hrListItems[0].parentElement as HTMLElement);
+  if (hrListItems.length && hrListItems[0].parentElement) {
+    const el: HTMLElement = hrListItems[0].parentElement;
+
+    fireEvent.mouseOver(el);
+  }
 
   expect(document.activeElement).not.toEqual(hrListItems[0].parentElement);
 });

--- a/packages/big-design/src/components/Fieldset/Legend/styled.tsx
+++ b/packages/big-design/src/components/Fieldset/Legend/styled.tsx
@@ -2,12 +2,14 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { DefaultTheme, StyledComponent } from 'styled-components';
 
 import { StyleableH4 } from '../../Typography/private';
+import { HeadingProps } from '../../Typography/types';
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-export const StyledFieldsetLegend = styled(StyleableH4).attrs({ as: 'legend' })`
+export const StyledFieldsetLegend = styled<
+  StyledComponent<'legend' | 'h4', DefaultTheme, Partial<HeadingProps>>
+>(StyleableH4).attrs({ as: 'legend' })`
   &:not(:last-child) {
     margin-bottom: ${({ theme }) => theme.spacing.xxSmall};
   }
-` as StyledComponent<'legend', DefaultTheme>;
+`;
 
 StyledFieldsetLegend.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Fieldset/Legend/styled.tsx
+++ b/packages/big-design/src/components/Fieldset/Legend/styled.tsx
@@ -3,6 +3,7 @@ import styled, { DefaultTheme, StyledComponent } from 'styled-components';
 
 import { StyleableH4 } from '../../Typography/private';
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export const StyledFieldsetLegend = styled(StyleableH4).attrs({ as: 'legend' })`
   &:not(:last-child) {
     margin-bottom: ${({ theme }) => theme.spacing.xxSmall};

--- a/packages/big-design/src/components/Fieldset/spec.tsx
+++ b/packages/big-design/src/components/Fieldset/spec.tsx
@@ -19,7 +19,7 @@ test('renders a fieldset tag', () => {
 test('renders legend', () => {
   const legendText = 'legend text';
   const { container } = render(<Fieldset legend={legendText} />);
-  const legend = container.querySelector('legend') as HTMLLegendElement;
+  const legend = container.querySelector('legend');
 
   expect(legend).toBeInTheDocument();
 });

--- a/packages/big-design/src/components/Flex/withFlex.ts
+++ b/packages/big-design/src/components/Flex/withFlex.ts
@@ -52,17 +52,20 @@ const getSimpleFlex = (
   ${cssKey}: ${flexedProp}
 `;
 
-const getResponsiveFlex: FlexedOverload = (
+const getResponsiveFlex = (
   flexedProp: any,
   theme: ThemeInterface,
   cssKey: string,
 ): FlattenSimpleInterpolation[] => {
   const breakpointKeys = Object.keys(flexedProp).sort(
     (firstBreakpoint, secondBreakpoint) =>
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       breakpointsOrder.indexOf(firstBreakpoint as keyof Breakpoints) -
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       breakpointsOrder.indexOf(secondBreakpoint as keyof Breakpoints),
   );
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return (breakpointKeys as Array<keyof Breakpoints>).map(
     (breakpointKey) =>
       css`

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -5,6 +5,7 @@ import { StyleableH4 } from '../../Typography/private';
 
 import { LabelProps } from './Label';
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export const StyledLabel = styled(StyleableH4).attrs({
   as: 'label',
 })<LabelProps>`

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -2,11 +2,13 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
 
 import { StyleableH4 } from '../../Typography/private';
+import { HeadingProps } from '../../Typography/types';
 
 import { LabelProps } from './Label';
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-export const StyledLabel = styled(StyleableH4).attrs({
+export const StyledLabel = styled<
+  StyledComponent<'label' | 'h4', DefaultTheme, Partial<HeadingProps>> & LabelProps
+>(StyleableH4).attrs({
   as: 'label',
 })<LabelProps>`
   cursor: pointer;
@@ -22,6 +24,6 @@ export const StyledLabel = styled(StyleableH4).attrs({
         font-weight: ${theme.typography.fontWeight.regular};
       }
     `}
-` as StyledComponent<'label', DefaultTheme>;
+`;
 
 StyledLabel.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Form/spec.tsx
+++ b/packages/big-design/src/components/Form/spec.tsx
@@ -1,7 +1,7 @@
 import React, { createRef } from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render, waitFor } from '@test/utils';
+import { fireEvent, render, screen, waitFor } from '@test/utils';
 
 import { Fieldset } from '../Fieldset';
 import { Input } from '../Input';
@@ -19,12 +19,12 @@ test('forwards ref', () => {
 
 test('calls onSubmit', async () => {
   const onSubmit = jest.fn();
-  const { container } = render(<Form onSubmit={onSubmit} />);
-  const form = container.querySelector('form');
 
-  if (form) {
-    await waitFor(() => fireEvent.submit(form));
-  }
+  render(<Form name="testForm" onSubmit={onSubmit} />);
+
+  const form = await screen.findByRole('form');
+
+  await waitFor(() => fireEvent.submit(form));
 
   expect(onSubmit).toHaveBeenCalled();
 });

--- a/packages/big-design/src/components/Form/spec.tsx
+++ b/packages/big-design/src/components/Form/spec.tsx
@@ -1,7 +1,7 @@
 import React, { createRef } from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, waitFor } from '@test/utils';
 
 import { Fieldset } from '../Fieldset';
 import { Input } from '../Input';
@@ -17,12 +17,14 @@ test('forwards ref', () => {
   expect(form).toBe(ref.current);
 });
 
-test('calls onSubmit', () => {
+test('calls onSubmit', async () => {
   const onSubmit = jest.fn();
   const { container } = render(<Form onSubmit={onSubmit} />);
-  const form = container.querySelector('form') as HTMLFormElement;
+  const form = container.querySelector('form');
 
-  fireEvent.submit(form);
+  if (form) {
+    await waitFor(() => fireEvent.submit(form));
+  }
 
   expect(onSubmit).toHaveBeenCalled();
 });

--- a/packages/big-design/src/components/Grid/withGrid.ts
+++ b/packages/big-design/src/components/Grid/withGrid.ts
@@ -66,10 +66,13 @@ const getResponsiveGrid: GridedOverload = (
 ): FlattenSimpleInterpolation[] => {
   const breakpointKeys = Object.keys(gridedProp).sort(
     (firstBreakpoint, secondBreakpoint) =>
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       breakpointsOrder.indexOf(firstBreakpoint as keyof Breakpoints) -
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       breakpointsOrder.indexOf(secondBreakpoint as keyof Breakpoints),
   );
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return (breakpointKeys as Array<keyof Breakpoints>).map(
     (breakpointKey) =>
       css`

--- a/packages/big-design/src/components/Grid/withGrid.ts
+++ b/packages/big-design/src/components/Grid/withGrid.ts
@@ -59,7 +59,7 @@ const getSimpleGrid = (
   ${cssKey}: ${gridedProp}
 `;
 
-const getResponsiveGrid: GridedOverload = (
+const getResponsiveGrid = (
   gridedProp: any,
   theme: ThemeInterface,
   cssKey: string,

--- a/packages/big-design/src/components/InlineMessage/spec.tsx
+++ b/packages/big-design/src/components/InlineMessage/spec.tsx
@@ -2,7 +2,7 @@ import { theme } from '@bigcommerce/big-design-theme';
 import React from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { InlineMessage, InlineMessageProps } from './InlineMessage';
 
@@ -52,21 +52,21 @@ test('render info InlineMessage', () => {
   );
 });
 
-test('renders with link', () => {
-  const { queryByRole, container } = render(
+test('renders with link', async () => {
+  const { container } = render(
     <InlineMessage messages={[{ text: 'Success', link: { text: 'Link', href: '#' } }]} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
 
-  const link = queryByRole('link') as HTMLAnchorElement;
+  const link = await screen.findByRole<HTMLAnchorElement>('link');
 
   expect(link).toBeInTheDocument();
   expect(link.href).toBe('http://localhost/#');
 });
 
-test('renders with external link', () => {
-  const { queryByRole, container } = render(
+test('renders with external link', async () => {
+  const { container } = render(
     <InlineMessage
       messages={[
         { text: 'Success', link: { text: 'Link', href: '#', external: true, target: '_blank' } },
@@ -76,7 +76,7 @@ test('renders with external link', () => {
 
   expect(container.firstChild).toMatchSnapshot();
 
-  const link = queryByRole('link') as HTMLAnchorElement;
+  const link = await screen.findByRole<HTMLAnchorElement>('link');
 
   expect(link).toBeInTheDocument();
   expect(link.href).toBe('http://localhost/#');
@@ -102,11 +102,12 @@ test('renders close button', () => {
   expect(queryByRole('button')).toBeDefined();
 });
 
-test('trigger onClose', () => {
+test('trigger onClose', async () => {
   const fn = jest.fn();
-  const { queryByRole } = render(<InlineMessage messages={[{ text: 'Success' }]} onClose={fn} />);
 
-  const button = queryByRole('button') as HTMLButtonElement;
+  render(<InlineMessage messages={[{ text: 'Success' }]} onClose={fn} />);
+
+  const button = await screen.findByRole<HTMLButtonElement>('button');
 
   fireEvent.click(button);
 
@@ -128,16 +129,13 @@ test('does not forward styles', () => {
 
 test('renders actions', () => {
   const onClick = jest.fn();
-  const actions = [
+  const actions: InlineMessageProps['actions'] = [
     { text: 'First Action', onClick },
-    { text: 'Second Action', variant: 'primary', onClick },
+    { text: 'Second Action', variant: 'secondary', onClick },
   ];
 
   const { container, getByRole } = render(
-    <InlineMessage
-      actions={actions as InlineMessageProps['actions']}
-      messages={[{ text: 'Success' }]}
-    />,
+    <InlineMessage actions={actions} messages={[{ text: 'Success' }]} />,
   );
   const firstAction = getByRole('button', { name: 'First Action' });
   const secondAction = getByRole('button', { name: 'Second Action' });

--- a/packages/big-design/src/components/InlineMessage/styled.ts
+++ b/packages/big-design/src/components/InlineMessage/styled.ts
@@ -38,6 +38,7 @@ export const StyledHeader = styled(StyleableH4)`
   margin-bottom: ${({ theme }) => theme.spacing.none};
 `;
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export const StyledMessageItem = styled(StyleableSmall).attrs({ as: 'span' })`
   color: ${({ theme }) => theme.colors.secondary70};
   vertical-align: middle;

--- a/packages/big-design/src/components/InlineMessage/styled.ts
+++ b/packages/big-design/src/components/InlineMessage/styled.ts
@@ -38,11 +38,12 @@ export const StyledHeader = styled(StyleableH4)`
   margin-bottom: ${({ theme }) => theme.spacing.none};
 `;
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-export const StyledMessageItem = styled(StyleableSmall).attrs({ as: 'span' })`
+export const StyledMessageItem = styled<StyledComponent<'span', DefaultTheme, Partial<TextProps>>>(
+  StyleableSmall,
+).attrs({ as: 'span' })`
   color: ${({ theme }) => theme.colors.secondary70};
   vertical-align: middle;
-` as StyledComponent<'span', DefaultTheme, TextProps>;
+`;
 
 export const StyledLink = styled(Link)`
   font-size: ${({ theme }) => theme.typography.fontSize.small};

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -70,6 +70,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
 
     if (isValidElement(label) && label.type === FormControlLabel) {
       return cloneElement(
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
         {
           id: labelId,

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -69,14 +69,10 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
     }
 
     if (isValidElement(label) && label.type === FormControlLabel) {
-      return cloneElement(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
-        {
-          id: labelId,
-          htmlFor: id,
-        },
-      );
+      return cloneElement<React.LabelHTMLAttributes<HTMLLabelElement>>(label, {
+        id: labelId,
+        htmlFor: id,
+      });
     }
 
     warning('label must be either a string or a FormControlLabel component.');

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -3,7 +3,7 @@ import { theme } from '@bigcommerce/big-design-theme';
 import React, { createRef } from 'react';
 import 'jest-styled-components';
 
-import { render } from '@test/utils';
+import { render, screen } from '@test/utils';
 
 import { warning } from '../../utils';
 import { FormControlDescription, FormControlError, FormControlLabel, FormGroup } from '../Form';
@@ -34,39 +34,42 @@ test('renders an input with matched label', () => {
   expect(queryByLabelText('Test Label')).toBeInTheDocument();
 });
 
-test('create unique ids if not provided', () => {
-  const { queryByTestId } = render(
+test('create unique ids if not provided', async () => {
+  render(
     <>
       <Input data-testid="item1" label="Test Label" />
       <Input data-testid="item2" label="Test Label" />
     </>,
   );
 
-  const item1 = queryByTestId('item1') as HTMLInputElement;
-  const item2 = queryByTestId('item2') as HTMLInputElement;
+  const item1 = await screen.findByTestId('item1');
+  const item2 = await screen.findByTestId('item2');
 
   expect(item1).toBeDefined();
   expect(item2).toBeDefined();
   expect(item1.id).not.toBe(item2.id);
 });
 
-test('respects provided id', () => {
-  const { container } = render(<Input id="test" label="Test Label" />);
-  const input = container.querySelector('#test') as HTMLInputElement;
+test('respects provided id', async () => {
+  render(<Input data-testid="test-input" id="test" label="Test Label" />);
+
+  const input = await screen.findByTestId<HTMLInputElement>('test-input');
 
   expect(input.id).toBe('test');
 });
 
-test('matches label htmlFor with id provided', () => {
-  const { container } = render(<Input id="test" label="Test Label" />);
-  const label = container.querySelector('label') as HTMLLabelElement;
+test('matches label htmlFor with id provided', async () => {
+  render(<Input id="test" label="Test Label" />);
+
+  const label = await screen.findByText<HTMLLabelElement>('Test Label');
 
   expect(label.htmlFor).toBe('test');
 });
 
-test('respects provided labelId', () => {
-  const { container } = render(<Input label="Test Label" labelId="test" />);
-  const label = container.querySelector('#test') as HTMLLabelElement;
+test('respects provided labelId', async () => {
+  render(<Input label="Test Label" labelId="test" />);
+
+  const label = await screen.findByText<HTMLLabelElement>('Test Label');
 
   expect(label.id).toBe('test');
 });

--- a/packages/big-design/src/components/Message/spec.tsx
+++ b/packages/big-design/src/components/Message/spec.tsx
@@ -2,7 +2,7 @@ import { theme } from '@bigcommerce/big-design-theme';
 import React from 'react';
 
 import 'jest-styled-components';
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { Message, MessageProps } from './Message';
 
@@ -52,21 +52,21 @@ test('render info Message', () => {
   );
 });
 
-test('renders with link', () => {
-  const { queryByRole, container } = render(
+test('renders with link', async () => {
+  const { container } = render(
     <Message messages={[{ text: 'Success', link: { text: 'Link', href: '#' } }]} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
 
-  const link = queryByRole('link') as HTMLAnchorElement;
+  const link = await screen.findByRole<HTMLAnchorElement>('link');
 
   expect(link).toBeInTheDocument();
   expect(link.href).toBe('http://localhost/#');
 });
 
-test('renders with external link', () => {
-  const { queryByRole, container } = render(
+test('renders with external link', async () => {
+  const { container } = render(
     <Message
       messages={[
         { text: 'Success', link: { text: 'Link', href: '#', external: true, target: '_blank' } },
@@ -76,7 +76,7 @@ test('renders with external link', () => {
 
   expect(container.firstChild).toMatchSnapshot();
 
-  const link = queryByRole('link') as HTMLAnchorElement;
+  const link = await screen.findByRole<HTMLAnchorElement>('link');
 
   expect(link).toBeInTheDocument();
   expect(link.href).toBe('http://localhost/#');
@@ -102,11 +102,12 @@ test('renders close button', () => {
   expect(queryByRole('button')).toBeDefined();
 });
 
-test('trigger onClose', () => {
+test('trigger onClose', async () => {
   const fn = jest.fn();
-  const { queryByRole } = render(<Message messages={[{ text: 'Success' }]} onClose={fn} />);
 
-  const button = queryByRole('button') as HTMLButtonElement;
+  render(<Message messages={[{ text: 'Success' }]} onClose={fn} />);
+
+  const button = await screen.findByRole<HTMLButtonElement>('button');
 
   fireEvent.click(button);
 
@@ -124,13 +125,13 @@ test('does not forward styles', () => {
 
 test('renders actions', () => {
   const onClick = jest.fn();
-  const actions = [
+  const actions: MessageProps['actions'] = [
     { text: 'First Action', onClick },
-    { text: 'Second Action', variant: 'primary', onClick },
+    { text: 'Second Action', variant: 'secondary', onClick },
   ];
 
   const { container, getByRole } = render(
-    <Message actions={actions as MessageProps['actions']} messages={[{ text: 'Success' }]} />,
+    <Message actions={actions} messages={[{ text: 'Success' }]} />,
   );
   const firstAction = getByRole('button', { name: 'First Action' });
   const secondAction = getByRole('button', { name: 'Second Action' });

--- a/packages/big-design/src/components/Message/styled.ts
+++ b/packages/big-design/src/components/Message/styled.ts
@@ -36,11 +36,12 @@ export const StyledHeader = styled(StyleableH4)`
   margin-bottom: ${({ theme }) => theme.spacing.none};
 `;
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-export const StyledMessageItem = styled(StyleableSmall).attrs({ as: 'span' })`
+export const StyledMessageItem = styled<StyledComponent<'span', DefaultTheme, Partial<TextProps>>>(
+  StyleableSmall,
+).attrs({ as: 'span' })`
   color: ${({ theme }) => theme.colors.secondary70};
   vertical-align: middle;
-` as StyledComponent<'span', DefaultTheme, TextProps>;
+`;
 
 export const StyledLink = styled(Link)`
   font-size: ${({ theme }) => theme.typography.fontSize.small};

--- a/packages/big-design/src/components/Message/styled.ts
+++ b/packages/big-design/src/components/Message/styled.ts
@@ -36,6 +36,7 @@ export const StyledHeader = styled(StyleableH4)`
   margin-bottom: ${({ theme }) => theme.spacing.none};
 `;
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export const StyledMessageItem = styled(StyleableSmall).attrs({ as: 'span' })`
   color: ${({ theme }) => theme.colors.secondary70};
   vertical-align: middle;

--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -69,7 +69,7 @@ const InternalModal: React.FC<ModalProps> = ({
   const initialBodyOverflowYRef = useRef('');
   const internalTrap = useRef<FocusTrap | null>(null);
   const headerUniqueId = useUniqueId('modal_header');
-  const [modalRef, setModalRef] = useState<HTMLDivElement | null>(null);
+  const [modalRef, setModalRef] = useState<HTMLDivElement | HTMLElement | null>(null);
 
   const onClickAway = (event: React.MouseEvent) => {
     if (closeOnClickOutside && modalRef === event.target) {
@@ -96,7 +96,7 @@ const InternalModal: React.FC<ModalProps> = ({
   // Setup focus-trap
   useEffect(() => {
     if (modalRef && internalTrap.current === null) {
-      internalTrap.current = focusTrap(modalRef as HTMLElement, { fallbackFocus: modalRef });
+      internalTrap.current = focusTrap(modalRef, { fallbackFocus: modalRef });
       internalTrap.current.activate();
     }
 

--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -69,7 +69,7 @@ const InternalModal: React.FC<ModalProps> = ({
   const initialBodyOverflowYRef = useRef('');
   const internalTrap = useRef<FocusTrap | null>(null);
   const headerUniqueId = useUniqueId('modal_header');
-  const [modalRef, setModalRef] = useState<HTMLDivElement | HTMLElement | null>(null);
+  const [modalRef, setModalRef] = useState<HTMLDivElement | null>(null);
 
   const onClickAway = (event: React.MouseEvent) => {
     if (closeOnClickOutside && modalRef === event.target) {

--- a/packages/big-design/src/components/Modal/spec.tsx
+++ b/packages/big-design/src/components/Modal/spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import 'jest-styled-components';
-import { fireEvent, render, waitFor } from '@test/utils';
+import { fireEvent, render, screen, waitFor } from '@test/utils';
 
 import { Button } from '../Button';
 import { Text } from '../Typography';
@@ -48,84 +48,84 @@ test('open/hides when props changes', () => {
   expect(queryByText(text)).toBeInTheDocument();
 });
 
-test('triggers onClose when pressing esc', () => {
+test('triggers onClose when pressing esc', async () => {
   const text = 'This is a modal';
   const onClose = jest.fn();
 
-  const { queryByText } = render(
+  render(
     <Modal isOpen={true} onClose={onClose}>
       {text}
     </Modal>,
   );
 
-  const element = queryByText(text) as HTMLElement;
+  const element = await screen.findByText<HTMLElement>(text);
 
   fireEvent.keyDown(element, { key: 'Escape' });
 
   expect(onClose).toHaveBeenCalled();
 });
 
-test('does not trigger onClose when pressing esc and closeOnEscKey is false', () => {
+test('does not trigger onClose when pressing esc and closeOnEscKey is false', async () => {
   const text = 'This is a modal';
   const onClose = jest.fn();
 
-  const { queryByText } = render(
+  render(
     <Modal closeOnEscKey={false} isOpen={true} onClose={onClose}>
       {text}
     </Modal>,
   );
 
-  const element = queryByText(text) as HTMLElement;
+  const element = await screen.findByText<HTMLElement>(text);
 
   fireEvent.keyDown(element, { key: 'Escape' });
 
   expect(onClose).not.toHaveBeenCalled();
 });
 
-test('trigger onClose when clicking outside the modal', () => {
+test('trigger onClose when clicking outside the modal', async () => {
   const text = 'This is a modal';
   const onClose = jest.fn();
 
-  const { queryByRole } = render(
+  render(
     <Modal closeOnClickOutside={true} isOpen={true} onClose={onClose}>
       {text}
     </Modal>,
   );
 
-  const element = queryByRole('dialog') as HTMLElement;
+  const element = await screen.findByRole<HTMLElement>('dialog');
 
   fireEvent.click(element);
 
   expect(onClose).toHaveBeenCalled();
 });
 
-test('do not trigger onClose when clicking outside the modal and closeOnClickOutside is false', () => {
+test('do not trigger onClose when clicking outside the modal and closeOnClickOutside is false', async () => {
   const text = 'This is a modal';
   const onClose = jest.fn();
 
-  const { queryByRole } = render(
+  render(
     <Modal isOpen={true} onClose={onClose}>
       {text}
     </Modal>,
   );
 
-  const element = queryByRole('dialog') as HTMLElement;
+  const element = await screen.findByRole<HTMLElement>('dialog');
 
   fireEvent.click(element);
 
   expect(onClose).not.toHaveBeenCalled();
 });
 
-test('do not trigger onClose when clicking inside the modal', () => {
+test('do not trigger onClose when clicking inside the modal', async () => {
   const onClose = jest.fn();
 
-  const { queryByTestId } = render(
+  render(
     <Modal isOpen={true} onClose={onClose}>
       <p data-testid="inside-modal">Content</p>
     </Modal>,
   );
 
-  const element = queryByTestId('inside-modal') as HTMLElement;
+  const element = await screen.findByTestId<HTMLElement>('inside-modal');
 
   fireEvent.click(element);
 

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -320,11 +320,7 @@ export const MultiSelect = typedMemo(
       }
 
       if (isValidElement(label) && label.type === FormControlLabel) {
-        return cloneElement(
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
-          getLabelProps(),
-        );
+        return cloneElement<React.LabelHTMLAttributes<HTMLLabelElement>>(label, getLabelProps());
       }
 
       warning('label must be either a string or a FormControlLabel component.');

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -321,6 +321,7 @@ export const MultiSelect = typedMemo(
 
       if (isValidElement(label) && label.type === FormControlLabel) {
         return cloneElement(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
           getLabelProps(),
         );
@@ -375,6 +376,7 @@ export const MultiSelect = typedMemo(
                     if (isOpen === false) {
                       openMenu();
                       // https://github.com/downshift-js/downshift/issues/734
+                      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                       (event.nativeEvent as any).preventDownshiftDefault = true;
                     }
 

--- a/packages/big-design/src/components/Pagination/spec.tsx
+++ b/packages/big-design/src/components/Pagination/spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import 'jest-styled-components';
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen, waitFor } from '@test/utils';
 
 import { Pagination } from './index';
 
@@ -108,7 +108,8 @@ test('trigger range change', async () => {
 test('trigger page decrease', async () => {
   const changePage = jest.fn();
   const changeRange = jest.fn();
-  const { findByTitle } = render(
+
+  render(
     <Pagination
       currentPage={2}
       itemsPerPage={3}
@@ -119,15 +120,17 @@ test('trigger page decrease', async () => {
     />,
   );
 
-  let title = await findByTitle('Previous page');
+  let title = await screen.findByTitle('Previous page');
 
-  const svg = title.parentNode as HTMLElement;
-  const span = svg.parentNode as HTMLElement;
-  const button = span.parentNode as HTMLButtonElement;
+  const svg = title.parentNode;
+  const span = svg?.parentNode ?? null;
+  const button = span?.parentNode ?? null;
 
-  fireEvent.click(button);
+  if (button) {
+    await waitFor(() => fireEvent.click(button));
+  }
 
-  title = await findByTitle('Previous page');
+  title = await screen.findByTitle('Previous page');
 
   expect(changePage).toHaveBeenCalled();
   expect(title).toBeInTheDocument();
@@ -136,7 +139,8 @@ test('trigger page decrease', async () => {
 test('trigger page increase', async () => {
   const changePage = jest.fn();
   const changeRange = jest.fn();
-  const { findByTitle } = render(
+
+  render(
     <Pagination
       currentPage={1}
       itemsPerPage={3}
@@ -147,15 +151,17 @@ test('trigger page increase', async () => {
     />,
   );
 
-  let title = await findByTitle('Next page');
+  let title = await screen.findByTitle('Next page');
 
-  const svg = title.parentNode as HTMLElement;
-  const span = svg.parentNode as HTMLElement;
-  const button = span.parentNode as HTMLButtonElement;
+  const svg = title.parentNode;
+  const span = svg?.parentNode ?? null;
+  const button = span?.parentNode ?? null;
 
-  fireEvent.click(button);
+  if (button) {
+    await waitFor(() => fireEvent.click(button));
+  }
 
-  title = await findByTitle('Next page');
+  title = await screen.findByTitle('Next page');
 
   expect(changePage).toHaveBeenCalled();
   expect(title).toBeInTheDocument();

--- a/packages/big-design/src/components/Popover/Popover.tsx
+++ b/packages/big-design/src/components/Popover/Popover.tsx
@@ -115,11 +115,10 @@ const InternalPopover: React.FC<InternalPopoverProps> = ({
   });
 
   useEffect(() => {
-    // @ts-expect-error current is HTMLElement
-    const prevFocus: HTMLElement = previousFocus.current;
+    const prevFocus = previousFocus.current;
 
     return () => {
-      if (prevFocus && typeof prevFocus.focus === 'function') {
+      if (prevFocus instanceof HTMLElement) {
         prevFocus.focus();
       }
     };

--- a/packages/big-design/src/components/Popover/Popover.tsx
+++ b/packages/big-design/src/components/Popover/Popover.tsx
@@ -115,7 +115,8 @@ const InternalPopover: React.FC<InternalPopoverProps> = ({
   });
 
   useEffect(() => {
-    const prevFocus = previousFocus.current as HTMLElement;
+    // @ts-expect-error current is HTMLElement
+    const prevFocus: HTMLElement = previousFocus.current;
 
     return () => {
       if (prevFocus && typeof prevFocus.focus === 'function') {

--- a/packages/big-design/src/components/Radio/Label/styled.tsx
+++ b/packages/big-design/src/components/Radio/Label/styled.tsx
@@ -1,13 +1,15 @@
 import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
 
+import { TextProps } from '../../Typography';
 import { StyleableText } from '../../Typography/private';
 
 export interface StyledLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
   disabled?: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-export const StyledLabel = styled(StyleableText).attrs({
+export const StyledLabel = styled<
+  StyledComponent<'label' | 'p', DefaultTheme, Partial<TextProps>> & StyledLabelProps
+>(StyleableText).attrs({
   as: 'label',
 })<StyledLabelProps>`
   cursor: pointer;
@@ -17,4 +19,4 @@ export const StyledLabel = styled(StyleableText).attrs({
     css`
       cursor: not-allowed;
     `}
-` as StyledComponent<'label', DefaultTheme, StyledLabelProps>;
+`;

--- a/packages/big-design/src/components/Radio/Label/styled.tsx
+++ b/packages/big-design/src/components/Radio/Label/styled.tsx
@@ -6,6 +6,7 @@ export interface StyledLabelProps extends React.LabelHTMLAttributes<HTMLLabelEle
   disabled?: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export const StyledLabel = styled(StyleableText).attrs({
   as: 'label',
 })<StyledLabelProps>`

--- a/packages/big-design/src/components/Radio/Radio.tsx
+++ b/packages/big-design/src/components/Radio/Radio.tsx
@@ -52,6 +52,7 @@ const RawRadio: React.FC<RadioProps & PrivateProps> = ({
 
     if (isValidElement(label) && label.type === RadioLabel) {
       return cloneElement(
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
         {
           htmlFor: id,

--- a/packages/big-design/src/components/Radio/Radio.tsx
+++ b/packages/big-design/src/components/Radio/Radio.tsx
@@ -51,14 +51,10 @@ const RawRadio: React.FC<RadioProps & PrivateProps> = ({
     }
 
     if (isValidElement(label) && label.type === RadioLabel) {
-      return cloneElement(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
-        {
-          htmlFor: id,
-          id: labelId,
-        },
-      );
+      return cloneElement<React.LabelHTMLAttributes<HTMLLabelElement>>(label, {
+        htmlFor: id,
+        id: labelId,
+      });
     }
 
     warning('label must be either a string or a RadioLabel component.');

--- a/packages/big-design/src/components/Radio/spec.tsx
+++ b/packages/big-design/src/components/Radio/spec.tsx
@@ -1,7 +1,7 @@
 import React, { createRef } from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { warning } from '../../utils';
 
@@ -74,30 +74,28 @@ test('render Radio (unchecked + disabled)', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('has correct value when checked', () => {
-  const { getByTestId } = render(
-    <Radio checked={true} data-testid="radio" label="Checked" onChange={() => null} />,
-  );
-  const radio = getByTestId('radio') as HTMLInputElement;
+test('has correct value when checked', async () => {
+  render(<Radio checked={true} data-testid="radio" label="Checked" onChange={() => null} />);
+
+  const radio = await screen.findByTestId<HTMLInputElement>('radio');
 
   expect(radio.checked).toBe(true);
 });
 
-test('has correct value when unchecked', () => {
-  const { getByTestId } = render(
-    <Radio checked={false} data-testid="radio" label="Unchecked" onChange={() => null} />,
-  );
-  const radio = getByTestId('radio') as HTMLInputElement;
+test('has correct value when unchecked', async () => {
+  render(<Radio checked={false} data-testid="radio" label="Unchecked" onChange={() => null} />);
+
+  const radio = await screen.findByTestId<HTMLInputElement>('radio');
 
   expect(radio.checked).toBe(false);
 });
 
-test('triggers onChange when clicking the radio button', () => {
+test('triggers onChange when clicking the radio button', async () => {
   const onChange = jest.fn();
-  const { getByTestId } = render(
-    <Radio checked={false} data-testid="radio" label="Checked" onChange={onChange} />,
-  );
-  const radio = getByTestId('radio') as HTMLInputElement;
+
+  render(<Radio checked={false} data-testid="radio" label="Checked" onChange={onChange} />);
+
+  const radio = await screen.findByTestId<HTMLInputElement>('radio');
 
   fireEvent.click(radio);
 

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -251,11 +251,7 @@ export const Select = typedMemo(
       }
 
       if (isValidElement(label) && label.type === FormControlLabel) {
-        return cloneElement(
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
-          getLabelProps(),
-        );
+        return cloneElement<React.LabelHTMLAttributes<HTMLLabelElement>>(label, getLabelProps());
       }
 
       warning('label must be either a string or a FormControlLabel component.');

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -252,6 +252,7 @@ export const Select = typedMemo(
 
       if (isValidElement(label) && label.type === FormControlLabel) {
         return cloneElement(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
           getLabelProps(),
         );
@@ -299,6 +300,7 @@ export const Select = typedMemo(
                     if (isOpen === false) {
                       openMenu();
                       // https://github.com/downshift-js/downshift/issues/734
+                      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                       (event.nativeEvent as any).preventDownshiftDefault = true;
                     }
 
@@ -313,6 +315,7 @@ export const Select = typedMemo(
                     }
 
                     // https://github.com/downshift-js/downshift/issues/734
+                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                     (event.nativeEvent as any).preventDownshiftDefault = true;
                     break;
                 }

--- a/packages/big-design/src/components/StatefulTable/reducer.ts
+++ b/packages/big-design/src/components/StatefulTable/reducer.ts
@@ -362,6 +362,7 @@ function onSearchSubmit<T>(
 ): T[] {
   return items.filter((item) =>
     columns.some((column) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const element = item[column.hash as keyof T];
 
       switch (typeof element) {

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -124,9 +124,9 @@ test('renders rows without checkboxes when opting in to selectable', () => {
 
 test('items are unselected by default', () => {
   const { container } = render(getSimpleTable({ selectable: true }));
-  const checkbox = container.querySelector('tbody > tr input') as HTMLInputElement;
+  const checkboxes: NodeListOf<HTMLInputElement> = container.querySelectorAll('tbody > tr input');
 
-  expect(checkbox.checked).toBe(false);
+  expect(checkboxes[0].checked).toBe(false);
 });
 
 test('items can be selected by default', () => {
@@ -135,9 +135,9 @@ test('items can be selected by default', () => {
   const { container } = render(
     getSimpleTable({ selectable: true, items, defaultSelected: [testItem] }),
   );
-  const checkbox = container.querySelector('tbody > tr input') as HTMLInputElement;
+  const checkboxes: NodeListOf<HTMLInputElement> = container.querySelectorAll('tbody > tr input');
 
-  expect(checkbox.checked).toBe(true);
+  expect(checkboxes[0].checked).toBe(true);
 });
 
 test('onSelectionChange gets called when an item selection happens', () => {
@@ -156,9 +156,9 @@ test('onSelectionChange gets called when an item selection happens', () => {
     }),
   );
 
-  const checkbox = container.querySelector('tbody > tr input') as HTMLInputElement;
+  const checkboxes: NodeListOf<HTMLInputElement> = container.querySelectorAll('tbody > tr input');
 
-  fireEvent.click(checkbox);
+  fireEvent.click(checkboxes[0]);
 
   expect(onSelectionChange).toHaveBeenCalledWith([testItemThree, testItemOne]);
 });
@@ -171,12 +171,14 @@ test('multi-page select', async () => {
   );
 
   const table = await findByTestId('simple-table');
-  let checkbox = table.querySelector('tbody > tr input') as HTMLInputElement;
+  let checkboxes: NodeListOf<HTMLInputElement> = table.querySelectorAll('tbody > tr input');
+  let checkbox = checkboxes[0];
 
   fireEvent.click(checkbox);
   fireEvent.click(getByTitle('Next page'));
 
-  checkbox = table.querySelector('tbody > tr input') as HTMLInputElement;
+  checkboxes = table.querySelectorAll('tbody > tr input');
+  checkbox = checkboxes[0];
   fireEvent.click(checkbox);
 
   expect(onSelectionChange).toHaveBeenCalledWith([

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { StatefulTable, StatefulTablePillTabFilter, StatefulTableProps } from './StatefulTable';
 
@@ -122,32 +122,33 @@ test('renders rows without checkboxes when opting in to selectable', () => {
   expect(queryAllByRole('checkbox')).toHaveLength(105);
 });
 
-test('items are unselected by default', () => {
-  const { container } = render(getSimpleTable({ selectable: true }));
-  const checkboxes: NodeListOf<HTMLInputElement> = container.querySelectorAll('tbody > tr input');
+test('items are unselected by default', async () => {
+  render(getSimpleTable({ selectable: true }));
+
+  const checkboxes = await screen.findAllByRole<HTMLInputElement>('checkbox');
 
   expect(checkboxes[0].checked).toBe(false);
 });
 
-test('items can be selected by default', () => {
+test('items can be selected by default', async () => {
   const testItem = { name: 'Test Item', stock: 1 };
   const items: TestItem[] = [testItem];
-  const { container } = render(
-    getSimpleTable({ selectable: true, items, defaultSelected: [testItem] }),
-  );
-  const checkboxes: NodeListOf<HTMLInputElement> = container.querySelectorAll('tbody > tr input');
+
+  render(getSimpleTable({ selectable: true, items, defaultSelected: [testItem] }));
+
+  const checkboxes = await screen.findAllByRole<HTMLInputElement>('checkbox');
 
   expect(checkboxes[0].checked).toBe(true);
 });
 
-test('onSelectionChange gets called when an item selection happens', () => {
+test('onSelectionChange gets called when an item selection happens', async () => {
   const testItemOne = { name: 'Test Item', stock: 1 };
   const testItemTwo = { name: 'Test Item Two', stock: 2 };
   const testItemThree = { name: 'Test Item Three', stock: 3 };
   const items: TestItem[] = [testItemOne, testItemTwo, testItemThree];
   const onSelectionChange = jest.fn();
 
-  const { container } = render(
+  render(
     getSimpleTable({
       selectable: true,
       items,
@@ -156,9 +157,9 @@ test('onSelectionChange gets called when an item selection happens', () => {
     }),
   );
 
-  const checkboxes: NodeListOf<HTMLInputElement> = container.querySelectorAll('tbody > tr input');
+  const checkboxes = await screen.findAllByRole<HTMLInputElement>('checkbox');
 
-  fireEvent.click(checkboxes[0]);
+  fireEvent.click(checkboxes[1]);
 
   expect(onSelectionChange).toHaveBeenCalledWith([testItemThree, testItemOne]);
 });

--- a/packages/big-design/src/components/Switch/spec.tsx
+++ b/packages/big-design/src/components/Switch/spec.tsx
@@ -1,7 +1,7 @@
 import React, { createRef } from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { Switch } from './index';
 
@@ -30,30 +30,28 @@ describe('render Switch', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('has correct value for checked', () => {
-    const { getByTestId } = render(
-      <Switch checked={true} data-testid="switch" onChange={() => null} />,
-    );
-    const input = getByTestId('switch') as HTMLInputElement;
+  test('has correct value for checked', async () => {
+    render(<Switch checked={true} data-testid="switch" onChange={() => null} />);
+
+    const input = await screen.findByTestId<HTMLInputElement>('switch');
 
     expect(input.checked).toBe(true);
   });
 
-  test('has correct value for unchecked', () => {
-    const { getByTestId } = render(
-      <Switch checked={false} data-testid="switch" onChange={() => null} />,
-    );
-    const input = getByTestId('switch') as HTMLInputElement;
+  test('has correct value for unchecked', async () => {
+    render(<Switch checked={false} data-testid="switch" onChange={() => null} />);
+
+    const input = await screen.findByTestId<HTMLInputElement>('switch');
 
     expect(input.checked).toBe(false);
   });
 
-  test('triggers onChange when clicking the checkbox', () => {
+  test('triggers onChange when clicking the checkbox', async () => {
     const onChange = jest.fn();
-    const { getByTestId } = render(
-      <Switch checked={true} data-testid="switch" onChange={onChange} />,
-    );
-    const checkbox = getByTestId('switch') as HTMLInputElement;
+
+    render(<Switch checked={true} data-testid="switch" onChange={onChange} />);
+
+    const checkbox = await screen.findByTestId<HTMLInputElement>('switch');
 
     fireEvent.click(checkbox);
 

--- a/packages/big-design/src/components/Table/mixins/display/display.tsx
+++ b/packages/big-design/src/components/Table/mixins/display/display.tsx
@@ -37,10 +37,13 @@ const getResponsiveDisplay: TableColumnDisplayOverload = (
 ): FlattenSimpleInterpolation[] => {
   const breakpointKeys = Object.keys(displayProp).sort(
     (firstBreakpoint, secondBreakpoint) =>
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       breakpointsOrder.indexOf(firstBreakpoint as keyof Breakpoints) -
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       breakpointsOrder.indexOf(secondBreakpoint as keyof Breakpoints),
   );
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return (breakpointKeys as Array<keyof Breakpoints>).map(
     (breakpointKey) =>
       css`

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -267,8 +267,8 @@ describe('selectable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('click on select all should call selectedItems with all items', () => {
-    const { getAllByRole } = render(
+  test('click on select all should call selectedItems with all items', async () => {
+    render(
       <Table
         columns={columns}
         itemName={itemName}
@@ -280,7 +280,7 @@ describe('selectable', () => {
       />,
     );
 
-    const [selectAllCheckbox] = getAllByRole('checkbox') as HTMLInputElement[];
+    const [selectAllCheckbox] = await screen.findAllByRole<HTMLInputElement>('checkbox');
 
     // Select All
     expect(selectAllCheckbox.checked).toBe(false);
@@ -290,14 +290,14 @@ describe('selectable', () => {
     expect(onSelectionChange).toHaveBeenCalledWith(items);
   });
 
-  test('click on select all should call selectedItems with all items respecting multi-page', () => {
+  test('click on select all should call selectedItems with all items respecting multi-page', async () => {
     const previouslySelectedItem = {
       sku: 'Test',
       name: 'Test Previously Select Item (multi-page)',
       stock: 25,
     };
 
-    const { getAllByRole } = render(
+    render(
       <Table
         columns={columns}
         itemName={itemName}
@@ -309,7 +309,7 @@ describe('selectable', () => {
       />,
     );
 
-    const [selectAllCheckbox] = getAllByRole('checkbox') as HTMLInputElement[];
+    const [selectAllCheckbox] = await screen.findAllByRole<HTMLInputElement>('checkbox');
 
     // Select All
     expect(selectAllCheckbox.checked).toBe(false);
@@ -319,8 +319,8 @@ describe('selectable', () => {
     expect(onSelectionChange).toHaveBeenCalledWith([previouslySelectedItem, ...items]);
   });
 
-  test('select all when already all selected should deselect all items', () => {
-    const { getAllByRole } = render(
+  test('select all when already all selected should deselect all items', async () => {
+    render(
       <Table
         columns={columns}
         itemName={itemName}
@@ -332,7 +332,7 @@ describe('selectable', () => {
       />,
     );
 
-    const [selectAllCheckbox] = getAllByRole('checkbox') as HTMLInputElement[];
+    const [selectAllCheckbox] = await screen.findAllByRole<HTMLInputElement>('checkbox');
 
     // Deselect all
     expect(selectAllCheckbox.checked).toBe(true);
@@ -342,14 +342,14 @@ describe('selectable', () => {
     expect(onSelectionChange).toHaveBeenCalledWith([]);
   });
 
-  test('select all when already all selected should deselect all items and respect multi-page', () => {
+  test('select all when already all selected should deselect all items and respect multi-page', async () => {
     const previouslySelectedItem = {
       sku: 'Test',
       name: 'Test Previously Select Item (multi-page)',
       stock: 25,
     };
 
-    const { getAllByRole } = render(
+    render(
       <Table
         columns={columns}
         itemName={itemName}
@@ -361,7 +361,7 @@ describe('selectable', () => {
       />,
     );
 
-    const [selectAllCheckbox] = getAllByRole('checkbox') as HTMLInputElement[];
+    const [selectAllCheckbox] = await screen.findAllByRole<HTMLInputElement>('checkbox');
 
     // Deselect all
     expect(selectAllCheckbox.checked).toBe(true);
@@ -422,9 +422,9 @@ describe('sortable', () => {
       />,
     );
 
-    const skuHeader = container.querySelector('th') as HTMLTableCellElement;
+    const skuHeaders: NodeListOf<HTMLTableCellElement> = container.querySelectorAll('th');
 
-    fireEvent.click(skuHeader);
+    fireEvent.click(skuHeaders[0]);
 
     expect(onSort).toHaveBeenCalledWith('sku', 'DESC', columns[0]);
   });
@@ -544,15 +544,19 @@ describe('draggable', () => {
     const spaceKey = { keyCode: 32 };
     const downKey = { keyCode: 40 };
     const { container } = render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
-    const dragEl = container.querySelector('[data-rbd-draggable-id]') as HTMLElement;
+    const dragEl: HTMLElement | null = container.querySelector('[data-rbd-draggable-id]');
 
-    dragEl.focus();
+    if (dragEl && dragEl.focus) {
+      dragEl.focus();
+    }
 
     expect(dragEl).toHaveFocus();
 
-    fireEvent.keyDown(dragEl, spaceKey);
-    fireEvent.keyDown(dragEl, downKey);
-    fireEvent.keyDown(dragEl, spaceKey);
+    if (dragEl) {
+      fireEvent.keyDown(dragEl, spaceKey);
+      fireEvent.keyDown(dragEl, downKey);
+      fireEvent.keyDown(dragEl, spaceKey);
+    }
 
     expect(onRowDrop).toHaveBeenCalledWith(0, 1);
   });

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -540,23 +540,22 @@ describe('draggable', () => {
     expect(dragIcons).toHaveLength(items.length);
   });
 
-  test('onRowDrop called with expected args when a row is dropped', () => {
+  test('onRowDrop called with expected args when a row is dropped', async () => {
     const spaceKey = { keyCode: 32 };
     const downKey = { keyCode: 40 };
-    const { container } = render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
-    const dragEl: HTMLElement | null = container.querySelector('[data-rbd-draggable-id]');
 
-    if (dragEl && dragEl.focus) {
-      dragEl.focus();
-    }
+    render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
+
+    const dragEls = await screen.findAllByRole<HTMLButtonElement>('button');
+    const dragEl = dragEls[0];
+
+    dragEl.focus();
 
     expect(dragEl).toHaveFocus();
 
-    if (dragEl) {
-      fireEvent.keyDown(dragEl, spaceKey);
-      fireEvent.keyDown(dragEl, downKey);
-      fireEvent.keyDown(dragEl, spaceKey);
-    }
+    fireEvent.keyDown(dragEl, spaceKey);
+    fireEvent.keyDown(dragEl, downKey);
+    fireEvent.keyDown(dragEl, spaceKey);
 
     expect(onRowDrop).toHaveBeenCalledWith(0, 1);
   });

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -52,14 +52,10 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
     }
 
     if (isValidElement(label) && label.type === FormControlLabel) {
-      return cloneElement(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
-        {
-          id: labelId,
-          htmlFor: id,
-        },
-      );
+      return cloneElement<React.LabelHTMLAttributes<HTMLLabelElement>>(label, {
+        id: labelId,
+        htmlFor: id,
+      });
     }
 
     warning('label must be either a string or a FormControlLabel component.');

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -53,6 +53,7 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
 
     if (isValidElement(label) && label.type === FormControlLabel) {
       return cloneElement(
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         label as React.ReactElement<React.LabelHTMLAttributes<HTMLLabelElement>>,
         {
           id: labelId,

--- a/packages/big-design/src/components/Textarea/spec.tsx
+++ b/packages/big-design/src/components/Textarea/spec.tsx
@@ -2,12 +2,12 @@ import 'jest-styled-components';
 import { theme } from '@bigcommerce/big-design-theme';
 import React, { createRef } from 'react';
 
-import { render } from '@test/utils';
+import { render, screen } from '@test/utils';
 
 import { warning } from '../../utils';
 import { FormControlDescription, FormControlError, FormControlLabel, FormGroup } from '../Form';
 
-import { Textarea, TextareaProps } from './index';
+import { Textarea } from './index';
 
 const basicBorderStyle = `1px solid ${theme.colors.secondary30}`;
 const errorBorderStyle = `1px solid ${theme.colors.danger40}`;
@@ -33,8 +33,8 @@ test('renders an textarea with matched label', () => {
   expect(queryByLabelText('Test Label')).toBeInTheDocument();
 });
 
-test('create unique ids if not provided', () => {
-  const { queryByTestId } = render(
+test('create unique ids if not provided', async () => {
+  render(
     <>
       <FormGroup>
         <Textarea data-testid="item1" label="Test Label" />
@@ -45,31 +45,34 @@ test('create unique ids if not provided', () => {
     </>,
   );
 
-  const item1 = queryByTestId('item1') as HTMLTextAreaElement;
-  const item2 = queryByTestId('item2') as HTMLTextAreaElement;
+  const item1 = await screen.findByTestId('item1');
+  const item2 = await screen.findByTestId('item2');
 
   expect(item1).toBeDefined();
   expect(item2).toBeDefined();
   expect(item1.id).not.toBe(item2.id);
 });
 
-test('respects provided id', () => {
-  const { container } = render(<Textarea id="test" label="Test Label" />);
-  const textarea = container.querySelector('#test') as HTMLTextAreaElement;
+test('respects provided id', async () => {
+  render(<Textarea id="test" label="Test Label" />);
+
+  const textarea = await screen.findByLabelText<HTMLTextAreaElement>('Test Label');
 
   expect(textarea.id).toBe('test');
 });
 
-test('matches label htmlFor with id provided', () => {
-  const { container } = render(<Textarea id="test" label="Test Label" />);
-  const label = container.querySelector('label') as HTMLLabelElement;
+test('matches label htmlFor with id provided', async () => {
+  render(<Textarea id="test" label="Test Label" />);
+
+  const label = await screen.findByText<HTMLLabelElement>('Test Label');
 
   expect(label.htmlFor).toBe('test');
 });
 
-test('respects provided labelId', () => {
-  const { container } = render(<Textarea label="Test Label" labelId="test" />);
-  const label = container.querySelector('#test') as HTMLLabelElement;
+test('respects provided labelId', async () => {
+  render(<Textarea label="Test Label" labelId="test" />);
+
+  const label = await screen.findByText<HTMLLabelElement>('Test Label');
 
   expect(label.id).toBe('test');
 });
@@ -233,22 +236,23 @@ describe('error does not show when invalid type', () => {
   });
 });
 
-test('accepts valid row property', () => {
+test('accepts valid row property', async () => {
   const rows = 3;
-  const { baseElement } = render(<Textarea data-testid="test-rows" rows={rows} />);
 
-  const textarea = baseElement.querySelector('textarea') as HTMLTextAreaElement;
+  render(<Textarea data-testid="test-rows" rows={rows} />);
+
+  const textarea = await screen.findByTestId('test-rows');
 
   expect(textarea.getAttribute('rows')).toBe(`${rows}`);
 });
 
-test('does not accept invalid row property', () => {
+test('does not accept invalid row property', async () => {
   const rows = 9;
-  const { baseElement } = render(
-    <Textarea data-testid="test-rows" rows={rows as TextareaProps['rows']} />,
-  );
 
-  const textarea = baseElement.querySelector('textarea') as HTMLTextAreaElement;
+  // @ts-expect-error negative test
+  render(<Textarea data-testid="test-rows" rows={rows} />);
+
+  const textarea = await screen.findByTestId('test-rows');
 
   expect(textarea.getAttribute('rows')).not.toBe(`${rows}`);
 });

--- a/packages/big-design/src/components/Tree/hooks/spec.ts
+++ b/packages/big-design/src/components/Tree/hooks/spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { renderHook } from '@testing-library/react-hooks';
 
 import {

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -244,17 +244,20 @@ test('renders worksheet', () => {
 });
 
 describe('selection', () => {
-  test('selects cell on click', () => {
-    const { getByText } = render(
-      <Worksheet columns={columns} items={items} onChange={handleChange} />,
-    );
-    const cell = getByText('Shoes Name One').parentElement as HTMLTableDataCellElement;
-    const row = cell.parentElement as HTMLTableRowElement;
+  test('selects cell on click', async () => {
+    render(<Worksheet columns={columns} items={items} onChange={handleChange} />);
 
-    fireEvent.click(cell);
+    const foundElement = await screen.findByText('Shoes Name One');
+    const cell = foundElement.parentElement;
+
+    if (cell) {
+      fireEvent.click(cell);
+    }
 
     expect(cell).toHaveStyle(`border-color: ${theme.colors.primary}`);
-    expect(row.firstChild).toHaveStyle(`background-color: ${theme.colors.primary}`);
+    expect(cell?.parentElement?.firstChild).toHaveStyle(
+      `background-color: ${theme.colors.primary}`,
+    );
   });
 });
 
@@ -270,7 +273,7 @@ describe('edition', () => {
 
     fireEvent.doubleClick(getByText('Shoes Name One'));
 
-    const input = getByDisplayValue('Shoes Name One') as HTMLInputElement;
+    const input = getByDisplayValue('Shoes Name One');
 
     fireEvent.change(input, { target: { value: 'Shoes Name One' } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -292,7 +295,7 @@ describe('edition', () => {
 
     fireEvent.doubleClick(cell);
 
-    const input = getByDisplayValue('Shoes Name One') as HTMLInputElement;
+    const input = getByDisplayValue('Shoes Name One');
 
     fireEvent.change(input, { target: { value: 'Shoes Name One Edit' } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -335,18 +338,18 @@ describe('validation', () => {
       <Worksheet columns={columns} items={items} onChange={handleChange} onErrors={handleErrors} />,
     );
 
-    const cell = getByText('$49.00').parentElement as HTMLTableDataCellElement;
-    const row = cell.parentElement as HTMLTableRowElement;
+    const cell = getByText('$49.00').parentElement;
+    const row = cell?.parentElement;
 
     expect(cell).toHaveStyle(`border-color: ${theme.colors.danger}`);
-    expect(row.firstChild).toHaveStyle(`background-color: ${theme.colors.danger}`);
+    expect(row?.firstChild).toHaveStyle(`background-color: ${theme.colors.danger}`);
   });
 
-  test('onErrors gets called with invalid cells', () => {
+  test('onErrors gets called with invalid cells', async () => {
     let cell;
     let input;
 
-    const { getByDisplayValue, getByText } = render(
+    const { getByText } = render(
       <Worksheet columns={columns} items={items} onChange={handleChange} onErrors={handleErrors} />,
     );
 
@@ -380,7 +383,7 @@ describe('validation', () => {
 
     fireEvent.doubleClick(cell);
 
-    input = getByDisplayValue('49') as HTMLInputElement;
+    input = await screen.findByDisplayValue<HTMLInputElement>('49');
 
     fireEvent.change(input, { target: { value: 40 } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -415,7 +418,7 @@ describe('validation', () => {
 
     fireEvent.doubleClick(cell);
 
-    input = getByDisplayValue('40') as HTMLInputElement;
+    input = await screen.findByDisplayValue<HTMLInputElement>('40');
 
     fireEvent.change(input, { target: { value: 60 } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -586,8 +589,8 @@ describe('keyboard navigation', () => {
 });
 
 describe('TextEditor', () => {
-  test('renders TextEditor', () => {
-    const { getByDisplayValue, getByText } = render(
+  test('renders TextEditor', async () => {
+    const { getByText } = render(
       <Worksheet columns={columns} items={items} onChange={handleChange} />,
     );
 
@@ -595,13 +598,13 @@ describe('TextEditor', () => {
 
     fireEvent.doubleClick(cell);
 
-    const input = getByDisplayValue('Shoes Name One') as HTMLInputElement;
+    const input = await screen.findByDisplayValue<HTMLInputElement>('Shoes Name One');
 
     expect(input).toBeDefined();
   });
 
-  test('TextEditor is editable', () => {
-    const { getByDisplayValue, getByText } = render(
+  test('TextEditor is editable', async () => {
+    const { getByText } = render(
       <Worksheet columns={columns} items={items} onChange={handleChange} />,
     );
 
@@ -614,7 +617,7 @@ describe('TextEditor', () => {
 
     fireEvent.doubleClick(cell);
 
-    input = getByDisplayValue('Shoes Name One') as HTMLInputElement;
+    input = await screen.findByDisplayValue<HTMLInputElement>('Shoes Name One');
 
     expect(input).toHaveStyle(`background-color: ${theme.colors.inherit}`);
 
@@ -639,13 +642,13 @@ describe('TextEditor', () => {
 
     fireEvent.doubleClick(cell);
 
-    input = getByDisplayValue('Shoes Name One Edit') as HTMLInputElement;
+    input = await screen.findByDisplayValue<HTMLInputElement>('Shoes Name One Edit');
 
     expect(input).toHaveStyle(`background-color: ${theme.colors.warning10};`);
   });
 
-  test('column type number returns number', () => {
-    const { getByDisplayValue, getByText } = render(
+  test('column type number returns number', async () => {
+    const { getByText } = render(
       <Worksheet columns={columns} items={items} onChange={handleChange} />,
     );
 
@@ -653,7 +656,7 @@ describe('TextEditor', () => {
 
     fireEvent.doubleClick(cell);
 
-    const input = getByDisplayValue('49') as HTMLInputElement;
+    const input = await screen.findByDisplayValue<HTMLInputElement>('49');
 
     fireEvent.change(input, { target: { value: 80 } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -822,7 +825,9 @@ describe('ModalEditor', () => {
     const parent = getByText('Category 0').parentNode?.parentNode;
     const checkbox = parent?.querySelector('label');
 
-    fireEvent.click(checkbox as HTMLLabelElement);
+    if (checkbox) {
+      fireEvent.click(checkbox);
+    }
 
     const save = getByText('Save');
 

--- a/packages/big-design/src/hooks/useComponentSize.ts
+++ b/packages/big-design/src/hooks/useComponentSize.ts
@@ -28,11 +28,10 @@ export const useComponentSize = <T extends HTMLElement>(ref: RefObject<T>): Comp
 
     handleResize();
 
-    if (typeof MutationObserver === 'function') {
+    if (typeof MutationObserver === 'function' && ref.current instanceof Node) {
       const observer = new MutationObserver(handleResize);
 
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      observer.observe(ref.current as unknown as Node, { childList: true });
+      observer.observe(ref.current, { childList: true });
 
       return () => {
         observer.disconnect();

--- a/packages/big-design/src/hooks/useComponentSize.ts
+++ b/packages/big-design/src/hooks/useComponentSize.ts
@@ -31,6 +31,7 @@ export const useComponentSize = <T extends HTMLElement>(ref: RefObject<T>): Comp
     if (typeof MutationObserver === 'function') {
       const observer = new MutationObserver(handleResize);
 
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       observer.observe(ref.current as unknown as Node, { childList: true });
 
       return () => {

--- a/packages/big-design/src/managers/alerts/manager.ts
+++ b/packages/big-design/src/managers/alerts/manager.ts
@@ -61,7 +61,7 @@ class AlertsManager {
   remove = (key: string) => {
     let removed: AlertProps | undefined;
 
-    this.alerts = this.alerts.reduce((acc: PrivateAlert[], alert) => {
+    this.alerts = this.alerts.reduce<PrivateAlert[]>((acc, alert) => {
       if (alert.key === key) {
         removed = alert;
 

--- a/packages/big-design/src/managers/alerts/manager.ts
+++ b/packages/big-design/src/managers/alerts/manager.ts
@@ -61,7 +61,7 @@ class AlertsManager {
   remove = (key: string) => {
     let removed: AlertProps | undefined;
 
-    this.alerts = this.alerts.reduce((acc, alert) => {
+    this.alerts = this.alerts.reduce((acc: PrivateAlert[], alert) => {
       if (alert.key === key) {
         removed = alert;
 
@@ -69,7 +69,7 @@ class AlertsManager {
       }
 
       return [...acc, alert];
-    }, [] as PrivateAlert[]);
+    }, []);
 
     this.afterEvent();
 
@@ -119,6 +119,7 @@ class AlertsManager {
   }
 
   private sortAlerts = (a: PrivateAlert, b: PrivateAlert) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return this.typeMap[a.type as keyof TypeMap] - this.typeMap[b.type as keyof TypeMap];
   };
 

--- a/packages/big-design/src/managers/alerts/spec.tsx
+++ b/packages/big-design/src/managers/alerts/spec.tsx
@@ -3,7 +3,7 @@ import 'jest-styled-components';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { AlertProps } from '../../components/Alert';
 
@@ -18,9 +18,9 @@ beforeEach(() => {
 
 describe('alertsManager functionality', () => {
   const testKey = 'test';
-  const alert = {
+  const alert: AlertProps = {
     messages: [{ text: 'Text' }],
-  } as AlertProps;
+  };
 
   test('assigns auto generated key to alert', () => {
     const alertKey = alertsManager.add(alert);
@@ -221,26 +221,26 @@ describe('alertsManager functionality', () => {
 });
 
 describe('AlertsManager', () => {
-  const successAlert = {
+  const successAlert: AlertProps = {
     messages: [{ text: 'Success' }],
     type: 'success',
     key: 'success',
     onClose: () => null,
-  } as AlertProps;
+  };
 
-  const errorAlert = {
+  const errorAlert: AlertProps = {
     messages: [{ text: 'Error' }],
     type: 'error',
     key: 'error',
     onClose: () => null,
-  } as AlertProps;
+  };
 
-  const infoAlert = {
+  const infoAlert: AlertProps = {
     messages: [{ text: 'Info' }],
     type: 'info',
     key: 'info',
     onClose: () => null,
-  } as AlertProps;
+  };
 
   const alerts: AlertProps[] = [infoAlert, errorAlert, successAlert];
 
@@ -281,20 +281,24 @@ describe('AlertsManager', () => {
     expect(queryByText(errorAlert.messages[0].text)).toBeInTheDocument();
 
     act(() => {
-      alertsManager.remove(errorAlert.key as string);
+      if (errorAlert.key) {
+        alertsManager.remove(errorAlert.key);
+      }
     });
 
     expect(queryByText(successAlert.messages[0].text)).toBeInTheDocument();
 
     act(() => {
-      alertsManager.remove(successAlert.key as string);
+      if (successAlert.key) {
+        alertsManager.remove(successAlert.key);
+      }
     });
 
     expect(queryByText(infoAlert.messages[0].text)).toBeInTheDocument();
   });
 
-  test('closes an alert with close button', () => {
-    const { queryByRole, container } = render(<AlertsManager manager={alertsManager} />);
+  test('closes an alert with close button', async () => {
+    const { queryByRole } = render(<AlertsManager manager={alertsManager} />);
 
     expect(queryByRole('alert')).not.toBeInTheDocument();
 
@@ -304,7 +308,7 @@ describe('AlertsManager', () => {
 
     expect(queryByRole('alert')).toBeInTheDocument();
 
-    const closeButton = container.querySelector('button') as HTMLButtonElement;
+    const closeButton = await screen.findByRole('button');
 
     expect(closeButton).toBeDefined();
 
@@ -317,7 +321,7 @@ describe('AlertsManager', () => {
 
   test('closes an alert with alertsManager', () => {
     let key: string;
-    let removedAlert: AlertProps;
+    let removedAlert: AlertProps | undefined;
     const { queryByRole } = render(<AlertsManager manager={alertsManager} />);
 
     expect(queryByRole('alert')).not.toBeInTheDocument();
@@ -329,7 +333,7 @@ describe('AlertsManager', () => {
     expect(queryByRole('alert')).toBeInTheDocument();
 
     act(() => {
-      removedAlert = alertsManager.remove(key) as AlertProps;
+      removedAlert = alertsManager.remove(key);
 
       expect(removedAlert).toBeDefined();
     });
@@ -355,12 +359,14 @@ describe('AlertsManager', () => {
     expect(subscriber).toHaveBeenCalledTimes(alerts.length);
 
     for (let index = 0; index < alerts.length; index++) {
-      const closeButton = container.querySelector('button') as HTMLButtonElement;
+      const closeButton = container.querySelector('button');
 
       expect(closeButton).toBeDefined();
 
       act(() => {
-        fireEvent.click(closeButton);
+        if (closeButton) {
+          fireEvent.click(closeButton);
+        }
       });
 
       expect(subscriber).toHaveBeenCalledTimes(alerts.length + index + 1);
@@ -389,7 +395,9 @@ describe('AlertsManager', () => {
 
     alerts.forEach((alert, index) => {
       act(() => {
-        alertsManager.remove(alert.key as string);
+        if (alert.key) {
+          alertsManager.remove(alert.key);
+        }
       });
 
       expect(subscriber).toHaveBeenCalledTimes(alerts.length + index + 1);

--- a/packages/big-design/src/managers/alerts/spec.tsx
+++ b/packages/big-design/src/managers/alerts/spec.tsx
@@ -12,6 +12,8 @@ import { createAlertsManager } from './manager';
 
 let alertsManager: ReturnType<typeof createAlertsManager>;
 
+type KeyedAlertProps = AlertProps & { key: string };
+
 beforeEach(() => {
   alertsManager = createAlertsManager();
 });
@@ -221,28 +223,28 @@ describe('alertsManager functionality', () => {
 });
 
 describe('AlertsManager', () => {
-  const successAlert: AlertProps = {
+  const successAlert: KeyedAlertProps = {
     messages: [{ text: 'Success' }],
     type: 'success',
     key: 'success',
     onClose: () => null,
   };
 
-  const errorAlert: AlertProps = {
+  const errorAlert: KeyedAlertProps = {
     messages: [{ text: 'Error' }],
     type: 'error',
     key: 'error',
     onClose: () => null,
   };
 
-  const infoAlert: AlertProps = {
+  const infoAlert: KeyedAlertProps = {
     messages: [{ text: 'Info' }],
     type: 'info',
     key: 'info',
     onClose: () => null,
   };
 
-  const alerts: AlertProps[] = [infoAlert, errorAlert, successAlert];
+  const alerts: KeyedAlertProps[] = [infoAlert, errorAlert, successAlert];
 
   test('renders alert', () => {
     const { queryByRole } = render(<AlertsManager manager={alertsManager} />);
@@ -281,17 +283,13 @@ describe('AlertsManager', () => {
     expect(queryByText(errorAlert.messages[0].text)).toBeInTheDocument();
 
     act(() => {
-      if (errorAlert.key) {
-        alertsManager.remove(errorAlert.key);
-      }
+      alertsManager.remove(errorAlert.key);
     });
 
     expect(queryByText(successAlert.messages[0].text)).toBeInTheDocument();
 
     act(() => {
-      if (successAlert.key) {
-        alertsManager.remove(successAlert.key);
-      }
+      alertsManager.remove(successAlert.key);
     });
 
     expect(queryByText(infoAlert.messages[0].text)).toBeInTheDocument();
@@ -341,9 +339,9 @@ describe('AlertsManager', () => {
     expect(queryByRole('alert')).not.toBeInTheDocument();
   });
 
-  test('closes multiple alerts with close button', () => {
+  test('closes multiple alerts with close button', async () => {
     const subscriber = jest.fn();
-    const { queryByRole, container } = render(<AlertsManager manager={alertsManager} />);
+    const { queryByRole } = render(<AlertsManager manager={alertsManager} />);
 
     alertsManager.subscribe(subscriber);
 
@@ -359,14 +357,13 @@ describe('AlertsManager', () => {
     expect(subscriber).toHaveBeenCalledTimes(alerts.length);
 
     for (let index = 0; index < alerts.length; index++) {
-      const closeButton = container.querySelector('button');
+      // eslint-disable-next-line no-await-in-loop
+      const closeButtons = await screen.findAllByRole('button');
 
-      expect(closeButton).toBeDefined();
+      expect(closeButtons[0]).toBeDefined();
 
       act(() => {
-        if (closeButton) {
-          fireEvent.click(closeButton);
-        }
+        fireEvent.click(closeButtons[0]);
       });
 
       expect(subscriber).toHaveBeenCalledTimes(alerts.length + index + 1);
@@ -395,9 +392,7 @@ describe('AlertsManager', () => {
 
     alerts.forEach((alert, index) => {
       act(() => {
-        if (alert.key) {
-          alertsManager.remove(alert.key);
-        }
+        alertsManager.remove(alert.key);
       });
 
       expect(subscriber).toHaveBeenCalledTimes(alerts.length + index + 1);

--- a/packages/big-design/src/mixins/display/display.tsx
+++ b/packages/big-design/src/mixins/display/display.tsx
@@ -37,10 +37,13 @@ const getResponsiveDisplay: DisplayOverload = (
 ): FlattenSimpleInterpolation[] => {
   const breakpointKeys = Object.keys(displayProp).sort(
     (firstBreakpoint, secondBreakpoint) =>
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       breakpointsOrder.indexOf(firstBreakpoint as keyof Breakpoints) -
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       breakpointsOrder.indexOf(secondBreakpoint as keyof Breakpoints),
   );
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return (breakpointKeys as Array<keyof Breakpoints>).map(
     (breakpointKey) =>
       css`

--- a/packages/big-design/src/mixins/spacings/spacings.ts
+++ b/packages/big-design/src/mixins/spacings/spacings.ts
@@ -51,15 +51,19 @@ function getResponsiveSpacings(
 ) {
   const breakpointKeys = Object.keys(responsiveSpacing).sort(
     (a, b) =>
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       breakpointsOrder.indexOf(a as keyof Breakpoints) -
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       breakpointsOrder.indexOf(b as keyof Breakpoints),
   );
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return (breakpointKeys as Array<keyof Breakpoints>).map(
     (breakpointKey) =>
       css`
         ${theme.breakpoints[breakpointKey]} {
           ${getSimpleSpacings(
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             responsiveSpacing[breakpointKey] as keyof Spacing,
             theme,
             spacingKeys,

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -10,7 +10,7 @@ import { SideNavLogo } from './SideNavLogo';
 import { SideNavMenu } from './SideNavMenu';
 import { StyledFlex } from './styled';
 
-const CodeSandboxUrl = process.env.CODE_SANDBOX_URL as string;
+const CodeSandboxUrl = process.env.CODE_SANDBOX_URL;
 
 export const SideNav: React.FC = () => {
   return (
@@ -30,7 +30,7 @@ export const SideNav: React.FC = () => {
         <SideNavGroup title="Introduction">
           <SideNavLink href="/">Getting Started</SideNavLink>
 
-          <Link title="CodeSandbox Example" url={CodeSandboxUrl} />
+          <Link title="CodeSandbox Example" url={String(CodeSandboxUrl)} />
         </SideNavGroup>
 
         <SideNavGroup title="Foundations">

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -10,7 +10,7 @@ import { SideNavLogo } from './SideNavLogo';
 import { SideNavMenu } from './SideNavMenu';
 import { StyledFlex } from './styled';
 
-const CodeSandboxUrl = process.env.CODE_SANDBOX_URL;
+const CodeSandboxUrl = process.env?.CODE_SANDBOX_URL ?? '';
 
 export const SideNav: React.FC = () => {
   return (
@@ -30,7 +30,7 @@ export const SideNav: React.FC = () => {
         <SideNavGroup title="Introduction">
           <SideNavLink href="/">Getting Started</SideNavLink>
 
-          <Link title="CodeSandbox Example" url={String(CodeSandboxUrl)} />
+          <Link title="CodeSandbox Example" url={CodeSandboxUrl} />
         </SideNavGroup>
 
         <SideNavGroup title="Foundations">

--- a/packages/docs/pages/alert.tsx
+++ b/packages/docs/pages/alert.tsx
@@ -33,7 +33,7 @@ const AlertPage = () => {
         <CodePreview scope={{ alertsManager }}>
           {/* jsx-to-string:start */}
           {function Example() {
-            const alert = {
+            const alert: AlertProps = {
               header: 'Optional Headline',
               messages: [
                 {
@@ -46,7 +46,7 @@ const AlertPage = () => {
               ],
               type: 'success',
               onClose: () => null,
-            } as AlertProps;
+            };
 
             return <Button onClick={() => alertsManager.add(alert)}>Trigger Alert</Button>;
           }}

--- a/packages/docs/pages/index.tsx
+++ b/packages/docs/pages/index.tsx
@@ -4,7 +4,7 @@ import { ThemeContext } from 'styled-components';
 
 import { Code, CodeSnippet, List } from '../components';
 
-const CodeSandboxUrl = process.env.CODE_SANDBOX_URL as string;
+const CodeSandboxUrl = process.env.CODE_SANDBOX_URL;
 
 const GettingStartedPage = () => {
   const { spacing } = useContext(ThemeContext);

--- a/packages/docs/pages/index.tsx
+++ b/packages/docs/pages/index.tsx
@@ -4,7 +4,7 @@ import { ThemeContext } from 'styled-components';
 
 import { Code, CodeSnippet, List } from '../components';
 
-const CodeSandboxUrl = process.env.CODE_SANDBOX_URL;
+const CodeSandboxUrl = process.env?.CODE_SANDBOX_URL ?? '';
 
 const GettingStartedPage = () => {
   const { spacing } = useContext(ThemeContext);


### PR DESCRIPTION
## What?

Enable @typescript-eslint/consistent-type-assertions and either fix easy issues or disable lines. 

## Why?

Eslint rules are currently disabled in Big Design in order to use BigCommerce’s public eslint config. 

## Screenshots/Screen Recordings

N/A

## Testing/Proof

All build checks pass
