### PR TITLE
fix(component): add set width if unset

### DIFF
--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -127,16 +127,10 @@ export const HeaderCheckboxCell: React.FC<HeaderCheckboxCellProps> = memo(
 );
 
 export const DragIconHeaderCell: React.FC<DragIconCellProps> = memo(
-  ({ actionsRef, headerCellIconRef, width }) => {
+  ({ actionsRef, headerCellIconRef }) => {
     const actionsSize = useComponentSize(actionsRef);
 
-    return (
-      <StyledTableHeaderIcon
-        ref={headerCellIconRef}
-        stickyHeight={actionsSize.height}
-        width={width}
-      />
-    );
+    return <StyledTableHeaderIcon ref={headerCellIconRef} stickyHeight={actionsSize.height} />;
   },
 );
 

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -12,7 +12,7 @@ import { Tooltip } from '../../Tooltip';
 import { TableColumnDisplayProps } from '../mixins';
 import { TableColumn, TableItem } from '../types';
 
-import { StyledFlex, StyledTableHeaderCell, StyledTableHeaderCheckbox } from './styled';
+import { StyledFlex, StyledTableHeaderCell, StyledTableHeaderIcon } from './styled';
 
 export interface HeaderCellProps<T>
   extends TableHTMLAttributes<HTMLTableCellElement>,
@@ -122,9 +122,7 @@ export const HeaderCheckboxCell: React.FC<HeaderCheckboxCellProps> = memo(
   ({ stickyHeader, actionsRef }) => {
     const actionsSize = useComponentSize(actionsRef);
 
-    return (
-      <StyledTableHeaderCheckbox stickyHeader={stickyHeader} stickyHeight={actionsSize.height} />
-    );
+    return <StyledTableHeaderIcon stickyHeader={stickyHeader} stickyHeight={actionsSize.height} />;
   },
 );
 
@@ -133,7 +131,7 @@ export const DragIconHeaderCell: React.FC<DragIconCellProps> = memo(
     const actionsSize = useComponentSize(actionsRef);
 
     return (
-      <StyledTableHeaderCell
+      <StyledTableHeaderIcon
         ref={headerCellIconRef}
         stickyHeight={actionsSize.height}
         width={width}

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -35,7 +35,6 @@ export interface HeaderCheckboxCellProps {
 export interface DragIconCellProps {
   actionsRef: RefObject<HTMLDivElement>;
   headerCellIconRef: RefObject<HTMLTableCellElement>;
-  width: number | string;
 }
 
 const InternalHeaderCell = <T extends TableItem>({

--- a/packages/big-design/src/components/Table/HeaderCell/styled.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/styled.tsx
@@ -60,7 +60,7 @@ export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
     `}
 `;
 
-export const StyledTableHeaderCheckbox = styled(StyledTableHeaderCell)`
+export const StyledTableHeaderIcon = styled(StyledTableHeaderCell)`
   width: ${({ theme }) => theme.helpers.addValues(theme.spacing.xLarge, theme.spacing.small)};
   white-space: nowrap;
 `;
@@ -89,4 +89,4 @@ export const StyledFlex = styled(Flex)<StyledFlexProps>`
 
 StyledFlex.defaultProps = { theme: defaultTheme };
 StyledTableHeaderCell.defaultProps = { theme: defaultTheme };
-StyledTableHeaderCheckbox.defaultProps = { theme: defaultTheme };
+StyledTableHeaderIcon.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -138,7 +138,7 @@ const InternalTable = <T extends TableItem>(
           <DragIconHeaderCell
             actionsRef={actionsRef}
             headerCellIconRef={headerCellIconRef}
-            width={headerCellWidths.length ? headerCellWidths[0] : '50px'}
+            width={headerCellWidths.length ? headerCellWidths[0] : 'auto'}
           />
         )}
         {isSelectable && <HeaderCheckboxCell actionsRef={actionsRef} stickyHeader={stickyHeader} />}

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -138,7 +138,7 @@ const InternalTable = <T extends TableItem>(
           <DragIconHeaderCell
             actionsRef={actionsRef}
             headerCellIconRef={headerCellIconRef}
-            width={headerCellWidths.length ? headerCellWidths[0] : 'auto'}
+            width={headerCellWidths.length ? headerCellWidths[0] : '50px'}
           />
         )}
         {isSelectable && <HeaderCheckboxCell actionsRef={actionsRef} stickyHeader={stickyHeader} />}

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -135,11 +135,7 @@ const InternalTable = <T extends TableItem>(
     <Head hidden={headerless}>
       <tr>
         {typeof onRowDrop === 'function' && (
-          <DragIconHeaderCell
-            actionsRef={actionsRef}
-            headerCellIconRef={headerCellIconRef}
-            width={headerCellWidths.length ? headerCellWidths[0] : 'auto'}
-          />
+          <DragIconHeaderCell actionsRef={actionsRef} headerCellIconRef={headerCellIconRef} />
         )}
         {isSelectable && <HeaderCheckboxCell actionsRef={actionsRef} stickyHeader={stickyHeader} />}
 


### PR DESCRIPTION
## What?

Keeps the draggable icon constrained instead of stretching potentially fixes: #859

## Why?

Adding a set width instead of auto keeps the draggable icon column constrained which is useful for when you're creating columns with draggable and selectable elements together. 50px was chosen as it's small enough to still be reasonable on smaller screens while also not constraining the drag icon svg at larger sizes.

## Screenshots/Screen Recordings


https://user-images.githubusercontent.com/99497246/174160129-be342025-91db-45a1-92ab-1893df8c2c0c.mp4


https://user-images.githubusercontent.com/99497246/174160239-3150f090-703e-4601-b0ff-9033bb2caf04.mp4

## Testing/Proof

Test coverage already accommodated the component and this change. Ran the test suite prior to this PR.
