### PR TITLE
fix(component): render empty string when prop is undefined

### DIFF
--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -102,19 +102,11 @@ const InternalCell = <T extends WorksheetItem>({
   }, [cell, rowIndex, setSelectedCells, setSelectedRows]);
 
   const renderedValue = useMemo(() => {
-    if (value !== 'undefined' && value !== '' && !Number.isNaN(value)) {
-      if (typeof formatting === 'function') {
-        return formatting(value);
-      }
-
-      return `${value}`;
+    if (typeof formatting === 'function' && value !== '' && !Number.isNaN(value)) {
+      return formatting(value);
     }
 
-    if (Number.isNaN(value)) {
-      return `${value}`;
-    }
-
-    return '';
+    return `${value}`;
   }, [formatting, value]);
 
   const renderedCell = useMemo(() => {

--- a/packages/big-design/src/components/Worksheet/Row/Row.tsx
+++ b/packages/big-design/src/components/Worksheet/Row/Row.tsx
@@ -67,7 +67,7 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
           rowIndex={rowIndex}
           type={column.type ?? 'text'}
           validation={column.validation}
-          value={row[column.hash]}
+          value={row[column.hash] ?? ''}
         />
       ))}
     </StyledTableRow>

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -380,10 +380,8 @@ exports[`renders worksheet 1`] = `
         <p
           class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
           color="secondary70"
-          title="Text"
-        >
-          Text
-        </p>
+          title=""
+        />
       </td>
       <td
         class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
@@ -584,16 +582,15 @@ exports[`renders worksheet 1`] = `
             class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
           >
             <input
-              aria-checked="true"
+              aria-checked=""
               aria-labelledby="bd-checkbox_label-14"
-              checked=""
               class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
               id="bd-checkbox-13"
               type="checkbox"
             />
             <label
               aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
+              class="styled__StyledCheckbox-sc-s1u0st-3 Brufm"
               for="bd-checkbox-13"
             >
               <svg
@@ -625,7 +622,7 @@ exports[`renders worksheet 1`] = `
                 hidden=""
                 id="bd-checkbox_label-14"
               >
-                Checked
+                Unchecked
               </label>
             </div>
           </div>
@@ -638,10 +635,8 @@ exports[`renders worksheet 1`] = `
         <p
           class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
           color="secondary70"
-          title="Text"
-        >
-          Text
-        </p>
+          title=""
+        />
       </td>
       <td
         class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
@@ -656,10 +651,8 @@ exports[`renders worksheet 1`] = `
             <p
               class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
               color="secondary70"
-              title="5"
-            >
-              5
-            </p>
+              title=""
+            />
           </div>
           <button
             class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
@@ -673,16 +666,14 @@ exports[`renders worksheet 1`] = `
         </div>
       </td>
       <td
-        class="styled__StyledCell-sc-1bt06ph-0 gdKilx"
+        class="styled__StyledCell-sc-1bt06ph-0 jFgUHj"
         type="number"
       >
         <p
           class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
           color="secondary70"
-          title="$50.00"
-        >
-          $50.00
-        </p>
+          title=""
+        />
       </td>
     </tr>
     <tr

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -36,7 +36,7 @@ const InternalModalEditor = <T extends WorksheetItem>({
   }, [cell, setEditingCell]);
 
   const renderedValue = useMemo(
-    () => (formatting ? formatting(value) : `${value}`),
+    () => (typeof formatting === 'function' ? formatting(value) : `${value}`),
     [formatting, value],
   );
 

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -139,7 +139,7 @@ const disabledColumns: Array<WorksheetColumn<Product>> = [
   },
 ];
 
-const items: Product[] = [
+const items: Array<Partial<Product>> = [
   {
     id: 1,
     productName: 'Shoes Name Three',
@@ -160,7 +160,6 @@ const items: Product[] = [
     id: 3,
     productName: 'Shoes Name One',
     visibleOnStorefront: false,
-    otherField: 'Text',
     otherField2: 3,
     numberField: 50,
   },
@@ -174,11 +173,6 @@ const items: Product[] = [
   },
   {
     id: 5,
-    productName: '',
-    visibleOnStorefront: true,
-    otherField: 'Text',
-    otherField2: 5,
-    numberField: 50,
   },
   {
     id: 6,
@@ -303,6 +297,15 @@ describe('edition', () => {
     cell = getByText('Shoes Name One Edit');
 
     expect(cell).toBeDefined();
+    expect(handleChange).toHaveBeenCalledWith([
+      {
+        id: 3,
+        numberField: 50,
+        otherField2: 3,
+        productName: 'Shoes Name One Edit',
+        visibleOnStorefront: false,
+      },
+    ]);
   });
 
   test('regains focus when it stops editing', () => {
@@ -325,7 +328,6 @@ describe('edition', () => {
       id: 3,
       productName: 'Shoes Name One',
       visibleOnStorefront: false,
-      otherField: 'Text',
       otherField2: 3,
       numberField: 50,
     });
@@ -358,13 +360,8 @@ describe('validation', () => {
       {
         item: {
           id: 5,
-          productName: '',
-          visibleOnStorefront: true,
-          otherField: 'Text',
-          otherField2: 5,
-          numberField: 50,
         },
-        errors: ['productName'],
+        errors: ['productName', 'numberField'],
       },
       {
         item: {
@@ -393,13 +390,8 @@ describe('validation', () => {
       {
         item: {
           id: 5,
-          productName: '',
-          visibleOnStorefront: true,
-          otherField: 'Text',
-          otherField2: 5,
-          numberField: 50,
         },
-        errors: ['productName'],
+        errors: ['productName', 'numberField'],
       },
       {
         item: {
@@ -428,13 +420,8 @@ describe('validation', () => {
       {
         item: {
           id: 5,
-          productName: '',
-          visibleOnStorefront: true,
-          otherField: 'Text',
-          otherField2: 5,
-          numberField: 50,
         },
-        errors: ['productName'],
+        errors: ['productName', 'numberField'],
       },
     ]);
   });
@@ -446,7 +433,7 @@ describe('formatting', () => {
       <Worksheet columns={columns} items={items} onChange={handleChange} />,
     );
 
-    expect(getAllByText('$50.00')).toHaveLength(8);
+    expect(getAllByText('$50.00')).toHaveLength(7);
   });
 });
 
@@ -630,7 +617,6 @@ describe('TextEditor', () => {
         id: 3,
         productName: 'Shoes Name One Edit',
         visibleOnStorefront: false,
-        otherField: 'Text',
         otherField2: 3,
         numberField: 50,
       },
@@ -760,11 +746,11 @@ describe('CheckboxEditor', () => {
 
     let cells = getAllByLabelText('Checked');
 
-    expect(cells).toHaveLength(7);
+    expect(cells).toHaveLength(6);
 
     cells = getAllByLabelText('Unchecked');
 
-    expect(cells).toHaveLength(2);
+    expect(cells).toHaveLength(3);
   });
 
   test('CheckboxEditor is editable', () => {

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -172,7 +172,7 @@ const WorksheetPage = () => {
                       },
                     ];
 
-                    const items: Product[] = [
+                    const items: Array<Partial<Product>> = [
                       {
                         id: 1,
                         productName: 'Product 1',
@@ -194,11 +194,6 @@ const WorksheetPage = () => {
                       {
                         id: 3,
                         productName: 'Product 3',
-                        isVisible: false,
-                        otherField: 'Text',
-                        otherField2: 'option-2',
-                        otherField3: 8,
-                        numberField: 50,
                       },
                       {
                         id: 4,


### PR DESCRIPTION
## What?

Render empty cells in `Worksheet` when a prop is missing in the item, instead of `undefined`. Shouldn't change the values of onChange until values are actually edited.

## Why?

When I build it I was under the assumption that the items should always have all the props but this is not always true.

## Screenshots/Screen Recordings

Before:
<img width="929" alt="Screen Shot 2022-08-31 at 4 52 40 PM" src="https://user-images.githubusercontent.com/196129/187791837-d98fa89a-9cb4-4125-8e22-3c35705a7c5c.png">

After:
<img width="945" alt="Screen Shot 2022-08-31 at 4 51 49 PM" src="https://user-images.githubusercontent.com/196129/187791717-e2fd0cc3-3b62-40bf-ba4d-9ea053cd7a37.png">

## Testing/Proof

Updated unit tests to reflect this change.
