### PR TITLE
feat(component): provide props for customising pagination button labels

### DIFF
--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -18,6 +18,9 @@ export interface PaginationProps extends MarginProps {
   totalItems: number;
   onPageChange(page: number): void;
   onItemsPerPageChange(range: number): void;
+  previousPageLabel?: string;
+  nextPageLabel?: string;
+  getRangeLabel?(start: number, end: number, totalItems: number): string;
 }
 
 export const Pagination: React.FC<PaginationProps> = memo(
@@ -28,6 +31,9 @@ export const Pagination: React.FC<PaginationProps> = memo(
     itemsPerPageOptions = [],
     onPageChange,
     onItemsPerPageChange,
+    previousPageLabel = 'Previous page',
+    nextPageLabel = 'Next page',
+    getRangeLabel = null,
   }) => {
     const [maxPages, setMaxPages] = useState(Math.max(1, Math.ceil(totalItems / itemsPerPage)));
     const [itemRange, setItemRange] = useState({ start: 0, end: 0 });
@@ -90,11 +96,10 @@ export const Pagination: React.FC<PaginationProps> = memo(
       return onItemsPerPageChange(Number(item.hash));
     };
 
-    const showRanges = () => {
-      return itemRange.start === itemRange.end
-        ? `${itemRange.start} of ${totalItems}`
-        : `${itemRange.start} - ${itemRange.end} of ${totalItems}`;
-    };
+    if (getRangeLabel === null) {
+      getRangeLabel = (start: number, end: number, totalItems: number): string =>
+        start === end ? `${start} of ${totalItems}` : `${start} - ${end} of ${totalItems}`;
+    }
 
     return (
       <Flex aria-label="pagination" flexDirection="row" role="navigation">
@@ -108,7 +113,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
             positionFixed={true}
             toggle={
               <StyledButton iconRight={<ArrowDropDownIcon size="xxLarge" />} variant="subtle">
-                {showRanges()}
+                {getRangeLabel(itemRange.start, itemRange.end, totalItems)}
               </StyledButton>
             }
           />
@@ -116,14 +121,14 @@ export const Pagination: React.FC<PaginationProps> = memo(
         <FlexItem>
           <StyledButton
             disabled={currentPage <= 1}
-            iconOnly={<ChevronLeftIcon title="Previous page" />}
+            iconOnly={<ChevronLeftIcon title={previousPageLabel} />}
             onClick={handlePageDecrease}
             variant="subtle"
           />
 
           <StyledButton
             disabled={currentPage >= maxPages}
-            iconOnly={<ChevronRightIcon title="Next page" />}
+            iconOnly={<ChevronRightIcon title={nextPageLabel} />}
             onClick={handlePageIncrease}
             variant="subtle"
           />

--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -24,6 +24,14 @@ export interface PaginationProps extends MarginProps {
   getRangeLabel?(start: number, end: number, totalItems: number): string;
 }
 
+const defaultGetRangeLabel = (start: number, end: number, totalItems: number): string => {
+  if (start === end) {
+    return `${start} of ${totalItems}`;
+  }
+
+  return `${start} - ${end} of ${totalItems}`;
+};
+
 export const Pagination: React.FC<PaginationProps> = memo(
   ({
     itemsPerPage,
@@ -35,7 +43,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
     label = 'pagination',
     previousLabel = 'Previous page',
     nextLabel = 'Next page',
-    getRangeLabel = null,
+    getRangeLabel = defaultGetRangeLabel,
   }) => {
     const [maxPages, setMaxPages] = useState(Math.max(1, Math.ceil(totalItems / itemsPerPage)));
     const [itemRange, setItemRange] = useState({ start: 0, end: 0 });
@@ -97,11 +105,6 @@ export const Pagination: React.FC<PaginationProps> = memo(
     const handleRangeChange = (item: DropdownItem) => {
       return onItemsPerPageChange(Number(item.hash));
     };
-
-    if (getRangeLabel === null) {
-      getRangeLabel = (start: number, end: number, totalItems: number): string =>
-        start === end ? `${start} of ${totalItems}` : `${start} - ${end} of ${totalItems}`;
-    }
 
     return (
       <Flex aria-label={label} flexDirection="row" role="navigation">

--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -18,8 +18,9 @@ export interface PaginationProps extends MarginProps {
   totalItems: number;
   onPageChange(page: number): void;
   onItemsPerPageChange(range: number): void;
-  previousPageLabel?: string;
-  nextPageLabel?: string;
+  label?: string;
+  previousLabel?: string;
+  nextLabel?: string;
   getRangeLabel?(start: number, end: number, totalItems: number): string;
 }
 
@@ -31,8 +32,9 @@ export const Pagination: React.FC<PaginationProps> = memo(
     itemsPerPageOptions = [],
     onPageChange,
     onItemsPerPageChange,
-    previousPageLabel = 'Previous page',
-    nextPageLabel = 'Next page',
+    label = 'pagination',
+    previousLabel = 'Previous page',
+    nextLabel = 'Next page',
     getRangeLabel = null,
   }) => {
     const [maxPages, setMaxPages] = useState(Math.max(1, Math.ceil(totalItems / itemsPerPage)));
@@ -102,7 +104,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
     }
 
     return (
-      <Flex aria-label="pagination" flexDirection="row" role="navigation">
+      <Flex aria-label={label} flexDirection="row" role="navigation">
         <FlexItem>
           <Dropdown
             items={itemsPerPageOptions.map((range) => ({
@@ -121,14 +123,14 @@ export const Pagination: React.FC<PaginationProps> = memo(
         <FlexItem>
           <StyledButton
             disabled={currentPage <= 1}
-            iconOnly={<ChevronLeftIcon title={previousPageLabel} />}
+            iconOnly={<ChevronLeftIcon title={previousLabel} />}
             onClick={handlePageDecrease}
             variant="subtle"
           />
 
           <StyledButton
             disabled={currentPage >= maxPages}
-            iconOnly={<ChevronRightIcon title={nextPageLabel} />}
+            iconOnly={<ChevronRightIcon title={nextLabel} />}
             onClick={handlePageIncrease}
             variant="subtle"
           />

--- a/packages/big-design/src/components/Pagination/spec.tsx
+++ b/packages/big-design/src/components/Pagination/spec.tsx
@@ -93,14 +93,16 @@ test('render pagination component while overriding button labels', () => {
       getRangeLabel={getRangeLabel}
       itemsPerPage={3}
       itemsPerPageOptions={[2, 3, 5]}
-      nextPageLabel="[Custom] Next page"
+      label="[Custom] Pagination"
+      nextLabel="[Custom] Next page"
       onItemsPerPageChange={changeRange}
       onPageChange={changePage}
-      previousPageLabel="[Custom] Previous page"
+      previousLabel="[Custom] Previous page"
       totalItems={10}
     />,
   );
 
+  getByRole('navigation', { name: '[Custom] Pagination' });
   getByRole('button', { name: '[Custom label] 1-3 of 10' });
   getByRole('button', { name: '[Custom] Previous page' });
   getByRole('button', { name: '[Custom] Next page' });

--- a/packages/big-design/src/components/Pagination/spec.tsx
+++ b/packages/big-design/src/components/Pagination/spec.tsx
@@ -81,6 +81,31 @@ test('render pagination component with no items', async () => {
   expect(pagination).toMatchSnapshot();
 });
 
+test('render pagination component while overriding button labels', () => {
+  const getRangeLabel = (first: number, last: number, totalItems: number) => {
+    return `[Custom label] ${first}-${last} of ${totalItems}`;
+  };
+  const changePage = jest.fn();
+  const changeRange = jest.fn();
+  const { getByRole } = render(
+    <Pagination
+      currentPage={1}
+      getRangeLabel={getRangeLabel}
+      itemsPerPage={3}
+      itemsPerPageOptions={[2, 3, 5]}
+      nextPageLabel="[Custom] Next page"
+      onItemsPerPageChange={changeRange}
+      onPageChange={changePage}
+      previousPageLabel="[Custom] Previous page"
+      totalItems={10}
+    />,
+  );
+
+  getByRole('button', { name: '[Custom label] 1-3 of 10' });
+  getByRole('button', { name: '[Custom] Previous page' });
+  getByRole('button', { name: '[Custom] Next page' });
+});
+
 test('trigger range change', async () => {
   const changePage = jest.fn();
   const changeRange = jest.fn();

--- a/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
@@ -6,10 +6,32 @@ import { TablePaginationProps } from '../types';
 import { StyledPaginationContainer } from './styled';
 
 export const TablePagination: React.FC<TablePaginationProps> = memo(
-  (props: TablePaginationProps) => {
+  ({
+    currentPage,
+    itemsPerPage,
+    itemsPerPageOptions,
+    onItemsPerPageChange,
+    onPageChange,
+    totalItems,
+    label,
+    previousLabel,
+    nextLabel,
+    getRangeLabel,
+  }) => {
     return (
       <StyledPaginationContainer flexShrink={0}>
-        <Pagination {...props} />
+        <Pagination
+          currentPage={currentPage}
+          getRangeLabel={getRangeLabel}
+          itemsPerPage={itemsPerPage}
+          itemsPerPageOptions={itemsPerPageOptions}
+          label={label}
+          nextLabel={nextLabel}
+          onItemsPerPageChange={onItemsPerPageChange}
+          onPageChange={onPageChange}
+          previousLabel={previousLabel}
+          totalItems={totalItems}
+        />
       </StyledPaginationContainer>
     );
   },

--- a/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
@@ -6,24 +6,10 @@ import { TablePaginationProps } from '../types';
 import { StyledPaginationContainer } from './styled';
 
 export const TablePagination: React.FC<TablePaginationProps> = memo(
-  ({
-    currentPage,
-    itemsPerPage,
-    itemsPerPageOptions,
-    onItemsPerPageChange,
-    onPageChange,
-    totalItems,
-  }) => {
+  (props: TablePaginationProps) => {
     return (
       <StyledPaginationContainer flexShrink={0}>
-        <Pagination
-          currentPage={currentPage}
-          itemsPerPage={itemsPerPage}
-          itemsPerPageOptions={itemsPerPageOptions}
-          onItemsPerPageChange={onItemsPerPageChange}
-          onPageChange={onPageChange}
-          totalItems={totalItems}
-        />
+        <Pagination {...props} />
       </StyledPaginationContainer>
     );
   },

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -263,12 +263,14 @@ test('renders a pagination component with custom button labels', () => {
         onItemsPerPageChange,
         onPageChange,
         getRangeLabel,
-        previousPageLabel: '[Custom] Previous page',
-        nextPageLabel: '[Custom] Next page',
+        label: '[Custom] Pagination',
+        previousLabel: '[Custom] Previous page',
+        nextLabel: '[Custom] Next page',
       }}
     />,
   );
 
+  getByRole('navigation', { name: '[Custom] Pagination' });
   getByRole('button', { name: '[Custom label] 1-3 of 5' });
   getByRole('button', { name: '[Custom] Previous page' });
   getByRole('button', { name: '[Custom] Next page' });

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -234,6 +234,46 @@ test('renders a pagination component', async () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
+test('renders a pagination component with custom button labels', () => {
+  const getRangeLabel = (first: number, last: number, totalItems: number) => {
+    return `[Custom label] ${first}-${last} of ${totalItems}`;
+  };
+  const onItemsPerPageChange = jest.fn();
+  const onPageChange = jest.fn();
+
+  const { getByRole } = render(
+    <Table
+      columns={[
+        { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+        { header: 'Name', hash: 'name', render: ({ name }) => name },
+        { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+      ]}
+      items={[
+        { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+        { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+        { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+        { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+        { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+      ]}
+      pagination={{
+        currentPage: 1,
+        itemsPerPage: 3,
+        totalItems: 5,
+        itemsPerPageOptions: [3, 5, 10],
+        onItemsPerPageChange,
+        onPageChange,
+        getRangeLabel,
+        previousPageLabel: '[Custom] Previous page',
+        nextPageLabel: '[Custom] Next page',
+      }}
+    />,
+  );
+
+  getByRole('button', { name: '[Custom label] 1-3 of 5' });
+  getByRole('button', { name: '[Custom] Previous page' });
+  getByRole('button', { name: '[Custom] Next page' });
+});
+
 describe('selectable', () => {
   let columns: Array<TableColumn<TableItem>>;
   let items: TableItem[];

--- a/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
@@ -6,10 +6,32 @@ import { TablePaginationProps } from '../types';
 import { StyledPaginationContainer } from './styled';
 
 export const TablePagination: React.FC<TablePaginationProps> = memo(
-  (props: TablePaginationProps) => {
+  ({
+    currentPage,
+    itemsPerPage,
+    itemsPerPageOptions,
+    onItemsPerPageChange,
+    onPageChange,
+    totalItems,
+    label,
+    previousLabel,
+    nextLabel,
+    getRangeLabel,
+  }) => {
     return (
       <StyledPaginationContainer flexShrink={0}>
-        <Pagination {...props} />
+        <Pagination
+          currentPage={currentPage}
+          getRangeLabel={getRangeLabel}
+          itemsPerPage={itemsPerPage}
+          itemsPerPageOptions={itemsPerPageOptions}
+          label={label}
+          nextLabel={nextLabel}
+          onItemsPerPageChange={onItemsPerPageChange}
+          onPageChange={onPageChange}
+          previousLabel={previousLabel}
+          totalItems={totalItems}
+        />
       </StyledPaginationContainer>
     );
   },

--- a/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
@@ -6,24 +6,10 @@ import { TablePaginationProps } from '../types';
 import { StyledPaginationContainer } from './styled';
 
 export const TablePagination: React.FC<TablePaginationProps> = memo(
-  ({
-    currentPage,
-    itemsPerPage,
-    itemsPerPageOptions,
-    onItemsPerPageChange,
-    onPageChange,
-    totalItems,
-  }) => {
+  (props: TablePaginationProps) => {
     return (
       <StyledPaginationContainer flexShrink={0}>
-        <Pagination
-          currentPage={currentPage}
-          itemsPerPage={itemsPerPage}
-          itemsPerPageOptions={itemsPerPageOptions}
-          onItemsPerPageChange={onItemsPerPageChange}
-          onPageChange={onPageChange}
-          totalItems={totalItems}
-        />
+        <Pagination {...props} />
       </StyledPaginationContainer>
     );
   },

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -250,6 +250,47 @@ describe('pagination', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('renders a pagination component with custom button labels', () => {
+    const getRangeLabel = (first: number, last: number, totalItems: number) => {
+      return `[Custom label] ${first}-${last} of ${totalItems}`;
+    };
+    const onItemsPerPageChange = jest.fn();
+    const onPageChange = jest.fn();
+
+    const { getByRole } = render(
+      <TableNext
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={[
+          { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+          { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+          { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+          { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+          { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+        ]}
+        keyField="sku"
+        pagination={{
+          currentPage: 1,
+          itemsPerPage: 3,
+          totalItems: 5,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange,
+          onPageChange,
+          previousPageLabel: '[Custom] Previous page',
+          nextPageLabel: '[Custom] Next page',
+          getRangeLabel,
+        }}
+      />,
+    );
+
+    getByRole('button', { name: '[Custom label] 1-3 of 5' });
+    getByRole('button', { name: '[Custom] Previous page' });
+    getByRole('button', { name: '[Custom] Next page' });
+  });
+
   test('selection persists indexes on other pages', async () => {
     const onSelectionChange = jest.fn();
 

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -279,13 +279,15 @@ describe('pagination', () => {
           itemsPerPageOptions: [3, 5, 10],
           onItemsPerPageChange,
           onPageChange,
-          previousPageLabel: '[Custom] Previous page',
-          nextPageLabel: '[Custom] Next page',
+          label: '[Custom] Pagination',
+          previousLabel: '[Custom] Previous page',
+          nextLabel: '[Custom] Next page',
           getRangeLabel,
         }}
       />,
     );
 
+    getByRole('navigation', { name: '[Custom] Pagination' });
     getByRole('button', { name: '[Custom label] 1-3 of 5' });
     getByRole('button', { name: '[Custom] Previous page' });
     getByRole('button', { name: '[Custom] Next page' });

--- a/packages/docs/PropTables/PaginationPropTable.tsx
+++ b/packages/docs/PropTables/PaginationPropTable.tsx
@@ -39,6 +39,26 @@ const paginationProps: Prop[] = [
     required: true,
     description: 'Function that will be called when a new per-page range is selected.',
   },
+  {
+    name: 'previousPageLabel',
+    types: 'string',
+    required: false,
+    defaultValue: 'Previous page',
+    description: 'Overrides the title and aria label of the previous page navigation arrow.',
+  },
+  {
+    name: 'nextPageLabel',
+    types: 'string',
+    required: false,
+    defaultValue: 'Next page',
+    description: 'Overrides the title and aria label of the next page navigation arrow.',
+  },
+  {
+    name: 'getRangeLabel',
+    types: '(start: number, end: number, totalItems: number) => string',
+    required: false,
+    description: 'A callback to format the label of the per-page range dropdown.',
+  },
 ];
 
 export const PaginationPropTable: React.FC<PropTableWrapper> = (props) => {

--- a/packages/docs/PropTables/PaginationPropTable.tsx
+++ b/packages/docs/PropTables/PaginationPropTable.tsx
@@ -40,14 +40,21 @@ const paginationProps: Prop[] = [
     description: 'Function that will be called when a new per-page range is selected.',
   },
   {
-    name: 'previousPageLabel',
+    name: 'label',
+    types: 'string',
+    required: false,
+    defaultValue: 'pagination',
+    description: 'Overrides the aria label of the pagination wrapper navigation element.',
+  },
+  {
+    name: 'previousLabel',
     types: 'string',
     required: false,
     defaultValue: 'Previous page',
     description: 'Overrides the title and aria label of the previous page navigation arrow.',
   },
   {
-    name: 'nextPageLabel',
+    name: 'nextLabel',
     types: 'string',
     required: false,
     defaultValue: 'Next page',


### PR DESCRIPTION
## What?

Adding a `label`, `previousLabel` , `nextLabel` and `getLabel` prop to the Pagination component that customise the labels of the navigation buttons and range selector 

## Why?

Allow greater customisability of the component.

## Screenshots/Screen Recordings


https://user-images.githubusercontent.com/109577044/195255292-47d6a00d-ea04-4765-858e-30ceebe9dcf5.mov



## Testing/Proof

Added jest spec tests to define behaviour of new pagination props. 