### PR TITLE
TableNext with expandable functionality

### DIFF
--- a/packages/big-design/src/components/Table/DataCell/styled.tsx
+++ b/packages/big-design/src/components/Table/DataCell/styled.tsx
@@ -5,6 +5,7 @@ import { withTableColumnDisplay } from '../mixins';
 
 import { DataCellProps } from './DataCell';
 
+// TODO: Use PaddingProps
 export const StyledTableDataCell = styled.td<DataCellProps>`
   ${withTableColumnDisplay()}
 

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -66,6 +66,7 @@ const InternalHeaderCell = <T extends TableItem>({
     );
   };
 
+  // TODO: Update this. Return early if we don't have tooltip.
   const renderTooltip = () => {
     if (typeof tooltip === 'string' && tooltip.length > 0) {
       return (

--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -5,7 +5,7 @@ import { FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
 import { SelectAll } from '../SelectAll';
 import { TablePagination } from '../TablePagination';
-import { TableItem, TablePaginationProps, TableSelectable } from '../types';
+import { TableExpandable, TableItem, TablePaginationProps, TableSelectable } from '../types';
 
 import { StyledFlex } from './styled';
 
@@ -14,11 +14,13 @@ export interface ActionsProps<T> {
   forwardedRef: RefObject<HTMLDivElement>;
   itemName?: string;
   items: T[];
+  isExpandable: boolean;
   pagination?: TablePaginationProps;
-  onSelectionChange?: TableSelectable<T>['onSelectionChange'];
-  selectedItems: Set<T>;
+  selectedItems: TableSelectable['selectedItems'];
   stickyHeader?: boolean;
   tableId: string;
+  expandedRowSelector?: TableExpandable<T>['expandedRowSelector'];
+  onSelectionChange?: TableSelectable['onSelectionChange'];
 }
 
 const InternalActions = <T extends TableItem>({
@@ -26,11 +28,13 @@ const InternalActions = <T extends TableItem>({
   forwardedRef,
   itemName,
   items = [],
-  onSelectionChange,
   pagination,
   selectedItems,
   stickyHeader,
   tableId,
+  isExpandable,
+  expandedRowSelector,
+  onSelectionChange,
   ...props
 }: ActionsProps<T>) => {
   const isSelectable = typeof onSelectionChange === 'function';
@@ -64,12 +68,16 @@ const InternalActions = <T extends TableItem>({
       stickyHeader={stickyHeader}
       {...props}
     >
-      <SelectAll
-        items={items}
-        onChange={onSelectionChange}
-        selectedItems={selectedItems}
-        totalItems={totalItems}
-      />
+      {isSelectable && (
+        <SelectAll
+          expandedRowSelector={expandedRowSelector}
+          isExpandable={isExpandable}
+          items={items}
+          onChange={onSelectionChange}
+          selectedItems={selectedItems}
+          totalItems={totalItems}
+        />
+      )}
       {renderItemName()}
       {renderActions()}
 

--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -1,0 +1,81 @@
+import React, { RefObject } from 'react';
+
+import { typedMemo } from '../../../utils';
+import { FlexItem } from '../../Flex';
+import { Text } from '../../Typography';
+import { SelectAll } from '../SelectAll';
+import { TablePagination } from '../TablePagination';
+import { TableItem, TablePaginationProps, TableSelectable } from '../types';
+
+import { StyledFlex } from './styled';
+
+export interface ActionsProps<T> {
+  customActions?: React.ReactNode;
+  forwardedRef: RefObject<HTMLDivElement>;
+  itemName?: string;
+  items: T[];
+  pagination?: TablePaginationProps;
+  onSelectionChange?: TableSelectable<T>['onSelectionChange'];
+  selectedItems: Set<T>;
+  stickyHeader?: boolean;
+  tableId: string;
+}
+
+const InternalActions = <T extends TableItem>({
+  customActions,
+  forwardedRef,
+  itemName,
+  items = [],
+  onSelectionChange,
+  pagination,
+  selectedItems,
+  stickyHeader,
+  tableId,
+  ...props
+}: ActionsProps<T>) => {
+  const isSelectable = typeof onSelectionChange === 'function';
+  const totalItems = pagination ? pagination.totalItems : items.length;
+
+  const renderItemName = () => {
+    if (typeof itemName !== 'string') {
+      return null;
+    }
+
+    const text = isSelectable ? itemName : `${totalItems} ${itemName}`;
+
+    return (
+      <FlexItem flexShrink={0} marginRight="medium">
+        <Text margin="none">{text}</Text>
+      </FlexItem>
+    );
+  };
+
+  const renderActions = () => {
+    return customActions ?? null;
+  };
+
+  return (
+    <StyledFlex
+      alignItems="center"
+      aria-controls={tableId}
+      flexDirection="row"
+      justifyContent="stretch"
+      ref={forwardedRef}
+      stickyHeader={stickyHeader}
+      {...props}
+    >
+      <SelectAll
+        items={items}
+        onChange={onSelectionChange}
+        selectedItems={selectedItems}
+        totalItems={totalItems}
+      />
+      {renderItemName()}
+      {renderActions()}
+
+      {pagination && <TablePagination {...pagination} />}
+    </StyledFlex>
+  );
+};
+
+export const Actions = typedMemo(InternalActions);

--- a/packages/big-design/src/components/TableNext/Actions/index.ts
+++ b/packages/big-design/src/components/TableNext/Actions/index.ts
@@ -1,0 +1,5 @@
+import { ActionsProps as _ActionsProps } from './Actions';
+
+export { Actions } from './Actions';
+
+export type ActionsProps<T> = _ActionsProps<T>;

--- a/packages/big-design/src/components/TableNext/Actions/styled.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/styled.tsx
@@ -1,0 +1,25 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled, { css } from 'styled-components';
+
+import { FlexProps } from '../../Flex';
+import { withFlexedContainer } from '../../Flex/withFlex';
+
+export const StyledFlex = styled.div<FlexProps & { stickyHeader?: boolean }>`
+  ${withFlexedContainer()}
+
+  background-color: ${({ theme }) => theme.colors.white};
+  display: flex;
+  padding: ${({ theme }) => `${theme.spacing.small} ${theme.spacing.xLarge}`};
+
+  ${({ theme, stickyHeader }) =>
+    stickyHeader &&
+    css`
+      ${theme.breakpoints.tablet} {
+        position: sticky;
+        top: 0;
+        z-index: ${theme.zIndex.sticky + 1};
+      }
+    `}
+`;
+
+StyledFlex.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/TableNext/Body/Body.tsx
+++ b/packages/big-design/src/components/TableNext/Body/Body.tsx
@@ -1,0 +1,21 @@
+import React, { forwardRef, memo, TableHTMLAttributes } from 'react';
+
+import { StyledTableBody } from './styled';
+
+export interface BodyProps extends TableHTMLAttributes<HTMLTableSectionElement> {
+  withFirstRowBorder?: boolean;
+}
+
+interface PrivateProps {
+  forwardedRef?: React.Ref<HTMLTableSectionElement>;
+}
+
+const RawBody: React.FC<BodyProps & PrivateProps> = (props) => (
+  <StyledTableBody ref={props.forwardedRef} {...props} />
+);
+
+export const Body = memo(
+  forwardRef<HTMLTableSectionElement, BodyProps>((props, ref) => (
+    <RawBody {...props} forwardedRef={ref} />
+  )),
+);

--- a/packages/big-design/src/components/TableNext/Body/index.ts
+++ b/packages/big-design/src/components/TableNext/Body/index.ts
@@ -1,0 +1,5 @@
+import { BodyProps as _BodyProps } from './Body';
+
+export { Body } from './Body';
+
+export type BodyProps = _BodyProps;

--- a/packages/big-design/src/components/TableNext/Body/styled.tsx
+++ b/packages/big-design/src/components/TableNext/Body/styled.tsx
@@ -1,0 +1,16 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled, { css } from 'styled-components';
+
+import { BodyProps } from './Body';
+
+export const StyledTableBody = styled.tbody<BodyProps>`
+  ${({ theme, withFirstRowBorder }) =>
+    withFirstRowBorder &&
+    css`
+      tr:first-of-type > td {
+        border-top: ${theme.border.box};
+      }
+    `}
+`;
+
+StyledTableBody.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
@@ -1,19 +1,21 @@
 import React, { memo, TableHTMLAttributes } from 'react';
 
+import { PaddingProps } from '../../../mixins';
 import { TableColumnDisplayProps } from '../mixins';
 
 import { StyledTableDataCell, StyledTableDataCheckbox } from './styled';
 
 export interface DataCellProps
   extends TableHTMLAttributes<HTMLTableCellElement>,
-    TableColumnDisplayProps {
+    TableColumnDisplayProps,
+    PaddingProps {
   align?: 'left' | 'center' | 'right';
   children?: React.ReactNode;
+  isExpandable?: boolean;
   isCheckbox?: boolean;
   verticalAlign?: 'top' | 'middle';
   width?: number | string;
   withBorder?: boolean;
-  withPadding?: boolean;
 }
 
 export const DataCell: React.FC<DataCellProps> = memo(
@@ -22,15 +24,19 @@ export const DataCell: React.FC<DataCellProps> = memo(
     children,
     display,
     isCheckbox,
+    isExpandable = false,
     verticalAlign,
     width,
     withBorder = true,
-    withPadding = true,
+    paddingHorizontal,
+    paddingVertical,
+    padding,
   }: DataCellProps) => {
     return isCheckbox ? (
       <StyledTableDataCheckbox
         align={align}
         display={display}
+        isExpandable={isExpandable}
         width={width}
         withBorder={withBorder}
       >
@@ -40,10 +46,12 @@ export const DataCell: React.FC<DataCellProps> = memo(
       <StyledTableDataCell
         align={align}
         display={display}
+        padding={padding}
+        paddingHorizontal={paddingHorizontal}
+        paddingVertical={paddingVertical}
         verticalAlign={verticalAlign}
         width={width}
         withBorder={withBorder}
-        withPadding={withPadding}
       >
         {children}
       </StyledTableDataCell>

--- a/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
@@ -1,0 +1,52 @@
+import React, { memo, TableHTMLAttributes } from 'react';
+
+import { TableColumnDisplayProps } from '../mixins';
+
+import { StyledTableDataCell, StyledTableDataCheckbox } from './styled';
+
+export interface DataCellProps
+  extends TableHTMLAttributes<HTMLTableCellElement>,
+    TableColumnDisplayProps {
+  align?: 'left' | 'center' | 'right';
+  children?: React.ReactNode;
+  isCheckbox?: boolean;
+  verticalAlign?: 'top' | 'middle';
+  width?: number | string;
+  withBorder?: boolean;
+  withPadding?: boolean;
+}
+
+export const DataCell: React.FC<DataCellProps> = memo(
+  ({
+    align,
+    children,
+    display,
+    isCheckbox,
+    verticalAlign,
+    width,
+    withBorder = true,
+    withPadding = true,
+  }: DataCellProps) => {
+    return isCheckbox ? (
+      <StyledTableDataCheckbox
+        align={align}
+        display={display}
+        width={width}
+        withBorder={withBorder}
+      >
+        {children}
+      </StyledTableDataCheckbox>
+    ) : (
+      <StyledTableDataCell
+        align={align}
+        display={display}
+        verticalAlign={verticalAlign}
+        width={width}
+        withBorder={withBorder}
+        withPadding={withPadding}
+      >
+        {children}
+      </StyledTableDataCell>
+    );
+  },
+);

--- a/packages/big-design/src/components/TableNext/DataCell/index.ts
+++ b/packages/big-design/src/components/TableNext/DataCell/index.ts
@@ -1,0 +1,5 @@
+import { DataCellProps as _DataCellProps } from './DataCell';
+
+export { DataCell } from './DataCell';
+
+export type DataCellProps = _DataCellProps;

--- a/packages/big-design/src/components/TableNext/DataCell/styled.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/styled.tsx
@@ -1,25 +1,28 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
+import { withPaddings } from '../../../mixins';
 import { withTableColumnDisplay } from '../mixins';
 
 import { DataCellProps } from './DataCell';
 
 export const StyledTableDataCell = styled.td<DataCellProps>`
   ${withTableColumnDisplay()}
-
+  ${withPaddings()}
+  
   background-color: ${({ theme }) => theme.colors.white};
   box-sizing: border-box;
   color: ${({ theme }) => theme.colors.secondary70};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
-  padding: ${({ theme, withPadding }) => (withPadding ? theme.spacing.small : 0)};
 
   &:first-of-type {
-    padding-left: ${({ theme, withPadding }) => (withPadding ? theme.spacing.xLarge : 0)};
+    padding-left: ${({ theme, paddingHorizontal, padding }) =>
+      padding || paddingHorizontal ? theme.spacing.xLarge : 0};
   }
 
   &:last-of-type {
-    padding-right: ${({ theme, withPadding }) => (withPadding ? theme.spacing.xLarge : 0)};
+    padding-right: ${({ theme, paddingHorizontal, padding }) =>
+      padding || paddingHorizontal ? theme.spacing.xLarge : 0};
   }
 
   ${({ theme, withBorder }) =>
@@ -57,9 +60,11 @@ export const StyledTableDataCheckbox = styled(StyledTableDataCell)`
     padding-left: ${({ theme }) => theme.spacing.xLarge};
   }
 
-  &:last-of-type {
-    padding-right: ${({ theme }) => theme.spacing.xLarge};
-  }
+  ${({ isExpandable }) =>
+    isExpandable &&
+    css`
+      padding-right: 0;
+    `}
 
   ${(props) =>
     props.isCheckbox &&

--- a/packages/big-design/src/components/TableNext/DataCell/styled.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/styled.tsx
@@ -1,0 +1,73 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled, { css } from 'styled-components';
+
+import { withTableColumnDisplay } from '../mixins';
+
+import { DataCellProps } from './DataCell';
+
+export const StyledTableDataCell = styled.td<DataCellProps>`
+  ${withTableColumnDisplay()}
+
+  background-color: ${({ theme }) => theme.colors.white};
+  box-sizing: border-box;
+  color: ${({ theme }) => theme.colors.secondary70};
+  font-size: ${({ theme }) => theme.typography.fontSize.medium};
+  padding: ${({ theme, withPadding }) => (withPadding ? theme.spacing.small : 0)};
+
+  &:first-of-type {
+    padding-left: ${({ theme, withPadding }) => (withPadding ? theme.spacing.xLarge : 0)};
+  }
+
+  &:last-of-type {
+    padding-right: ${({ theme, withPadding }) => (withPadding ? theme.spacing.xLarge : 0)};
+  }
+
+  ${({ theme, withBorder }) =>
+    withBorder &&
+    css`
+      border-bottom: ${theme.border.box};
+    `}
+
+  ${({ align }) =>
+    align &&
+    css`
+      text-align: ${align};
+    `};
+
+  ${({ verticalAlign }) =>
+    verticalAlign &&
+    css`
+      vertical-align: ${verticalAlign};
+    `};
+
+  ${({ width }) =>
+    width !== undefined &&
+    css`
+      width: ${typeof width === 'string' ? width : `${width}px`};
+    `};
+`;
+
+export const StyledTableDataCheckbox = styled(StyledTableDataCell)`
+  ${withTableColumnDisplay()}
+
+  background-color: ${({ theme }) => theme.colors.white};
+  padding: ${({ theme }) => `0 ${theme.spacing.small}`};
+
+  &:first-of-type {
+    padding-left: ${({ theme }) => theme.spacing.xLarge};
+  }
+
+  &:last-of-type {
+    padding-right: ${({ theme }) => theme.spacing.xLarge};
+  }
+
+  ${(props) =>
+    props.isCheckbox &&
+    css`
+      width: ${({ theme }) => theme.helpers.addValues(theme.spacing.xLarge, theme.spacing.small)};
+      white-space: nowrap;
+    `};
+`;
+
+StyledTableDataCell.defaultProps = { theme: defaultTheme };
+StyledTableDataCheckbox.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/TableNext/Head/Head.tsx
+++ b/packages/big-design/src/components/TableNext/Head/Head.tsx
@@ -1,0 +1,11 @@
+import React, { memo } from 'react';
+
+import { StyledTableHead } from './styled';
+
+export type HeadProps = React.TableHTMLAttributes<HTMLTableSectionElement> & {
+  hidden?: boolean;
+};
+
+export const Head: React.FC<HeadProps> = memo(({ className, style, hidden = false, ...props }) => (
+  <StyledTableHead hidden={hidden} {...props} />
+));

--- a/packages/big-design/src/components/TableNext/Head/index.ts
+++ b/packages/big-design/src/components/TableNext/Head/index.ts
@@ -1,0 +1,5 @@
+import { HeadProps as _HeadProps } from './Head';
+
+export { Head } from './Head';
+
+export type HeadProps = _HeadProps;

--- a/packages/big-design/src/components/TableNext/Head/styled.tsx
+++ b/packages/big-design/src/components/TableNext/Head/styled.tsx
@@ -1,0 +1,11 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { hideVisually } from 'polished';
+import styled from 'styled-components';
+
+import { HeadProps } from './Head';
+
+export const StyledTableHead = styled.thead<HeadProps>`
+  ${({ hidden }) => hidden && hideVisually()}
+`;
+
+StyledTableHead.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
@@ -1,0 +1,137 @@
+import {
+  ArrowDownwardIcon,
+  ArrowUpwardIcon,
+  BaselineHelpIcon,
+} from '@bigcommerce/big-design-icons';
+import React, { memo, RefObject, TableHTMLAttributes } from 'react';
+
+import { useComponentSize, useUniqueId } from '../../../hooks';
+import { typedMemo } from '../../../utils';
+import { Box } from '../../Box';
+import { Tooltip } from '../../Tooltip';
+import { TableColumnDisplayProps } from '../mixins';
+import { TableColumn, TableItem } from '../types';
+
+import { StyledFlex, StyledTableHeaderCell, StyledTableHeaderIcon } from './styled';
+
+export interface HeaderCellProps<T>
+  extends TableHTMLAttributes<HTMLTableCellElement>,
+    TableColumnDisplayProps {
+  actionsRef: RefObject<HTMLDivElement>;
+  children?: React.ReactNode;
+  column: TableColumn<T>;
+  id: string;
+  hide?: boolean;
+  isSorted?: boolean;
+  sortDirection?: 'ASC' | 'DESC';
+  stickyHeader?: boolean;
+  onSortClick?(column: TableColumn<T>): void;
+}
+
+export interface HeaderCheckboxCellProps {
+  actionsRef: RefObject<HTMLDivElement>;
+  stickyHeader?: boolean;
+}
+
+export interface DragIconCellProps {
+  actionsRef: RefObject<HTMLDivElement>;
+  headerCellIconRef: RefObject<HTMLTableCellElement>;
+}
+
+const InternalHeaderCell = <T extends TableItem>({
+  actionsRef,
+  children,
+  column,
+  display,
+  hide = false,
+  id,
+  isSorted,
+  onSortClick,
+  sortDirection,
+  stickyHeader,
+}: HeaderCellProps<T>) => {
+  const { align = 'left', isSortable, width, tooltip } = column;
+  const actionsSize = useComponentSize(actionsRef);
+  const tooltipId = useUniqueId('table-header-tooltip');
+
+  const renderSortIcon = () => {
+    if (!isSorted) {
+      return null;
+    }
+
+    return sortDirection === 'ASC' ? (
+      <ArrowUpwardIcon data-testid="asc-icon" size="medium" title="Ascending order" />
+    ) : (
+      <ArrowDownwardIcon data-testid="desc-icon" size="medium" title="Descending order" />
+    );
+  };
+
+  const renderTooltip = () => {
+    if (typeof tooltip === 'string' && tooltip.length > 0) {
+      return (
+        <Tooltip
+          id={tooltipId}
+          placement="right"
+          trigger={
+            <Box as="span" marginLeft="xxSmall">
+              <BaselineHelpIcon
+                aria-describedby={tooltipId}
+                size="medium"
+                title="Hover or focus for additional context."
+              />
+            </Box>
+          }
+        >
+          {tooltip}
+        </Tooltip>
+      );
+    }
+
+    return null;
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    if (isSortable && typeof onSortClick === 'function') {
+      onSortClick(column);
+    }
+  };
+
+  return (
+    <StyledTableHeaderCell
+      display={display}
+      id={id}
+      isSortable={isSortable}
+      onClick={handleClick}
+      stickyHeader={stickyHeader}
+      stickyHeight={actionsSize.height}
+      width={width}
+    >
+      <StyledFlex align={align} alignItems="center" flexDirection="row" hide={hide}>
+        {children}
+        {!hide && renderSortIcon()}
+        {renderTooltip()}
+      </StyledFlex>
+      {hide && renderSortIcon()}
+    </StyledTableHeaderCell>
+  );
+};
+
+export const HeaderCheckboxCell: React.FC<HeaderCheckboxCellProps> = memo(
+  ({ stickyHeader, actionsRef }) => {
+    const actionsSize = useComponentSize(actionsRef);
+
+    return <StyledTableHeaderIcon stickyHeader={stickyHeader} stickyHeight={actionsSize.height} />;
+  },
+);
+
+export const DragIconHeaderCell: React.FC<DragIconCellProps> = memo(
+  ({ actionsRef, headerCellIconRef }) => {
+    const actionsSize = useComponentSize(actionsRef);
+
+    return <StyledTableHeaderIcon ref={headerCellIconRef} stickyHeight={actionsSize.height} />;
+  },
+);
+
+export const HeaderCell = typedMemo(InternalHeaderCell);

--- a/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
@@ -67,27 +67,23 @@ const InternalHeaderCell = <T extends TableItem>({
   };
 
   const renderTooltip = () => {
-    if (typeof tooltip === 'string' && tooltip.length > 0) {
-      return (
-        <Tooltip
-          id={tooltipId}
-          placement="right"
-          trigger={
-            <Box as="span" marginLeft="xxSmall">
-              <BaselineHelpIcon
-                aria-describedby={tooltipId}
-                size="medium"
-                title="Hover or focus for additional context."
-              />
-            </Box>
-          }
-        >
-          {tooltip}
-        </Tooltip>
-      );
-    }
-
-    return null;
+    return (
+      <Tooltip
+        id={tooltipId}
+        placement="right"
+        trigger={
+          <Box as="span" marginLeft="xxSmall">
+            <BaselineHelpIcon
+              aria-describedby={tooltipId}
+              size="medium"
+              title="Hover or focus for additional context."
+            />
+          </Box>
+        }
+      >
+        {tooltip}
+      </Tooltip>
+    );
   };
 
   const handleClick = (e: React.MouseEvent) => {
@@ -111,7 +107,7 @@ const InternalHeaderCell = <T extends TableItem>({
       <StyledFlex align={align} alignItems="center" flexDirection="row" hide={hide}>
         {children}
         {!hide && renderSortIcon()}
-        {renderTooltip()}
+        {Boolean(tooltip) && renderTooltip()}
       </StyledFlex>
       {hide && renderSortIcon()}
     </StyledTableHeaderCell>
@@ -133,5 +129,11 @@ export const DragIconHeaderCell: React.FC<DragIconCellProps> = memo(
     return <StyledTableHeaderIcon ref={headerCellIconRef} stickyHeight={actionsSize.height} />;
   },
 );
+
+export const ExpandableHeaderCell: React.FC<DragIconCellProps> = memo(({ actionsRef }) => {
+  const actionsSize = useComponentSize(actionsRef);
+
+  return <StyledTableHeaderIcon stickyHeight={actionsSize.height} />;
+});
 
 export const HeaderCell = typedMemo(InternalHeaderCell);

--- a/packages/big-design/src/components/TableNext/HeaderCell/index.ts
+++ b/packages/big-design/src/components/TableNext/HeaderCell/index.ts
@@ -1,0 +1,5 @@
+import { HeaderCellProps as _HeaderCellProps } from './HeaderCell';
+
+export { HeaderCell } from './HeaderCell';
+
+export type HeaderCellProps<T> = _HeaderCellProps<T>;

--- a/packages/big-design/src/components/TableNext/HeaderCell/styled.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/styled.tsx
@@ -1,0 +1,92 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { hideVisually } from 'polished';
+import styled, { css } from 'styled-components';
+
+import { Flex } from '../../Flex';
+import { TableColumnDisplayProps, withTableColumnDisplay } from '../mixins';
+
+interface StyledTableHeaderCellProps extends TableColumnDisplayProps {
+  isSortable?: boolean;
+  width?: number | string;
+  stickyHeader?: boolean;
+  stickyHeight: number;
+}
+
+interface StyledFlexProps {
+  align?: 'left' | 'center' | 'right';
+  hide: boolean;
+}
+
+export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
+  ${withTableColumnDisplay()}
+  background-color: ${({ theme }) => theme.colors.white};
+  border-bottom: ${({ theme }) => theme.border.box};
+  border-top: ${({ theme }) => theme.border.box};
+  box-sizing: border-box;
+  color: ${({ theme }) => theme.colors.secondary70};
+  font-size: ${({ theme }) => theme.typography.fontSize.medium};
+  padding: ${({ theme }) => theme.spacing.small};
+  white-space: nowrap;
+
+  &:first-of-type {
+    padding-left: ${({ theme }) => theme.spacing.xLarge};
+  }
+
+  &:last-of-type {
+    padding-right: ${({ theme }) => theme.spacing.xLarge};
+  }
+
+  ${({ isSortable }) =>
+    isSortable &&
+    css`
+      cursor: pointer;
+    `};
+
+  ${({ width }) =>
+    width !== undefined &&
+    css`
+      width: ${typeof width === 'string' ? width : `${width}px`};
+    `};
+
+  ${({ theme, stickyHeader, stickyHeight }) =>
+    stickyHeader &&
+    stickyHeight >= 0 &&
+    css`
+      ${theme.breakpoints.tablet} {
+        position: sticky;
+        top: ${theme.helpers.remCalc(stickyHeight)};
+        z-index: ${theme.zIndex.sticky};
+      }
+    `}
+`;
+
+export const StyledTableHeaderIcon = styled(StyledTableHeaderCell)`
+  width: ${({ theme }) => theme.helpers.addValues(theme.spacing.xLarge, theme.spacing.small)};
+  white-space: nowrap;
+`;
+
+export const StyledFlex = styled(Flex)<StyledFlexProps>`
+  ${({ align }) => {
+    switch (align) {
+      case 'center':
+        return css`
+          justify-content: center;
+        `;
+
+      case 'right':
+        return css`
+          justify-content: flex-end;
+        `;
+
+      default:
+        return css`
+          justify-content: flex-start;
+        `;
+    }
+  }};
+  ${({ hide }) => hide && hideVisually()};
+`;
+
+StyledFlex.defaultProps = { theme: defaultTheme };
+StyledTableHeaderCell.defaultProps = { theme: defaultTheme };
+StyledTableHeaderIcon.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -1,0 +1,90 @@
+import { DragIndicatorIcon } from '@bigcommerce/big-design-icons';
+import React, { forwardRef, TableHTMLAttributes } from 'react';
+
+import { typedMemo } from '../../../utils';
+import { Checkbox } from '../../Checkbox';
+import { DataCell } from '../DataCell';
+import { TableColumn, TableItem } from '../types';
+
+import { StyledTableRow } from './styled';
+
+export interface RowProps<T> extends TableHTMLAttributes<HTMLTableRowElement> {
+  columns: Array<TableColumn<T>>;
+  headerCellWidths: Array<number | string>;
+  item: T;
+  isDragging?: boolean;
+  isSelected?: boolean;
+  isSelectable?: boolean;
+  showDragIcon?: boolean;
+  onItemSelect?(item: T): void;
+}
+
+interface PrivateProps {
+  forwardedRef?: React.Ref<HTMLTableRowElement>;
+}
+
+const InternalRow = <T extends TableItem>({
+  columns,
+  forwardedRef,
+  headerCellWidths,
+  isDragging = false,
+  isSelectable = false,
+  isSelected = false,
+  item,
+  showDragIcon = false,
+  onItemSelect,
+  ...rest
+}: RowProps<T> & PrivateProps) => {
+  const onChange = () => {
+    if (onItemSelect) {
+      onItemSelect(item);
+    }
+  };
+
+  const label = isSelected ? `Selected` : `Unselected`;
+
+  return (
+    <StyledTableRow isDragging={isDragging} isSelected={isSelected} ref={forwardedRef} {...rest}>
+      {showDragIcon && (
+        <DataCell width={headerCellWidths[0]}>
+          <DragIndicatorIcon />
+        </DataCell>
+      )}
+      {isSelectable && (
+        <DataCell isCheckbox={true} key="data-checkbox">
+          <Checkbox checked={isSelected} hiddenLabel label={label} onChange={onChange} />
+        </DataCell>
+      )}
+
+      {columns.map(
+        (
+          { render: CellContent, align, display, verticalAlign, width, withPadding = true },
+          columnIndex,
+        ) => {
+          const cellWidth = headerCellWidths[columnIndex + 1];
+
+          return (
+            <DataCell
+              align={align}
+              display={display}
+              key={columnIndex}
+              verticalAlign={verticalAlign}
+              width={isDragging ? cellWidth : width}
+              withPadding={withPadding}
+            >
+              {/*
+          // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
+              <CellContent {...item} />
+            </DataCell>
+          );
+        },
+      )}
+    </StyledTableRow>
+  );
+};
+
+export const Row = typedMemo(
+  forwardRef<HTMLTableRowElement, RowProps<any>>((props, ref) => (
+    <InternalRow {...props} forwardedRef={ref} />
+  )),
+);

--- a/packages/big-design/src/components/TableNext/Row/index.ts
+++ b/packages/big-design/src/components/TableNext/Row/index.ts
@@ -1,0 +1,5 @@
+import { RowProps as _RowProps } from './Row';
+
+export { Row } from './Row';
+
+export type RowProps<T> = _RowProps<T>;

--- a/packages/big-design/src/components/TableNext/Row/styled.tsx
+++ b/packages/big-design/src/components/TableNext/Row/styled.tsx
@@ -2,6 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withTransition } from '../../../mixins/transitions';
+import { StyleableButton } from '../../Button/Button';
 
 interface StyledTableRowProps {
   isDragging: boolean;
@@ -20,4 +21,10 @@ export const StyledTableRow = styled.tr<StyledTableRowProps>`
   }
 `;
 
+export const StyledExpandedIcon = styled(StyleableButton)`
+  color: ${({ theme }) => theme.colors.secondary60};
+  padding: 0;
+`;
+
 StyledTableRow.defaultProps = { theme: defaultTheme };
+StyledExpandedIcon.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/TableNext/Row/styled.tsx
+++ b/packages/big-design/src/components/TableNext/Row/styled.tsx
@@ -1,0 +1,23 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled from 'styled-components';
+
+import { withTransition } from '../../../mixins/transitions';
+
+interface StyledTableRowProps {
+  isDragging: boolean;
+  isSelected: boolean;
+}
+
+export const StyledTableRow = styled.tr<StyledTableRowProps>`
+  ${withTransition(['background-color'])}
+  display: ${({ isDragging }) => (isDragging ? 'table' : 'table-row')};
+
+  background-color: ${({ isSelected, theme }) =>
+    isSelected ? theme.colors.primary10 : 'transparent'};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.secondary10};
+  }
+`;
+
+StyledTableRow.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/TableNext/Row/useRowState.ts
+++ b/packages/big-design/src/components/TableNext/Row/useRowState.ts
@@ -1,0 +1,72 @@
+import { OnItemSelectFn } from '../hooks';
+import { TableSelectable } from '../types';
+
+interface UseRowStateProps<T> {
+  childRowIndex?: number;
+  childrenRows: T[];
+  isExpandable: boolean;
+  isParentRow: boolean;
+  isSelected?: boolean;
+  selectedItems: TableSelectable['selectedItems'];
+  onExpandedRow?(parentRowIndex: number | null): void;
+  onItemSelect?: OnItemSelectFn;
+  parentRowIndex: number;
+}
+
+export const useRowState = <T>({
+  childRowIndex,
+  childrenRows,
+  isExpandable,
+  isParentRow,
+  isSelected,
+  selectedItems,
+  onExpandedRow,
+  onItemSelect,
+  parentRowIndex,
+}: UseRowStateProps<T>) => {
+  const onChange = () => {
+    if (onItemSelect) {
+      onItemSelect({
+        childRowIndex: childRowIndex ?? null,
+        childrenRows,
+        isParentRow,
+        isExpandable,
+        parentRowIndex,
+      });
+    }
+  };
+
+  const onExpandedChange = () => {
+    if (onExpandedRow) {
+      onExpandedRow(parentRowIndex ?? null);
+    }
+  };
+
+  const hasChildrenRows = childrenRows.length > 0;
+
+  const allChildrenRowsSelected =
+    isExpandable &&
+    childrenRows.every((_childRow, childRowIndex) => {
+      return selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
+    });
+
+  const someChildrenRowsSelected =
+    isExpandable &&
+    childrenRows.some((_childRow, childRowIndex) => {
+      return selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
+    });
+
+  const label = isSelected ? `Selected` : `Unselected`;
+
+  const isChecked = isExpandable && hasChildrenRows ? allChildrenRowsSelected : isSelected;
+  const isIndeterminate = isExpandable && hasChildrenRows ? someChildrenRowsSelected : undefined;
+
+  return {
+    hasChildrenRows,
+    isChecked,
+    isIndeterminate,
+    label,
+    onChange,
+    onExpandedChange,
+  };
+};

--- a/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
+++ b/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
@@ -1,0 +1,100 @@
+import React, { forwardRef } from 'react';
+
+import { typedMemo } from '../../../utils';
+import { Row, RowProps } from '../Row';
+import { TableExpandable, TableItem } from '../types';
+
+interface InternalRowContainerProps<T>
+  extends Omit<RowProps<T>, 'isSelected' | 'isParentRows' | 'childrenRows' | 'isDraggable'> {
+  expandedRows: TableExpandable<T>['expandedRows'];
+  expandedRowSelector?: TableExpandable<T>['expandedRowSelector'];
+  getItemKey: (item: T, index: number) => string | number;
+  headerless?: boolean;
+}
+
+interface PrivateProps {
+  forwardedRef?: React.Ref<HTMLTableRowElement>;
+}
+
+const InternalRowContainer = <T extends TableItem>({
+  isDragging,
+  columns,
+  expandedRows,
+  forwardedRef,
+  headerCellWidths,
+  isExpandable = false,
+  isSelectable = false,
+  item,
+  parentRowIndex,
+  showDragIcon,
+  expandedRowSelector,
+  getItemKey,
+  onItemSelect,
+  onExpandedRow,
+  selectedItems,
+  ...rest
+}: InternalRowContainerProps<T> & PrivateProps) => {
+  const isParentRowSelected = selectedItems[parentRowIndex] !== undefined;
+  const isExpanded = expandedRows[parentRowIndex] !== undefined;
+  const childrenRows: T[] | undefined = expandedRowSelector ? expandedRowSelector?.(item) : [];
+  const isDraggable: boolean = showDragIcon === true;
+
+  return (
+    <>
+      <Row
+        childrenRows={childrenRows ?? []}
+        columns={columns}
+        headerCellWidths={headerCellWidths}
+        isDraggable={isDraggable}
+        isDragging={isDragging}
+        isExpandable={isExpandable}
+        isExpanded={isExpanded}
+        isParentRow={true}
+        isSelectable={isSelectable}
+        isSelected={isParentRowSelected}
+        item={item}
+        onExpandedRow={onExpandedRow}
+        onItemSelect={onItemSelect}
+        parentRowIndex={parentRowIndex}
+        ref={forwardedRef}
+        selectedItems={selectedItems}
+        showDragIcon={showDragIcon}
+        {...rest}
+      />
+      {childrenRows &&
+        isExpanded &&
+        childrenRows?.map((childRow: T, childRowIndex: number) => {
+          const key = getItemKey(childRow, childRowIndex);
+          const isChildRowSelected =
+            selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
+
+          return (
+            <Row
+              childRowIndex={childRowIndex}
+              childrenRows={childrenRows ?? []}
+              columns={columns}
+              headerCellWidths={headerCellWidths}
+              isDraggable={isDraggable}
+              isDragging={false}
+              isExpandable={isExpandable}
+              isParentRow={false}
+              isSelectable={isSelectable}
+              isSelected={isChildRowSelected}
+              item={childRow}
+              key={key}
+              onItemSelect={onItemSelect}
+              parentRowIndex={parentRowIndex}
+              selectedItems={selectedItems}
+              showDragIcon={showDragIcon}
+            />
+          );
+        })}
+    </>
+  );
+};
+
+export const RowContainer = typedMemo(
+  forwardRef<HTMLTableRowElement, InternalRowContainerProps<any>>((props, ref) => (
+    <InternalRowContainer {...props} forwardedRef={ref} />
+  )),
+);

--- a/packages/big-design/src/components/TableNext/RowContainer/index.ts
+++ b/packages/big-design/src/components/TableNext/RowContainer/index.ts
@@ -1,0 +1,1 @@
+export { RowContainer } from './RowContainer';

--- a/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { Checkbox } from '../../Checkbox';
+import { Flex, FlexItem } from '../../Flex';
+import { Text } from '../../Typography';
+import { TableItem, TablePaginationProps, TableSelectable } from '../types';
+
+export interface SelectAllProps<T> {
+  items: T[];
+  totalItems: number;
+  onChange?: TableSelectable<T>['onSelectionChange'];
+  pagination?: TablePaginationProps;
+  selectedItems: Set<T>;
+}
+
+export const SelectAll = <T extends TableItem>({
+  items = [],
+  onChange,
+  selectedItems,
+  totalItems,
+}: SelectAllProps<T>) => {
+  const allInPageSelected = items.length > 0 && items.every((item) => selectedItems.has(item));
+  const someInPageSelected = items.length > 0 && items.some((item) => selectedItems.has(item));
+
+  const handleSelectAll = () => {
+    if (typeof onChange !== 'function') {
+      return;
+    }
+
+    if (selectedItems.size === 0) {
+      return onChange([...items]);
+    }
+
+    if (allInPageSelected) {
+      const newSelectedItems = new Set(selectedItems);
+
+      items.forEach((item) => newSelectedItems.delete(item));
+
+      return onChange([...newSelectedItems]);
+    }
+
+    return onChange([...new Set([...selectedItems, ...items])]);
+  };
+
+  if (typeof onChange !== 'function') {
+    return null;
+  }
+
+  const totalSelectedItems = selectedItems.size;
+
+  const label = allInPageSelected ? 'Deselect All' : 'Select All';
+
+  return (
+    <FlexItem flexShrink={0} marginRight="xxSmall">
+      <Flex flexDirection="row">
+        <Checkbox
+          checked={allInPageSelected}
+          hiddenLabel
+          isIndeterminate={someInPageSelected}
+          label={label}
+          onChange={handleSelectAll}
+        />
+        <Text marginLeft="small">
+          {totalSelectedItems === 0 ? `${totalItems}` : `${totalSelectedItems}/${totalItems}`}
+        </Text>
+      </Flex>
+    </FlexItem>
+  );
+};

--- a/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
@@ -3,52 +3,29 @@ import React from 'react';
 import { Checkbox } from '../../Checkbox';
 import { Flex, FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
-import { TableItem, TablePaginationProps, TableSelectable } from '../types';
+import { TableExpandable, TableItem, TableSelectable } from '../types';
+
+import { useSelectAllState } from './useSelectAllState';
 
 export interface SelectAllProps<T> {
+  expandedRowSelector?: TableExpandable<T>['expandedRowSelector'];
+  isExpandable: boolean;
   items: T[];
+  onChange?: TableSelectable['onSelectionChange'];
+  selectedItems: TableSelectable['selectedItems'];
   totalItems: number;
-  onChange?: TableSelectable<T>['onSelectionChange'];
-  pagination?: TablePaginationProps;
-  selectedItems: Set<T>;
 }
 
 export const SelectAll = <T extends TableItem>({
+  expandedRowSelector,
+  isExpandable,
   items = [],
   onChange,
   selectedItems,
   totalItems,
 }: SelectAllProps<T>) => {
-  const allInPageSelected = items.length > 0 && items.every((item) => selectedItems.has(item));
-  const someInPageSelected = items.length > 0 && items.some((item) => selectedItems.has(item));
-
-  const handleSelectAll = () => {
-    if (typeof onChange !== 'function') {
-      return;
-    }
-
-    if (selectedItems.size === 0) {
-      return onChange([...items]);
-    }
-
-    if (allInPageSelected) {
-      const newSelectedItems = new Set(selectedItems);
-
-      items.forEach((item) => newSelectedItems.delete(item));
-
-      return onChange([...newSelectedItems]);
-    }
-
-    return onChange([...new Set([...selectedItems, ...items])]);
-  };
-
-  if (typeof onChange !== 'function') {
-    return null;
-  }
-
-  const totalSelectedItems = selectedItems.size;
-
-  const label = allInPageSelected ? 'Deselect All' : 'Select All';
+  const { allInPageSelected, handleSelectAll, label, someInPageSelected, totalSelectedItems } =
+    useSelectAllState({ expandedRowSelector, isExpandable, items, selectedItems, onChange });
 
   return (
     <FlexItem flexShrink={0} marginRight="xxSmall">

--- a/packages/big-design/src/components/TableNext/SelectAll/helpers.ts
+++ b/packages/big-design/src/components/TableNext/SelectAll/helpers.ts
@@ -1,0 +1,124 @@
+import { TableExpandable, TableSelectable } from '../types';
+
+interface SelectAllRowsArg<T> {
+  isExpandable: boolean;
+  items: T[];
+  selectedItems: TableSelectable['selectedItems'];
+  expandedRowSelector?: TableExpandable<T>['expandedRowSelector'];
+}
+
+export function getTotalSelectedItems<T>(
+  items: T[],
+  selectedItems: TableSelectable['selectedItems'],
+) {
+  return items.reduce((acc, _parentRow, parentRowIndex) => {
+    if (selectedItems[parentRowIndex] !== undefined) {
+      return acc + 1;
+    }
+
+    return acc;
+  }, 0);
+}
+
+export function getChildrenRows<T>(
+  parentRow: T,
+  expandedRowSelector?: TableExpandable<T>['expandedRowSelector'],
+) {
+  const expandedRowMode = expandedRowSelector !== undefined;
+
+  if (!expandedRowMode) {
+    return [];
+  }
+
+  return expandedRowSelector(parentRow) ?? [];
+}
+
+export function areAllInPageSelected<T>({
+  isExpandable,
+  items,
+  selectedItems,
+  expandedRowSelector,
+}: SelectAllRowsArg<T>) {
+  if (items.length <= 0) {
+    return false;
+  }
+
+  return items.every((parentRow, parentRowIndex) => {
+    const childrenRows: T[] = getChildrenRows(parentRow, expandedRowSelector);
+
+    // Not need to check childrens since expandable mode is not used.
+    if (!isExpandable || childrenRows.length === 0) {
+      return selectedItems[parentRowIndex] !== undefined;
+    }
+
+    return areAllParentsAndChildrenSelected(childrenRows, selectedItems, parentRowIndex);
+  });
+}
+
+export function areSomeInPageSelected<T>({
+  isExpandable,
+  items,
+  selectedItems,
+  expandedRowSelector,
+}: SelectAllRowsArg<T>): boolean {
+  if (items.length <= 0) {
+    return false;
+  }
+
+  return items.some((parentRow, parentRowIndex) => {
+    const childrenRows: T[] = getChildrenRows(parentRow, expandedRowSelector);
+
+    // Not need to check childrens since expandable mode is not used.
+    if (!isExpandable || childrenRows.length === 0) {
+      return selectedItems[parentRowIndex] !== undefined;
+    }
+
+    return areSomeParentsAndChildrenSelected(childrenRows, selectedItems, parentRowIndex);
+  });
+}
+
+function areAllParentsAndChildrenSelected<T>(
+  childrenRows: T[],
+  selectedItems: TableSelectable['selectedItems'],
+  parentRowIndex: number,
+) {
+  const allChildrenRowsSelected = childrenRows.every((_childRow, childRowIndex) => {
+    return selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
+  });
+
+  return selectedItems[parentRowIndex] !== undefined && allChildrenRowsSelected;
+}
+
+function areSomeParentsAndChildrenSelected<T>(
+  childrenRows: T[],
+  selectedItems: TableSelectable['selectedItems'],
+  parentRowIndex: number,
+) {
+  const someChildrenRowsInPageSelected = childrenRows.some((_childRow, childRowIndex) => {
+    return selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
+  });
+
+  return selectedItems[parentRowIndex] !== undefined && someChildrenRowsInPageSelected;
+}
+
+export function selectAll<T>({
+  expandedRowSelector,
+  isExpandable,
+  items,
+}: Omit<SelectAllRowsArg<T>, 'selectedItems'>): TableSelectable['selectedItems'] {
+  const newSelectedItems = items.map((parentRow, parentRowIndex) => {
+    const childrenRows: T[] = getChildrenRows(parentRow, expandedRowSelector);
+
+    if (isExpandable) {
+      const newSelectedChildrenRows = childrenRows.map<[string, true]>((_child, childRowIndex) => {
+        return [`${parentRowIndex}.${childRowIndex}`, true];
+      });
+
+      return [[`${parentRowIndex}`, true], ...newSelectedChildrenRows];
+    }
+
+    return [[`${parentRowIndex}`, true]];
+  });
+
+  return Object.fromEntries(newSelectedItems.flat());
+}

--- a/packages/big-design/src/components/TableNext/SelectAll/index.ts
+++ b/packages/big-design/src/components/TableNext/SelectAll/index.ts
@@ -1,0 +1,1 @@
+export * from './SelectAll';

--- a/packages/big-design/src/components/TableNext/SelectAll/useSelectAllState.ts
+++ b/packages/big-design/src/components/TableNext/SelectAll/useSelectAllState.ts
@@ -1,0 +1,67 @@
+import { TableExpandable, TableSelectable } from '../types';
+
+import {
+  areAllInPageSelected,
+  areSomeInPageSelected,
+  getTotalSelectedItems,
+  selectAll,
+} from './helpers';
+
+interface useSelectAllStateProps<T> {
+  isExpandable: boolean;
+  items: T[];
+  selectedItems: TableSelectable['selectedItems'];
+  expandedRowSelector?: TableExpandable<T>['expandedRowSelector'];
+  onChange?: TableSelectable['onSelectionChange'];
+}
+
+export const useSelectAllState = <T>({
+  expandedRowSelector,
+  isExpandable,
+  items,
+  selectedItems,
+  onChange,
+}: useSelectAllStateProps<T>) => {
+  const allInPageSelected = areAllInPageSelected({
+    expandedRowSelector,
+    isExpandable,
+    items,
+    selectedItems,
+  });
+
+  const someInPageSelected = areSomeInPageSelected({
+    expandedRowSelector,
+    isExpandable,
+    items,
+    selectedItems,
+  });
+
+  const totalSelectedItems = getTotalSelectedItems(items, selectedItems);
+  const label = allInPageSelected ? 'Deselect All' : 'Select All';
+
+  const handleSelectAll = () => {
+    if (typeof onChange !== 'function') {
+      return;
+    }
+
+    if (allInPageSelected) {
+      return onChange({});
+    }
+
+    const newSelectedItems = selectAll({
+      expandedRowSelector,
+      isExpandable,
+      items,
+    });
+
+    return onChange(newSelectedItems);
+  };
+
+  return {
+    allInPageSelected,
+    handleSelectAll,
+    label,
+    someInPageSelected,
+    totalSelectedItems,
+  };
+};

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -1,0 +1,273 @@
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
+
+import { useEventCallback, useUniqueId } from '../../hooks';
+import { MarginProps } from '../../mixins';
+import { typedMemo } from '../../utils';
+
+import { Actions } from './Actions';
+import { Body } from './Body';
+import { Head } from './Head';
+import { HeaderCell } from './HeaderCell';
+import { DragIconHeaderCell, HeaderCheckboxCell } from './HeaderCell/HeaderCell';
+import { Row } from './Row';
+import { StyledTable, StyledTableFigure } from './styled';
+import { TableColumn, TableItem, TableProps } from './types';
+
+const InternalTableNext = <T extends TableItem>(
+  props: TableProps<T>,
+): React.ReactElement<TableProps<T>> => {
+  const {
+    actions,
+    className,
+    columns,
+    emptyComponent,
+    headerless = false,
+    id,
+    itemName,
+    items,
+    keyField = 'id',
+    onRowDrop,
+    pagination,
+    selectable,
+    sortable,
+    stickyHeader,
+    style,
+    ...rest
+  } = props;
+
+  const actionsRef = useRef<HTMLDivElement>(null);
+  const uniqueTableId = useUniqueId('table');
+  const tableIdRef = useRef(id || uniqueTableId);
+  const isSelectable = Boolean(selectable);
+  const [selectedItems, setSelectedItems] = useState<Set<T>>(new Set());
+  const [headerCellWidths, setHeaderCellWidths] = useState<Array<number | string>>([]);
+  const headerCellIconRef = useRef<HTMLTableCellElement>(null);
+  const eventCallback = useEventCallback((item: T) => {
+    if (!selectable || !item) {
+      return;
+    }
+
+    const { onSelectionChange } = selectable;
+    const nextIsSelected = !selectedItems.has(item);
+
+    if (nextIsSelected) {
+      onSelectionChange([...selectedItems, item]);
+    } else {
+      onSelectionChange([...selectedItems].filter((selectedItem) => selectedItem !== item));
+    }
+  });
+
+  const selectableConditionalDep = selectable ? selectable.selectedItems : null;
+
+  useEffect(() => {
+    if (selectable) {
+      setSelectedItems(new Set(selectable.selectedItems));
+    }
+  }, [selectable, selectableConditionalDep]);
+
+  const onItemSelect = selectable ? eventCallback : undefined;
+
+  const onSortClick = useCallback(
+    (column: TableColumn<T>) => {
+      if (!sortable || !column.isSortable) {
+        return;
+      }
+
+      const { hash } = column;
+      const sortDirection = sortable.direction === 'ASC' ? 'DESC' : 'ASC';
+
+      if (typeof sortable.onSort === 'function') {
+        sortable.onSort(hash, sortDirection, column);
+      }
+    },
+    [sortable],
+  );
+
+  const onDragEnd = useCallback(
+    (result: DropResult) => {
+      const { destination, source } = result;
+
+      if (!destination) {
+        return;
+      }
+
+      if (destination.droppableId === source.droppableId && destination.index === source.index) {
+        return;
+      }
+
+      if (typeof onRowDrop === 'function') {
+        onRowDrop(source.index, destination.index);
+      }
+
+      setHeaderCellWidths([]);
+    },
+    [onRowDrop],
+  );
+
+  const onBeforeDragStart = () => {
+    const headerCellIconWidth = headerCellIconRef.current?.offsetWidth ?? 'auto';
+
+    const headerCellsWidths = columns.map((_column, index) => {
+      const headerCellElement = window.document.getElementById(`header-cell-${index}`);
+
+      return headerCellElement?.getBoundingClientRect().width ?? 'auto';
+    });
+
+    const allHeaderWidths = [headerCellIconWidth, ...headerCellsWidths];
+
+    setHeaderCellWidths(allHeaderWidths);
+  };
+
+  const shouldRenderActions = () => {
+    return Boolean(actions) || Boolean(pagination) || Boolean(selectable) || Boolean(itemName);
+  };
+
+  const getItemKey = (item: T, index: number): string | number => {
+    if (item[keyField] !== undefined) {
+      return item[keyField];
+    }
+
+    return index;
+  };
+
+  const renderHeaders = () => (
+    <Head hidden={headerless}>
+      <tr>
+        {typeof onRowDrop === 'function' && (
+          <DragIconHeaderCell actionsRef={actionsRef} headerCellIconRef={headerCellIconRef} />
+        )}
+        {isSelectable && <HeaderCheckboxCell actionsRef={actionsRef} stickyHeader={stickyHeader} />}
+
+        {columns.map((column, index) => {
+          const { display, hash, header, isSortable, hideHeader, width } = column;
+          const isSorted = isSortable && sortable && hash === sortable.columnHash;
+          const sortDirection = sortable && sortable.direction;
+          const headerCellWidth = headerCellWidths[index + 1];
+          const widthColumn = headerCellWidth ?? width;
+
+          return (
+            <HeaderCell
+              actionsRef={actionsRef}
+              column={{ ...column, width: widthColumn }}
+              display={display}
+              hide={hideHeader}
+              id={`header-cell-${index}`}
+              isSorted={isSorted}
+              key={index}
+              onSortClick={onSortClick}
+              sortDirection={sortDirection}
+              stickyHeader={stickyHeader}
+            >
+              {header}
+            </HeaderCell>
+          );
+        })}
+      </tr>
+    </Head>
+  );
+
+  const renderDroppableItems = () => (
+    <Droppable droppableId={`${uniqueTableId}-bd-droppable`}>
+      {(provided) => (
+        <Body ref={provided.innerRef} withFirstRowBorder={headerless} {...provided.droppableProps}>
+          {items.map((item: T, index) => {
+            const key = getItemKey(item, index);
+            const isSelected = selectedItems.has(item);
+
+            return (
+              <Draggable draggableId={String(key)} index={index} key={key}>
+                {(provided, snapshot) => (
+                  <Row
+                    isDragging={snapshot.isDragging}
+                    {...provided.dragHandleProps}
+                    {...provided.draggableProps}
+                    columns={columns}
+                    headerCellWidths={headerCellWidths}
+                    isSelectable={isSelectable}
+                    isSelected={isSelected}
+                    item={item}
+                    onItemSelect={onItemSelect}
+                    ref={provided.innerRef}
+                    showDragIcon={true}
+                  />
+                )}
+              </Draggable>
+            );
+          })}
+          {provided.placeholder}
+        </Body>
+      )}
+    </Droppable>
+  );
+
+  const renderItems = () =>
+    onRowDrop ? (
+      renderDroppableItems()
+    ) : (
+      <Body withFirstRowBorder={headerless}>
+        {items.map((item: T, index) => {
+          const key = getItemKey(item, index);
+          const isSelected = selectedItems.has(item);
+
+          return (
+            <Row
+              columns={columns}
+              headerCellWidths={headerCellWidths}
+              isSelectable={isSelectable}
+              isSelected={isSelected}
+              item={item}
+              key={key}
+              onItemSelect={onItemSelect}
+            />
+          );
+        })}
+      </Body>
+    );
+
+  const renderEmptyState = () => {
+    if (items.length === 0 && emptyComponent) {
+      return emptyComponent;
+    }
+
+    return null;
+  };
+
+  return (
+    <>
+      {shouldRenderActions() && (
+        <Actions
+          customActions={actions}
+          forwardedRef={actionsRef}
+          itemName={itemName}
+          items={items}
+          onSelectionChange={selectable && selectable.onSelectionChange}
+          pagination={pagination}
+          selectedItems={selectedItems}
+          stickyHeader={stickyHeader}
+          tableId={tableIdRef.current}
+        />
+      )}
+      <StyledTable {...rest} id={tableIdRef.current}>
+        {onRowDrop ? (
+          <DragDropContext onBeforeDragStart={onBeforeDragStart} onDragEnd={onDragEnd}>
+            {renderHeaders()}
+            {renderItems()}
+          </DragDropContext>
+        ) : (
+          <>
+            {renderHeaders()}
+            {renderItems()}
+          </>
+        )}
+      </StyledTable>
+
+      {renderEmptyState()}
+    </>
+  );
+};
+
+export const TableNext = typedMemo(InternalTableNext);
+export const TableNextFigure: React.FC<{ children?: React.ReactNode } & MarginProps> = memo(
+  (props) => <StyledTableFigure {...props} />,
+);

--- a/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
@@ -1,0 +1,30 @@
+import React, { memo } from 'react';
+
+import { Pagination } from '../../Pagination';
+import { TablePaginationProps } from '../types';
+
+import { StyledPaginationContainer } from './styled';
+
+export const TablePagination: React.FC<TablePaginationProps> = memo(
+  ({
+    currentPage,
+    itemsPerPage,
+    itemsPerPageOptions,
+    onItemsPerPageChange,
+    onPageChange,
+    totalItems,
+  }) => {
+    return (
+      <StyledPaginationContainer flexShrink={0}>
+        <Pagination
+          currentPage={currentPage}
+          itemsPerPage={itemsPerPage}
+          itemsPerPageOptions={itemsPerPageOptions}
+          onItemsPerPageChange={onItemsPerPageChange}
+          onPageChange={onPageChange}
+          totalItems={totalItems}
+        />
+      </StyledPaginationContainer>
+    );
+  },
+);

--- a/packages/big-design/src/components/TableNext/TablePagination/index.ts
+++ b/packages/big-design/src/components/TableNext/TablePagination/index.ts
@@ -1,0 +1,1 @@
+export * from './TablePagination';

--- a/packages/big-design/src/components/TableNext/TablePagination/styled.tsx
+++ b/packages/big-design/src/components/TableNext/TablePagination/styled.tsx
@@ -1,0 +1,10 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled from 'styled-components';
+
+import { FlexItem } from '../../Flex';
+
+export const StyledPaginationContainer = styled(FlexItem)`
+  margin-left: auto;
+`;
+
+StyledPaginationContainer.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -1,0 +1,1005 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a pagination component 1`] = `
+.c10 {
+  vertical-align: middle;
+  height: 2rem;
+  width: 2rem;
+}
+
+.c14 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  box-sizing: border-box;
+}
+
+.c11 {
+  box-sizing: border-box;
+  z-index: 1060;
+}
+
+.c4 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c5 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.c12 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
+.c6 {
+  position: relative;
+}
+
+.c7 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  padding-right: 0.5rem;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c7 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c7:active {
+  background-color: #DBE3FE;
+}
+
+.c7:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c7:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c7[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c13 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  padding: 0 0.5rem;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c13 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c13:active {
+  background-color: #DBE3FE;
+}
+
+.c13:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c13:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c13[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c9 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+}
+
+.c8 {
+  color: #313440;
+  width: auto;
+}
+
+.c3 {
+  margin-left: auto;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: stretch;
+  -webkit-justify-content: stretch;
+  -ms-flex-pack: stretch;
+  justify-content: stretch;
+  background-color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0.75rem 1.5rem;
+}
+
+@media (min-width:720px) {
+  .c7 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c7 {
+    width: auto;
+  }
+}
+
+@media (min-width:720px) {
+  .c13 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c13 {
+    width: auto;
+  }
+}
+
+<div
+  aria-controls="bd-table-1"
+  class="c0"
+>
+  <div
+    class="c1 c2 c3"
+  >
+    <div
+      aria-label="pagination"
+      class="c1 c4"
+      role="navigation"
+    >
+      <div
+        class="c1 c5"
+      >
+        <div
+          class="c1 c6"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="bd-dropdown-2-label bd-dropdown-2-toggle-button"
+            class="c7 c8"
+            id="bd-dropdown-2-toggle-button"
+          >
+            <span
+              class="c9"
+            >
+              1 - 3 of 5
+              <svg
+                aria-hidden="true"
+                class="c10"
+                fill="currentColor"
+                height="24"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M0 0h24v24H0V0z"
+                  fill="none"
+                />
+                <path
+                  d="M8.71 11.71l2.59 2.59c.39.39 1.02.39 1.41 0l2.59-2.59c.63-.63.18-1.71-.71-1.71H9.41c-.89 0-1.33 1.08-.7 1.71z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="c11"
+            style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
+          >
+            <ul
+              aria-labelledby="bd-dropdown-2-label"
+              class="c12"
+              id="bd-dropdown-2-menu"
+              role="listbox"
+              tabindex="-1"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="c1 c5"
+      >
+        <button
+          class="c13 c8"
+          disabled=""
+        >
+          <span
+            class="c9"
+          >
+            <svg
+              aria-labelledby="bd-icon-4"
+              class="c14"
+              fill="currentColor"
+              height="24"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <title
+                id="bd-icon-4"
+              >
+                Previous page
+              </title>
+              <path
+                d="M0 0h24v24H0V0z"
+                fill="none"
+              />
+              <path
+                d="M14.71 6.71a.996.996 0 00-1.41 0L8.71 11.3a.996.996 0 000 1.41l4.59 4.59a.996.996 0 101.41-1.41L10.83 12l3.88-3.88c.39-.39.38-1.03 0-1.41z"
+              />
+            </svg>
+          </span>
+        </button>
+        <button
+          class="c13 c8"
+        >
+          <span
+            class="c9"
+          >
+            <svg
+              aria-labelledby="bd-icon-5"
+              class="c14"
+              fill="currentColor"
+              height="24"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <title
+                id="bd-icon-5"
+              >
+                Next page
+              </title>
+              <path
+                d="M0 0h24v24H0V0z"
+                fill="none"
+              />
+              <path
+                d="M9.29 6.71a.996.996 0 000 1.41L13.17 12l-3.88 3.88a.996.996 0 101.41 1.41l4.59-4.59a.996.996 0 000-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders a simple table 1`] = `
+.c2 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D9DCE9;
+  border-top: 1px solid #D9DCE9;
+  box-sizing: border-box;
+  color: #313440;
+  font-size: 1rem;
+  padding: 0.75rem;
+  white-space: nowrap;
+}
+
+.c1:first-of-type {
+  padding-left: 1.5rem;
+}
+
+.c1:last-of-type {
+  padding-right: 1.5rem;
+}
+
+.c4 {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c6 {
+  background-color: #FFFFFF;
+  box-sizing: border-box;
+  color: #313440;
+  font-size: 1rem;
+  padding: 0.75rem;
+  border-bottom: 1px solid #D9DCE9;
+}
+
+.c6:first-of-type {
+  padding-left: 1.5rem;
+}
+
+.c6:last-of-type {
+  padding-right: 1.5rem;
+}
+
+.c5 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color;
+  transition-property: background-color;
+  display: table-row;
+  background-color: transparent;
+}
+
+.c5:hover {
+  background-color: #F6F7FC;
+}
+
+.c0 {
+  border-color: transparent;
+  border-spacing: 0;
+  color: #313440;
+  text-align: left;
+  width: 100%;
+}
+
+<table
+  class="c0"
+  id="bd-table-1"
+>
+  <thead
+    class=""
+  >
+    <tr>
+      <th
+        class="c1"
+        id="header-cell-0"
+      >
+        <div
+          class="c2 c3 c4"
+        >
+          Sku
+        </div>
+      </th>
+      <th
+        class="c1"
+        id="header-cell-1"
+      >
+        <div
+          class="c2 c3 c4"
+        >
+          Name
+        </div>
+      </th>
+      <th
+        class="c1"
+        id="header-cell-2"
+      >
+        <div
+          class="c2 c3 c4"
+        >
+          Stock
+        </div>
+      </th>
+    </tr>
+  </thead>
+  <tbody
+    class=""
+  >
+    <tr
+      class="c5"
+    >
+      <td
+        class="c6"
+      >
+        SM13
+      </td>
+      <td
+        class="c6"
+      >
+        [Sample] Smith Journal 13
+      </td>
+      <td
+        class="c6"
+      >
+        25
+      </td>
+    </tr>
+    <tr
+      class="c5"
+    >
+      <td
+        class="c6"
+      >
+        DPB
+      </td>
+      <td
+        class="c6"
+      >
+        [Sample] Dustpan & Brush
+      </td>
+      <td
+        class="c6"
+      >
+        34
+      </td>
+    </tr>
+    <tr
+      class="c5"
+    >
+      <td
+        class="c6"
+      >
+        OFSUC
+      </td>
+      <td
+        class="c6"
+      >
+        [Sample] Utility Caddy
+      </td>
+      <td
+        class="c6"
+      >
+        45
+      </td>
+    </tr>
+    <tr
+      class="c5"
+    >
+      <td
+        class="c6"
+      >
+        CLC
+      </td>
+      <td
+        class="c6"
+      >
+        [Sample] Canvas Laundry Cart
+      </td>
+      <td
+        class="c6"
+      >
+        2
+      </td>
+    </tr>
+    <tr
+      class="c5"
+    >
+      <td
+        class="c6"
+      >
+        CGLD
+      </td>
+      <td
+        class="c6"
+      >
+        [Sample] Laundry Detergent
+      </td>
+      <td
+        class="c6"
+      >
+        29
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`renders a table figure 1`] = `
+.c0 {
+  margin: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+@media (min-width:720px) {
+  .c0 {
+    white-space: normal;
+  }
+}
+
+<figure
+  class="c0"
+/>
+`;
+
+exports[`selectable renders selectable actions and checkboxes 1`] = `
+.c10 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  margin-right: 0.25rem;
+  box-sizing: border-box;
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c15 {
+  margin-right: 1rem;
+  box-sizing: border-box;
+}
+
+.c4 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c12 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c12:last-child {
+  margin-bottom: 0;
+}
+
+.c14 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin-left: 0.75rem;
+}
+
+.c14:last-child {
+  margin-bottom: 0;
+}
+
+.c16 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0;
+}
+
+.c16:last-child {
+  margin-bottom: 0;
+}
+
+.c13 {
+  cursor: pointer;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11 {
+  margin-left: 0.5rem;
+}
+
+.c5 {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c9 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
+  transition-property: border-color,background,box-shadow,color,opacity;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #FFFFFF;
+  box-sizing: border-box;
+  border: 1px solid #D9DCE9;
+  border-color: #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 1.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-bottom: 0.125rem;
+  margin-top: 0.125rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1.25rem;
+}
+
+.c9:hover {
+  border-color: #B4BAD1;
+}
+
+.c6:focus + .c8 {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c9 svg {
+  opacity: 0;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: stretch;
+  -webkit-justify-content: stretch;
+  -ms-flex-pack: stretch;
+  justify-content: stretch;
+  background-color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0.75rem 1.5rem;
+}
+
+<div
+  aria-controls="bd-table-1"
+  class="c0"
+>
+  <div
+    class="c1 c2"
+  >
+    <div
+      class="c3 c4"
+    >
+      <div
+        class="c5"
+      >
+        <input
+          aria-checked="false"
+          aria-labelledby="bd-checkbox_label-3"
+          class="c6 c7"
+          id="bd-checkbox-2"
+          type="checkbox"
+        />
+        <label
+          aria-hidden="true"
+          class="c8 c9"
+          for="bd-checkbox-2"
+        >
+          <svg
+            aria-hidden="true"
+            class="c10"
+            fill="currentColor"
+            height="24"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M0 0h24v24H0V0z"
+              fill="none"
+            />
+            <path
+              d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+            />
+          </svg>
+        </label>
+        <div
+          class="c11"
+        >
+          <label
+            class="c12 c13"
+            for="bd-checkbox-2"
+            hidden=""
+            id="bd-checkbox_label-3"
+          >
+            Select All
+          </label>
+        </div>
+      </div>
+      <p
+        class="c14"
+      >
+        5
+      </p>
+    </div>
+  </div>
+  <div
+    class="c15 c2"
+  >
+    <p
+      class="c16"
+    >
+      Product
+    </p>
+  </div>
+</div>
+`;

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -469,6 +469,14 @@ exports[`renders a simple table 1`] = `
   box-sizing: border-box;
 }
 
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+}
+
 .c3 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
@@ -520,11 +528,11 @@ exports[`renders a simple table 1`] = `
 }
 
 .c6 {
+  padding: 0.75rem;
   background-color: #FFFFFF;
   box-sizing: border-box;
   color: #313440;
   font-size: 1rem;
-  padding: 0.75rem;
   border-bottom: 1px solid #D9DCE9;
 }
 
@@ -606,36 +614,32 @@ exports[`renders a simple table 1`] = `
       <td
         class="c6"
       >
-        SM13
+        <div
+          class="c7"
+          display="flex"
+        >
+          SM13
+        </div>
       </td>
       <td
         class="c6"
       >
-        [Sample] Smith Journal 13
+        <div
+          class="c7"
+          display="flex"
+        >
+          [Sample] Smith Journal 13
+        </div>
       </td>
       <td
         class="c6"
       >
-        25
-      </td>
-    </tr>
-    <tr
-      class="c5"
-    >
-      <td
-        class="c6"
-      >
-        DPB
-      </td>
-      <td
-        class="c6"
-      >
-        [Sample] Dustpan & Brush
-      </td>
-      <td
-        class="c6"
-      >
-        34
+        <div
+          class="c7"
+          display="flex"
+        >
+          25
+        </div>
       </td>
     </tr>
     <tr
@@ -644,36 +648,32 @@ exports[`renders a simple table 1`] = `
       <td
         class="c6"
       >
-        OFSUC
+        <div
+          class="c7"
+          display="flex"
+        >
+          DPB
+        </div>
       </td>
       <td
         class="c6"
       >
-        [Sample] Utility Caddy
+        <div
+          class="c7"
+          display="flex"
+        >
+          [Sample] Dustpan & Brush
+        </div>
       </td>
       <td
         class="c6"
       >
-        45
-      </td>
-    </tr>
-    <tr
-      class="c5"
-    >
-      <td
-        class="c6"
-      >
-        CLC
-      </td>
-      <td
-        class="c6"
-      >
-        [Sample] Canvas Laundry Cart
-      </td>
-      <td
-        class="c6"
-      >
-        2
+        <div
+          class="c7"
+          display="flex"
+        >
+          34
+        </div>
       </td>
     </tr>
     <tr
@@ -682,17 +682,100 @@ exports[`renders a simple table 1`] = `
       <td
         class="c6"
       >
-        CGLD
+        <div
+          class="c7"
+          display="flex"
+        >
+          OFSUC
+        </div>
       </td>
       <td
         class="c6"
       >
-        [Sample] Laundry Detergent
+        <div
+          class="c7"
+          display="flex"
+        >
+          [Sample] Utility Caddy
+        </div>
       </td>
       <td
         class="c6"
       >
-        29
+        <div
+          class="c7"
+          display="flex"
+        >
+          45
+        </div>
+      </td>
+    </tr>
+    <tr
+      class="c5"
+    >
+      <td
+        class="c6"
+      >
+        <div
+          class="c7"
+          display="flex"
+        >
+          CLC
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <div
+          class="c7"
+          display="flex"
+        >
+          [Sample] Canvas Laundry Cart
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <div
+          class="c7"
+          display="flex"
+        >
+          2
+        </div>
+      </td>
+    </tr>
+    <tr
+      class="c5"
+    >
+      <td
+        class="c6"
+      >
+        <div
+          class="c7"
+          display="flex"
+        >
+          CGLD
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <div
+          class="c7"
+          display="flex"
+        >
+          [Sample] Laundry Detergent
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <div
+          class="c7"
+          display="flex"
+        >
+          29
+        </div>
       </td>
     </tr>
   </tbody>
@@ -926,6 +1009,300 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
+}
+
+<div
+  aria-controls="bd-table-1"
+  class="c0"
+>
+  <div
+    class="c1 c2"
+  >
+    <div
+      class="c3 c4"
+    >
+      <div
+        class="c5"
+      >
+        <input
+          aria-checked="false"
+          aria-labelledby="bd-checkbox_label-3"
+          class="c6 c7"
+          id="bd-checkbox-2"
+          type="checkbox"
+        />
+        <label
+          aria-hidden="true"
+          class="c8 c9"
+          for="bd-checkbox-2"
+        >
+          <svg
+            aria-hidden="true"
+            class="c10"
+            fill="currentColor"
+            height="24"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M0 0h24v24H0V0z"
+              fill="none"
+            />
+            <path
+              d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+            />
+          </svg>
+        </label>
+        <div
+          class="c11"
+        >
+          <label
+            class="c12 c13"
+            for="bd-checkbox-2"
+            hidden=""
+            id="bd-checkbox_label-3"
+          >
+            Select All
+          </label>
+        </div>
+      </div>
+      <p
+        class="c14"
+      >
+        5
+      </p>
+    </div>
+  </div>
+  <div
+    class="c15 c2"
+  >
+    <p
+      class="c16"
+    >
+      Product
+    </p>
+  </div>
+</div>
+`;
+
+exports[`selectable renders selectable actions, checkboxes when having parent rows and children rows 1`] = `
+.c10 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  margin-right: 0.25rem;
+  box-sizing: border-box;
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c15 {
+  margin-right: 1rem;
+  box-sizing: border-box;
+}
+
+.c4 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c12 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c12:last-child {
+  margin-bottom: 0;
+}
+
+.c14 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin-left: 0.75rem;
+}
+
+.c14:last-child {
+  margin-bottom: 0;
+}
+
+.c16 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0;
+}
+
+.c16:last-child {
+  margin-bottom: 0;
+}
+
+.c13 {
+  cursor: pointer;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11 {
+  margin-left: 0.5rem;
+}
+
+.c5 {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c9 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
+  transition-property: border-color,background,box-shadow,color,opacity;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #FFFFFF;
+  box-sizing: border-box;
+  border: 1px solid #D9DCE9;
+  border-color: #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 1.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-bottom: 0.125rem;
+  margin-top: 0.125rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1.25rem;
+}
+
+.c9:hover {
+  border-color: #B4BAD1;
+}
+
+.c6:focus + .c8 {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c9 svg {
+  opacity: 0;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: stretch;
+  -webkit-justify-content: stretch;
+  -ms-flex-pack: stretch;
+  justify-content: stretch;
+  background-color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0.75rem 1.5rem;
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
 }
 
 <div

--- a/packages/big-design/src/components/TableNext/hooks/index.ts
+++ b/packages/big-design/src/components/TableNext/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useExpandable';
+export * from './useSelectable';

--- a/packages/big-design/src/components/TableNext/hooks/useExpandable/index.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useExpandable/index.ts
@@ -1,0 +1,1 @@
+export * from './useExpandable';

--- a/packages/big-design/src/components/TableNext/hooks/useExpandable/useExpandable.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useExpandable/useExpandable.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+import { useEventCallback } from '../../../../hooks';
+import { TableExpandable } from '../../types';
+
+export const useExpandable = <T>(expandable?: TableExpandable<T>) => {
+  const [expandedRows, setExpandedRows] = useState<TableExpandable<T>['expandedRows']>({});
+  const isExpandable = Boolean(expandable);
+
+  const expandedItemsEventCallback = useEventCallback((parentRowIndex: number | null) => {
+    if (!expandable || parentRowIndex === null) {
+      return;
+    }
+
+    const { onExpandedChange } = expandable;
+
+    const isExpandedRow = expandedRows[parentRowIndex] !== undefined;
+
+    if (isExpandedRow) {
+      const newExpandedRows = Object.entries(expandedRows).filter(
+        ([key]) => key !== `${parentRowIndex}`,
+      );
+
+      onExpandedChange(Object.fromEntries(newExpandedRows));
+    } else {
+      const newExpandedRows = { ...expandedRows };
+
+      newExpandedRows[parentRowIndex] = true;
+
+      onExpandedChange(newExpandedRows);
+    }
+  });
+
+  useEffect(() => {
+    if (expandable?.expandedRows) {
+      setExpandedRows({ ...expandable.expandedRows });
+    }
+  }, [expandable?.expandedRows]);
+
+  return {
+    expandedRows,
+    expandedRowSelector: expandable?.expandedRowSelector,
+    isExpandable,
+    onExpandedRow: isExpandable ? expandedItemsEventCallback : undefined,
+    setExpandedRows,
+  };
+};

--- a/packages/big-design/src/components/TableNext/hooks/useSelectable/helpers.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useSelectable/helpers.ts
@@ -1,0 +1,199 @@
+import { TableSelectable } from '../../types';
+
+export interface SelectRowArg<T> {
+  childrenRows?: T[];
+  childRowIndex?: number;
+  isExpandable?: boolean;
+  isTheOnlySelectedChildRow?: boolean;
+  parentRowIndex: number;
+  selectedItems: TableSelectable['selectedItems'];
+  isParentRow?: boolean;
+}
+
+export function selectParentRow<T>({
+  childrenRows,
+  isExpandable,
+  parentRowIndex,
+  selectedItems,
+}: SelectRowArg<T>): TableSelectable['selectedItems'] {
+  const isSelectedParent = selectedItems[parentRowIndex] !== undefined;
+
+  if (isSelectedParent) {
+    const newSelectedItems = unselectParent({
+      childrenRows,
+      isExpandable,
+      parentRowIndex,
+      selectedItems,
+    });
+
+    return newSelectedItems;
+  }
+
+  const newSelectedItems = selectParent({
+    childrenRows,
+    isExpandable,
+    parentRowIndex,
+    selectedItems,
+  });
+
+  return newSelectedItems;
+}
+
+function unselectParent<T>({
+  childrenRows,
+  isExpandable,
+  parentRowIndex,
+  selectedItems,
+}: SelectRowArg<T>): TableSelectable['selectedItems'] {
+  const hasChildrenRows = isExpandable && childrenRows !== undefined;
+
+  // If parent has children, unselect it's childrenRows
+  if (hasChildrenRows) {
+    const newSelectedItems = unselectParentAndChildren({
+      selectedItems,
+      parentRowIndex,
+    });
+
+    return newSelectedItems;
+  }
+
+  // Unselect the parent row
+  const newSelectedItems = Object.entries(selectedItems).filter(
+    ([key]) => key !== `${parentRowIndex}`,
+  );
+
+  return Object.fromEntries(newSelectedItems);
+}
+
+function unselectParentAndChildren<T>({ selectedItems, parentRowIndex }: SelectRowArg<T>) {
+  const newSelectedItems = Object.entries(selectedItems).filter(
+    ([key]) => !key.startsWith(`${parentRowIndex}`),
+  );
+
+  return Object.fromEntries(newSelectedItems);
+}
+
+function selectParent<T>({
+  childrenRows,
+  isExpandable,
+  parentRowIndex,
+  selectedItems,
+}: SelectRowArg<T>): TableSelectable['selectedItems'] {
+  const hasChildrenRows = isExpandable && childrenRows !== undefined;
+
+  // If parent has children, select it's childrenRows
+  if (hasChildrenRows) {
+    const newSelectedItems = selectParentAndChildren({
+      selectedItems,
+      childrenRows,
+      parentRowIndex,
+    });
+
+    return newSelectedItems;
+  }
+
+  return {
+    ...selectedItems,
+    [parentRowIndex]: true,
+  };
+}
+
+function selectParentAndChildren<T>({
+  selectedItems,
+  childrenRows = [],
+  parentRowIndex,
+}: SelectRowArg<T>) {
+  const newSelectedItems = { ...selectedItems };
+
+  newSelectedItems[parentRowIndex] = true;
+
+  for (let index = 0; index < childrenRows.length; index++) {
+    const childRowIndex = index;
+
+    newSelectedItems[`${parentRowIndex}.${childRowIndex}`] = true;
+  }
+
+  return newSelectedItems;
+}
+
+export function selectChildRow<T>({
+  childRowIndex,
+  isTheOnlySelectedChildRow,
+  selectedItems,
+  parentRowIndex,
+}: SelectRowArg<T>): TableSelectable['selectedItems'] {
+  const isSelectedParent = selectedItems[parentRowIndex] !== undefined;
+
+  if (!isSelectedParent) {
+    const newSelectedItems = selectChild({ childRowIndex, parentRowIndex, selectedItems });
+
+    return newSelectedItems;
+  }
+
+  const isSelectedChild = selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
+
+  if (isSelectedChild) {
+    const newSelectedItems = unselectChild({
+      selectedItems,
+      parentRowIndex,
+      childRowIndex,
+      isTheOnlySelectedChildRow,
+    });
+
+    return newSelectedItems;
+  }
+
+  // SelectedParent but child is not selected.
+  const newSelectedItems = { ...selectedItems };
+
+  newSelectedItems[`${parentRowIndex}.${childRowIndex}`] = true;
+
+  return newSelectedItems;
+}
+
+function selectChild<T>({
+  childRowIndex,
+  parentRowIndex,
+  selectedItems,
+}: SelectRowArg<T>): TableSelectable['selectedItems'] {
+  const newSelectedItems = { ...selectedItems };
+
+  newSelectedItems[`${parentRowIndex}`] = true;
+  newSelectedItems[`${parentRowIndex}.${childRowIndex}`] = true;
+
+  return newSelectedItems;
+}
+
+function unselectChild<T>({
+  selectedItems,
+  parentRowIndex,
+  childRowIndex,
+  isTheOnlySelectedChildRow,
+}: SelectRowArg<T>) {
+  const newSelectedItems = Object.entries(selectedItems)
+    .filter(([key]) => key !== `${parentRowIndex}.${childRowIndex}`)
+    .filter(([key]) => {
+      // Remove the parent row if it's the only selected child.
+      if (isTheOnlySelectedChildRow) {
+        return key !== `${parentRowIndex}`;
+      }
+
+      return true;
+    });
+
+  return Object.fromEntries(newSelectedItems);
+}
+
+export function getTotalSelectedChildRows<T>({
+  childrenRows,
+  parentRowIndex,
+  selectedItems,
+}: SelectRowArg<T>) {
+  return childrenRows?.reduce((acc, _childRow, childRowIndex) => {
+    if (selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined) {
+      return acc + 1;
+    }
+
+    return acc;
+  }, 0);
+}

--- a/packages/big-design/src/components/TableNext/hooks/useSelectable/index.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useSelectable/index.ts
@@ -1,0 +1,1 @@
+export * from './useSelectable';

--- a/packages/big-design/src/components/TableNext/hooks/useSelectable/useSelectable.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useSelectable/useSelectable.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+
+import { useEventCallback } from '../../../../hooks';
+import { TableSelectable } from '../../types';
+
+import {
+  getTotalSelectedChildRows,
+  selectChildRow,
+  selectParentRow,
+  SelectRowArg,
+} from './helpers';
+
+interface OnItemSelectFnArg<T> extends Omit<SelectRowArg<T>, 'childRowIndex' | 'selectedItems'> {
+  childRowIndex: number | null;
+  isParentRow: boolean;
+}
+
+export type OnItemSelectFn = <T>({
+  childRowIndex,
+  childrenRows,
+  isParentRow,
+  isExpandable,
+  parentRowIndex,
+}: OnItemSelectFnArg<T>) => void;
+
+export const useSelectable = (selectable?: TableSelectable) => {
+  const isSelectable = Boolean(selectable);
+  const [selectedItems, setSelectedItems] = useState<TableSelectable['selectedItems']>({});
+
+  const onItemSelectEventCallback: OnItemSelectFn = useEventCallback(
+    ({ childRowIndex, childrenRows, isParentRow, isExpandable, parentRowIndex }) => {
+      if (!selectable) {
+        return;
+      }
+
+      const { onSelectionChange } = selectable;
+
+      if (isParentRow) {
+        const newSelectedItems = selectParentRow({
+          childrenRows,
+          isExpandable,
+          parentRowIndex,
+          selectedItems,
+        });
+
+        onSelectionChange(newSelectedItems);
+      } else if (childRowIndex !== null) {
+        const totalSelectedChildRows = getTotalSelectedChildRows({
+          childrenRows,
+          parentRowIndex,
+          selectedItems,
+        });
+
+        const isTheOnlySelectedChildRow = totalSelectedChildRows === 1;
+
+        const newSelectedItems = selectChildRow({
+          childRowIndex,
+          isTheOnlySelectedChildRow,
+          parentRowIndex,
+          selectedItems,
+        });
+
+        onSelectionChange(newSelectedItems);
+      }
+    },
+  );
+
+  useEffect(() => {
+    if (selectable?.selectedItems) {
+      setSelectedItems({ ...selectable.selectedItems });
+    }
+  }, [selectable?.selectedItems]);
+
+  return {
+    isSelectable,
+    onItemSelect: isSelectable ? onItemSelectEventCallback : undefined,
+    selectedItems,
+  };
+};

--- a/packages/big-design/src/components/TableNext/index.ts
+++ b/packages/big-design/src/components/TableNext/index.ts
@@ -1,1 +1,1 @@
-export { TableNext, TableNextFigure } from './TableNext';
+export { TableNext, TableFigureNext } from './TableNext';

--- a/packages/big-design/src/components/TableNext/index.ts
+++ b/packages/big-design/src/components/TableNext/index.ts
@@ -1,0 +1,1 @@
+export { TableNext, TableNextFigure } from './TableNext';

--- a/packages/big-design/src/components/TableNext/mixins/display/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/mixins/display/__snapshots__/spec.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`responsive display 1`] = `
+@media (min-width:0px) {
+  .c0 {
+    display: none;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    display: table-cell;
+  }
+}
+
+<div
+  class="c0"
+  display="[object Object]"
+/>
+`;

--- a/packages/big-design/src/components/TableNext/mixins/display/display.tsx
+++ b/packages/big-design/src/components/TableNext/mixins/display/display.tsx
@@ -1,0 +1,56 @@
+import { Breakpoints, breakpointsOrder, ThemeInterface } from '@bigcommerce/big-design-theme';
+import { css, FlattenSimpleInterpolation } from 'styled-components';
+
+import { TableColumnDisplayOverload, TableColumnDisplayProps } from './types';
+
+export const withTableColumnDisplay = () => css<TableColumnDisplayProps>`
+  ${({ display, theme }) => display && getDisplayStyles(display, theme, 'display')};
+`;
+
+const getDisplayStyles: TableColumnDisplayOverload = (
+  displayProp: any,
+  theme: ThemeInterface,
+  cssKey: any,
+): FlattenSimpleInterpolation => {
+  if (typeof displayProp === 'object') {
+    return getResponsiveDisplay(displayProp, theme, cssKey);
+  }
+
+  if (typeof displayProp === 'string' || typeof displayProp === 'number') {
+    return getSimpleDisplay(displayProp, cssKey);
+  }
+
+  return [];
+};
+
+const getSimpleDisplay = (
+  displayProp: string | number,
+  cssKey: string,
+): FlattenSimpleInterpolation => css`
+  ${cssKey}: ${displayProp}
+`;
+
+const getResponsiveDisplay: TableColumnDisplayOverload = (
+  displayProp: any,
+  theme: ThemeInterface,
+  cssKey: string,
+): FlattenSimpleInterpolation[] => {
+  const breakpointKeys = Object.keys(displayProp).sort(
+    (firstBreakpoint, secondBreakpoint) =>
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      breakpointsOrder.indexOf(firstBreakpoint as keyof Breakpoints) -
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      breakpointsOrder.indexOf(secondBreakpoint as keyof Breakpoints),
+  );
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return (breakpointKeys as Array<keyof Breakpoints>).map(
+    (breakpointKey) =>
+      css`
+        ${theme.breakpoints[breakpointKey]} {
+          ${/* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access */ ''}
+          ${getSimpleDisplay(displayProp[breakpointKey], cssKey)}
+        }
+      `,
+  );
+};

--- a/packages/big-design/src/components/TableNext/mixins/display/index.ts
+++ b/packages/big-design/src/components/TableNext/mixins/display/index.ts
@@ -1,0 +1,5 @@
+import { TableColumnDisplayProps as _TableColumnDisplayProps } from './types';
+
+export { withTableColumnDisplay } from './display';
+
+export type TableColumnDisplayProps = _TableColumnDisplayProps;

--- a/packages/big-design/src/components/TableNext/mixins/display/spec.tsx
+++ b/packages/big-design/src/components/TableNext/mixins/display/spec.tsx
@@ -1,0 +1,29 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import 'jest-styled-components';
+import React from 'react';
+import styled from 'styled-components';
+
+import { render } from '@test/utils';
+
+import { withTableColumnDisplay } from './display';
+import { TableColumnDisplayProps } from './types';
+
+const TestComponent = styled.div<TableColumnDisplayProps>`
+  ${withTableColumnDisplay()};
+`;
+
+TestComponent.defaultProps = { theme: defaultTheme };
+
+test('display', () => {
+  const { container } = render(<TestComponent display="table-cell" />);
+
+  expect(container.firstChild).toHaveStyle('display: table-cell');
+});
+
+test('responsive display', () => {
+  const { container } = render(
+    <TestComponent display={{ mobile: 'none', tablet: 'table-cell' }} />,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/packages/big-design/src/components/TableNext/mixins/display/types.ts
+++ b/packages/big-design/src/components/TableNext/mixins/display/types.ts
@@ -1,0 +1,16 @@
+import { ThemeInterface } from '@bigcommerce/big-design-theme';
+import { FlattenSimpleInterpolation } from 'styled-components';
+
+import { ResponsiveProp } from '../../../../types';
+
+type TableColumnDisplayProp = ResponsiveProp<'table-cell' | 'none'>;
+
+export type TableColumnDisplayProps = Partial<{
+  display: TableColumnDisplayProp;
+}>;
+
+export type TableColumnDisplayOverload = (
+  displayProp: TableColumnDisplayProp,
+  theme: ThemeInterface,
+  cssKey: 'display',
+) => FlattenSimpleInterpolation;

--- a/packages/big-design/src/components/TableNext/mixins/display/types.ts
+++ b/packages/big-design/src/components/TableNext/mixins/display/types.ts
@@ -5,9 +5,9 @@ import { ResponsiveProp } from '../../../../types';
 
 type TableColumnDisplayProp = ResponsiveProp<'table-cell' | 'none'>;
 
-export type TableColumnDisplayProps = Partial<{
-  display: TableColumnDisplayProp;
-}>;
+export interface TableColumnDisplayProps {
+  display?: TableColumnDisplayProp;
+}
 
 export type TableColumnDisplayOverload = (
   displayProp: TableColumnDisplayProp,

--- a/packages/big-design/src/components/TableNext/mixins/index.ts
+++ b/packages/big-design/src/components/TableNext/mixins/index.ts
@@ -1,0 +1,1 @@
+export * from './display';

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -1,0 +1,571 @@
+import React, { CSSProperties } from 'react';
+import 'jest-styled-components';
+
+import { fireEvent, render, screen } from '@test/utils';
+
+import { TableNext, TableNextFigure } from './TableNext';
+import { TableColumn, TableItem } from './types';
+
+interface SimpleTableOptions {
+  className?: string;
+  columns?: Array<TableColumn<TableItem>>;
+  items?: TableItem[];
+  dataTestId?: string;
+  emptyComponent?: React.ReactElement;
+  headerless?: boolean;
+  id?: string;
+  itemName?: string;
+  style?: CSSProperties;
+}
+
+const getSimpleTable = ({
+  className,
+  columns,
+  dataTestId,
+  emptyComponent,
+  headerless,
+  id,
+  itemName,
+  items,
+  style,
+}: SimpleTableOptions = {}) => (
+  <TableNext
+    className={className}
+    columns={
+      columns || [
+        { hash: 'sku', header: 'Sku', render: ({ sku }) => sku },
+        { hash: 'name', header: 'Name', render: ({ name }) => name },
+        { hash: 'stock', header: 'Stock', render: ({ stock }) => stock },
+      ]
+    }
+    data-testid={dataTestId}
+    emptyComponent={emptyComponent}
+    headerless={headerless}
+    id={id}
+    itemName={itemName}
+    items={
+      items || [
+        { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+        { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+        { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+        { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+        { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+      ]
+    }
+    style={style}
+  />
+);
+
+test('renders a simple table', () => {
+  const { container } = render(getSimpleTable());
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('renders a table figure', () => {
+  const { container } = render(<TableNextFigure />);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('generates a table id automatically', () => {
+  const { getByRole } = render(getSimpleTable());
+
+  const table = getByRole('table');
+
+  expect(table.id).toBeTruthy();
+});
+
+test('forwards id and testid when provided', () => {
+  const id = 'testId';
+  const dataTestId = 'dataTestId';
+
+  const { getByRole } = render(getSimpleTable({ id, dataTestId }));
+
+  const table = getByRole('table');
+
+  expect(table.id).toBe(id);
+  expect(table.dataset.testid).toBe(dataTestId);
+});
+
+test('does not forward styles', () => {
+  const { container } = render(getSimpleTable({ className: 'test', style: { background: 'red' } }));
+
+  expect(container.getElementsByClassName('test')).toHaveLength(0);
+  expect(container.firstChild).not.toHaveStyle('background: red');
+});
+
+test('renders column with custom component', () => {
+  const { getAllByTestId } = render(
+    getSimpleTable({
+      columns: [
+        { hash: 'sku', header: 'Sku', render: ({ sku }: any) => sku },
+        {
+          hash: 'name',
+          header: 'Name',
+          render: ({ name }: any) => <h3 data-testid="name">{name}</h3>,
+        },
+      ],
+    }),
+  );
+
+  expect(getAllByTestId('name')).toHaveLength(5);
+});
+
+test('renders column with tooltip icon', () => {
+  const { getByTitle } = render(
+    getSimpleTable({
+      columns: [
+        { hash: 'sku', header: 'Sku', render: ({ sku }: any) => sku },
+        { hash: 'name', header: 'Name', tooltip: 'Some text', render: ({ name }: any) => name },
+      ],
+    }),
+  );
+
+  expect(getByTitle('Hover or focus for additional context.')).toBeTruthy();
+});
+
+test('renders tooltip when hovering on icon', async () => {
+  const { getByTitle } = render(
+    getSimpleTable({
+      columns: [
+        { hash: 'sku', header: 'Sku', render: ({ sku }: any) => sku },
+        { hash: 'name', header: 'Name', tooltip: 'Some text', render: ({ name }: any) => name },
+      ],
+    }),
+  );
+
+  fireEvent.mouseOver(getByTitle('Hover or focus for additional context.'));
+
+  const result = await screen.findByText('Some text');
+
+  expect(result).toBeInTheDocument();
+});
+
+test('tweaks column styles with props', () => {
+  const { container } = render(
+    getSimpleTable({
+      columns: [
+        {
+          hash: '1',
+          header: 'Sku',
+          render: ({ sku }: any) => sku,
+          align: 'right',
+          verticalAlign: 'middle',
+        },
+        {
+          hash: '2',
+          header: 'Name',
+          render: ({ name }: any) => name,
+          width: 100,
+          withPadding: false,
+        },
+      ],
+    }),
+  );
+
+  const headers = container.querySelectorAll('th');
+  const skuHeader = headers[0];
+  const nameHeader = headers[1];
+
+  expect(skuHeader.childNodes[0]).toHaveStyleRule('justify-content', 'flex-end');
+  expect(skuHeader).not.toHaveStyleRule('vertical-align', 'center');
+
+  expect(nameHeader).toHaveStyleRule('width', '100px');
+  expect(skuHeader).not.toHaveStyleRule('padding', '0');
+
+  const columns = container.querySelectorAll('tbody td');
+  const skuTd = columns[0];
+  const nameTd = columns[1];
+
+  expect(skuTd).toHaveStyle(`
+    text-align: right;
+    vertical-align: middle;
+  `);
+
+  expect(nameTd).toHaveStyle(`
+    width: 100px;
+    padding: 0 0 0 0;
+  `);
+});
+
+test('renders the total number of items + item name', () => {
+  const { getByText } = render(getSimpleTable({ itemName: 'Test Items' }));
+
+  const itemNameNode = getByText(`5 Test Items`);
+
+  expect(itemNameNode).toBeInTheDocument();
+});
+
+test('renders a pagination component', async () => {
+  const onItemsPerPageChange = jest.fn();
+  const onPageChange = jest.fn();
+
+  const { container, findByRole, getByTitle } = render(
+    <TableNext
+      columns={[
+        { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+        { header: 'Name', hash: 'name', render: ({ name }) => name },
+        { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+      ]}
+      items={[
+        { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+        { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+        { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+        { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+        { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+      ]}
+      pagination={{
+        currentPage: 1,
+        itemsPerPage: 3,
+        totalItems: 5,
+        itemsPerPageOptions: [3, 5, 10],
+        onItemsPerPageChange,
+        onPageChange,
+      }}
+    />,
+  );
+
+  fireEvent.click(getByTitle('Next page'));
+
+  await findByRole('table');
+
+  expect(onPageChange).toHaveBeenCalledWith(2);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+describe('selectable', () => {
+  let columns: Array<TableColumn<TableItem>>;
+  let items: TableItem[];
+  let onSelectionChange: jest.Mock;
+  const itemName = 'Product';
+
+  beforeEach(() => {
+    onSelectionChange = jest.fn();
+    items = [
+      { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+      { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+      { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+      { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+      { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+    ];
+    columns = [
+      { header: 'Sku', hash: 'sku', render: ({ sku }: any) => sku },
+      { header: 'Name', hash: 'name', render: ({ name }: any) => name },
+      { header: 'Stock', hash: 'stock', render: ({ stock }: any) => stock },
+    ];
+  });
+
+  test('renders selectable actions and checkboxes', () => {
+    const { container, getAllByRole } = render(
+      <TableNext
+        columns={columns}
+        itemName={itemName}
+        items={items}
+        selectable={{
+          onSelectionChange,
+          selectedItems: [],
+        }}
+      />,
+    );
+
+    // One per item + Actions (select all) checkbox
+    expect(getAllByRole('checkbox')).toHaveLength(items.length + 1);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('click on select all should call selectedItems with all items', async () => {
+    render(
+      <TableNext
+        columns={columns}
+        itemName={itemName}
+        items={items}
+        selectable={{
+          onSelectionChange,
+          selectedItems: [],
+        }}
+      />,
+    );
+
+    const [selectAllCheckbox] = await screen.findAllByRole<HTMLInputElement>('checkbox');
+
+    // Select All
+    expect(selectAllCheckbox.checked).toBe(false);
+
+    fireEvent.click(selectAllCheckbox);
+
+    expect(onSelectionChange).toHaveBeenCalledWith(items);
+  });
+
+  test('click on select all should call selectedItems with all items respecting multi-page', async () => {
+    const previouslySelectedItem = {
+      sku: 'Test',
+      name: 'Test Previously Select Item (multi-page)',
+      stock: 25,
+    };
+
+    render(
+      <TableNext
+        columns={columns}
+        itemName={itemName}
+        items={items}
+        selectable={{
+          onSelectionChange,
+          selectedItems: [previouslySelectedItem],
+        }}
+      />,
+    );
+
+    const [selectAllCheckbox] = await screen.findAllByRole<HTMLInputElement>('checkbox');
+
+    // Select All
+    expect(selectAllCheckbox.checked).toBe(false);
+
+    fireEvent.click(selectAllCheckbox);
+
+    expect(onSelectionChange).toHaveBeenCalledWith([previouslySelectedItem, ...items]);
+  });
+
+  test('select all when already all selected should deselect all items', async () => {
+    render(
+      <TableNext
+        columns={columns}
+        itemName={itemName}
+        items={items}
+        selectable={{
+          onSelectionChange,
+          selectedItems: items,
+        }}
+      />,
+    );
+
+    const [selectAllCheckbox] = await screen.findAllByRole<HTMLInputElement>('checkbox');
+
+    // Deselect all
+    expect(selectAllCheckbox.checked).toBe(true);
+
+    fireEvent.click(selectAllCheckbox);
+
+    expect(onSelectionChange).toHaveBeenCalledWith([]);
+  });
+
+  test('select all when already all selected should deselect all items and respect multi-page', async () => {
+    const previouslySelectedItem = {
+      sku: 'Test',
+      name: 'Test Previously Select Item (multi-page)',
+      stock: 25,
+    };
+
+    render(
+      <TableNext
+        columns={columns}
+        itemName={itemName}
+        items={items}
+        selectable={{
+          onSelectionChange,
+          selectedItems: [previouslySelectedItem, ...items],
+        }}
+      />,
+    );
+
+    const [selectAllCheckbox] = await screen.findAllByRole<HTMLInputElement>('checkbox');
+
+    // Deselect all
+    expect(selectAllCheckbox.checked).toBe(true);
+
+    fireEvent.click(selectAllCheckbox);
+
+    expect(onSelectionChange).toHaveBeenCalledWith([previouslySelectedItem]);
+  });
+});
+
+describe('sortable', () => {
+  let columns: Array<TableColumn<TableItem>>;
+  let items: TableItem[];
+  let onSort: jest.Mock;
+
+  beforeEach(() => {
+    onSort = jest.fn();
+    items = [
+      { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+      { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+      { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+      { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+      { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+    ];
+    columns = [
+      { header: 'Sku', hash: 'sku', render: ({ sku }: any) => sku, isSortable: true },
+      { header: 'Name', hash: 'name', render: ({ name }: any) => name },
+      { header: 'Stock', hash: 'stock', render: ({ stock }: any) => stock },
+    ];
+  });
+
+  test('renders ASC header icon', () => {
+    const { getByTestId } = render(
+      <TableNext
+        columns={columns}
+        items={items}
+        sortable={{
+          columnHash: 'sku',
+          direction: 'ASC',
+          onSort,
+        }}
+      />,
+    );
+
+    expect(getByTestId('asc-icon')).toBeInTheDocument();
+  });
+
+  test('calls onSort when pressing a sortable header', () => {
+    const { container } = render(
+      <TableNext
+        columns={columns}
+        items={items}
+        sortable={{
+          columnHash: 'sku',
+          direction: 'ASC',
+          onSort,
+        }}
+      />,
+    );
+
+    const skuHeaders: NodeListOf<HTMLTableCellElement> = container.querySelectorAll('th');
+
+    fireEvent.click(skuHeaders[0]);
+
+    expect(onSort).toHaveBeenCalledWith('sku', 'DESC', columns[0]);
+  });
+
+  test('does not call onSort when pressing a non-sortable header', () => {
+    const { container } = render(
+      <TableNext
+        columns={columns}
+        items={items}
+        sortable={{
+          columnHash: 'sku',
+          direction: 'ASC',
+          onSort,
+        }}
+      />,
+    );
+
+    const nameHeader = container.querySelectorAll('th');
+
+    fireEvent.click(nameHeader[1]);
+
+    expect(onSort).not.toHaveBeenCalled();
+  });
+
+  test('calls onSort when pressing the direction icon', () => {
+    const { getByTestId } = render(
+      <TableNext
+        columns={columns}
+        items={items}
+        sortable={{
+          columnHash: 'sku',
+          direction: 'ASC',
+          onSort,
+        }}
+      />,
+    );
+
+    const sortIcon = getByTestId('asc-icon');
+
+    fireEvent.click(sortIcon);
+
+    expect(onSort).toHaveBeenCalledWith('sku', 'DESC', columns[0]);
+  });
+
+  test('renders custom actions', () => {
+    const { getByTestId } = render(
+      <TableNext
+        actions={<div data-testid="customAction">Test Action</div>}
+        columns={columns}
+        items={items}
+      />,
+    );
+
+    const customAction = getByTestId('customAction');
+
+    expect(customAction).toBeInTheDocument();
+    expect(customAction).toBeVisible();
+  });
+
+  test('renders headers by default and hides then via prop', () => {
+    const { container, rerender } = render(getSimpleTable());
+
+    expect(container.querySelector('th')).toBeVisible();
+
+    rerender(getSimpleTable({ headerless: true }));
+
+    expect(container.querySelector('th')).toBeInTheDocument();
+    expect(container.querySelector('th')).not.toBeVisible();
+  });
+
+  test('renders the emptyComponent when there are no items', () => {
+    const emptyComponent = <p>There are no items!</p>;
+
+    render(getSimpleTable({ items: [], emptyComponent }));
+
+    expect(screen.getByText(/no items/i)).toBeInTheDocument();
+  });
+
+  test('does not render emptyComponent if there are items', () => {
+    const emptyComponent = <p>There are no items!</p>;
+
+    render(getSimpleTable({ emptyComponent }));
+
+    expect(screen.queryByText(/no items/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('draggable', () => {
+  let columns: Array<TableColumn<TableItem>>;
+  let items: TableItem[];
+  let onRowDrop: jest.Mock;
+
+  beforeEach(() => {
+    onRowDrop = jest.fn();
+    items = [
+      { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+      { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+      { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+      { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+      { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+    ];
+    columns = [
+      { header: 'Sku', hash: 'sku', render: ({ sku }: any) => sku, isSortable: true },
+      { header: 'Name', hash: 'name', render: ({ name }: any) => name },
+      { header: 'Stock', hash: 'stock', render: ({ stock }: any) => stock },
+    ];
+  });
+
+  test('renders drag and drop icon', () => {
+    const { container } = render(
+      <TableNext columns={columns} items={items} onRowDrop={onRowDrop} />,
+    );
+    const dragIcons = container.querySelectorAll('svg');
+
+    expect(dragIcons).toHaveLength(items.length);
+  });
+
+  test('onRowDrop called with expected args when a row is dropped', async () => {
+    const spaceKey = { keyCode: 32 };
+    const downKey = { keyCode: 40 };
+
+    render(<TableNext columns={columns} items={items} onRowDrop={onRowDrop} />);
+
+    const dragEls = await screen.findAllByRole<HTMLButtonElement>('button');
+    const dragEl = dragEls[0];
+
+    dragEl.focus();
+
+    expect(dragEl).toHaveFocus();
+
+    fireEvent.keyDown(dragEl, spaceKey);
+    fireEvent.keyDown(dragEl, downKey);
+    fireEvent.keyDown(dragEl, spaceKey);
+
+    expect(onRowDrop).toHaveBeenCalledWith(0, 1);
+  });
+});

--- a/packages/big-design/src/components/TableNext/styled.tsx
+++ b/packages/big-design/src/components/TableNext/styled.tsx
@@ -1,0 +1,28 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled from 'styled-components';
+
+import { MarginProps, withMargins } from '../../mixins';
+
+export const StyledTableFigure = styled.figure<MarginProps>`
+  margin: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  white-space: nowrap;
+
+  ${({ theme }) => theme.breakpoints.tablet} {
+    white-space: normal;
+  }
+
+  ${withMargins()};
+`;
+
+export const StyledTable = styled.table`
+  border-color: transparent;
+  border-spacing: 0;
+  color: ${({ theme }) => theme.colors.secondary70};
+  text-align: left;
+  width: 100%;
+`;
+
+StyledTableFigure.defaultProps = { theme: defaultTheme };
+StyledTable.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/TableNext/types.ts
+++ b/packages/big-design/src/components/TableNext/types.ts
@@ -1,0 +1,56 @@
+import { ReactNode } from 'react';
+
+import { MarginProps } from '../../mixins';
+import { PaginationProps } from '../Pagination';
+
+import { TableColumnDisplayProps } from './mixins';
+
+export interface TableSelectable<T> {
+  selectedItems: T[];
+  onSelectionChange(selectedItems: T[]): void;
+}
+
+export type TableSortDirection = 'ASC' | 'DESC';
+
+export interface TableSortable<T> {
+  direction: TableSortDirection;
+  columnHash?: string;
+  onSort(columnHash: string, direction: TableSortDirection, column: TableColumn<T>): void;
+}
+
+export interface TableItem {
+  id?: string | number;
+  [key: string]: any;
+}
+
+export interface TableColumn<T> extends TableColumnDisplayProps {
+  align?: 'left' | 'center' | 'right';
+  hash: string;
+  header: string;
+  tooltip?: string;
+  hideHeader?: boolean;
+  isSortable?: boolean;
+  render:
+    | React.ComponentType<T & { children?: ReactNode }>
+    | ((props: T & { children?: ReactNode }, context?: any) => string | number);
+  verticalAlign?: 'top' | 'middle';
+  width?: number | string;
+  withPadding?: boolean;
+}
+
+export type TablePaginationProps = Omit<PaginationProps, keyof MarginProps>;
+
+export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElement> {
+  actions?: React.ReactNode;
+  columns: Array<TableColumn<T>>;
+  emptyComponent?: React.ReactElement;
+  headerless?: boolean;
+  itemName?: string;
+  items: T[];
+  keyField?: string;
+  onRowDrop?(from: number, to: number): void;
+  pagination?: TablePaginationProps;
+  selectable?: TableSelectable<T>;
+  sortable?: TableSortable<T>;
+  stickyHeader?: boolean;
+}

--- a/packages/big-design/src/components/TableNext/types.ts
+++ b/packages/big-design/src/components/TableNext/types.ts
@@ -5,9 +5,15 @@ import { PaginationProps } from '../Pagination';
 
 import { TableColumnDisplayProps } from './mixins';
 
-export interface TableSelectable<T> {
-  selectedItems: T[];
-  onSelectionChange(selectedItems: T[]): void;
+export interface TableSelectable {
+  selectedItems: Record<string, true>;
+  onSelectionChange(selectedItems: Record<string, true>): void;
+}
+
+export interface TableExpandable<T> {
+  expandedRows: Record<string, true>;
+  onExpandedChange(expandedItems: Record<string, true>): void;
+  expandedRowSelector: (item: T) => T[] | undefined;
 }
 
 export type TableSortDirection = 'ASC' | 'DESC';
@@ -44,13 +50,14 @@ export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElemen
   actions?: React.ReactNode;
   columns: Array<TableColumn<T>>;
   emptyComponent?: React.ReactElement;
+  expandable?: TableExpandable<T>;
   headerless?: boolean;
   itemName?: string;
   items: T[];
   keyField?: string;
   onRowDrop?(from: number, to: number): void;
   pagination?: TablePaginationProps;
-  selectable?: TableSelectable<T>;
+  selectable?: TableSelectable;
   sortable?: TableSortable<T>;
   stickyHeader?: boolean;
 }

--- a/packages/big-design/src/components/index.ts
+++ b/packages/big-design/src/components/index.ts
@@ -34,6 +34,7 @@ export * from './StatefulTree';
 export * from './Stepper';
 export * from './Switch';
 export * from './Table';
+export * from './TableNext';
 export * from './Tabs';
 export * from './Textarea';
 export * from './Timepicker';

--- a/packages/big-design/src/hooks/useEventCallback.ts
+++ b/packages/big-design/src/hooks/useEventCallback.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-type Callback<T> = (...args: T[]) => void;
+type Callback<T extends unknown[]> = (...args: T) => void;
 
-export function useEventCallback<T>(fn: Callback<T>) {
+export function useEventCallback<T extends unknown[]>(fn: Callback<T>) {
   const ref = useRef<Callback<T>>(fn);
 
   // TODO: Change to useIsomorphicLayoutEffect
@@ -10,7 +10,7 @@ export function useEventCallback<T>(fn: Callback<T>) {
     ref.current = fn;
   });
 
-  return useCallback((...args: T[]) => {
+  return useCallback((...args: T) => {
     const fun = ref.current;
 
     return fun(...args);


### PR DESCRIPTION
## What?
Create a new `<TableNext/>` component which has all the `Table` component's functionality + expandable functionality. This PR just focus on adding the expandable functionality that works together with Select and Drag and Drop. 

Pagination + Expandable is gonna be in another PR (Plan start working on that today)

If we want to use the expandable functionality we will need to use the `<TableNext/>` component instead, and not the `<Table/>` component. For now we are gonna use this component internally, so we don't plan to add it in the BD documentation until we add tan-stack in the component.

Tan-stack: https://tanstack.com/table/v8

## Why?
We decided to create this new component since we wanted to avoid a breaking change for now because our current Select API in our `<Table/>` component was complicating the things when adding the expandable functionality so it was necessary to change the API. 

**Pros and Cons with this approach:**

**Pros:**
- We can trying out for a bit without breaking current Table usages
- We get a similar api to tan-stack, so its prob easier to port later
- Avoid breaking change (for now)

**Cons:**
- Bigger bundle size since we now have 2 tables
- If we want to add things to the table, we now have multiple tables

**Things to keep in mind:**

- We can reduce the bundle size by not including by default and have a special import import TableNext from '@bigcommerce/big-design/table-next' or something.
- If we make a change to the table, we can temporary add the changes in both tables.
- We need to be "all-in" in terms of getting TableNext be the real Table soon.
- We have a lot of different functionality of our table component that we might need to rethink the future of the component and how we can have it be extensible.
- Prefer we consume the new API of TableNext for a bit, what if we have to do changes and end up with 2 breaking Table changes back 2 back.

The new select API it's gonna be the same as the one that tan-stack uses, since we are planning to add this library in our <TableNext/> component. 

New API for select functionality:
```js
{
0: true
0.0: true
0.1: true
1: true
1.0: true
1.1: true
2: true
2.0: true
2.1: true
}
```
Example:
`0: true` <--- this means that a parent row was selected.
`0.0: true` <--- this means that a parent's child row was selected.

API for expandable functionality:

```js
{0: true, 1: true, 2: true}
```

## Screenshots/Screen Recordings


https://user-images.githubusercontent.com/39739180/179029437-4343c25c-82e3-42a2-aa6c-40dc884b2ad6.mp4


https://user-images.githubusercontent.com/39739180/179029463-11bc738b-eb49-45b6-aedc-a5473e3a32f1.mp4


https://user-images.githubusercontent.com/39739180/179029471-4285e6f0-b695-4eb0-8427-95170ecac084.mp4


## Testing/Proof
Tests pass
