### PR TITLE
feat(component): remove tooltip wrapper

### DIFF
--- a/packages/big-design/src/components/List/Item/Content.tsx
+++ b/packages/big-design/src/components/List/Item/Content.tsx
@@ -51,9 +51,8 @@ export const Content = memo(({ item, isHighlighted }: ContentProps) => {
   );
 
   const wrapInTooltip = useCallback(
-    (tooltip: string, tooltipTrigger: React.ReactChild) => (
+    (tooltip: string, tooltipTrigger: React.ReactElement) => (
       <Tooltip
-        inline={false}
         modifiers={[{ name: 'preventOverflow' }, { name: 'offset', options: { offset: [0, 20] } }]}
         placement="left"
         trigger={tooltipTrigger}

--- a/packages/big-design/src/components/Tooltip/Tooltip.tsx
+++ b/packages/big-design/src/components/Tooltip/Tooltip.tsx
@@ -1,22 +1,21 @@
 import { Placement } from '@popperjs/core';
-import React, { HTMLAttributes, memo, useEffect, useMemo, useState } from 'react';
+import React, { cloneElement, HTMLAttributes, memo, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Manager, Popper, PopperProps, Reference } from 'react-popper';
 
 import { Small } from '../Typography';
 
-import { StyledTooltip, StyledTooltipTrigger } from './styled';
+import { StyledTooltip } from './styled';
 
 export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
   placement: Placement;
-  trigger: React.ReactChild;
+  trigger: React.ReactElement;
   modifiers?: PopperProps<any>['modifiers'];
-  inline?: boolean;
 }
 
 export const Tooltip: React.FC<TooltipProps> = memo(
-  ({ children, inline = true, modifiers, trigger, id, ...props }) => {
+  ({ children, modifiers, trigger, id, ...props }) => {
     const [isVisible, setIsVisible] = useState(false);
     const [tooltipContainer, setTooltipContainer] = useState<HTMLDivElement | null>(null);
     const tooltipModifiers = useMemo(() => {
@@ -65,19 +64,16 @@ export const Tooltip: React.FC<TooltipProps> = memo(
     return (
       <Manager>
         <Reference>
-          {({ ref }) => (
-            <StyledTooltipTrigger
-              inline={inline}
-              onBlur={hideTooltip}
-              onFocus={showTooltip}
-              onKeyDown={onKeyDown}
-              onMouseEnter={showTooltip}
-              onMouseLeave={hideTooltip}
-              ref={ref}
-            >
-              {trigger}
-            </StyledTooltipTrigger>
-          )}
+          {({ ref }) =>
+            cloneElement(trigger, {
+              ref,
+              onBlur: hideTooltip,
+              onFocus: showTooltip,
+              onKeyDown,
+              onMouseEnter: showTooltip,
+              onMouseLeave: hideTooltip,
+            })
+          }
         </Reference>
         {tooltipContainer
           ? createPortal(

--- a/packages/big-design/src/components/Tooltip/spec.tsx
+++ b/packages/big-design/src/components/Tooltip/spec.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from './Tooltip';
 
 test('passes id to tooltip wrapper', async () => {
   render(
-    <Tooltip id="test-id" placement="auto" trigger="Trigger">
+    <Tooltip id="test-id" placement="auto" trigger={<div>Trigger</div>}>
       Testing
     </Tooltip>,
   );

--- a/packages/big-design/src/components/Tooltip/styled.tsx
+++ b/packages/big-design/src/components/Tooltip/styled.tsx
@@ -1,16 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled, { css } from 'styled-components';
-
-export const StyledTooltipTrigger = styled.div<{ inline?: boolean }>`
-  display: inline-block;
-
-  ${({ inline }) =>
-    !inline &&
-    css`
-      display: block;
-      flex-grow: 1;
-    `}
-`;
+import styled from 'styled-components';
 
 export const StyledTooltip = styled.div`
   ${({ theme }) => theme.shadow.floating};
@@ -22,4 +11,3 @@ export const StyledTooltip = styled.div`
 `;
 
 StyledTooltip.defaultProps = { theme: defaultTheme };
-StyledTooltipTrigger.defaultProps = { theme: defaultTheme };

--- a/packages/docs/PropTables/TooltipPropTable.tsx
+++ b/packages/docs/PropTables/TooltipPropTable.tsx
@@ -5,9 +5,9 @@ import { Prop, PropTable, PropTableWrapper } from '../components';
 const tooltipProps: Prop[] = [
   {
     name: 'trigger',
-    types: 'ReactNode',
+    types: 'ReactElement',
     required: true,
-    description: 'React Node that triggers the tooltip on hover.',
+    description: 'React Element that triggers the tooltip on hover.',
   },
   {
     name: 'placement',


### PR DESCRIPTION


## What?

Removes the `StyledTooltipTrigger` wrapper from the `Tooltip` component. 

This is a breaking change as a result of it:

```
BREAKING CHANGE:
- Removes the `inline` prop on the tooltip
- Strings are not allowed in the `trigger` prop
```

## Why?

This was causing some layout issues when using it with `Icon` + `Button` components. For example,
```tsx
<Button
  iconLeft={
    <Tooltip placement="bottom" trigger={<InfoIcon size={20} />}>
      Tooltip
    </Tooltip>
  }
  iconRight={<ArrowDropDownIcon />}
>
   Label
</Button>
```

Would misalign the icon within the button:
![Screen Shot 2022-07-05 at 13 35 11](https://user-images.githubusercontent.com/10539418/177426204-6cac706c-24c2-461f-887c-c70e0bef5b40.png)

This leaves the layout up to the consumer to position it with a button. I have found `inline-flex` and `inline-grid` good alignment `display` values.

## Screenshots/Screen Recordings

![Screen Shot 2022-07-05 at 17 18 43](https://user-images.githubusercontent.com/10539418/177426502-dbf9b848-610f-4bb8-b6ec-acb0d923e506.png)

## Testing/Proof

Updated tests to reflect changes.
