### PR TITLE
fix(component): fix counter component when submitting a form

### DIFF
--- a/packages/big-design/src/components/Counter/Counter.tsx
+++ b/packages/big-design/src/components/Counter/Counter.tsx
@@ -19,9 +19,9 @@ import { useInputErrors } from '../Form/useInputErrors';
 import { StyledCounterButton, StyledCounterInput, StyledCounterWrapper } from './styled';
 
 export interface CounterProps extends InputHTMLAttributes<HTMLInputElement> {
-  label?: React.ReactChild;
+  label?: React.ReactNode;
   labelId?: string;
-  description?: React.ReactChild;
+  description?: React.ReactNode;
   error?: React.ReactNode | React.ReactNode[];
   value: number;
   step?: number;
@@ -74,9 +74,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
       return onBlur && onBlur(event);
     };
 
-    const handleIncrease = (event: React.KeyboardEvent | React.MouseEvent) => {
-      event.preventDefault();
-
+    const handleIncrease = () => {
       if (value + step > max) {
         return;
       }
@@ -91,9 +89,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
       }
     };
 
-    const handleDecrease = (event: React.KeyboardEvent | React.MouseEvent) => {
-      event.preventDefault();
-
+    const handleDecrease = () => {
       if (value - step < min) {
         return;
       }
@@ -127,15 +123,11 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
     const handleKeyPress = (event: React.KeyboardEvent) => {
       switch (event.key) {
         case 'ArrowUp':
-          handleIncrease(event);
+          handleIncrease();
           break;
 
         case 'ArrowDown':
-          handleDecrease(event);
-          break;
-
-        case 'Enter':
-          event.preventDefault();
+          handleDecrease();
           break;
 
         case 'Escape':
@@ -198,6 +190,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
             disabled={disabled || value <= min}
             iconOnly={<RemoveCircleOutlineIcon title="Decrease count" />}
             onClick={handleDecrease}
+            type="button"
           />
           <StyledCounterInput
             {...props}
@@ -215,6 +208,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
             disabled={disabled || value >= max}
             iconOnly={<AddCircleOutlineIcon title="Increase count" />}
             onClick={handleIncrease}
+            type="button"
           />
         </StyledCounterWrapper>
       </div>

--- a/packages/big-design/src/components/Counter/spec.tsx
+++ b/packages/big-design/src/components/Counter/spec.tsx
@@ -1,9 +1,18 @@
 import React, { createRef, Ref } from 'react';
 import 'jest-styled-components';
 
+import userEvent from '@testing-library/user-event';
+
 import { fireEvent, render, screen } from '@test/utils';
 
-import { FormControlDescription, FormControlError, FormControlLabel, FormGroup } from '../Form';
+import { Button } from '../Button';
+import {
+  Form,
+  FormControlDescription,
+  FormControlError,
+  FormControlLabel,
+  FormGroup,
+} from '../Form';
 
 import { Counter, CounterProps } from './index';
 
@@ -361,6 +370,28 @@ test('error shows when an array of Errors', () => {
   );
 
   testIds.forEach((id) => expect(getByTestId(id)).toBeInTheDocument());
+});
+
+test('testing', async () => {
+  const handleOnSubmit = jest.fn((e) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    e.preventDefault();
+  });
+
+  const { getByTestId } = render(
+    <Form onSubmit={handleOnSubmit}>
+      <FormGroup>
+        {counterMock({ ...requiredAttributes, dataTestId: 'counter-input', value: 5 })}
+      </FormGroup>
+      <Button type="submit">Save</Button>
+    </Form>,
+  );
+
+  const input = getByTestId('counter-input');
+
+  await userEvent.type(input, '6{enter}');
+
+  expect(handleOnSubmit).toHaveBeenCalledTimes(1);
 });
 
 describe('error does not show when invalid type', () => {

--- a/packages/big-design/src/components/Counter/spec.tsx
+++ b/packages/big-design/src/components/Counter/spec.tsx
@@ -367,14 +367,14 @@ test('error shows when an array of Errors', () => {
   testIds.forEach((id) => expect(getByTestId(id)).toBeInTheDocument());
 });
 
-test('input value does not change when submitting the form via Enter key', async () => {
+test('input counter value does not change when using it inside a form', async () => {
   const handleOnSubmit = jest.fn((e: React.FormEvent) => {
     e.preventDefault();
   });
 
   render(
     <Form onSubmit={handleOnSubmit}>
-      <FormGroup>{counterMock({ ...requiredAttributes })}</FormGroup>
+      <FormGroup>{counterMock(requiredAttributes)}</FormGroup>
       <Button type="submit">Save</Button>
     </Form>,
   );


### PR DESCRIPTION
## What?
- Set type attribute as "button" in Decrease and Increate buttons.
- Remove events in handlers.
- Implement tests.
- Additional update: replace `fireEvent` with `userEvent`.

## Why?
- To prevent counter input value decrementing when hitting enter to submit a form. Fixes [#940]("https://github.com/bigcommerce/big-design/issues/940").

By default a button has a type "submit" so that is why the input value was changing instead of submitting the form. Also the event.preventDefault() used in the handlers were blocking the event used in a form.

## Screenshots/Screen Recordings
Before:

https://user-images.githubusercontent.com/39739180/193672053-712fcfbb-0ada-418f-a1b4-9c24a6a24351.mp4

After:

https://user-images.githubusercontent.com/39739180/193671323-c2e3abb9-e82d-41cb-9aaa-51a3af6f44c3.mp4


## Testing/Proof
Test pass