### PR TITLE
chore(icons): remove .tsbuildinfo before releasing

### DIFF
--- a/packages/big-design-icons/package.json
+++ b/packages/big-design-icons/package.json
@@ -19,8 +19,9 @@
     "build:dt": "tsc --emitDeclarationOnly",
     "build:icons": "node scripts/build.js",
     "build:flags": "node scripts/build-flags.js",
+    "clean": "rimraf dist && rimraf .tsbuildinfo",
     "download": "node scripts/downloader.js",
-    "prepublishOnly": "rimraf dist && yarn run typeCheck && yarn run build",
+    "prepublishOnly": "yarn run clean && yarn run typeCheck && yarn run build",
     "typeCheck": "tsc --noEmit"
   },
   "files": [


### PR DESCRIPTION
## What?

Removes the `.tsbuildinfo` file before releasing the icon package.

## Why?

The current `prepublishOnly` script removes `dist/` folder, thus removing existing types and because we incrementally build icons then next run of the `build` script won't generate the types again. This causes issues when trying to release big-design as it errors out when running `lerna run build --stream`.

## Screenshots/Screen Recordings

![Screen Shot 2022-07-07 at 09 37 05](https://user-images.githubusercontent.com/10539418/177801435-c18eba44-f66d-4c59-b1b8-442ef89db81a.png)

## Testing/Proof

See screenshot.
