### PR TITLE
fix(component): Fix space and alignment in TableNext CHP-7624

### DIFF
--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -165,7 +165,7 @@ const InternalRow = <T extends TableItem>({
               verticalAlign={verticalAlign}
               width={isDragging ? cellWidth : width}
             >
-              <Flex alignItems="center">
+              <Flex alignItems="center" flexDirection="row">
                 {columnIndex === 0 && isExpandable && isSelectable && !isParentRow && (
                   <Checkbox
                     checked={isSelected}

--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -2,9 +2,9 @@ import { ChevronRightIcon, DragIndicatorIcon, ExpandMoreIcon } from '@bigcommerc
 import React, { forwardRef, ReactNode, TableHTMLAttributes } from 'react';
 
 import { typedMemo } from '../../../utils';
-import { Box } from '../../Box';
 import { MessagingButton } from '../../Button/private';
 import { Checkbox } from '../../Checkbox';
+import { Flex } from '../../Flex';
 import { DataCell } from '../DataCell';
 import { OnItemSelectFn } from '../hooks';
 import { TableColumn, TableItem, TableSelectable } from '../types';
@@ -106,7 +106,7 @@ const InternalRow = <T extends TableItem>({
       const needsHorizontalPadding = !isSelectable && !isDraggable;
 
       return (
-        <DataCell paddingHorizontal={needsHorizontalPadding ? 'small' : 'none'}>
+        <DataCell align="center" paddingHorizontal={needsHorizontalPadding ? 'small' : 'none'}>
           <MessagingButton
             iconOnly={isExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
             onClick={onExpandedChange}
@@ -165,7 +165,7 @@ const InternalRow = <T extends TableItem>({
               verticalAlign={verticalAlign}
               width={isDragging ? cellWidth : width}
             >
-              <Box display="flex">
+              <Flex alignItems="center">
                 {columnIndex === 0 && isExpandable && isSelectable && !isParentRow && (
                   <Checkbox
                     checked={isSelected}
@@ -178,7 +178,7 @@ const InternalRow = <T extends TableItem>({
                 {/*
           // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
                 <CellContent {...item} />
-              </Box>
+              </Flex>
             </DataCell>
           );
         },

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -303,14 +303,6 @@ exports[`renders a pagination component 1`] = `
   padding: 0.75rem 1.5rem;
 }
 
-@media (min-width:0px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
 @media (min-width:720px) {
   .c7 + .bd-button {
     margin-top: 0;
@@ -501,27 +493,6 @@ exports[`renders a simple table 1`] = `
   display: flex;
 }
 
-.c7 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .c1 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D9DCE9;
@@ -586,22 +557,6 @@ exports[`renders a simple table 1`] = `
   width: 100%;
 }
 
-@media (min-width:0px) {
-  .c7 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-  }
-}
-
-@media (min-width:720px) {
-  .c7 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
 <table
   class="c0"
   id="bd-table-1"
@@ -652,7 +607,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           SM13
         </div>
@@ -661,7 +616,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           [Sample] Smith Journal 13
         </div>
@@ -670,7 +625,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           25
         </div>
@@ -683,7 +638,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           DPB
         </div>
@@ -692,7 +647,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           [Sample] Dustpan & Brush
         </div>
@@ -701,7 +656,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           34
         </div>
@@ -714,7 +669,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           OFSUC
         </div>
@@ -723,7 +678,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           [Sample] Utility Caddy
         </div>
@@ -732,7 +687,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           45
         </div>
@@ -745,7 +700,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           CLC
         </div>
@@ -754,7 +709,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           [Sample] Canvas Laundry Cart
         </div>
@@ -763,7 +718,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           2
         </div>
@@ -776,7 +731,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           CGLD
         </div>
@@ -785,7 +740,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           [Sample] Laundry Detergent
         </div>
@@ -794,7 +749,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c2 c7"
+          class="c2 c3"
         >
           29
         </div>
@@ -1031,14 +986,6 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
-}
-
-@media (min-width:0px) {
-
-}
-
-@media (min-width:720px) {
-
 }
 
 <div
@@ -1325,14 +1272,6 @@ exports[`selectable renders selectable actions, checkboxes when having parent ro
   display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
-}
-
-@media (min-width:0px) {
-
-}
-
-@media (min-width:720px) {
-
 }
 
 @media (min-width:720px) {

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -303,6 +303,14 @@ exports[`renders a pagination component 1`] = `
   padding: 0.75rem 1.5rem;
 }
 
+@media (min-width:0px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
 @media (min-width:720px) {
   .c7 + .bd-button {
     margin-top: 0;
@@ -469,14 +477,6 @@ exports[`renders a simple table 1`] = `
   box-sizing: border-box;
 }
 
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-}
-
 .c3 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
@@ -488,6 +488,27 @@ exports[`renders a simple table 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
@@ -565,6 +586,22 @@ exports[`renders a simple table 1`] = `
   width: 100%;
 }
 
+@media (min-width:0px) {
+  .c7 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:720px) {
+  .c7 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
 <table
   class="c0"
   id="bd-table-1"
@@ -615,8 +652,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           SM13
         </div>
@@ -625,8 +661,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           [Sample] Smith Journal 13
         </div>
@@ -635,8 +670,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           25
         </div>
@@ -649,8 +683,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           DPB
         </div>
@@ -659,8 +692,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           [Sample] Dustpan & Brush
         </div>
@@ -669,8 +701,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           34
         </div>
@@ -683,8 +714,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           OFSUC
         </div>
@@ -693,8 +723,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           [Sample] Utility Caddy
         </div>
@@ -703,8 +732,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           45
         </div>
@@ -717,8 +745,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           CLC
         </div>
@@ -727,8 +754,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           [Sample] Canvas Laundry Cart
         </div>
@@ -737,8 +763,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           2
         </div>
@@ -751,8 +776,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           CGLD
         </div>
@@ -761,8 +785,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           [Sample] Laundry Detergent
         </div>
@@ -771,8 +794,7 @@ exports[`renders a simple table 1`] = `
         class="c6"
       >
         <div
-          class="c7"
-          display="flex"
+          class="c2 c7"
         >
           29
         </div>
@@ -1009,6 +1031,14 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:720px) {
+
 }
 
 <div
@@ -1295,6 +1325,14 @@ exports[`selectable renders selectable actions, checkboxes when having parent ro
   display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:720px) {
+
 }
 
 @media (min-width:720px) {


### PR DESCRIPTION
## What?
Space between the arrow and the next column is too big.
The text in the first column in subrows is not vertically centered.

## Why?
Fix bug

## Screenshots/Screen Recordings\

Before:
<img width="1301" alt="Screen Shot 2022-08-08 at 10 20 05 AM" src="https://user-images.githubusercontent.com/39739180/183453306-412bf1ae-ab95-4578-bd2d-5b8441ea7911.png">

After:
<img width="1332" alt="Screen Shot 2022-08-08 at 10 21 25 AM" src="https://user-images.githubusercontent.com/39739180/183453441-6d5e2c5b-34a8-4644-9797-265c11281baa.png">

<img width="751" alt="Screen Shot 2022-08-08 at 3 54 02 PM" src="https://user-images.githubusercontent.com/39739180/183512821-17f14390-c60d-4ba1-b982-52dd9d4e87dc.png">



<img width="1026" alt="Screen Shot 2022-08-08 at 10 21 44 AM" src="https://user-images.githubusercontent.com/39739180/183453497-aee4603b-0b31-4e53-9b59-a099e9a0b326.png">


## Testing/Proof
Test locally pass
