### PR TITLE
feat(component): implement default expanded worksheet rows

### DIFF
--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -21,6 +21,7 @@ const InternalWorksheet = typedMemo(
   <T extends WorksheetItem>({
     columns,
     expandableRows,
+    defaultExpandedRows,
     disabledRows,
     items,
     onChange,
@@ -66,7 +67,10 @@ const InternalWorksheet = typedMemo(
       setRows([...items]);
     }, [items, setRows]);
     useEffect(() => setColumns(expandedColumns), [expandedColumns, setColumns]);
-    useEffect(() => setExpandableRows(expandableRows || {}), [expandableRows, setExpandableRows]);
+    useEffect(
+      () => setExpandableRows(expandableRows || {}, defaultExpandedRows || []),
+      [expandableRows, defaultExpandedRows, setExpandableRows],
+    );
     useEffect(() => setDisabledRows(disabledRows || []), [disabledRows, setDisabledRows]);
     useEffect(() => setTableRef(tableRef.current), [setTableRef, tableRef]);
 

--- a/packages/big-design/src/components/Worksheet/hooks/useWorksheetStore/useWorksheetStore.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useWorksheetStore/useWorksheetStore.ts
@@ -23,7 +23,10 @@ export interface BaseState<Item> {
   removeInvalidCells: (cells: Array<Cell<Item>>) => void;
   setColumns: (columns: Array<InternalWorksheetColumn<Item>>) => void;
   setEditingCell: (cell: Cell<Item> | null) => void;
-  setExpandableRows: (expandableRows: ExpandableRows) => void;
+  setExpandableRows: (
+    expandableRows: ExpandableRows,
+    defaultExpandedRows?: Array<string | number>,
+  ) => void;
   setDisabledRows: (disabledRows: DisabledRows) => void;
   setHiddenRows: (hiddenRow: Array<string | number>) => void;
   setOpenModal: (value: keyof Item | null) => void;
@@ -55,8 +58,12 @@ export const createWorksheetStore = <Item>() =>
       set((state) => ({ ...state, invalidCells: deleteCells(state.invalidCells, cells) })),
     setColumns: (columns) => set((state) => ({ ...state, columns })),
     setEditingCell: (cell) => set((state) => ({ ...state, editingCell: cell })),
-    setExpandableRows: (expandableRows) =>
-      set((state) => ({ ...state, expandableRows, hiddenRows: getHiddenRows(expandableRows) })),
+    setExpandableRows: (expandableRows, defaultExpandedRows) =>
+      set((state) => ({
+        ...state,
+        expandableRows,
+        hiddenRows: getHiddenRows(expandableRows, defaultExpandedRows),
+      })),
     setDisabledRows: (disabledRows) => set((state) => ({ ...state, disabledRows })),
     setHiddenRows: (hiddenRows) => set((state) => ({ ...state, hiddenRows })),
     setOpenModal: (value) => set((state) => ({ ...state, openedModal: value })),

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -12,6 +12,7 @@ export interface WorksheetProps<Item extends WorksheetItem> {
   columns: Array<WorksheetColumn<Item>>;
   items: Item[];
   expandableRows?: ExpandableRows;
+  defaultExpandedRows?: Array<string | number>;
   disabledRows?: DisabledRows;
   onChange(items: Item[]): void;
   onErrors?(items: Array<WorksheetError<Item>>): void;

--- a/packages/big-design/src/components/Worksheet/utils.ts
+++ b/packages/big-design/src/components/Worksheet/utils.ts
@@ -69,6 +69,12 @@ export const invalidRows = <T extends WorksheetItem>(invalidCells: Array<Cell<T>
   }));
 };
 
-export const getHiddenRows = (expandableRows: ExpandableRows) => {
-  return Object.values(expandableRows).flat();
-};
+export const getHiddenRows = (
+  expandableRows: ExpandableRows,
+  defaultExpandedRows: Array<string | number> = [],
+) =>
+  Object.entries(expandableRows).reduce<Array<string | number>>(
+    (accum, [key, value]) =>
+      defaultExpandedRows.map(String).includes(key) ? accum : [...accum, ...value],
+    [],
+  );

--- a/packages/docs/PropTables/WorksheetPropTable.tsx
+++ b/packages/docs/PropTables/WorksheetPropTable.tsx
@@ -60,6 +60,11 @@ const worksheetProps: Prop[] = [
       'Accepts an object with parent ids as keys and an array of child ids that will be hidden on render.',
   },
   {
+    name: 'defaultExpandedRows',
+    types: 'Array<string | number>',
+    description: 'Accepts an array with parent ids that will be expanded by default.',
+  },
+  {
     name: 'disabledRows',
     types: 'Array<string | number>',
     description: 'Accepts an array with ids of rows that will be disabled.',

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -649,6 +649,7 @@ const WorksheetPage = () => {
                     return (
                       <Worksheet
                         columns={columns}
+                        defaultExpandedRows={[4]}
                         expandableRows={expandableRows}
                         items={items}
                         onChange={(items) => items}


### PR DESCRIPTION
## What?
 Implement default expanded worksheet rows

## Why?
To be able to display an expanded row by default.

## Screenshots/Screen Recordings
<img width="912" alt="Screenshot 2022-09-15 at 19 33 30" src="https://user-images.githubusercontent.com/84462142/190458781-4bd66f35-2a64-4115-94ea-bc956556c8df.png">
<img width="376" alt="Screenshot 2022-09-15 at 19 33 48" src="https://user-images.githubusercontent.com/84462142/190458839-0c157efc-2500-47b7-adf0-c1ddfcaca02f.png">
<img width="964" alt="Screenshot 2022-09-15 at 19 35 57" src="https://user-images.githubusercontent.com/84462142/190459324-15c012e8-0d52-4d48-a9e6-e20d68b8b9bf.png">

## Testing/Proof

Locally.