### PR TITLE
feat(component): add rows disabling for the Worksheet

### DIFF
--- a/packages/big-design/src/components/Worksheet/Row/Row.tsx
+++ b/packages/big-design/src/components/Worksheet/Row/Row.tsx
@@ -26,6 +26,9 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
   const isExpanded = useStore(
     useMemo(() => (state) => !state.hiddenRows.includes(row.id), [row.id]),
   );
+  const isDisabled = useStore(
+    useMemo(() => (state) => state.disabledRows.includes(row.id), [row.id]),
+  );
 
   const parentId = useMemo(() => {
     if (!expandableRows) {
@@ -54,7 +57,7 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
       {columns.map((column, columnIndex) => (
         <Cell
           columnIndex={columnIndex}
-          disabled={column.disabled}
+          disabled={column.disabled || isDisabled}
           formatting={hasFormatting(column) ? column.formatting : undefined}
           hash={column.hash}
           key={`${rowIndex}-${columnIndex}`}

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -20,6 +20,7 @@ const InternalWorksheet = typedMemo(
   <T extends WorksheetItem>({
     columns,
     expandableRows,
+    disabledRows,
     items,
     onChange,
     onErrors,
@@ -29,6 +30,7 @@ const InternalWorksheet = typedMemo(
     const setRows = useStore((state) => state.setRows);
     const setColumns = useStore((state) => state.setColumns);
     const setExpandableRows = useStore((state) => state.setExpandableRows);
+    const setDisabledRows = useStore((state) => state.setDisabledRows);
     const setTableRef = useStore((state) => state.setTableRef);
 
     const rows = useStore(useMemo(() => (state) => state.rows, []));
@@ -46,6 +48,7 @@ const InternalWorksheet = typedMemo(
     useEffect(() => setRows([...items]), [items, setRows]);
     useEffect(() => setColumns(expandedColumns), [expandedColumns, setColumns]);
     useEffect(() => setExpandableRows(expandableRows || {}), [expandableRows, setExpandableRows]);
+    useEffect(() => setDisabledRows(disabledRows || []), [disabledRows, setDisabledRows]);
     useEffect(() => setTableRef(tableRef.current), [setTableRef, tableRef]);
 
     useEffect(() => {

--- a/packages/big-design/src/components/Worksheet/hooks/useStore/useStore.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useStore/useStore.ts
@@ -1,7 +1,7 @@
 import create, { State } from 'zustand';
 import createContext from 'zustand/context';
 
-import { Cell, ExpandableRows, InternalWorksheetColumn } from '../../types';
+import { Cell, DisabledRows, ExpandableRows, InternalWorksheetColumn } from '../../types';
 import { deleteCells, getHiddenRows, mergeCells } from '../../utils';
 
 export const { Provider, useStore } = createContext<BaseState<any>>();
@@ -11,6 +11,7 @@ interface BaseState<Item> extends State {
   editedCells: Array<Cell<Item>>;
   editingCell: Cell<Item> | null;
   expandableRows: ExpandableRows;
+  disabledRows: DisabledRows;
   hiddenRows: Array<string | number>;
   invalidCells: Array<Cell<Item>>;
   openedModal: keyof Item | null;
@@ -24,6 +25,7 @@ interface BaseState<Item> extends State {
   setColumns: (columns: Array<InternalWorksheetColumn<Item>>) => void;
   setEditingCell: (cell: Cell<Item> | null) => void;
   setExpandableRows: (expandableRows: ExpandableRows) => void;
+  setDisabledRows: (disabledRows: DisabledRows) => void;
   setHiddenRows: (hiddenRow: Array<string | number>) => void;
   setOpenModal: (value: keyof Item | null) => void;
   setRows: (rows: Item[]) => void;
@@ -38,6 +40,7 @@ export const createStore = () =>
     editedCells: [],
     editingCell: null,
     expandableRows: {},
+    disabledRows: [],
     hiddenRows: [],
     invalidCells: [],
     openedModal: null,
@@ -55,6 +58,7 @@ export const createStore = () =>
     setEditingCell: (cell) => set((state) => ({ ...state, editingCell: cell })),
     setExpandableRows: (expandableRows) =>
       set((state) => ({ ...state, expandableRows, hiddenRows: getHiddenRows(expandableRows) })),
+    setDisabledRows: (disabledRows) => set((state) => ({ ...state, disabledRows })),
     setHiddenRows: (hiddenRows) => set((state) => ({ ...state, hiddenRows })),
     setOpenModal: (value) => set((state) => ({ ...state, openedModal: value })),
     setRows: (rows) => set((state) => ({ ...state, rows })),

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -928,6 +928,83 @@ describe('disable', () => {
   });
 });
 
+describe('disable rows', () => {
+  test('navigation works on disabled cells', () => {
+    render(
+      <Worksheet columns={columns} disabledRows={[1, 2]} items={items} onChange={handleChange} />,
+    );
+
+    let cell = screen.getByText('Shoes Name Three');
+
+    fireEvent.click(cell);
+
+    expect(cell.parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
+
+    fireEvent.keyDown(cell, { key: 'ArrowLeft' });
+
+    expect(cell.parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
+
+    fireEvent.keyDown(cell, { key: 'ArrowDown' });
+
+    cell = screen.getByText('Shoes Name Two');
+
+    expect(cell.parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
+
+    fireEvent.keyDown(cell, { key: 'ArrowUp' });
+
+    cell = screen.getByText('Shoes Name Three');
+
+    expect(cell.parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
+
+    fireEvent.keyDown(cell, { key: 'ArrowRight' });
+    fireEvent.keyDown(cell, { key: 'ArrowRight' });
+
+    const cells = screen.getAllByText('Text');
+
+    expect(cells[0].parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
+  });
+
+  test('enter does not start editing the cell', () => {
+    render(
+      <Worksheet columns={columns} disabledRows={[1, 2]} items={items} onChange={handleChange} />,
+    );
+
+    const worksheet = screen.getByRole('table');
+
+    const cell = screen.getByText('Shoes Name Three');
+
+    fireEvent.click(cell);
+    fireEvent.keyDown(worksheet, { key: 'Enter' });
+
+    expect(screen.queryByDisplayValue('Shoes Name Three')).toBeNull();
+  });
+
+  test('space does not start editing the cell', () => {
+    render(
+      <Worksheet columns={columns} disabledRows={[1, 2]} items={items} onChange={handleChange} />,
+    );
+
+    const worksheet = screen.getByRole('table');
+
+    const cell = screen.getByText('Shoes Name Three');
+
+    fireEvent.click(cell);
+    fireEvent.keyDown(worksheet, { key: ' ' });
+
+    expect(screen.queryByDisplayValue('Shoes Name Three')).toBeNull();
+  });
+
+  test('mouse will not trigger input field', () => {
+    render(
+      <Worksheet columns={columns} disabledRows={[1, 3]} items={items} onChange={handleChange} />,
+    );
+
+    fireEvent.doubleClick(screen.getByText('Shoes Name One'));
+
+    expect(screen.queryByDisplayValue('Shoes Name One')).toBeNull();
+  });
+});
+
 describe('expandable', () => {
   test('renders expandable buttons', () => {
     render(

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -6,10 +6,13 @@ export interface ExpandableRows {
   [key: string]: Array<string | number>;
 }
 
+export type DisabledRows = Array<string | number>;
+
 export interface WorksheetProps<Item extends WorksheetItem> {
   columns: Array<WorksheetColumn<Item>>;
   items: Item[];
   expandableRows?: ExpandableRows;
+  disabledRows?: DisabledRows;
   onChange(items: Item[]): void;
   onErrors?(items: Array<WorksheetError<Item>>): void;
 }

--- a/packages/docs/PropTables/WorksheetPropTable.tsx
+++ b/packages/docs/PropTables/WorksheetPropTable.tsx
@@ -60,6 +60,11 @@ const worksheetProps: Prop[] = [
       'Accepts an object with parent ids as keys and an array of child ids that will be hidden on render.',
   },
   {
+    name: 'disabledRows',
+    types: 'Array<string | number>',
+    description: 'Accepts an array with ids of rows that will be disabled.',
+  },
+  {
     name: 'items',
     types: 'any[]',
     description: 'The array of items to display.',

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -665,6 +665,66 @@ const WorksheetPage = () => {
                 </CodePreview>
               ),
             },
+            {
+              id: 'disabled-rows',
+              title: 'Disabled rows',
+              render: () => (
+                <CodePreview key="disabled-rows">
+                  {/* jsx-to-string:start */}
+                  {function Example() {
+                    const columns: Array<WorksheetColumn<Partial<Product>>> = [
+                      {
+                        hash: 'productName',
+                        header: 'Product name',
+                        validation: (value) => !!value,
+                      },
+                      { hash: 'otherField', header: 'Other field' },
+                    ];
+
+                    const disabledRows = [2, 4];
+
+                    const items: Array<Partial<Product>> = [
+                      {
+                        id: 1,
+                        productName: 'Product 1',
+                        otherField: 'Text',
+                      },
+                      {
+                        id: 2,
+                        productName: 'Product 2',
+                        otherField: 'Text',
+                      },
+                      {
+                        id: 3,
+                        productName: 'Product 3',
+                        otherField: 'Text',
+                      },
+                      {
+                        id: 4,
+                        productName: 'Product 4',
+                        otherField: 'Text',
+                      },
+                      {
+                        id: 5,
+                        productName: 'Product 5',
+                        otherField: 'Text',
+                      },
+                    ];
+
+                    return (
+                      <Worksheet
+                        columns={columns}
+                        disabledRows={disabledRows}
+                        items={items}
+                        onChange={(items) => items}
+                        onErrors={(items) => items}
+                      />
+                    );
+                  }}
+                  {/* jsx-to-string:end */}
+                </CodePreview>
+              ),
+            },
           ]}
         />
       </Panel>


### PR DESCRIPTION
## What?
Add rows disabling for the Worksheet.

## Why?
To be able to disable a certain line of the worksheet

## Screenshots/Screen Recordings

<img width="1149" alt="Screenshot 2022-06-21 at 13 58 08" src="https://user-images.githubusercontent.com/84462142/174783893-dc11ad04-69b8-4494-8a24-14d33490a551.png">

Disabling for expanded rows:
<img width="962" alt="Screenshot 2022-06-21 at 17 58 19" src="https://user-images.githubusercontent.com/84462142/174831817-35fc84f3-8935-45e7-ab28-3a41c75e471a.png">

Props:

<img width="998" alt="Screenshot 2022-06-21 at 18 01 24" src="https://user-images.githubusercontent.com/84462142/174832768-7d707956-5f71-4f8b-8b51-8dfe4715223c.png">


## Testing/Proof
Locally + UT