### PR TITLE
feat(component): support button as anchor

### DIFF
--- a/packages/big-design/src/components/Button/Button.tsx
+++ b/packages/big-design/src/components/Button/Button.tsx
@@ -1,17 +1,20 @@
-import React, { ButtonHTMLAttributes, forwardRef, memo, Ref } from 'react';
+import React, { forwardRef, memo } from 'react';
 
 import { MarginProps } from '../../mixins';
+import {
+  PolymorphicForwardRefExoticComponent,
+  PolymorphicMemoExoticComponent,
+  PolymorphicPropsWithoutRef,
+  PolymorphicPropsWithRef,
+} from '../../utils/polymorphic';
 import { ProgressCircle } from '../ProgressCircle';
 
 import { ContentWrapper, LoadingSpinnerWrapper, StyledButton } from './styled';
 
-interface PrivateProps {
-  forwardedRef: Ref<HTMLButtonElement>;
-}
-
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, MarginProps {
+export interface InternalButtonProps {
   actionType?: 'normal' | 'destructive';
   children?: React.ReactNode;
+  disabled?: boolean;
   iconLeft?: React.ReactNode;
   iconOnly?: React.ReactNode;
   iconRight?: React.ReactNode;
@@ -20,42 +23,96 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, Ma
   variant?: 'primary' | 'secondary' | 'subtle';
 }
 
+interface PrivateProps {
+  forwardedRef: React.ForwardedRef<Element>;
+}
+
+const ButtonDefaultElement = 'button';
+
+type ButtonAllowedElements = 'button' | 'a';
+
+export type ButtonProps<T extends React.ElementType = typeof ButtonDefaultElement> =
+  PolymorphicPropsWithRef<InternalButtonProps & MarginProps, T, ButtonAllowedElements>;
+
 const LoadingSpinner = () => (
   <LoadingSpinnerWrapper alignItems="center">
     <ProgressCircle size="xxSmall" />
   </LoadingSpinnerWrapper>
 );
 
-const RawButton: React.FC<ButtonProps & PrivateProps> = memo(
-  ({ forwardedRef, isLoading, disabled, ...props }) => {
-    return (
-      <StyledButton
-        className="bd-button"
-        {...props}
-        disabled={isLoading || disabled}
-        ref={forwardedRef}
-      >
-        {isLoading ? <LoadingSpinner /> : null}
-        <ContentWrapper isLoading={isLoading}>
-          {!props.iconOnly && props.iconLeft}
-          {props.iconOnly}
-          {!props.iconOnly && props.children}
-          {!props.iconOnly && props.iconRight}
-        </ContentWrapper>
-      </StyledButton>
-    );
+const RawButton = <T extends React.ElementType = typeof ButtonDefaultElement>({
+  as,
+  forwardedRef,
+  isLoading,
+  disabled,
+  ...props
+}: ButtonProps<T> & PrivateProps) => {
+  return (
+    <StyledButton
+      as={as || 'button'}
+      className="bd-button"
+      {...props}
+      disabled={isLoading || disabled}
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      ref={forwardedRef as any}
+    >
+      {isLoading ? <LoadingSpinner /> : null}
+      <ContentWrapper isLoading={isLoading}>
+        {!props.iconOnly && props.iconLeft}
+        {props.iconOnly}
+        {!props.iconOnly && props.children}
+        {!props.iconOnly && props.iconRight}
+      </ContentWrapper>
+    </StyledButton>
+  );
+};
+
+const MemoRawButton: PolymorphicMemoExoticComponent<
+  ButtonProps<React.ElementType> & PrivateProps,
+  typeof ButtonDefaultElement,
+  ButtonAllowedElements
+> = memo(RawButton);
+
+export const StyleableButton: PolymorphicForwardRefExoticComponent<
+  InternalButtonProps & MarginProps,
+  typeof ButtonDefaultElement,
+  ButtonAllowedElements
+> = forwardRef(
+  <T extends React.ElementType = typeof ButtonDefaultElement>(
+    {
+      as,
+      ...props
+    }: PolymorphicPropsWithoutRef<InternalButtonProps & MarginProps, T, ButtonAllowedElements>,
+    ref: React.ForwardedRef<Element>,
+  ) => {
+    const renderAs: React.ElementType = as || ButtonDefaultElement;
+
+    return <MemoRawButton {...props} as={renderAs} forwardedRef={ref} />;
   },
 );
 
-export const StyleableButton = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => (
-  <RawButton {...props} forwardedRef={ref} />
-));
+export const Button: PolymorphicForwardRefExoticComponent<
+  InternalButtonProps & MarginProps,
+  typeof ButtonDefaultElement,
+  ButtonAllowedElements
+> = forwardRef(
+  <T extends React.ElementType = typeof ButtonDefaultElement>(
+    {
+      as,
+      className,
+      style,
+      ...props
+    }: PolymorphicPropsWithoutRef<InternalButtonProps & MarginProps, T, ButtonAllowedElements>,
+    ref: React.ForwardedRef<Element>,
+  ) => {
+    const renderAs: React.ElementType = as || ButtonDefaultElement;
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, style, ...props }, ref) => <RawButton {...props} forwardedRef={ref} />,
+    return <MemoRawButton {...props} as={renderAs} forwardedRef={ref} />;
+  },
 );
 
 const defaultProps = {
+  as: 'button' as const,
   actionType: 'normal' as const,
   isLoading: false,
   mobileWidth: '100%' as const,

--- a/packages/big-design/src/components/Button/index.ts
+++ b/packages/big-design/src/components/Button/index.ts
@@ -1,4 +1,4 @@
 import { ButtonProps as _ButtonProps } from './Button';
 
 export { Button } from './Button';
-export type ButtonProps = _ButtonProps;
+export type ButtonProps<T extends 'button' | 'a'> = _ButtonProps<T>;

--- a/packages/big-design/src/components/Button/spec.tsx
+++ b/packages/big-design/src/components/Button/spec.tsx
@@ -182,6 +182,19 @@ test('render only icon only with left and right icons button', () => {
   expect(screen.getAllByTestId('icon-only')).toHaveLength(1);
 });
 
+test('renders as anchor', () => {
+  render(
+    <Button as="a" href="https://example.com">
+      Link
+    </Button>,
+  );
+
+  const link = screen.getByRole('link', { name: 'Link' });
+
+  expect(link).toHaveAttribute('href', 'https://example.com');
+  expect(link.tagName).toBe('A');
+});
+
 describe('isLoading', () => {
   test('render loading button', () => {
     render(<Button isLoading={true}>Button</Button>);

--- a/packages/big-design/src/components/Button/styled.tsx
+++ b/packages/big-design/src/components/Button/styled.tsx
@@ -5,9 +5,11 @@ import { MarginProps, withMargins } from '../../mixins';
 import { withTransition } from '../../mixins/transitions';
 import { Flex } from '../Flex';
 
-import { ButtonProps } from './index';
+import { InternalButtonProps as ButtonProps } from './Button';
 
-export const StyledButton = styled.button<ButtonProps & MarginProps>`
+type Props = ButtonProps & MarginProps;
+
+export const StyledButton = styled.button<Props>`
   ${withTransition(['background-color', 'border-color', 'box-shadow', 'color'])}
 
   && {

--- a/packages/big-design/src/utils/polymorphic.ts
+++ b/packages/big-design/src/utils/polymorphic.ts
@@ -1,0 +1,65 @@
+// Types from https://github.com/kripod/react-polymorphic-types with a few modifications for Big Design.
+
+// Block external access to auxiliary types
+export {};
+
+type Merge<T, U> = Omit<T, keyof U> & U;
+
+type PropsWithAs<
+  P,
+  T extends React.ElementType,
+  S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements,
+> = P & {
+  as?: T extends keyof JSX.IntrinsicElements ? (T extends S ? T : never) : never;
+};
+
+export type PolymorphicPropsWithoutRef<
+  P,
+  T extends React.ElementType,
+  S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements,
+> = Merge<
+  T extends keyof JSX.IntrinsicElements
+    ? React.PropsWithoutRef<JSX.IntrinsicElements[T]>
+    : React.ComponentPropsWithoutRef<T>,
+  PropsWithAs<P, T, S>
+>;
+
+export type PolymorphicPropsWithRef<
+  P,
+  T extends React.ElementType,
+  S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements,
+> = Merge<
+  T extends keyof JSX.IntrinsicElements
+    ? React.PropsWithRef<JSX.IntrinsicElements[T]>
+    : React.ComponentPropsWithRef<T>,
+  PropsWithAs<P, T, S>
+>;
+
+type PolymorphicExoticComponent<
+  P = Record<string, unknown>,
+  T extends React.ElementType = React.ElementType,
+  S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements,
+> = Merge<
+  React.ExoticComponent<P & { [key: string]: unknown }>,
+  /**
+   * **NOTE**: Exotic components are not callable.
+   */
+  <InstanceT extends React.ElementType = T>(
+    props: PolymorphicPropsWithRef<P, InstanceT, S>,
+  ) => React.ReactElement | null
+>;
+
+export type PolymorphicForwardRefExoticComponent<
+  P,
+  T extends React.ElementType,
+  S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements,
+> = Merge<
+  React.ForwardRefExoticComponent<P & { [key: string]: unknown }>,
+  PolymorphicExoticComponent<P, T, S>
+>;
+
+export type PolymorphicMemoExoticComponent<
+  P,
+  T extends React.ElementType,
+  S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements,
+> = Merge<React.MemoExoticComponent<React.ComponentType<any>>, PolymorphicExoticComponent<P, T, S>>;

--- a/packages/docs/PropTables/ButtonPropTable.tsx
+++ b/packages/docs/PropTables/ButtonPropTable.tsx
@@ -10,6 +10,13 @@ const buttonProps: Prop[] = [
     description: "Indicates whether your button's action is of normal or destructive nature.",
   },
   {
+    name: 'as',
+    types: ['button', 'a'],
+    defaultValue: 'button',
+    description:
+      'While discouraged, you can change the element type of the button. This is useful for using the button as a link.',
+  },
+  {
     name: 'iconLeft',
     types: <NextLink href="/icons">Icon</NextLink>,
     description: (


### PR DESCRIPTION
## What?
Adds support for rendering a button as an anchor.

```tsx
<Button as="a" href="https://example.com">...
```

## Why?
While we discourage this usage, we have some edge cases where we still need it. Some apps are working around it and we should support their use case.

## Screenshots/Screen Recordings

Proper types when changing it to an anchor:

<img width="439" alt="Screenshot 2022-07-12 at 13 53 33@2x" src="https://user-images.githubusercontent.com/2752665/178572382-a90bbebd-89d2-4754-9b27-6b57d9b2c646.png">

Doesn't allow anchor props by default:
<img width="452" alt="Screenshot 2022-07-12 at 13 55 28@2x" src="https://user-images.githubusercontent.com/2752665/178572518-671d5baa-5d67-4321-a66d-13948de5c453.png">

Disallows any other tag:
<img width="278" alt="Screenshot 2022-07-12 at 13 57 00@2x" src="https://user-images.githubusercontent.com/2752665/178572830-c1d68148-5d40-4bf4-bc9d-c4bccec29bbc.png">

## Caveat:
The `disabled` prop is not fully supported for anchor tags. It will disable click events but it still tab accessible. While we can support this it's not part of the spec and we probably shouldn't be disabling links. We can revisit this if required in the future.

## Testing/Proof
Tested locally and wrong a unit test.

Closes https://github.com/bigcommerce/big-design/issues/430