### PR TITLE
feat(component): allow custom column widths and overflow worksheet

### DIFF
--- a/packages/big-design/src/components/Worksheet/Cell/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/styled.tsx
@@ -51,6 +51,7 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
   & p {
     display: block;
     white-space: inherit;
+    word-break: break-word;
   }
 `;
 

--- a/packages/big-design/src/components/Worksheet/Cell/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/styled.tsx
@@ -50,6 +50,7 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
 
   & p {
     display: block;
+    white-space: inherit;
   }
 `;
 

--- a/packages/big-design/src/components/Worksheet/RowStatus/styled.ts
+++ b/packages/big-design/src/components/Worksheet/RowStatus/styled.ts
@@ -5,6 +5,7 @@ export const Status = styled.td<{ isInvalid?: boolean; isSelected?: boolean }>`
   background-color: ${({ theme }) => theme.colors.secondary30};
   border-top: ${({ theme }) => `${theme.helpers.remCalc(0.5)} solid ${theme.colors.secondary30}`};
   box-sizing: border-box;
+  min-width: ${({ theme }) => theme.spacing.xxSmall};
   padding: 0;
   width: ${({ theme }) => theme.spacing.xxSmall};
 
@@ -14,13 +15,12 @@ export const Status = styled.td<{ isInvalid?: boolean; isSelected?: boolean }>`
       background-color: ${({ theme }) => `${theme.colors.danger}`};
       border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} solid ${theme.colors.danger}`};
     `}
-
   ${({ isSelected }) =>
     isSelected &&
     css`
       background-color: ${({ theme }) => `${theme.colors.primary}`};
       border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} solid ${theme.colors.primary}`};
-    `}
+    `};
 `;
 
 Status.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -8,7 +8,7 @@ import { BaseState, createWorksheetStore, useKeyEvents, useWorksheetStore } from
 import { WorksheetModal } from './Modal/Modal';
 import { Row } from './Row';
 import { Status } from './RowStatus/styled';
-import { Header, Table } from './styled';
+import { Header, StyledBox, Table } from './styled';
 import {
   InternalWorksheetColumn,
   WorksheetItem,
@@ -54,7 +54,9 @@ const InternalWorksheet = typedMemo(
 
     // Add a column for the toggle components
     const expandedColumns: Array<InternalWorksheetColumn<T>> = useMemo(() => {
-      return expandableRows ? [{ hash: '', header: '', type: 'toggle' }, ...columns] : columns;
+      return expandableRows
+        ? [{ hash: '', header: '', type: 'toggle', width: 50 }, ...columns]
+        : columns;
     }, [columns, expandableRows]);
 
     useEffect(() => {
@@ -92,13 +94,18 @@ const InternalWorksheet = typedMemo(
           <tr>
             <Status />
             {expandedColumns.map((column, index) => (
-              <Header columnType={column.type} key={index}>
+              <Header columnType={column.type} columnWidth={column.width || 'auto'} key={index}>
                 {column.header}
               </Header>
             ))}
           </tr>
         </thead>
       ),
+      [expandedColumns],
+    );
+
+    const tableHasStaticWidth = useMemo(
+      () => expandedColumns.every((column) => column.width && typeof column.width === 'number'),
       [expandedColumns],
     );
 
@@ -123,10 +130,17 @@ const InternalWorksheet = typedMemo(
 
     return (
       <UpdateItemsProvider items={rows}>
-        <Table onKeyDown={handleKeyDown} ref={tableRef} tabIndex={0}>
-          {renderedHeaders}
-          {renderedRows}
-        </Table>
+        <StyledBox>
+          <Table
+            hasStaticWidth={tableHasStaticWidth}
+            onKeyDown={handleKeyDown}
+            ref={tableRef}
+            tabIndex={0}
+          >
+            {renderedHeaders}
+            {renderedRows}
+          </Table>
+        </StyledBox>
         {renderedModals}
       </UpdateItemsProvider>
     );

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -48,7 +48,7 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 eDVZgo"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -60,7 +60,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          class="styled__StyledCell-sc-1bt06ph-0 jzGnjp"
           type="checkbox"
         >
           <div
@@ -118,7 +118,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -130,7 +130,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="modal"
         >
           <div
@@ -159,7 +159,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          class="styled__StyledCell-sc-1bt06ph-0 BTghS"
           type="number"
         >
           <p
@@ -178,7 +178,7 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 eDVZgo"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -190,7 +190,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          class="styled__StyledCell-sc-1bt06ph-0 jzGnjp"
           type="checkbox"
         >
           <div
@@ -248,7 +248,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -260,7 +260,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="modal"
         >
           <div
@@ -289,7 +289,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          class="styled__StyledCell-sc-1bt06ph-0 BTghS"
           type="number"
         >
           <p
@@ -308,7 +308,7 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 eDVZgo"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -320,7 +320,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          class="styled__StyledCell-sc-1bt06ph-0 jzGnjp"
           type="checkbox"
         >
           <div
@@ -377,7 +377,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -387,7 +387,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="modal"
         >
           <div
@@ -416,7 +416,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          class="styled__StyledCell-sc-1bt06ph-0 BTghS"
           type="number"
         >
           <p
@@ -435,7 +435,7 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 eDVZgo"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -447,7 +447,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          class="styled__StyledCell-sc-1bt06ph-0 jzGnjp"
           type="checkbox"
         >
           <div
@@ -505,7 +505,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -517,7 +517,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="modal"
         >
           <div
@@ -546,7 +546,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          class="styled__StyledCell-sc-1bt06ph-0 BTghS"
           type="number"
         >
           <p
@@ -565,7 +565,7 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 hiVCKy"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 dpaAYe"
+          class="styled__StyledCell-sc-1bt06ph-0 bghzHj"
           type="text"
         >
           <p
@@ -575,7 +575,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          class="styled__StyledCell-sc-1bt06ph-0 jzGnjp"
           type="checkbox"
         >
           <div
@@ -631,7 +631,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -641,7 +641,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="modal"
         >
           <div
@@ -668,7 +668,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 cnCCrd"
+          class="styled__StyledCell-sc-1bt06ph-0 itnbkE"
           type="number"
         >
           <p
@@ -685,7 +685,7 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 eDVZgo"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -697,7 +697,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          class="styled__StyledCell-sc-1bt06ph-0 jzGnjp"
           type="checkbox"
         >
           <div
@@ -755,7 +755,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -767,7 +767,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="modal"
         >
           <div
@@ -796,7 +796,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          class="styled__StyledCell-sc-1bt06ph-0 BTghS"
           type="number"
         >
           <p
@@ -815,7 +815,7 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 hiVCKy"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -827,7 +827,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          class="styled__StyledCell-sc-1bt06ph-0 jzGnjp"
           type="checkbox"
         >
           <div
@@ -884,7 +884,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -896,7 +896,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="modal"
         >
           <div
@@ -925,7 +925,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 cnCCrd"
+          class="styled__StyledCell-sc-1bt06ph-0 itnbkE"
           type="number"
         >
           <p
@@ -944,7 +944,7 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 eDVZgo"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -956,7 +956,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          class="styled__StyledCell-sc-1bt06ph-0 jzGnjp"
           type="checkbox"
         >
           <div
@@ -1014,7 +1014,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -1026,7 +1026,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="modal"
         >
           <div
@@ -1055,7 +1055,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          class="styled__StyledCell-sc-1bt06ph-0 BTghS"
           type="number"
         >
           <p
@@ -1074,7 +1074,7 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 eDVZgo"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -1086,7 +1086,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          class="styled__StyledCell-sc-1bt06ph-0 jzGnjp"
           type="checkbox"
         >
           <div
@@ -1144,7 +1144,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="text"
         >
           <p
@@ -1156,7 +1156,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          class="styled__StyledCell-sc-1bt06ph-0 ljerDV"
           type="modal"
         >
           <div
@@ -1185,7 +1185,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          class="styled__StyledCell-sc-1bt06ph-0 BTghS"
           type="number"
         >
           <p

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -1,1199 +1,1203 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders worksheet 1`] = `
-<table
-  class="styled__Table-sc-16rzzpq-0 iUSyNN"
-  tabindex="0"
+<div
+  class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-16rzzpq-2 jjhxof"
 >
-  <thead>
-    <tr>
-      <td
-        class="styled__Status-sc-1aacki0-0 gvIVpq"
-      />
-      <th
-        class="styled__Header-sc-16rzzpq-1 hUnkHB"
-      >
-        Product name
-      </th>
-      <th
-        class="styled__Header-sc-16rzzpq-1 hUnkHB"
-      >
-        Visible on storefront
-      </th>
-      <th
-        class="styled__Header-sc-16rzzpq-1 hUnkHB"
-      >
-        Other field
-      </th>
-      <th
-        class="styled__Header-sc-16rzzpq-1 hUnkHB"
-      >
-        Other field
-      </th>
-      <th
-        class="styled__Header-sc-16rzzpq-1 cuShoS"
-      >
-        Number field
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr
-      class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
-    >
-      <td
-        class="styled__Status-sc-1aacki0-0 gvIVpq"
-      />
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Shoes Name Three"
+  <table
+    class="styled__Table-sc-16rzzpq-0 hiKdjk"
+    tabindex="0"
+  >
+    <thead>
+      <tr>
+        <td
+          class="styled__Status-sc-1aacki0-0 eDVZgo"
+        />
+        <th
+          class="styled__Header-sc-16rzzpq-1 cRvCWu"
         >
-          Shoes Name Three
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jotRGO"
-        type="checkbox"
+          Product name
+        </th>
+        <th
+          class="styled__Header-sc-16rzzpq-1 biTmCe"
+        >
+          Visible on storefront
+        </th>
+        <th
+          class="styled__Header-sc-16rzzpq-1 cRvCWu"
+        >
+          Other field
+        </th>
+        <th
+          class="styled__Header-sc-16rzzpq-1 cRvCWu"
+        >
+          Other field
+        </th>
+        <th
+          class="styled__Header-sc-16rzzpq-1 cyFJXl"
+        >
+          Number field
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
       >
-        <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
+        <td
+          class="styled__Status-sc-1aacki0-0 eDVZgo"
+        />
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Shoes Name Three"
+          >
+            Shoes Name Three
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          type="checkbox"
         >
           <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
+            class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
           >
-            <input
-              aria-checked="true"
-              aria-labelledby="bd-checkbox_label-2"
-              checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
-              id="bd-checkbox-1"
-              type="checkbox"
-            />
-            <label
-              aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
-              for="bd-checkbox-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
-                fill="currentColor"
-                height="24"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
-                />
-              </svg>
-            </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
             >
+              <input
+                aria-checked="true"
+                aria-labelledby="bd-checkbox_label-2"
+                checked=""
+                class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
+                id="bd-checkbox-1"
+                type="checkbox"
+              />
               <label
-                aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                aria-hidden="true"
+                class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
                 for="bd-checkbox-1"
-                hidden=""
-                id="bd-checkbox_label-2"
               >
-                Checked
+                <svg
+                  aria-hidden="true"
+                  class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                  fill="currentColor"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M0 0h24v24H0V0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+                  />
+                </svg>
               </label>
+              <div
+                class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              >
+                <label
+                  aria-hidden="false"
+                  class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                  for="bd-checkbox-1"
+                  hidden=""
+                  id="bd-checkbox_label-2"
+                >
+                  Checked
+                </label>
+              </div>
             </div>
           </div>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Text"
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
         >
-          Text
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="modal"
-      >
-        <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Text"
+          >
+            Text
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="modal"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
           >
-            <p
-              class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-              color="secondary70"
-              title="1"
-            >
-              1
-            </p>
-          </div>
-          <button
-            class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
-          >
-            <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
-            >
-              Edit
-            </span>
-          </button>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 gdKilx"
-        type="number"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="$50.00"
-        >
-          $50.00
-        </p>
-      </td>
-    </tr>
-    <tr
-      class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
-    >
-      <td
-        class="styled__Status-sc-1aacki0-0 gvIVpq"
-      />
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Shoes Name Two"
-        >
-          Shoes Name Two
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jotRGO"
-        type="checkbox"
-      >
-        <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
-        >
-          <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
-          >
-            <input
-              aria-checked="true"
-              aria-labelledby="bd-checkbox_label-5"
-              checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
-              id="bd-checkbox-4"
-              type="checkbox"
-            />
-            <label
-              aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
-              for="bd-checkbox-4"
-            >
-              <svg
-                aria-hidden="true"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
-                fill="currentColor"
-                height="24"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
-                />
-              </svg>
-            </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
             >
+              <p
+                class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+                color="secondary70"
+                title="1"
+              >
+                1
+              </p>
+            </div>
+            <button
+              class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
+            >
+              <span
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              >
+                Edit
+              </span>
+            </button>
+          </div>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="$50.00"
+          >
+            $50.00
+          </p>
+        </td>
+      </tr>
+      <tr
+        class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
+      >
+        <td
+          class="styled__Status-sc-1aacki0-0 eDVZgo"
+        />
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Shoes Name Two"
+          >
+            Shoes Name Two
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          type="checkbox"
+        >
+          <div
+            class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
+          >
+            <div
+              class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
+            >
+              <input
+                aria-checked="true"
+                aria-labelledby="bd-checkbox_label-5"
+                checked=""
+                class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
+                id="bd-checkbox-4"
+                type="checkbox"
+              />
               <label
-                aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                aria-hidden="true"
+                class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
                 for="bd-checkbox-4"
-                hidden=""
-                id="bd-checkbox_label-5"
               >
-                Checked
+                <svg
+                  aria-hidden="true"
+                  class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                  fill="currentColor"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M0 0h24v24H0V0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+                  />
+                </svg>
               </label>
+              <div
+                class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              >
+                <label
+                  aria-hidden="false"
+                  class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                  for="bd-checkbox-4"
+                  hidden=""
+                  id="bd-checkbox_label-5"
+                >
+                  Checked
+                </label>
+              </div>
             </div>
           </div>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Text"
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
         >
-          Text
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="modal"
-      >
-        <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Text"
+          >
+            Text
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="modal"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
           >
-            <p
-              class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-              color="secondary70"
-              title="2"
-            >
-              2
-            </p>
-          </div>
-          <button
-            class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
-          >
-            <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
-            >
-              Edit
-            </span>
-          </button>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 gdKilx"
-        type="number"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="$50.00"
-        >
-          $50.00
-        </p>
-      </td>
-    </tr>
-    <tr
-      class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
-    >
-      <td
-        class="styled__Status-sc-1aacki0-0 gvIVpq"
-      />
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Shoes Name One"
-        >
-          Shoes Name One
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jotRGO"
-        type="checkbox"
-      >
-        <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
-        >
-          <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
-          >
-            <input
-              aria-checked="false"
-              aria-labelledby="bd-checkbox_label-8"
-              class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
-              id="bd-checkbox-7"
-              type="checkbox"
-            />
-            <label
-              aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 Brufm"
-              for="bd-checkbox-7"
-            >
-              <svg
-                aria-hidden="true"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
-                fill="currentColor"
-                height="24"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
-                />
-              </svg>
-            </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
             >
+              <p
+                class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+                color="secondary70"
+                title="2"
+              >
+                2
+              </p>
+            </div>
+            <button
+              class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
+            >
+              <span
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              >
+                Edit
+              </span>
+            </button>
+          </div>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="$50.00"
+          >
+            $50.00
+          </p>
+        </td>
+      </tr>
+      <tr
+        class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
+      >
+        <td
+          class="styled__Status-sc-1aacki0-0 eDVZgo"
+        />
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Shoes Name One"
+          >
+            Shoes Name One
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          type="checkbox"
+        >
+          <div
+            class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
+          >
+            <div
+              class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
+            >
+              <input
+                aria-checked="false"
+                aria-labelledby="bd-checkbox_label-8"
+                class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
+                id="bd-checkbox-7"
+                type="checkbox"
+              />
               <label
-                aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                aria-hidden="true"
+                class="styled__StyledCheckbox-sc-s1u0st-3 Brufm"
                 for="bd-checkbox-7"
-                hidden=""
-                id="bd-checkbox_label-8"
               >
-                Unchecked
+                <svg
+                  aria-hidden="true"
+                  class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                  fill="currentColor"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M0 0h24v24H0V0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+                  />
+                </svg>
               </label>
+              <div
+                class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              >
+                <label
+                  aria-hidden="false"
+                  class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                  for="bd-checkbox-7"
+                  hidden=""
+                  id="bd-checkbox_label-8"
+                >
+                  Unchecked
+                </label>
+              </div>
             </div>
           </div>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title=""
-        />
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="modal"
-      >
-        <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title=""
+          />
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="modal"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
           >
-            <p
-              class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-              color="secondary70"
-              title="3"
-            >
-              3
-            </p>
-          </div>
-          <button
-            class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
-          >
-            <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
-            >
-              Edit
-            </span>
-          </button>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 gdKilx"
-        type="number"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="$50.00"
-        >
-          $50.00
-        </p>
-      </td>
-    </tr>
-    <tr
-      class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
-    >
-      <td
-        class="styled__Status-sc-1aacki0-0 gvIVpq"
-      />
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Variant 1"
-        >
-          Variant 1
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jotRGO"
-        type="checkbox"
-      >
-        <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
-        >
-          <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
-          >
-            <input
-              aria-checked="true"
-              aria-labelledby="bd-checkbox_label-11"
-              checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
-              id="bd-checkbox-10"
-              type="checkbox"
-            />
-            <label
-              aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
-              for="bd-checkbox-10"
-            >
-              <svg
-                aria-hidden="true"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
-                fill="currentColor"
-                height="24"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
-                />
-              </svg>
-            </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
             >
+              <p
+                class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+                color="secondary70"
+                title="3"
+              >
+                3
+              </p>
+            </div>
+            <button
+              class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
+            >
+              <span
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              >
+                Edit
+              </span>
+            </button>
+          </div>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="$50.00"
+          >
+            $50.00
+          </p>
+        </td>
+      </tr>
+      <tr
+        class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
+      >
+        <td
+          class="styled__Status-sc-1aacki0-0 eDVZgo"
+        />
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Variant 1"
+          >
+            Variant 1
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          type="checkbox"
+        >
+          <div
+            class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
+          >
+            <div
+              class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
+            >
+              <input
+                aria-checked="true"
+                aria-labelledby="bd-checkbox_label-11"
+                checked=""
+                class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
+                id="bd-checkbox-10"
+                type="checkbox"
+              />
               <label
-                aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                aria-hidden="true"
+                class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
                 for="bd-checkbox-10"
-                hidden=""
-                id="bd-checkbox_label-11"
               >
-                Checked
+                <svg
+                  aria-hidden="true"
+                  class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                  fill="currentColor"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M0 0h24v24H0V0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+                  />
+                </svg>
               </label>
+              <div
+                class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              >
+                <label
+                  aria-hidden="false"
+                  class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                  for="bd-checkbox-10"
+                  hidden=""
+                  id="bd-checkbox_label-11"
+                >
+                  Checked
+                </label>
+              </div>
             </div>
           </div>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Text"
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
         >
-          Text
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="modal"
-      >
-        <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Text"
+          >
+            Text
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="modal"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
           >
-            <p
-              class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-              color="secondary70"
-              title="4"
-            >
-              4
-            </p>
-          </div>
-          <button
-            class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
-          >
-            <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
-            >
-              Edit
-            </span>
-          </button>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 gdKilx"
-        type="number"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="$50.00"
-        >
-          $50.00
-        </p>
-      </td>
-    </tr>
-    <tr
-      class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
-    >
-      <td
-        class="styled__Status-sc-1aacki0-0 dHmMaY"
-      />
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 hXGgag"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title=""
-        />
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jotRGO"
-        type="checkbox"
-      >
-        <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
-        >
-          <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
-          >
-            <input
-              aria-labelledby="bd-checkbox_label-14"
-              class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
-              id="bd-checkbox-13"
-              type="checkbox"
-            />
-            <label
-              aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 Brufm"
-              for="bd-checkbox-13"
-            >
-              <svg
-                aria-hidden="true"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
-                fill="currentColor"
-                height="24"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
-                />
-              </svg>
-            </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
             >
+              <p
+                class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+                color="secondary70"
+                title="4"
+              >
+                4
+              </p>
+            </div>
+            <button
+              class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
+            >
+              <span
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              >
+                Edit
+              </span>
+            </button>
+          </div>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="$50.00"
+          >
+            $50.00
+          </p>
+        </td>
+      </tr>
+      <tr
+        class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
+      >
+        <td
+          class="styled__Status-sc-1aacki0-0 hiVCKy"
+        />
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 dpaAYe"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title=""
+          />
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          type="checkbox"
+        >
+          <div
+            class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
+          >
+            <div
+              class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
+            >
+              <input
+                aria-labelledby="bd-checkbox_label-14"
+                class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
+                id="bd-checkbox-13"
+                type="checkbox"
+              />
               <label
-                aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                aria-hidden="true"
+                class="styled__StyledCheckbox-sc-s1u0st-3 Brufm"
                 for="bd-checkbox-13"
-                hidden=""
-                id="bd-checkbox_label-14"
               >
-                Unchecked
+                <svg
+                  aria-hidden="true"
+                  class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                  fill="currentColor"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M0 0h24v24H0V0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+                  />
+                </svg>
               </label>
+              <div
+                class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              >
+                <label
+                  aria-hidden="false"
+                  class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                  for="bd-checkbox-13"
+                  hidden=""
+                  id="bd-checkbox_label-14"
+                >
+                  Unchecked
+                </label>
+              </div>
             </div>
           </div>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title=""
-        />
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="modal"
-      >
-        <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title=""
+          />
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="modal"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
           >
-            <p
-              class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-              color="secondary70"
-              title=""
-            />
-          </div>
-          <button
-            class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
-          >
-            <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
-            >
-              Edit
-            </span>
-          </button>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jFgUHj"
-        type="number"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title=""
-        />
-      </td>
-    </tr>
-    <tr
-      class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
-    >
-      <td
-        class="styled__Status-sc-1aacki0-0 gvIVpq"
-      />
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Variant 2"
-        >
-          Variant 2
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jotRGO"
-        type="checkbox"
-      >
-        <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
-        >
-          <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
-          >
-            <input
-              aria-checked="true"
-              aria-labelledby="bd-checkbox_label-17"
-              checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
-              id="bd-checkbox-16"
-              type="checkbox"
-            />
-            <label
-              aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
-              for="bd-checkbox-16"
-            >
-              <svg
-                aria-hidden="true"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
-                fill="currentColor"
-                height="24"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
-                />
-              </svg>
-            </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
             >
+              <p
+                class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+                color="secondary70"
+                title=""
+              />
+            </div>
+            <button
+              class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
+            >
+              <span
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              >
+                Edit
+              </span>
+            </button>
+          </div>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 cnCCrd"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title=""
+          />
+        </td>
+      </tr>
+      <tr
+        class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
+      >
+        <td
+          class="styled__Status-sc-1aacki0-0 eDVZgo"
+        />
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Variant 2"
+          >
+            Variant 2
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          type="checkbox"
+        >
+          <div
+            class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
+          >
+            <div
+              class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
+            >
+              <input
+                aria-checked="true"
+                aria-labelledby="bd-checkbox_label-17"
+                checked=""
+                class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
+                id="bd-checkbox-16"
+                type="checkbox"
+              />
               <label
-                aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                aria-hidden="true"
+                class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
                 for="bd-checkbox-16"
-                hidden=""
-                id="bd-checkbox_label-17"
               >
-                Checked
+                <svg
+                  aria-hidden="true"
+                  class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                  fill="currentColor"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M0 0h24v24H0V0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+                  />
+                </svg>
               </label>
+              <div
+                class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              >
+                <label
+                  aria-hidden="false"
+                  class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                  for="bd-checkbox-16"
+                  hidden=""
+                  id="bd-checkbox_label-17"
+                >
+                  Checked
+                </label>
+              </div>
             </div>
           </div>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Text"
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
         >
-          Text
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="modal"
-      >
-        <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Text"
+          >
+            Text
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="modal"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
           >
-            <p
-              class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-              color="secondary70"
-              title="6"
-            >
-              6
-            </p>
-          </div>
-          <button
-            class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
-          >
-            <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
-            >
-              Edit
-            </span>
-          </button>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 gdKilx"
-        type="number"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="$50.00"
-        >
-          $50.00
-        </p>
-      </td>
-    </tr>
-    <tr
-      class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
-    >
-      <td
-        class="styled__Status-sc-1aacki0-0 dHmMaY"
-      />
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Variant 3"
-        >
-          Variant 3
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jotRGO"
-        type="checkbox"
-      >
-        <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
-        >
-          <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
-          >
-            <input
-              aria-checked="false"
-              aria-labelledby="bd-checkbox_label-20"
-              class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
-              id="bd-checkbox-19"
-              type="checkbox"
-            />
-            <label
-              aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 Brufm"
-              for="bd-checkbox-19"
-            >
-              <svg
-                aria-hidden="true"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
-                fill="currentColor"
-                height="24"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
-                />
-              </svg>
-            </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
             >
+              <p
+                class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+                color="secondary70"
+                title="6"
+              >
+                6
+              </p>
+            </div>
+            <button
+              class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
+            >
+              <span
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              >
+                Edit
+              </span>
+            </button>
+          </div>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="$50.00"
+          >
+            $50.00
+          </p>
+        </td>
+      </tr>
+      <tr
+        class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
+      >
+        <td
+          class="styled__Status-sc-1aacki0-0 hiVCKy"
+        />
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Variant 3"
+          >
+            Variant 3
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          type="checkbox"
+        >
+          <div
+            class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
+          >
+            <div
+              class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
+            >
+              <input
+                aria-checked="false"
+                aria-labelledby="bd-checkbox_label-20"
+                class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
+                id="bd-checkbox-19"
+                type="checkbox"
+              />
               <label
-                aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                aria-hidden="true"
+                class="styled__StyledCheckbox-sc-s1u0st-3 Brufm"
                 for="bd-checkbox-19"
-                hidden=""
-                id="bd-checkbox_label-20"
               >
-                Unchecked
+                <svg
+                  aria-hidden="true"
+                  class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                  fill="currentColor"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M0 0h24v24H0V0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+                  />
+                </svg>
               </label>
+              <div
+                class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              >
+                <label
+                  aria-hidden="false"
+                  class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                  for="bd-checkbox-19"
+                  hidden=""
+                  id="bd-checkbox_label-20"
+                >
+                  Unchecked
+                </label>
+              </div>
             </div>
           </div>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Text"
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
         >
-          Text
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="modal"
-      >
-        <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Text"
+          >
+            Text
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="modal"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
           >
-            <p
-              class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-              color="secondary70"
-              title="7"
-            >
-              7
-            </p>
-          </div>
-          <button
-            class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
-          >
-            <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
-            >
-              Edit
-            </span>
-          </button>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jFgUHj"
-        type="number"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="$49.00"
-        >
-          $49.00
-        </p>
-      </td>
-    </tr>
-    <tr
-      class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
-    >
-      <td
-        class="styled__Status-sc-1aacki0-0 gvIVpq"
-      />
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Dress Name One"
-        >
-          Dress Name One
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jotRGO"
-        type="checkbox"
-      >
-        <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
-        >
-          <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
-          >
-            <input
-              aria-checked="true"
-              aria-labelledby="bd-checkbox_label-23"
-              checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
-              id="bd-checkbox-22"
-              type="checkbox"
-            />
-            <label
-              aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
-              for="bd-checkbox-22"
-            >
-              <svg
-                aria-hidden="true"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
-                fill="currentColor"
-                height="24"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
-                />
-              </svg>
-            </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
             >
+              <p
+                class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+                color="secondary70"
+                title="7"
+              >
+                7
+              </p>
+            </div>
+            <button
+              class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
+            >
+              <span
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              >
+                Edit
+              </span>
+            </button>
+          </div>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 cnCCrd"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="$49.00"
+          >
+            $49.00
+          </p>
+        </td>
+      </tr>
+      <tr
+        class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
+      >
+        <td
+          class="styled__Status-sc-1aacki0-0 eDVZgo"
+        />
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Dress Name One"
+          >
+            Dress Name One
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          type="checkbox"
+        >
+          <div
+            class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
+          >
+            <div
+              class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
+            >
+              <input
+                aria-checked="true"
+                aria-labelledby="bd-checkbox_label-23"
+                checked=""
+                class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
+                id="bd-checkbox-22"
+                type="checkbox"
+              />
               <label
-                aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                aria-hidden="true"
+                class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
                 for="bd-checkbox-22"
-                hidden=""
-                id="bd-checkbox_label-23"
               >
-                Checked
+                <svg
+                  aria-hidden="true"
+                  class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                  fill="currentColor"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M0 0h24v24H0V0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+                  />
+                </svg>
               </label>
+              <div
+                class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              >
+                <label
+                  aria-hidden="false"
+                  class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                  for="bd-checkbox-22"
+                  hidden=""
+                  id="bd-checkbox_label-23"
+                >
+                  Checked
+                </label>
+              </div>
             </div>
           </div>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Text"
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
         >
-          Text
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="modal"
-      >
-        <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Text"
+          >
+            Text
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="modal"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
           >
-            <p
-              class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-              color="secondary70"
-              title="8"
-            >
-              8
-            </p>
-          </div>
-          <button
-            class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
-          >
-            <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
-            >
-              Edit
-            </span>
-          </button>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 gdKilx"
-        type="number"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="$50.00"
-        >
-          $50.00
-        </p>
-      </td>
-    </tr>
-    <tr
-      class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
-    >
-      <td
-        class="styled__Status-sc-1aacki0-0 gvIVpq"
-      />
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Fans Name One"
-        >
-          Fans Name One
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 jotRGO"
-        type="checkbox"
-      >
-        <div
-          class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
-        >
-          <div
-            class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
-          >
-            <input
-              aria-checked="true"
-              aria-labelledby="bd-checkbox_label-26"
-              checked=""
-              class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
-              id="bd-checkbox-25"
-              type="checkbox"
-            />
-            <label
-              aria-hidden="true"
-              class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
-              for="bd-checkbox-25"
-            >
-              <svg
-                aria-hidden="true"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
-                fill="currentColor"
-                height="24"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M0 0h24v24H0V0z"
-                  fill="none"
-                />
-                <path
-                  d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
-                />
-              </svg>
-            </label>
             <div
-              class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
             >
-              <label
-                aria-hidden="false"
-                class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
-                for="bd-checkbox-25"
-                hidden=""
-                id="bd-checkbox_label-26"
+              <p
+                class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+                color="secondary70"
+                title="8"
               >
-                Checked
-              </label>
+                8
+              </p>
             </div>
+            <button
+              class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
+            >
+              <span
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              >
+                Edit
+              </span>
+            </button>
           </div>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="text"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="Text"
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          type="number"
         >
-          Text
-        </p>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 xtpxS"
-        type="modal"
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="$50.00"
+          >
+            $50.00
+          </p>
+        </td>
+      </tr>
+      <tr
+        class="styled__StyledTableRow-sc-1bzgr3l-0 kbQxFQ"
       >
-        <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
+        <td
+          class="styled__Status-sc-1aacki0-0 eDVZgo"
+        />
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Fans Name One"
+          >
+            Fans Name One
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 TDGVM"
+          type="checkbox"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
+            class="styled__CheckboxWrapper-sc-1pcspgo-0 btbwgC"
           >
-            <p
-              class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-              color="secondary70"
-              title="9"
+            <div
+              class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
             >
-              9
-            </p>
+              <input
+                aria-checked="true"
+                aria-labelledby="bd-checkbox_label-26"
+                checked=""
+                class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
+                id="bd-checkbox-25"
+                type="checkbox"
+              />
+              <label
+                aria-hidden="true"
+                class="styled__StyledCheckbox-sc-s1u0st-3 kppkKN"
+                for="bd-checkbox-25"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                  fill="currentColor"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M0 0h24v24H0V0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+                  />
+                </svg>
+              </label>
+              <div
+                class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+              >
+                <label
+                  aria-hidden="false"
+                  class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk cEsRHG"
+                  for="bd-checkbox-25"
+                  hidden=""
+                  id="bd-checkbox_label-26"
+                >
+                  Checked
+                </label>
+              </div>
+            </div>
           </div>
-          <button
-            class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
-          >
-            <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
-            >
-              Edit
-            </span>
-          </button>
-        </div>
-      </td>
-      <td
-        class="styled__StyledCell-sc-1bt06ph-0 gdKilx"
-        type="number"
-      >
-        <p
-          class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
-          color="secondary70"
-          title="$50.00"
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="text"
         >
-          $50.00
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="Text"
+          >
+            Text
+          </p>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 ddWBuI"
+          type="modal"
+        >
+          <div
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 ktRUuG"
+          >
+            <div
+              class="styled__StyledBox-sc-sj5f1m-0 fzPbIA styled__StyledFlexItem-sc-smjqtt-0 jMEPcV styled__StyledFlexItem-sc-zoq9bz-1 cMa-dHw"
+            >
+              <p
+                class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+                color="secondary70"
+                title="9"
+              >
+                9
+              </p>
+            </div>
+            <button
+              class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__StyledButton-sc-zoq9bz-0 lnZrnv"
+            >
+              <span
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              >
+                Edit
+              </span>
+            </button>
+          </div>
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 btQrtn"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 dCgytK"
+            color="secondary70"
+            title="$50.00"
+          >
+            $50.00
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 `;

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -69,8 +69,8 @@ const TreeComponent = (
 
 const columns: Array<WorksheetColumn<Product>> = [
   { hash: 'productName', header: 'Product name', validation: (value: string) => !!value },
-  { hash: 'visibleOnStorefront', header: 'Visible on storefront', type: 'checkbox' },
-  { hash: 'otherField', header: 'Other field' },
+  { hash: 'visibleOnStorefront', header: 'Visible on storefront', type: 'checkbox', width: 80 },
+  { hash: 'otherField', header: 'Other field', width: 'auto' },
   {
     hash: 'otherField2',
     header: 'Other field',
@@ -83,6 +83,7 @@ const columns: Array<WorksheetColumn<Product>> = [
     type: 'number',
     validation: (value: number) => value >= 50,
     formatting: (value: number) => `$${value}.00`,
+    width: 90,
   },
 ];
 
@@ -1085,5 +1086,37 @@ describe('expandable', () => {
     cell = screen.getByText('Shoes Name One');
 
     expect(cell.parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
+  });
+});
+
+describe('column widths', () => {
+  test('table has 100% width when some or none columns have fixed width', () => {
+    render(<Worksheet columns={columns} items={items} onChange={handleChange} />);
+
+    const table = screen.getByRole('table');
+
+    expect(table).toHaveStyle('width: 100%');
+  });
+
+  test('table has auto width if all columns have fixed width', () => {
+    render(
+      <Worksheet columns={[{ ...columns[0], width: 90 }]} items={items} onChange={handleChange} />,
+    );
+
+    const table = screen.getByRole('table');
+
+    expect(table).toHaveStyle('width: auto');
+  });
+
+  test('columns have defined widths (or auto if none)', async () => {
+    render(<Worksheet columns={columns} items={items} onChange={handleChange} />);
+
+    const productNameColumn = await screen.findByText('Product name');
+    const visibleOnStorefrontColumn = await screen.findByText('Visible on storefront');
+    const numberFieldColumn = await screen.findByText('Number field');
+
+    expect(productNameColumn).toHaveStyle('width: auto');
+    expect(visibleOnStorefrontColumn).toHaveStyle('width: 80px');
+    expect(numberFieldColumn).toHaveStyle('width: 90px');
   });
 });

--- a/packages/big-design/src/components/Worksheet/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/styled.tsx
@@ -1,28 +1,40 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
+import { Box } from '../Box';
+
 import { InternalWorksheetColumn } from './types';
 
-export const Table = styled.table`
+export const Table = styled.table<{ hasStaticWidth: boolean }>`
   border-collapse: collapse;
   border-spacing: 0;
-  table-layout: fixed;
-  width: 100%;
+  width: ${({ hasStaticWidth }) => (hasStaticWidth ? 'auto' : '100%')};
 
   &:focus {
     outline: none;
   }
 `;
 
-export const Header = styled.th<{ columnType: InternalWorksheetColumn<unknown>['type'] }>`
+export const Header = styled.th<{
+  columnType: InternalWorksheetColumn<unknown>['type'];
+  columnWidth: InternalWorksheetColumn<unknown>['width'];
+}>`
   border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} solid ${theme.colors.secondary30}`};
   box-sizing: border-box;
   color: ${({ theme }) => theme.colors.secondary60};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   height: ${({ theme }) => theme.helpers.remCalc(52)};
+  min-width: ${({ columnWidth }) =>
+    typeof columnWidth === 'string' ? columnWidth : `${columnWidth}px`};
+  overflow: hidden;
   padding: ${({ theme }) => `0 ${theme.helpers.remCalc(17)}`};
   text-align: ${({ columnType }) => (columnType === 'number' ? 'right' : 'left')};
-  width: ${({ columnType, theme }) => (columnType === 'toggle' ? theme.spacing.small : 'auto')};
+  width: ${({ columnWidth }) =>
+    typeof columnWidth === 'string' ? columnWidth : `${columnWidth}px`};
+`;
+
+export const StyledBox = styled(Box)`
+  overflow-x: scroll;
 `;
 
 Header.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -42,6 +42,7 @@ interface WorksheetBaseColumn<Item> {
   disabled?: boolean;
   hash: keyof Item;
   header: string;
+  width?: string | number;
   validation?(value: Item[keyof Item] | ''): boolean;
 }
 

--- a/packages/docs/PropTables/WorksheetPropTable.tsx
+++ b/packages/docs/PropTables/WorksheetPropTable.tsx
@@ -131,6 +131,11 @@ const worksheetTextColumnProps: Prop[] = [
     types: 'boolean',
     description: 'Disables cell manipulation for the entire column.',
   },
+  {
+    name: 'width',
+    types: ['string', 'number'],
+    description: 'Sets column width.',
+  },
 ];
 
 const worksheetNumberColumnProps: Prop[] = [
@@ -168,6 +173,11 @@ const worksheetNumberColumnProps: Prop[] = [
     types: 'boolean',
     description: 'Disables cell manipulation for the entire column.',
   },
+  {
+    name: 'width',
+    types: ['string', 'number'],
+    description: 'Sets column width.',
+  },
 ];
 
 const worksheetCheckboxColumnProps: Prop[] = [
@@ -199,6 +209,11 @@ const worksheetCheckboxColumnProps: Prop[] = [
     name: 'disable',
     types: 'boolean',
     description: 'Disables cell manipulation for the entire column.',
+  },
+  {
+    name: 'width',
+    types: ['string', 'number'],
+    description: 'Sets column width.',
   },
 ];
 
@@ -259,6 +274,11 @@ const worksheetSelectableColumnProps: Prop[] = [
     types: 'boolean',
     description: 'Disables cell manipulation for the entire column.',
   },
+  {
+    name: 'width',
+    types: ['string', 'number'],
+    description: 'Sets column width.',
+  },
 ];
 
 const worksheetModalColumnProps: Prop[] = [
@@ -316,6 +336,11 @@ const worksheetModalColumnProps: Prop[] = [
     name: 'disable',
     types: 'boolean',
     description: 'Disables cell manipulation for the entire column.',
+  },
+  {
+    name: 'width',
+    types: ['string', 'number'],
+    description: 'Sets column width.',
   },
 ];
 

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -136,8 +136,9 @@ const WorksheetPage = () => {
                         hash: 'productName',
                         header: 'Product name',
                         validation: (value) => !!value,
+                        width: 200,
                       },
-                      { hash: 'isVisible', header: 'Visible', type: 'checkbox' },
+                      { hash: 'isVisible', header: 'Visible', type: 'checkbox', width: 80 },
                       { hash: 'otherField', header: 'Other field' },
                       {
                         hash: 'otherField2',
@@ -151,6 +152,7 @@ const WorksheetPage = () => {
                           ],
                         },
                         validation: (value) => !!value,
+                        width: 200,
                       },
                       {
                         hash: 'otherField3',
@@ -169,6 +171,7 @@ const WorksheetPage = () => {
                         formatting: (value: number) => `$${value}.00`,
                         validation: (value: number) =>
                           typeof value === 'number' && !Number.isNaN(value),
+                        width: 100,
                       },
                     ];
 


### PR DESCRIPTION
## What?

**Breaking changes (??)**

- Allow custom widths to Worksheet columns.
- Scrollable overflow when columns are wider than table view. 
- Columns wont ellipsis anymore, instead words will wrap.
- When all columns have a fixed width, set Worksheet to auto width (instead of 100%).

## Screenshots/Screen Recordings
**Before**:
![Kapture 2022-09-19 at 16 32 16](https://user-images.githubusercontent.com/196129/191123494-ceefe935-b2b9-46b1-955e-9c9c9b17ae35.gif)

**After**:
<img width="943" alt="Screen Shot 2022-09-19 at 3 56 10 PM" src="https://user-images.githubusercontent.com/196129/191115292-59674904-f660-49fd-accf-4f4183447061.png">

![Kapture 2022-09-19 at 16 20 34](https://user-images.githubusercontent.com/196129/191119383-b59c7735-99fc-4b99-be71-d65394d7e80b.gif)

All columns are fixed width:
<img width="404" alt="Screen Shot 2022-09-19 at 4 22 27 PM" src="https://user-images.githubusercontent.com/196129/191122608-a8ed4d90-77f1-4774-8e01-27ff1ab1a2ff.png">

At least one column is auto:
<img width="778" alt="Screen Shot 2022-09-19 at 4 23 19 PM" src="https://user-images.githubusercontent.com/196129/191120648-9acae1de-98d3-4a6d-8757-30f0d0f403ed.png">

## Testing/Proof

Locally, added unit tests.
