### PR TITLE
chore(deps): use userEvent in alert, button group and checkbox

### DIFF
--- a/packages/big-design/src/components/Alert/spec.tsx
+++ b/packages/big-design/src/components/Alert/spec.tsx
@@ -1,9 +1,10 @@
 import { theme } from '@bigcommerce/big-design-theme';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { render } from '@test/utils';
 
 import { Alert } from './Alert';
 
@@ -97,14 +98,14 @@ test('renders close button', () => {
   expect(button).toBeDefined();
 });
 
-test('trigger onClose', () => {
+test('trigger onClose', async () => {
   const fn = jest.fn();
 
   render(<Alert messages={[{ text: 'Success' }]} onClose={fn} />);
 
   const button = screen.getByRole('button');
 
-  fireEvent.click(button);
+  await userEvent.click(button);
 
   expect(fn).toHaveBeenCalled();
 });

--- a/packages/big-design/src/components/ButtonGroup/spec.tsx
+++ b/packages/big-design/src/components/ButtonGroup/spec.tsx
@@ -1,5 +1,6 @@
 import { AddIcon } from '@bigcommerce/big-design-icons';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { ButtonGroup } from './ButtonGroup';
@@ -57,7 +58,7 @@ test('renders dropdown if items do not fit', async () => {
 
   expect(screen.getByText('button 4')).not.toBeVisible();
 
-  fireEvent.click(screen.getByTitle('more'));
+  await userEvent.click(screen.getByRole('button', { name: 'more' }));
 
   expect(await screen.findByRole('option', { name: /button 4/i })).toBeVisible();
 });
@@ -75,7 +76,7 @@ test('renders dropdown if some of items have destructive type', async () => {
 
   expect(screen.getByText('button 1')).not.toBeVisible();
 
-  fireEvent.click(screen.getByTitle('more'));
+  await userEvent.click(screen.getByRole('button', { name: 'more' }));
 
   expect(await screen.findByRole('option', { name: /button 1/i })).toBeVisible();
 });
@@ -92,9 +93,9 @@ test('renders icon only with dropdown item', async () => {
     />,
   );
 
-  expect(screen.queryByTitle('button 3 icon')).toBeNull();
+  expect(screen.queryByTitle('button 3 icon')).not.toBeInTheDocument();
 
-  fireEvent.click(screen.getByTitle('more'));
+  await userEvent.click(screen.getByRole('button', { name: 'more' }));
 
   expect(await screen.findByTitle('button 4 icon')).toBeInTheDocument();
 });
@@ -122,10 +123,8 @@ test('dropdown item on click callback receives synthetic event', async () => {
     hidden: true,
   });
 
-  await act(async () => {
-    fireEvent.click(screen.getByTitle('more'));
-    fireEvent.click(await screen.findByRole('option', { name: /button 4/i }));
-  });
+  await userEvent.click(screen.getByRole('button', { name: 'more' }));
+  await userEvent.click(await screen.findByRole('option', { name: /button 4/i }));
 
   expect(mockOnClick).toHaveBeenCalledWith(expect.objectContaining({ target: button }));
 });

--- a/packages/big-design/src/components/Checkbox/spec.tsx
+++ b/packages/big-design/src/components/Checkbox/spec.tsx
@@ -1,7 +1,8 @@
+import userEvent from '@testing-library/user-event';
 import React, { createRef } from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render, screen } from '@test/utils';
+import { render, screen } from '@test/utils';
 
 import { warning } from '../../utils';
 
@@ -131,20 +132,21 @@ test('triggers onChange when clicking the checkbox', async () => {
 
   const checkbox = await screen.findByTestId<HTMLInputElement>('checkbox');
 
-  fireEvent.click(checkbox);
+  await userEvent.click(checkbox);
 
   expect(onChange).toHaveBeenCalled();
 });
 
-test('triggers onChange when clicking styled and text label', () => {
+test('triggers onChange when clicking styled and text label', async () => {
   const onChange = jest.fn();
   const { container } = render(
     <Checkbox checked={true} data-testid="checkbox" label="Checked" onChange={onChange} />,
   );
 
-  const labels = container.querySelectorAll('label');
+  const [labelWithText, labelWithoutText] = Array.from(container.querySelectorAll('label'));
 
-  labels.forEach((label) => fireEvent.click(label));
+  await userEvent.click(labelWithText);
+  await userEvent.click(labelWithoutText);
 
   expect(onChange).toHaveBeenCalledTimes(2);
 });


### PR DESCRIPTION
## What?
We want to replace `fireEvent` with `userEvent` when testing events in components.

Since most of the component's test files use `fireEvent` this PR is just gonna focus on making the change in `Alert`, `ButtonGroup` and `Checkbox` tests files.

## Why?
Based on react-testing library it’s recommend to use `userEvent` since it resembles how user interacts with our code (in this case for the BD components).

## Screenshots/Screen Recordings
n/a

## Testing/Proof
tests pass.
