### PR TITLE
TableNext with helperRow component

### DIFF
--- a/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
@@ -1,4 +1,4 @@
-import React, { memo, TableHTMLAttributes } from 'react';
+import React, { memo, TdHTMLAttributes } from 'react';
 
 import { PaddingProps } from '../../../mixins';
 import { TableColumnDisplayProps } from '../mixins';
@@ -6,13 +6,12 @@ import { TableColumnDisplayProps } from '../mixins';
 import { StyledTableDataCell, StyledTableDataCheckbox } from './styled';
 
 export interface DataCellProps
-  extends TableHTMLAttributes<HTMLTableCellElement>,
+  extends TdHTMLAttributes<HTMLTableCellElement>,
     TableColumnDisplayProps,
     PaddingProps {
   align?: 'left' | 'center' | 'right';
   checkEmptyCell?: boolean;
   children?: React.ReactNode;
-  colSpan?: number;
   isExpandable?: boolean;
   isCheckbox?: boolean;
   verticalAlign?: 'top' | 'middle';

--- a/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
@@ -10,7 +10,9 @@ export interface DataCellProps
     TableColumnDisplayProps,
     PaddingProps {
   align?: 'left' | 'center' | 'right';
+  checkEmptyCell?: boolean;
   children?: React.ReactNode;
+  colSpan?: number;
   isExpandable?: boolean;
   isCheckbox?: boolean;
   verticalAlign?: 'top' | 'middle';
@@ -21,7 +23,9 @@ export interface DataCellProps
 export const DataCell: React.FC<DataCellProps> = memo(
   ({
     align,
+    checkEmptyCell,
     children,
+    colSpan,
     display,
     isCheckbox,
     isExpandable = false,
@@ -45,6 +49,8 @@ export const DataCell: React.FC<DataCellProps> = memo(
     ) : (
       <StyledTableDataCell
         align={align}
+        checkEmptyCell={checkEmptyCell}
+        colSpan={colSpan}
         display={display}
         padding={padding}
         paddingHorizontal={paddingHorizontal}

--- a/packages/big-design/src/components/TableNext/DataCell/styled.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/styled.tsx
@@ -43,6 +43,17 @@ export const StyledTableDataCell = styled.td<DataCellProps>`
       vertical-align: ${verticalAlign};
     `};
 
+  ${({ checkEmptyCell }) => {
+    return (
+      checkEmptyCell &&
+      css`
+        &:empty {
+          display: none;
+        }
+      `
+    );
+  }};
+
   ${({ width }) =>
     width !== undefined &&
     css`

--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -73,13 +73,7 @@ const InternalRow = <T extends TableItem>({
   const renderSelectDataCell = () => {
     if (isSelectable && isParentRow) {
       return (
-        <DataCell
-          cellPadding={0}
-          isCheckbox={true}
-          isExpandable={isExpandable}
-          key="data-checkbox"
-          width={10}
-        >
+        <DataCell isCheckbox={true} isExpandable={isExpandable} key="data-checkbox" width={10}>
           <Checkbox
             checked={isChecked}
             hiddenLabel

--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -17,7 +17,7 @@ interface PrivateProps {
 }
 
 export interface RowProps<T> extends TableHTMLAttributes<HTMLTableRowElement> {
-  childrenRows: T[];
+  childrenRows?: T[];
   childRowIndex?: number;
   columns: Array<TableColumn<T>>;
   headerCellWidths: Array<number | string>;
@@ -57,7 +57,7 @@ const InternalRow = <T extends TableItem>({
   isParentRow = false,
   ...rest
 }: RowProps<T> & PrivateProps) => {
-  const { hasChildrenRows, label, onChange, onExpandedChange, isChecked, isIndeterminate } =
+  const { hasChildrenRows, isChecked, isIndeterminate, label, onChange, onExpandedChange } =
     useRowState({
       childRowIndex,
       childrenRows,

--- a/packages/big-design/src/components/TableNext/Row/useRowState.ts
+++ b/packages/big-design/src/components/TableNext/Row/useRowState.ts
@@ -3,7 +3,7 @@ import { TableSelectable } from '../types';
 
 interface UseRowStateProps<T> {
   childRowIndex?: number;
-  childrenRows: T[];
+  childrenRows?: T[];
   isExpandable: boolean;
   isParentRow: boolean;
   isSelected?: boolean;
@@ -28,7 +28,7 @@ export const useRowState = <T>({
     if (onItemSelect) {
       onItemSelect({
         childRowIndex: childRowIndex ?? null,
-        childrenRows,
+        childrenRows: childrenRows ?? [],
         isParentRow,
         isExpandable,
         parentRowIndex,
@@ -42,23 +42,28 @@ export const useRowState = <T>({
     }
   };
 
-  const hasChildrenRows = childrenRows.length > 0;
+  const hasChildrenRows = childrenRows !== undefined;
+  const totalChildrenRows = childrenRows?.length ?? 0;
 
   const allChildrenRowsSelected =
     isExpandable &&
+    hasChildrenRows &&
     childrenRows.every((_childRow, childRowIndex) => {
       return selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
     });
 
   const someChildrenRowsSelected =
     isExpandable &&
+    hasChildrenRows &&
     childrenRows.some((_childRow, childRowIndex) => {
       return selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
     });
 
   const label = isSelected ? `Selected` : `Unselected`;
 
-  const isChecked = isExpandable && hasChildrenRows ? allChildrenRowsSelected : isSelected;
+  const isChecked =
+    isExpandable && hasChildrenRows && totalChildrenRows > 0 ? allChildrenRowsSelected : isSelected;
+
   const isIndeterminate = isExpandable && hasChildrenRows ? someChildrenRowsSelected : undefined;
 
   return {

--- a/packages/big-design/src/components/TableNext/Row/useRowState.ts
+++ b/packages/big-design/src/components/TableNext/Row/useRowState.ts
@@ -42,27 +42,23 @@ export const useRowState = <T>({
     }
   };
 
-  const hasChildrenRows = childrenRows !== undefined;
-  const totalChildrenRows = childrenRows?.length ?? 0;
+  const hasChildrenRows = Array.isArray(childrenRows);
 
   const allChildrenRowsSelected =
     isExpandable &&
-    hasChildrenRows &&
-    childrenRows.every((_childRow, childRowIndex) => {
+    childrenRows?.every((_childRow, childRowIndex) => {
       return selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
     });
 
   const someChildrenRowsSelected =
     isExpandable &&
-    hasChildrenRows &&
-    childrenRows.some((_childRow, childRowIndex) => {
+    childrenRows?.some((_childRow, childRowIndex) => {
       return selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
     });
 
   const label = isSelected ? `Selected` : `Unselected`;
 
-  const isChecked =
-    isExpandable && hasChildrenRows && totalChildrenRows > 0 ? allChildrenRowsSelected : isSelected;
+  const isChecked = isExpandable && hasChildrenRows ? allChildrenRowsSelected : isSelected;
 
   const isIndeterminate = isExpandable && hasChildrenRows ? someChildrenRowsSelected : undefined;
 

--- a/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
+++ b/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
@@ -11,7 +11,7 @@ interface InternalRowContainerProps<T>
   expandedRowSelector?: TableExpandable<T>['expandedRowSelector'];
   getItemKey: (item: T, index: number) => string | number;
   headerless?: boolean;
-  renderHelperRow?: TableExpandable<T>['renderHelperRow'];
+  helperRowRenderer?: TableExpandable<T>['helperRowRenderer'];
 }
 
 interface PrivateProps {
@@ -29,7 +29,7 @@ const InternalRowContainer = <T extends TableItem>({
   item,
   parentRowIndex,
   showDragIcon,
-  renderHelperRow: HelperRow,
+  helperRowRenderer: HelperRow,
   expandedRowSelector,
   getItemKey,
   onItemSelect,

--- a/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
+++ b/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 
 import { typedMemo } from '../../../utils';
+import { DataCell } from '../DataCell';
 import { Row, RowProps } from '../Row';
 import { TableExpandable, TableItem } from '../types';
 
@@ -10,6 +11,7 @@ interface InternalRowContainerProps<T>
   expandedRowSelector?: TableExpandable<T>['expandedRowSelector'];
   getItemKey: (item: T, index: number) => string | number;
   headerless?: boolean;
+  renderHelperRow?: TableExpandable<T>['renderHelperRow'];
 }
 
 interface PrivateProps {
@@ -27,6 +29,7 @@ const InternalRowContainer = <T extends TableItem>({
   item,
   parentRowIndex,
   showDragIcon,
+  renderHelperRow: HelperRow,
   expandedRowSelector,
   getItemKey,
   onItemSelect,
@@ -38,11 +41,12 @@ const InternalRowContainer = <T extends TableItem>({
   const isExpanded = expandedRows[parentRowIndex] !== undefined;
   const childrenRows: T[] | undefined = expandedRowSelector ? expandedRowSelector?.(item) : [];
   const isDraggable: boolean = showDragIcon === true;
+  const hasHelperRowComponent = HelperRow !== undefined;
 
   return (
     <>
       <Row
-        childrenRows={childrenRows ?? []}
+        childrenRows={childrenRows}
         columns={columns}
         headerCellWidths={headerCellWidths}
         isDraggable={isDraggable}
@@ -89,6 +93,15 @@ const InternalRowContainer = <T extends TableItem>({
             />
           );
         })}
+      {isExpanded && childrenRows !== undefined && hasHelperRowComponent && (
+        <tr key={`extra-helper-row-${parentRowIndex}`}>
+          <DataCell checkEmptyCell={true} colSpan={10000} width={100}>
+            {/*
+// @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
+            <HelperRow parentRowIndex={parentRowIndex} />
+          </DataCell>
+        </tr>
+      )}
     </>
   );
 };

--- a/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
+++ b/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
@@ -5,6 +5,8 @@ import { DataCell } from '../DataCell';
 import { Row, RowProps } from '../Row';
 import { TableExpandable, TableItem } from '../types';
 
+import { calculateColSpan } from './helpers';
+
 interface InternalRowContainerProps<T>
   extends Omit<RowProps<T>, 'isSelected' | 'isParentRows' | 'childrenRows' | 'isDraggable'> {
   expandedRows: TableExpandable<T>['expandedRows'];
@@ -95,7 +97,10 @@ const InternalRowContainer = <T extends TableItem>({
         })}
       {isExpanded && childrenRows !== undefined && hasHelperRowComponent && (
         <tr key={`extra-helper-row-${parentRowIndex}`}>
-          <DataCell checkEmptyCell={true} colSpan={10000} width={100}>
+          <DataCell
+            checkEmptyCell={true}
+            colSpan={calculateColSpan({ columns, isExpandable, isDraggable, isSelectable })}
+          >
             {/*
 // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
             <HelperRow parentRowIndex={parentRowIndex} />

--- a/packages/big-design/src/components/TableNext/RowContainer/helpers.ts
+++ b/packages/big-design/src/components/TableNext/RowContainer/helpers.ts
@@ -1,0 +1,31 @@
+import { RowProps } from '../Row';
+
+interface CalculateColSpanArg<T> {
+  columns: RowProps<T>['columns'];
+  isExpandable?: RowProps<T>['isExpandable'];
+  isDraggable?: RowProps<T>['isDraggable'];
+  isSelectable?: RowProps<T>['isSelectable'];
+}
+
+export const calculateColSpan = <T>({
+  columns,
+  isExpandable,
+  isDraggable,
+  isSelectable,
+}: CalculateColSpanArg<T>) => {
+  let totalColSpans = columns.length;
+
+  if (isExpandable) {
+    totalColSpans += 1;
+  }
+
+  if (isDraggable) {
+    totalColSpans += 1;
+  }
+
+  if (isSelectable) {
+    totalColSpans += 1;
+  }
+
+  return totalColSpans;
+};

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -179,6 +179,7 @@ const InternalTableNext = <T extends TableItem>(
                     expandedRows={expandedRows}
                     getItemKey={getItemKey}
                     headerCellWidths={headerCellWidths}
+                    helperRowRenderer={expandable?.helperRowRenderer}
                     isExpandable={isExpandable}
                     isSelectable={isSelectable}
                     item={item}
@@ -187,7 +188,6 @@ const InternalTableNext = <T extends TableItem>(
                     onItemSelect={onItemSelect}
                     parentRowIndex={index}
                     ref={provided.innerRef}
-                    renderHelperRow={expandable?.renderHelperRow}
                     selectedItems={selectedItems}
                     showDragIcon={true}
                   />
@@ -217,6 +217,7 @@ const InternalTableNext = <T extends TableItem>(
               getItemKey={getItemKey}
               headerCellWidths={headerCellWidths}
               headerless={headerless}
+              helperRowRenderer={expandable?.helperRowRenderer}
               isExpandable={isExpandable}
               isSelectable={isSelectable}
               item={item}
@@ -224,7 +225,6 @@ const InternalTableNext = <T extends TableItem>(
               onExpandedRow={onExpandedRow}
               onItemSelect={onItemSelect}
               parentRowIndex={index}
-              renderHelperRow={expandable?.renderHelperRow}
               selectedItems={selectedItems}
             />
           );

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -187,6 +187,7 @@ const InternalTableNext = <T extends TableItem>(
                     onItemSelect={onItemSelect}
                     parentRowIndex={index}
                     ref={provided.innerRef}
+                    renderHelperRow={expandable?.renderHelperRow}
                     selectedItems={selectedItems}
                     showDragIcon={true}
                   />
@@ -223,6 +224,7 @@ const InternalTableNext = <T extends TableItem>(
               onExpandedRow={onExpandedRow}
               onItemSelect={onItemSelect}
               parentRowIndex={index}
+              renderHelperRow={expandable?.renderHelperRow}
               selectedItems={selectedItems}
             />
           );

--- a/packages/big-design/src/components/TableNext/hooks/useExpandable/useExpandable.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useExpandable/useExpandable.ts
@@ -21,13 +21,13 @@ export const useExpandable = <T>(expandable?: TableExpandable<T>) => {
         ([key]) => key !== `${parentRowIndex}`,
       );
 
-      onExpandedChange(Object.fromEntries(newExpandedRows));
+      onExpandedChange(Object.fromEntries(newExpandedRows), parentRowIndex);
     } else {
       const newExpandedRows = { ...expandedRows };
 
       newExpandedRows[parentRowIndex] = true;
 
-      onExpandedChange(newExpandedRows);
+      onExpandedChange(newExpandedRows, parentRowIndex);
     }
   });
 

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -891,7 +891,7 @@ describe('expandable', () => {
           expandedRows: { 0: true, 1: true, 2: true },
           expandedRowSelector: ({ children }) => children,
           onExpandedChange,
-          renderHelperRow: HelperRow,
+          helperRowRenderer: HelperRow,
         }}
         items={items}
       />,
@@ -918,7 +918,7 @@ describe('expandable', () => {
           expandedRows: { 0: true, 1: true, 2: true },
           expandedRowSelector: ({ children }) => children,
           onExpandedChange,
-          renderHelperRow: HelperRow,
+          helperRowRenderer: HelperRow,
         }}
         items={items}
       />,

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, FC } from 'react';
 import 'jest-styled-components';
 
 import { fireEvent, render, screen, within } from '@test/utils';
@@ -852,7 +852,7 @@ describe('expandable', () => {
 
     await userEvent.click(expandIcon);
 
-    expect(onExpandedChange).toHaveBeenCalledWith({ 0: true });
+    expect(onExpandedChange).toHaveBeenCalledWith({ 0: true }, 0);
     expect(onExpandedChange).not.toHaveBeenCalledWith({ 1: true });
     expect(onExpandedChange).not.toHaveBeenCalledWith({ 2: true });
   });
@@ -875,7 +875,57 @@ describe('expandable', () => {
 
     await userEvent.click(expandIcon);
 
-    expect(onExpandedChange).toHaveBeenCalledWith({ 1: true, 2: true });
+    expect(onExpandedChange).toHaveBeenCalledWith({ 1: true, 2: true }, 0);
     expect(onExpandedChange).not.toHaveBeenCalledWith({ 0: true, 1: true, 2: true });
+  });
+
+  test('renders a cell with a helper row component in a expanded parent', async () => {
+    const HelperRow: FC<{ parentRowIndex: number }> = ({ parentRowIndex }) => {
+      return <button>View more {parentRowIndex}</button>;
+    };
+
+    render(
+      <TableNext
+        columns={columns}
+        expandable={{
+          expandedRows: { 0: true, 1: true, 2: true },
+          expandedRowSelector: ({ children }) => children,
+          onExpandedChange,
+          renderHelperRow: HelperRow,
+        }}
+        items={items}
+      />,
+    );
+
+    const cellsWithHelperRow = await screen.findAllByRole('cell', { name: /View more/ });
+
+    expect(cellsWithHelperRow).toHaveLength(3);
+  });
+
+  test('does not render a cell component when a helper row component returns null', async () => {
+    const HelperRow: FC<{ parentRowIndex: number }> = ({ parentRowIndex }) => {
+      if (parentRowIndex === 0) {
+        return <button>Only 0 index!</button>;
+      }
+
+      return null;
+    };
+
+    render(
+      <TableNext
+        columns={columns}
+        expandable={{
+          expandedRows: { 0: true, 1: true, 2: true },
+          expandedRowSelector: ({ children }) => children,
+          onExpandedChange,
+          renderHelperRow: HelperRow,
+        }}
+        items={items}
+      />,
+    );
+
+    const cellsWithHelperRow = await screen.findAllByRole('cell', { name: 'Only 0 index!' });
+
+    expect(cellsWithHelperRow).toHaveLength(1);
   });
 });

--- a/packages/big-design/src/components/TableNext/types.ts
+++ b/packages/big-design/src/components/TableNext/types.ts
@@ -14,7 +14,7 @@ export interface TableExpandable<T> {
   expandedRows: Record<string, true>;
   expandedRowSelector: (item: T) => T[] | undefined;
   onExpandedChange(expandedItems: Record<string, true>, expandedIndex: number): void;
-  renderHelperRow?:
+  helperRowRenderer?:
     | ComponentType<{ parentRowIndex: number; children?: ReactNode }>
     | ((props: { parentRowIndex: number; children?: ReactNode }, context?: any) => ReactNode);
 }

--- a/packages/big-design/src/components/TableNext/types.ts
+++ b/packages/big-design/src/components/TableNext/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import React, { ComponentType, ReactNode, TableHTMLAttributes } from 'react';
 
 import { MarginProps } from '../../mixins';
 import { PaginationProps } from '../Pagination';
@@ -12,8 +12,11 @@ export interface TableSelectable {
 
 export interface TableExpandable<T> {
   expandedRows: Record<string, true>;
-  onExpandedChange(expandedItems: Record<string, true>): void;
   expandedRowSelector: (item: T) => T[] | undefined;
+  onExpandedChange(expandedItems: Record<string, true>, expandedIndex: number): void;
+  renderHelperRow?:
+    | ComponentType<{ parentRowIndex: number; children?: ReactNode }>
+    | ((props: { parentRowIndex: number; children?: ReactNode }, context?: any) => ReactNode);
 }
 
 export type TableSortDirection = 'ASC' | 'DESC';
@@ -46,7 +49,7 @@ export interface TableColumn<T> extends TableColumnDisplayProps {
 
 export type TablePaginationProps = Omit<PaginationProps, keyof MarginProps>;
 
-export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElement> {
+export interface TableProps<T> extends TableHTMLAttributes<HTMLTableElement> {
   actions?: React.ReactNode;
   columns: Array<TableColumn<T>>;
   emptyComponent?: React.ReactElement;


### PR DESCRIPTION
## What?

Add `renderHelperRow` prop. This prop accepts a functional component or class component. This component is gonna help the user render children rows dynamically and showing loader when doing a request. Also, this component must receive a `parentRowIndex` prop which is gonna be helpful to request additional children rows by parent.

Also, another change that was made was inside the expanded props, specifically on the `onExpandedChange` fn. This function is gonna receives two arguments. `expandedItems` and `parentRowIndex`. The last one is gonna help the user fetch data dynamically after clicking on the expanded icon.

Example: 

```tsx

    const HelperRow = ({ parentRowIndex }) => {
        if (state[parentIndex].isLoading) {
           return <LoadingIcon/>
        }

        if (state[parentIndex] !== undefined && state[parentIndex].remaining) {
            const itemsToView = state[parentIndex].remaining;

            return <Button onClick={() => viewMore(parentRowIndex)} />
        }

        return null
    };

    <TableNext
      columns={columns}
      expandable={{
        expandedRows,
        onExpandedChange: (newExpandedRows: Record<string, true>, parentRowIndex: number) => {
          setExpandedRows(newExpandedRows);

          if (newExpandedRows[parentRowIndex]) {
            handleOnClickFirstFetch(parentRowIndex);
          }
        },
        expandedRowSelector: ({ subRows }) => subRows,
        helperRowRenderer: RenderRow,
      }}
      itemName="Products"
      items={items}
      keyField="sku"
      selectable={{ selectedItems, onSelectionChange: setSelectedItems }}
    />
  );
```

## Why?

These changes were made in order to fetch data dynamically.

## Screenshots/Screen Recordings


https://user-images.githubusercontent.com/39739180/180834073-9ffbcee4-3a99-439f-8b85-fbdb13e2dfd2.mp4



## Testing/Proof
Test pass locally
