### PR TITLE
fix(component):  worksheet context

### DIFF
--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -152,7 +152,7 @@ const InternalWorksheet = typedMemo(
 export const WorksheetContext = createContext<StoreApi<BaseState<any>> | null>(null);
 
 export const Worksheet = typedMemo(<T extends WorksheetItem>(props: WorksheetProps<T>) => {
-  const store = createWorksheetStore<T>();
+  const store = useMemo(() => createWorksheetStore<T>(), []);
 
   return (
     <WorksheetContext.Provider value={store}>


### PR DESCRIPTION
## What?
Memo context value in Worksheet component. 


## Why?
Every time we set new Items in `onChange` fn, the Worksheet component re-rendered so a new store was created every time.

```tsx
const WorksheetPage = () => {
  const [state, setState] = useState([
    {
      id: 'variant=1',
      label: 'Test name 1',
      sku: 'sku 1',
      adjustBy: 849,
    },
    {
      id: 'variant=2',
      label: 'Test name 2',
      sku: 'sku 2',
      adjustBy: 345,
    },
    {
      id: 'variant=3',
      label: 'Test name 3',
      sku: 'sku 3',
      adjustBy: 123,
    },
  ]);

  return (
    <>
      <Worksheet
        columns={[
          { hash: 'label', header: 'Product name' },
          { hash: 'sku', header: 'SKU' },
          { hash: 'adjustBy', header: 'Adjust by', type: 'number' },
        ]}
        items={state}
        key={0}
        onChange={(changedItems) => {
          const res = state.map((item) => {
            const changedItem = changedItems.find((changedItem) => changedItem.id === item.id);

            return changedItem || item;
          });

          setState([...res]);
        }}
      />
    </>
  );
};
```

## Screenshots/Screen Recordings
**Before:**

https://user-images.githubusercontent.com/39739180/195221798-3ef50cd4-6d4f-4306-8af0-4913a9e96605.mp4


**After:**

https://user-images.githubusercontent.com/39739180/195221801-166be5aa-f76f-49a0-9e04-667d792c742d.mp4

## Testing/Proof
Test pass
