### PR TITLE
chore(deps): remove types/yup dependency

### DIFF
--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -21,7 +21,6 @@
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",
     "@types/styled-components": "^5.1.11",
-    "@types/yup": "^0.29.13",
     "@vitejs/plugin-react": "^1.0.0",
     "typescript": "^4.4.3",
     "vite": "^3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3347,11 +3347,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yup@^0.29.13":
-  version "0.29.14"
-  resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.29.14.tgz#754f1dccedcc66fc2bbe290c27f5323b407ceb00"
-  integrity sha512-Ynb/CjHhE/Xp/4bhHmQC4U1Ox+I2OpfRYF3dnNgQqn1cHa6LK3H1wJMNPT02tSVZA6FYuXE2ITORfbnb6zBCSA==
-
 "@typescript-eslint/eslint-plugin@^5.22.0":
   version "5.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz#059798888720ec52ffa96c5f868e31a8f70fa3ec"


### PR DESCRIPTION
## What?
Remove @types/yup dependency since is already deprecated. @yup library already manages its types.

## Why?
@types/yup no longer necessary.

## Screenshots/Screen Recordings
n/a

## Testing/Proof
Reference: https://www.npmjs.com/package/@types/yup
