### PR TITLE
fix(component): prevent column resizing when editing text field

### DIFF
--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -24,6 +24,7 @@ const InternalWorksheet = typedMemo(
     defaultExpandedRows,
     disabledRows,
     items,
+    minWidth,
     onChange,
     onErrors,
   }: WorksheetProps<T>): React.ReactElement<WorksheetProps<T>> => {
@@ -133,6 +134,7 @@ const InternalWorksheet = typedMemo(
         <StyledBox>
           <Table
             hasStaticWidth={tableHasStaticWidth}
+            minWidth={minWidth}
             onKeyDown={handleKeyDown}
             ref={tableRef}
             tabIndex={0}

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`renders worksheet 1`] = `
   class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-16rzzpq-2 jjhxof"
 >
   <table
-    class="styled__Table-sc-16rzzpq-0 hiKdjk"
+    class="styled__Table-sc-16rzzpq-0 iumFEW"
     tabindex="0"
   >
     <thead>
@@ -14,27 +14,27 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 eDVZgo"
         />
         <th
-          class="styled__Header-sc-16rzzpq-1 cRvCWu"
+          class="styled__Header-sc-16rzzpq-1 bAyhTK"
         >
           Product name
         </th>
         <th
-          class="styled__Header-sc-16rzzpq-1 biTmCe"
+          class="styled__Header-sc-16rzzpq-1 iEhMHd"
         >
           Visible on storefront
         </th>
         <th
-          class="styled__Header-sc-16rzzpq-1 cRvCWu"
+          class="styled__Header-sc-16rzzpq-1 bAyhTK"
         >
           Other field
         </th>
         <th
-          class="styled__Header-sc-16rzzpq-1 cRvCWu"
+          class="styled__Header-sc-16rzzpq-1 bAyhTK"
         >
           Other field
         </th>
         <th
-          class="styled__Header-sc-16rzzpq-1 cyFJXl"
+          class="styled__Header-sc-16rzzpq-1 ZLAqT"
         >
           Number field
         </th>

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -1,5 +1,6 @@
 import { theme } from '@bigcommerce/big-design-theme';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { StatefulTree } from '../StatefulTree';
@@ -726,11 +727,11 @@ describe('SelectEditor', () => {
 
     const cells = await findAllByDisplayValue('Value 1');
 
-    fireEvent.click(cells[0]);
+    await userEvent.click(cells[0]);
 
     const options = await findAllByRole('option');
 
-    fireEvent.click(options[2]);
+    await userEvent.click(options[2]);
 
     expect(handleChange).toHaveBeenCalledTimes(1);
     expect(handleChange).toHaveBeenLastCalledWith([
@@ -1145,6 +1146,14 @@ describe('column widths', () => {
     const table = screen.getByRole('table');
 
     expect(table).toHaveStyle('width: auto');
+  });
+
+  test('table accepts a minWidth prop', () => {
+    render(<Worksheet columns={columns} items={items} minWidth={900} onChange={handleChange} />);
+
+    const table = screen.getByRole('table');
+
+    expect(table).toHaveStyle('min-width: 900px');
   });
 
   test('columns have defined widths (or auto if none)', async () => {

--- a/packages/big-design/src/components/Worksheet/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/styled.tsx
@@ -5,9 +5,12 @@ import { Box } from '../Box';
 
 import { InternalWorksheetColumn } from './types';
 
-export const Table = styled.table<{ hasStaticWidth: boolean }>`
+export const Table = styled.table<{ minWidth?: number; hasStaticWidth: boolean }>`
   border-collapse: collapse;
   border-spacing: 0;
+  min-width: ${({ minWidth, hasStaticWidth }) =>
+    minWidth && !hasStaticWidth ? `${minWidth}px` : 'auto'};
+  table-layout: fixed;
   width: ${({ hasStaticWidth }) => (hasStaticWidth ? 'auto' : '100%')};
 
   &:focus {
@@ -24,8 +27,6 @@ export const Header = styled.th<{
   color: ${({ theme }) => theme.colors.secondary60};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   height: ${({ theme }) => theme.helpers.remCalc(52)};
-  min-width: ${({ columnWidth }) =>
-    typeof columnWidth === 'string' ? columnWidth : `${columnWidth}px`};
   overflow: hidden;
   padding: ${({ theme }) => `0 ${theme.helpers.remCalc(17)}`};
   text-align: ${({ columnType }) => (columnType === 'number' ? 'right' : 'left')};

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -14,6 +14,7 @@ export interface WorksheetProps<Item extends WorksheetItem> {
   expandableRows?: ExpandableRows;
   defaultExpandedRows?: Array<string | number>;
   disabledRows?: DisabledRows;
+  minWidth?: number;
   onChange(items: Item[]): void;
   onErrors?(items: Array<WorksheetError<Item>>): void;
 }

--- a/packages/docs/PropTables/WorksheetPropTable.tsx
+++ b/packages/docs/PropTables/WorksheetPropTable.tsx
@@ -94,6 +94,11 @@ const worksheetProps: Prop[] = [
       </>
     ),
   },
+  {
+    name: 'minWidth',
+    types: 'number',
+    description: 'Sets a min-width.',
+  },
 ];
 
 const worksheetTextColumnProps: Prop[] = [

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -267,6 +267,7 @@ const WorksheetPage = () => {
                       <Worksheet
                         columns={columns}
                         items={items}
+                        minWidth={900}
                         onChange={(items) => items}
                         onErrors={(items) => items}
                       />


### PR DESCRIPTION
## What?

Sets Worksheet to `table-layout: fixed` and add `minWidth` prop.

Fixes this issue introduced by #975:

![Kapture 2022-09-28 at 12 01 48](https://user-images.githubusercontent.com/196129/192844635-45d7bef5-2600-4363-adb5-ca72130ba574.gif)

## Why?

The bug is happening because I set `table-layout: auto`, which means the table will try to automatically fit the content in the table (this is cool if we want all columns to remain visible even when shrinking the window), and overflow what doesn't fit (so we get a scroll bar).

Problem is that the `input` element is set to `width: 100%` and unless the `td` has a fixed width (set with the new width prop in the column), it won't calculate the 100% as I expected.

What I'm doing is reverting the table to `table-layout: fixed`. The problem with fixed and having static width columns it that when the table shrinks in size it will shrink all auto columns to 0 to accommodate the fixed width columns.

Like so:

![Kapture 2022-09-28 at 10 46 43](https://user-images.githubusercontent.com/196129/192844810-d933f8b7-74de-4131-9ef2-dad3cd4116d7.gif)

To solve this I expose a `minWidth` prop for the Worksheet, so that we can set a minimum width. However this needs to be controlled by the developer, otherwise the issue above will happen.

![Kapture 2022-09-28 at 10 49 35](https://user-images.githubusercontent.com/196129/192845097-713e79ca-6b05-42d7-be9f-6fdc38b1f78d.gif)

Table will still have a static width if all columns have static widths.

Fixed inputs:

![Kapture 2022-09-28 at 12 08 21](https://user-images.githubusercontent.com/196129/192845742-30609786-e510-49d2-99a0-937cf06eb3dd.gif)

Overall this feels like a good compromise. We added the ability to set fixed widths to columns but by doing so developer needs to be mindful of setting a min-width if viewport gets too shrunk for the table. I believe `minWidth` was long overdue because the Worksheet has been breaking this way since it was introduced.

## Testing/Proof

Locally.
