### PR TITLE
fix(component): fix worksheet's onError triggering

### DIFF
--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -96,7 +96,7 @@ const InternalWorksheet = typedMemo(
     }, [editedCells, onChange, rows]);
 
     useEffect(() => {
-      if (typeof onErrors === 'function' && invalidCells.length) {
+      if (typeof onErrors === 'function' && shouldBeTriggeredOnChange.current) {
         onErrors(invalidRows(invalidCells, rows));
       }
     }, [invalidCells, onErrors, rows]);


### PR DESCRIPTION
## What? Why?
1. Remove the checking of the condition `invalidCells.length > 0` before triggering `onError`.
2. Add the fix to avoid extra triggering of the `onError` when passing the new items to the `Worksheet` from the outside

This is the same issue as it was with `onChange`: [PR](https://github.com/bigcommerce/big-design/pull/896)

## Testing/Proof

Locally.
