### PR TITLE
feat(component): normalize panel shadow across breakpoints

### DIFF
--- a/packages/big-design/src/components/AccordionPanel/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/AccordionPanel/__snapshots__/spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`it renders accordion panel header 1`] = `
 <h2
-  class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 kEGvNd fjdBDH"
+  class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-0 kEGvNd gRjkZy"
 >
   Accordion Panel Header
 </h2>

--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -2,10 +2,11 @@ import React, { forwardRef, HTMLAttributes, memo, Ref } from 'react';
 
 import { MarginProps } from '../../mixins';
 import { excludePaddingProps } from '../../mixins/paddings/paddings';
+import { Box } from '../Box';
 import { Button, ButtonProps } from '../Button';
 import { Flex } from '../Flex';
 
-import { StyledH2, StyledPanel } from './styled';
+import { StyledH2 } from './styled';
 
 interface PrivateProps {
   forwardedRef: Ref<HTMLDivElement>;
@@ -44,7 +45,8 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
   };
 
   return (
-    <StyledPanel
+    <Box
+      marginBottom="medium"
       {...rest}
       backgroundColor="white"
       borderRadius="none"
@@ -54,7 +56,7 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
     >
       {renderHeader()}
       {children}
-    </StyledPanel>
+    </Box>
   );
 });
 

--- a/packages/big-design/src/components/Panel/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Panel/__snapshots__/spec.tsx.snap
@@ -22,15 +22,8 @@ exports[`render panel 1`] = `
   }
 }
 
-@media (min-width:720px) {
-  .c1 {
-    border-radius: 0.25rem;
-    box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  }
-}
-
 <div
-  class="c0 c1"
+  class="c0"
 >
   Dolore proident eiusmod sint est enim laboris anim minim quis ut adipisicing consectetur officia ex. Ipsum eiusmod fugiat amet pariatur culpa tempor aliquip tempor nisi. Irure esse deserunt nostrud ipsum id adipisicing enim velit labore. Nulla exercitation laborum laboris Lorem irure sit esse nulla mollit aliquip consectetur velit
 </div>

--- a/packages/big-design/src/components/Panel/styled.tsx
+++ b/packages/big-design/src/components/Panel/styled.tsx
@@ -1,14 +1,7 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
-import { Box } from '../Box';
 import { StyleableH2 } from '../Typography/private';
-
-export const StyledPanel = styled(Box)`
-  ${({ theme }) => theme.breakpoints.tablet} {
-    ${({ theme }) => theme.shadow.floating}
-  }
-`;
 
 export const StyledH2 = styled(StyleableH2)`
   flex-grow: 1;
@@ -19,8 +12,4 @@ export const StyledH2 = styled(StyleableH2)`
   }
 `;
 
-StyledPanel.defaultProps = {
-  theme: defaultTheme,
-  marginBottom: 'medium',
-};
 StyledH2.defaultProps = { theme: defaultTheme };


### PR DESCRIPTION
## What?

Updates the `Panel` components shadow to be `raised` across all breakpoints.

## Why?

The design team wants to make this a consistent experience across devices.

## Screenshots/Screen Recordings

![screencapture-localhost-3000-panel-2022-09-01-15_14_41](https://user-images.githubusercontent.com/10539418/188003892-817779c6-bb91-4787-920a-32c5878a966b.png)


## Testing/Proof

Updated snapshots.
