### PR TITLE
feat(component): add tan stack basic functionality in table component

### DIFF
--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -36,6 +36,7 @@
     "@bigcommerce/big-design-icons": "^0.18.0",
     "@bigcommerce/big-design-theme": "^0.14.0",
     "@popperjs/core": "^2.5.4",
+    "@tanstack/react-table": "8.0.0-beta.8",
     "@types/react-datepicker": "^3.1.5",
     "date-fns": "2.28.0",
     "downshift": "6.1.7",

--- a/packages/big-design/src/components/Table/Row/Row.tsx
+++ b/packages/big-design/src/components/Table/Row/Row.tsx
@@ -56,7 +56,8 @@ const InternalRow = <T extends TableItem>({
         </DataCell>
       )}
 
-      {columns.map(({ render: CellContent, align, display, verticalAlign, width, withPadding = true }, columnIndex) => {
+      {columns.map(({ columnDef }: any, columnIndex) => {
+        const { render: CellContent, align, display, verticalAlign, width, withPadding = true } = columnDef.meta;
         const cellWidth = headerCellWidths[columnIndex + 1];
 
         return (
@@ -68,8 +69,6 @@ const InternalRow = <T extends TableItem>({
             width={isDragging ? cellWidth : width}
             withPadding={withPadding}
           >
-            {/*
-          // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
             <CellContent {...item} />
           </DataCell>
         );

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -38,9 +38,9 @@ const getSimpleTable = ({
     style={style}
     columns={
       columns || [
-        { header: 'Sku', render: ({ sku }) => sku },
-        { header: 'Name', render: ({ name }) => name },
-        { header: 'Stock', render: ({ stock }) => stock },
+        { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+        { header: 'Name', hash: 'name', render: ({ name }) => name },
+        { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
       ]
     }
     items={
@@ -98,8 +98,8 @@ test('renders column with custom component', () => {
   const { getAllByTestId } = render(
     getSimpleTable({
       columns: [
-        { header: 'Sku', render: ({ sku }: any) => sku },
-        { header: 'Name', render: ({ name }: any) => <h3 data-testid="name">{name}</h3> },
+        { header: 'Sku', hash: 'sku', render: ({ sku }: any) => sku },
+        { header: 'Name', hash: 'name', render: ({ name }: any) => <h3 data-testid="name">{name}</h3> },
       ],
     }),
   );
@@ -111,8 +111,8 @@ test('renders column with tooltip icon', () => {
   const { getByTitle } = render(
     getSimpleTable({
       columns: [
-        { header: 'Sku', render: ({ sku }: any) => sku },
-        { header: 'Name', tooltip: 'Some text', render: ({ name }: any) => name },
+        { header: 'Sku', hash: 'sku', render: ({ sku }: any) => sku },
+        { header: 'Name', hash: 'name', tooltip: 'Some text', render: ({ name }: any) => name },
       ],
     }),
   );
@@ -124,8 +124,8 @@ test('renders tooltip when hovering on icon', async () => {
   const { getByTitle } = render(
     getSimpleTable({
       columns: [
-        { header: 'Sku', render: ({ sku }: any) => sku },
-        { header: 'Name', tooltip: 'Some text', render: ({ name }: any) => name },
+        { header: 'Sku', hash: 'sku', render: ({ sku }: any) => sku },
+        { header: 'Name', hash: 'name', tooltip: 'Some text', render: ({ name }: any) => name },
       ],
     }),
   );
@@ -143,12 +143,14 @@ test('tweaks column styles with props', () => {
       columns: [
         {
           header: 'Sku',
+          hash: 'sku',
           render: ({ sku }: any) => sku,
           align: 'right',
           verticalAlign: 'middle',
         },
         {
           header: 'Name',
+          hash: 'name',
           render: ({ name }: any) => name,
           width: 100,
           withPadding: false,

--- a/packages/docs/pages/table.tsx
+++ b/packages/docs/pages/table.tsx
@@ -41,10 +41,12 @@ const sort = (items, columnHash, direction) => {
 };
 
 const dragEnd = (items, from, to) => {
-  const item = items.splice(from, 1);
-  items.splice(to, 0, ...item);
+  const newItems = [...items];
+  const item = newItems.splice(from, 1);
 
-  return items;
+  newItems.splice(to, 0, ...item);
+
+  return newItems;
 };
 
 const TablePage = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2612,6 +2612,18 @@
     deepmerge "^4.2.2"
     svgo "^1.2.2"
 
+"@tanstack/react-table@8.0.0-beta.8":
+  version "8.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-beta.8.tgz#f5992029a216e1b0eac0bb2289d6387806fb5a34"
+  integrity sha512-hffDi9NnSI2tl/l3cW0CH8ErI1aJOWzIo6of0t1KMGdfES6mDcnfYMMRjm89ffaWogqVrdkKFJfbNAwV0g/0iA==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-beta.8"
+
+"@tanstack/table-core@8.0.0-beta.8":
+  version "8.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-beta.8.tgz#ade867e0f8f282ffba15fb465fbed2847c4a6832"
+  integrity sha512-uIl9kHsuyP09Mc5DBhCzBavRg/e2KNUnZmb7/SW6ec+l2cyC4n64c1B64rDVzIn0CaV/0ajuXB4gI3xfcGsPfg==
+
 "@testing-library/dom@^8.0.0", "@testing-library/dom@^8.11.1":
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"


### PR DESCRIPTION
## What?
Add tan stack basic functionality in table component.

Note: we are not using tan-stack pagination, sortable, and selectable for the moment.
## Why?
 To implement expandable functionality in our table component.
 
 Reference: https://tanstack.com/table/v8/docs/examples/react/expanding

## Screenshots/Screen Recordings

Table

https://user-images.githubusercontent.com/39739180/175326680-0aaeac7a-2e59-4b9c-9375-e540508898d3.mp4


Stateful table

https://user-images.githubusercontent.com/39739180/175326693-9ad843f1-7a95-4ac4-a679-c97b73fdb846.mp4


## Testing/Proof
Tests pass
