### PR TITLE
fix(component): persist selection across TableNext pages

### DIFF
--- a/packages/big-design/jest.config.js
+++ b/packages/big-design/jest.config.js
@@ -9,10 +9,10 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
   coverageThreshold: {
     global: {
-      statements: 95,
+      statements: 96,
       branches: 87,
       functions: 97,
-      lines: 95,
+      lines: 96,
     },
   },
 };

--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -74,6 +74,7 @@ const InternalActions = <T extends TableItem>({
           isExpandable={isExpandable}
           items={items}
           onChange={onSelectionChange}
+          pagination={pagination}
           selectedItems={selectedItems}
           totalItems={totalItems}
         />

--- a/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Checkbox } from '../../Checkbox';
 import { Flex, FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
-import { TableExpandable, TableItem, TableSelectable } from '../types';
+import { TableExpandable, TableItem, TablePaginationProps, TableSelectable } from '../types';
 
 import { useSelectAllState } from './useSelectAllState';
 
@@ -14,18 +14,14 @@ export interface SelectAllProps<T> {
   onChange?: TableSelectable['onSelectionChange'];
   selectedItems: TableSelectable['selectedItems'];
   totalItems: number;
+  pagination?: TablePaginationProps;
 }
 
-export const SelectAll = <T extends TableItem>({
-  expandedRowSelector,
-  isExpandable,
-  items = [],
-  onChange,
-  selectedItems,
-  totalItems,
-}: SelectAllProps<T>) => {
+export const SelectAll = <T extends TableItem>(props: SelectAllProps<T>) => {
   const { allInPageSelected, handleSelectAll, label, someInPageSelected, totalSelectedItems } =
-    useSelectAllState({ expandedRowSelector, isExpandable, items, selectedItems, onChange });
+    useSelectAllState(props);
+
+  const { totalItems } = props;
 
   return (
     <FlexItem flexShrink={0} marginRight="xxSmall">

--- a/packages/big-design/src/components/TableNext/SelectAll/useSelectAllState.ts
+++ b/packages/big-design/src/components/TableNext/SelectAll/useSelectAllState.ts
@@ -1,42 +1,17 @@
-import { TableExpandable, TableSelectable } from '../types';
-
 import {
   areAllInPageSelected,
   areSomeInPageSelected,
+  getSelectAllState,
   getTotalSelectedItems,
-  selectAll,
 } from './helpers';
+import { SelectAllProps } from './SelectAll';
 
-interface useSelectAllStateProps<T> {
-  isExpandable: boolean;
-  items: T[];
-  selectedItems: TableSelectable['selectedItems'];
-  expandedRowSelector?: TableExpandable<T>['expandedRowSelector'];
-  onChange?: TableSelectable['onSelectionChange'];
-}
+export const useSelectAllState = <T>(props: SelectAllProps<T>) => {
+  const { selectedItems, onChange } = props;
 
-export const useSelectAllState = <T>({
-  expandedRowSelector,
-  isExpandable,
-  items,
-  selectedItems,
-  onChange,
-}: useSelectAllStateProps<T>) => {
-  const allInPageSelected = areAllInPageSelected({
-    expandedRowSelector,
-    isExpandable,
-    items,
-    selectedItems,
-  });
-
-  const someInPageSelected = areSomeInPageSelected({
-    expandedRowSelector,
-    isExpandable,
-    items,
-    selectedItems,
-  });
-
-  const totalSelectedItems = getTotalSelectedItems(items, selectedItems);
+  const allInPageSelected = areAllInPageSelected(props);
+  const someInPageSelected = areSomeInPageSelected(props);
+  const totalSelectedItems = getTotalSelectedItems(selectedItems);
   const label = allInPageSelected ? 'Deselect All' : 'Select All';
 
   const handleSelectAll = () => {
@@ -44,15 +19,7 @@ export const useSelectAllState = <T>({
       return;
     }
 
-    if (allInPageSelected) {
-      return onChange({});
-    }
-
-    const newSelectedItems = selectAll({
-      expandedRowSelector,
-      isExpandable,
-      items,
-    });
+    const newSelectedItems = getSelectAllState(props);
 
     return onChange(newSelectedItems);
   };

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -14,6 +14,7 @@ import {
   ExpandableHeaderCell,
   HeaderCheckboxCell,
 } from './HeaderCell/HeaderCell';
+import { getPagedIndex } from './helpers';
 import { useExpandable, useSelectable } from './hooks';
 import { RowContainer } from './RowContainer';
 import { StyledTable, StyledTableFigure } from './styled';
@@ -166,6 +167,7 @@ const InternalTableNext = <T extends TableItem>(
         <Body ref={provided.innerRef} withFirstRowBorder={headerless} {...provided.droppableProps}>
           {items.map((item: T, index) => {
             const key = getItemKey(item, index);
+            const pagedIndex = getPagedIndex(index, pagination);
 
             return (
               <Draggable draggableId={String(key)} index={index} key={key}>
@@ -186,7 +188,7 @@ const InternalTableNext = <T extends TableItem>(
                     key={key}
                     onExpandedRow={onExpandedRow}
                     onItemSelect={onItemSelect}
-                    parentRowIndex={index}
+                    parentRowIndex={pagedIndex}
                     ref={provided.innerRef}
                     selectedItems={selectedItems}
                     showDragIcon={true}
@@ -208,6 +210,7 @@ const InternalTableNext = <T extends TableItem>(
       <Body withFirstRowBorder={headerless}>
         {items.map((item: T, index) => {
           const key = getItemKey(item, index);
+          const pagedIndex = getPagedIndex(index, pagination);
 
           return (
             <RowContainer
@@ -224,7 +227,7 @@ const InternalTableNext = <T extends TableItem>(
               key={key}
               onExpandedRow={onExpandedRow}
               onItemSelect={onItemSelect}
-              parentRowIndex={index}
+              parentRowIndex={pagedIndex}
               selectedItems={selectedItems}
             />
           );

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a pagination component 1`] = `
+exports[`pagination renders a pagination component 1`] = `
 .c10 {
   vertical-align: middle;
   height: 2rem;

--- a/packages/big-design/src/components/TableNext/helpers.ts
+++ b/packages/big-design/src/components/TableNext/helpers.ts
@@ -1,0 +1,7 @@
+import { TablePaginationProps } from './types';
+
+export function getPagedIndex(index: number, pagination?: TablePaginationProps) {
+  const { currentPage, itemsPerPage } = pagination ?? { currentPage: 1, itemsPerPage: 0 };
+
+  return index + (currentPage - 1) * itemsPerPage;
+}

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -211,42 +211,262 @@ test('renders the total number of items + item name', () => {
   expect(itemNameNode).toBeInTheDocument();
 });
 
-test('renders a pagination component', async () => {
-  const onItemsPerPageChange = jest.fn();
-  const onPageChange = jest.fn();
+describe('pagination', () => {
+  test('renders a pagination component', async () => {
+    const onItemsPerPageChange = jest.fn();
+    const onPageChange = jest.fn();
 
-  const { container, findByRole, getByTitle } = render(
-    <TableNext
-      columns={[
-        { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
-        { header: 'Name', hash: 'name', render: ({ name }) => name },
-        { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
-      ]}
-      items={[
-        { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
-        { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
-        { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
-        { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
-        { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
-      ]}
-      keyField="sku"
-      pagination={{
-        currentPage: 1,
-        itemsPerPage: 3,
-        totalItems: 5,
-        itemsPerPageOptions: [3, 5, 10],
-        onItemsPerPageChange,
-        onPageChange,
-      }}
-    />,
-  );
+    const { container, findByRole, getByTitle } = render(
+      <TableNext
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={[
+          { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+          { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+          { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+          { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+          { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+        ]}
+        keyField="sku"
+        pagination={{
+          currentPage: 1,
+          itemsPerPage: 3,
+          totalItems: 5,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange,
+          onPageChange,
+        }}
+      />,
+    );
 
-  fireEvent.click(getByTitle('Next page'));
+    fireEvent.click(getByTitle('Next page'));
 
-  await findByRole('table');
+    await findByRole('table');
 
-  expect(onPageChange).toHaveBeenCalledWith(2);
-  expect(container.firstChild).toMatchSnapshot();
+    expect(onPageChange).toHaveBeenCalledWith(2);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('selection persists indexes on other pages', async () => {
+    const onSelectionChange = jest.fn();
+
+    const items = [
+      { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+      { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+      { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+      { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+      { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+    ];
+
+    render(
+      <TableNext
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={items.filter((_, index) => index >= 3 && index < 6)}
+        keyField="sku"
+        pagination={{
+          currentPage: 2,
+          itemsPerPage: 3,
+          totalItems: items.length,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange: jest.fn(),
+          onPageChange: jest.fn(),
+        }}
+        selectable={{
+          selectedItems: { 0: true },
+          onSelectionChange,
+        }}
+      />,
+    );
+
+    const [, firstRow] = await screen.findAllByRole('row');
+    const firstRowCheckbox = within(firstRow).getByRole('checkbox');
+
+    await userEvent.click(firstRowCheckbox);
+
+    expect(onSelectionChange).toHaveBeenCalledWith({ 0: true, 3: true });
+  });
+
+  test('deselection persists indexes on other pages', async () => {
+    const onSelectionChange = jest.fn();
+
+    const items = [
+      { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+      { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+      { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+      { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+      { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+    ];
+
+    render(
+      <TableNext
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={items.filter((_, index) => index >= 3 && index < 6)}
+        keyField="sku"
+        pagination={{
+          currentPage: 2,
+          itemsPerPage: 3,
+          totalItems: items.length,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange: jest.fn(),
+          onPageChange: jest.fn(),
+        }}
+        selectable={{
+          selectedItems: { 0: true, 3: true },
+          onSelectionChange,
+        }}
+      />,
+    );
+
+    const [, firstRow] = await screen.findAllByRole('row');
+    const firstRowCheckbox = within(firstRow).getByRole('checkbox');
+
+    await userEvent.click(firstRowCheckbox);
+
+    expect(onSelectionChange).toHaveBeenCalledWith({ 0: true });
+  });
+
+  test('select all persists indexes on other pages', async () => {
+    const onSelectionChange = jest.fn();
+
+    const items = [
+      { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+      { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+      { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+      { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+      { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+    ];
+
+    render(
+      <TableNext
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={items.filter((_, index) => index >= 3 && index < 6)}
+        keyField="sku"
+        pagination={{
+          currentPage: 2,
+          itemsPerPage: 3,
+          totalItems: items.length,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange: jest.fn(),
+          onPageChange: jest.fn(),
+        }}
+        selectable={{
+          selectedItems: { 0: true, 3: true },
+          onSelectionChange,
+        }}
+      />,
+    );
+
+    const selectAll = await screen.findByRole('checkbox', { name: /select all/i });
+
+    await userEvent.click(selectAll);
+
+    expect(onSelectionChange).toHaveBeenCalledWith({ 0: true, 3: true, 4: true });
+  });
+
+  test('deselect all persists indexes on other pages', async () => {
+    const onSelectionChange = jest.fn();
+
+    const items = [
+      { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+      { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+      { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+      { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+      { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+    ];
+
+    render(
+      <TableNext
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={items.filter((_, index) => index >= 3 && index < 6)}
+        keyField="sku"
+        pagination={{
+          currentPage: 2,
+          itemsPerPage: 3,
+          totalItems: items.length,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange: jest.fn(),
+          onPageChange: jest.fn(),
+        }}
+        selectable={{
+          selectedItems: { 0: true, 3: true, 4: true },
+          onSelectionChange,
+        }}
+      />,
+    );
+
+    const deselectAll = await screen.findByRole('checkbox', { name: /deselect all/i });
+
+    await userEvent.click(deselectAll);
+
+    expect(onSelectionChange).toHaveBeenCalledWith({ 0: true });
+  });
+
+  test("selected expandable rows doesn't count towards total selected items", () => {
+    const items = [
+      { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+      { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+      { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+      {
+        sku: 'CLC',
+        name: '[Sample] Canvas Laundry Cart',
+        stock: 2,
+        variants: [{ sku: 'CLC-RED', name: '[Sample] Canvas Laundry Cart - Red', stock: 2 }],
+      },
+      { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+    ];
+
+    render(
+      <TableNext
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        expandable={{
+          expandedRows: {},
+          onExpandedChange: jest.fn(),
+          expandedRowSelector: (row) => row?.variants,
+        }}
+        items={items.filter((_, index) => index >= 3 && index < 6)}
+        keyField="sku"
+        pagination={{
+          currentPage: 2,
+          itemsPerPage: 3,
+          totalItems: items.length,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange: jest.fn(),
+          onPageChange: jest.fn(),
+        }}
+        selectable={{
+          selectedItems: { 0: true, 3: true, '3.0': true, 4: true },
+          onSelectionChange: jest.fn(),
+        }}
+      />,
+    );
+
+    const selectedItems = screen.getByText('3/5');
+
+    expect(selectedItems).toBeInTheDocument();
+  });
 });
 
 describe('selectable', () => {


### PR DESCRIPTION
## What?

Enables `TableNext` to persist selected items across pagination.

## Why?

For each page, we were returning the indexes of items without accounting for pagination. If you were on page 2, the indexes you were getting back were `{ 0: true, 1: true, 2.0: true, ...etc }`. This made it difficult to both Selected all products across pages and persist selected items across pages. This update aligns with our vision of moving toward using `@tanstack/react-table` or other similar headless table API's to power our `TableNext` component.

## Screenshots/Screen Recordings

https://user-images.githubusercontent.com/10539418/192371874-5c04a746-750c-4a56-8694-293a6e98134f.mov

## Testing/Proof

Here's the `dev.tsx` page I used if you want to test it out yourself:
```tsx
import { TableNext } from '@bigcommerce/big-design/dist/es/components/TableNext';
import React, { useEffect, useState } from 'react';

interface Item {
  name: string;
  children?: Item[];
}

const items = new Array(25).fill(undefined).map<Item>((_, index) => ({
  name: `Hello ${index}`,
  children: [{ name: `Child ${index}` }, { name: `Child ${index}` }],
}));

const DevPage = () => {
  const [currentPage, onPageChange] = useState(1);
  const [itemsPerPage, onItemsPerPageChange] = useState(10);
  const [selectedItems, onSelectionChange] = useState<Record<string, true>>({});
  const [pagedItems, setPagedItems] = useState<typeof items>([]);
  const [expandedRows, onExpandedChange] = useState({});

  useEffect(() => {
    setPagedItems(
      items.filter(
        (_item, index) =>
          index >= (currentPage - 1) * itemsPerPage && index < currentPage * itemsPerPage,
      ),
    );
  }, [currentPage, itemsPerPage]);

  return (
    <TableNext
      columns={[{ hash: 'name', header: 'Name', render: ({ name }) => name }]}
      expandable={{
        expandedRows,
        onExpandedChange,
        expandedRowSelector: ({ children }) => {
          if (children) {
            return children;
          }

          return undefined;
        },
      }}
      itemName="Worlds"
      items={pagedItems}
      pagination={{
        currentPage,
        onPageChange,
        itemsPerPage,
        totalItems: items.length,
        onItemsPerPageChange,
        itemsPerPageOptions: [10, 20, 30],
      }}
      selectable={{ onSelectionChange, selectedItems }}
    />
  );
};

export default DevPage;
```

```ts
// global.d.ts

// ...

declare module '@bigcommerce/big-design/dist/es/components/TableNext' {
  export * from '@bigcommerce/big-design/dist/components/TableNext';
}