### PR TITLE
fix(component): keys presses fill the field in with the key code in worksheet

### DIFF
--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -52,6 +52,10 @@ const InternalCell = <T extends WorksheetItem>({
     useMemo(() => (state) => state.editWithValue, []),
   );
 
+  const isMetaKey = useStore(store, (state) => state.isMetaKey);
+
+  const isControlKey = useStore(store, (state) => state.isControlKey);
+
   const isSelected = useStore(
     store,
     useMemo(
@@ -153,7 +157,9 @@ const InternalCell = <T extends WorksheetItem>({
           <TextEditor
             cell={cell}
             initialValue={editWithValue}
+            isControlKey={isControlKey}
             isEdited={isEdited}
+            isMetaKey={isMetaKey}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
           />
@@ -164,19 +170,21 @@ const InternalCell = <T extends WorksheetItem>({
         );
     }
   }, [
+    type,
     cell,
-    disabled,
-    editWithValue,
-    formatting,
     handleBlur,
     handleChange,
-    handleKeyDown,
-    isEditing,
-    isEdited,
     options,
-    renderedValue,
+    isEditing,
+    formatting,
     rowId,
-    type,
+    disabled,
+    editWithValue,
+    isControlKey,
+    isEdited,
+    isMetaKey,
+    handleKeyDown,
+    renderedValue,
   ]);
 
   return (

--- a/packages/big-design/src/components/Worksheet/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Worksheet/Modal/Modal.tsx
@@ -39,7 +39,7 @@ const InternalWorksheetModal = <T extends WorksheetItem>({ column }: WorksheetMo
 
   const handleClose = useCallback(() => {
     setOpenModal(null);
-    setEditingCell(null);
+    setEditingCell({ cell: null });
     focusTable();
   }, [focusTable, setEditingCell, setOpenModal]);
 

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -34,7 +34,7 @@ const InternalModalEditor = <T extends WorksheetItem>({
   }, [hash, isEditing, setOpenModal]);
 
   const handleClick = useCallback(() => {
-    setEditingCell(cell);
+    setEditingCell({ cell });
   }, [cell, setEditingCell]);
 
   const renderedValue = useMemo(

--- a/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
@@ -41,12 +41,12 @@ const InternalSelectEditor = <T extends WorksheetItem>({
   );
 
   const handleOpen = useCallback(() => {
-    setEditingCell(cell);
+    setEditingCell({ cell });
   }, [cell, setEditingCell]);
 
   const handleClose = useCallback(() => {
     onBlur();
-    setEditingCell(null);
+    setEditingCell({ cell: null });
   }, [onBlur, setEditingCell]);
 
   return (

--- a/packages/big-design/src/components/Worksheet/editors/TextEditor/TextEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/TextEditor/TextEditor.tsx
@@ -12,6 +12,8 @@ export interface TextEditorProps<Item> {
   isEdited: boolean;
   onBlur(event?: React.FocusEvent<HTMLInputElement>, cell?: Cell<Item>): void;
   onKeyDown: EditableCellOnKeyDown;
+  isMetaKey: boolean;
+  isControlKey: boolean;
 }
 
 const InternalTextEditor = <T extends WorksheetItem>({
@@ -20,9 +22,13 @@ const InternalTextEditor = <T extends WorksheetItem>({
   initialValue,
   onBlur,
   onKeyDown,
+  isMetaKey,
+  isControlKey,
 }: TextEditorProps<T>) => {
   const [value, setValue] = useState(initialValue || `${cell.value}`);
   const isBlurBlocked = useRef(false);
+  const [isMetaKeyValue, setIsMetaKeyValue] = useState(isMetaKey);
+  const [isControlValue, setIsControlKeyValue] = useState(isControlKey);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
@@ -33,6 +39,14 @@ const InternalTextEditor = <T extends WorksheetItem>({
     // since we handle `onBlur` as saving of the cell data and it conflicts;
     if (event.key === 'Escape') {
       isBlurBlocked.current = true;
+    } else if (isMetaKeyValue && event.key === 'v' && event.metaKey) {
+      setValue('');
+      isBlurBlocked.current = false;
+      setIsMetaKeyValue(false);
+    } else if (isControlValue && event.key === 'v' && event.ctrlKey) {
+      setValue('');
+      isBlurBlocked.current = false;
+      setIsControlKeyValue(false);
     } else {
       isBlurBlocked.current = false;
     }

--- a/packages/big-design/src/components/Worksheet/editors/ToggleEditor/ToggleEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ToggleEditor/ToggleEditor.tsx
@@ -22,7 +22,7 @@ const InternalToggleEditor = ({ rowId, toggle }: ToggleEditorProps) => {
       onToggle(hasExpanded);
     }
 
-    setEditingCell(null);
+    setEditingCell({ cell: null });
   }, [hasExpanded, isExpandable, onToggle, setEditingCell, toggle]);
 
   return isExpandable ? (

--- a/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
@@ -30,13 +30,13 @@ export const useEditableCell = <T extends WorksheetItem>(cell: Cell<T>) => {
   );
 
   const restoreFocus = useCallback(() => {
-    setEditingCell(null);
+    setEditingCell({ cell: null });
     focusTable();
   }, [focusTable, setEditingCell]);
 
   const handleDoubleClick = useCallback(() => {
     if (!cell.disabled) {
-      setEditingCell(cell);
+      setEditingCell({ cell });
     }
   }, [cell, setEditingCell]);
 

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
@@ -86,6 +86,7 @@ export const useKeyEvents = () => {
           default:
             if (
               key !== 'Escape' &&
+              key.length === 1 &&
               (selectedCell.type === 'text' || selectedCell.type === 'number')
             ) {
               event.preventDefault();

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
@@ -3,6 +3,12 @@ import React, { useCallback, useMemo } from 'react';
 import { useNavigation } from '../useNavigation';
 import { useWorksheetStore } from '../useWorksheetStore';
 
+export interface EditingCellsArgs {
+  editWithValue?: string;
+  isMetaKey?: boolean;
+  isControlKey?: boolean;
+}
+
 export const useKeyEvents = () => {
   const { store, useStore } = useWorksheetStore();
 
@@ -21,9 +27,9 @@ export const useKeyEvents = () => {
   const { navigate } = useNavigation(selectedCell);
 
   const editSelectedCell = useCallback(
-    (editWithValue = '') => {
+    ({ isMetaKey = false, isControlKey = false, editWithValue = '' }: EditingCellsArgs = {}) => {
       if (selectedCell) {
-        setEditingCell(selectedCell, editWithValue);
+        return setEditingCell({ cell: selectedCell, isMetaKey, isControlKey, editWithValue });
       }
     },
     [selectedCell, setEditingCell],
@@ -47,7 +53,7 @@ export const useKeyEvents = () => {
         switch (key) {
           case 'Enter':
             if (selectedCell && !selectedCell.disabled) {
-              editSelectedCell();
+              editSelectedCell({});
 
               if (selectedCell.type === 'checkbox') {
                 navigate({ rowIndex: 1, columnIndex: 0 });
@@ -84,11 +90,17 @@ export const useKeyEvents = () => {
             break;
 
           case 'Meta':
-            editSelectedCell();
+            if (selectedCell) {
+              editSelectedCell({ isMetaKey: true });
+            }
+
             break;
 
           case 'Control':
-            editSelectedCell();
+            if (selectedCell) {
+              editSelectedCell({ isControlKey: true });
+            }
+
             break;
 
           default:
@@ -98,7 +110,7 @@ export const useKeyEvents = () => {
               (selectedCell.type === 'text' || selectedCell.type === 'number')
             ) {
               event.preventDefault();
-              editSelectedCell(key);
+              editSelectedCell({ editWithValue: key });
             }
 
             break;

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
@@ -83,6 +83,14 @@ export const useKeyEvents = () => {
             navigate({ rowIndex: 0, columnIndex: -1 });
             break;
 
+          case 'Meta':
+            editSelectedCell();
+            break;
+
+          case 'Control':
+            editSelectedCell();
+            break;
+
           default:
             if (
               key !== 'Escape' &&

--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
@@ -100,6 +100,8 @@ export const useKeyEvents = () => {
               event.preventDefault();
               editSelectedCell(key);
             }
+
+            break;
         }
 
         event.preventDefault();

--- a/packages/big-design/src/components/Worksheet/hooks/useWorksheetStore/useWorksheetStore.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useWorksheetStore/useWorksheetStore.ts
@@ -10,11 +10,18 @@ import {
 } from '../../types';
 import { deleteCells, getHiddenRows, mergeCells } from '../../utils';
 import { WorksheetContext } from '../../Worksheet';
+import { EditingCellsArgs } from '../useKeyEvents';
+
+export interface SetEditingCellArgs<T> extends EditingCellsArgs {
+  cell: Cell<T> | null;
+}
 
 export interface BaseState<Item> {
   columns: Array<InternalWorksheetColumn<Item>>;
   editedCells: Array<Cell<Item>>;
   editingCell: Cell<Item> | null;
+  isMetaKey: boolean;
+  isControlKey: boolean;
   editWithValue: string;
   expandableRows: ExpandableRows;
   disabledRows: DisabledRows;
@@ -33,7 +40,12 @@ export interface BaseState<Item> {
     expandableRows: ExpandableRows,
     defaultExpandedRows?: Array<string | number>,
   ) => void;
-  setEditingCell: (cell: Cell<Item> | null, editWithValue?: string) => void;
+  setEditingCell: ({
+    cell,
+    isMetaKey,
+    isControlKey,
+    editWithValue,
+  }: SetEditingCellArgs<Item>) => void;
   setDisabledRows: (disabledRows: DisabledRows) => void;
   setHiddenRows: (hiddenRow: Array<string | number>) => void;
   setOpenModal: (value: keyof Item | null) => void;
@@ -48,6 +60,8 @@ export const createWorksheetStore = <Item extends WorksheetItem>() =>
     columns: [],
     editedCells: [],
     editingCell: null,
+    isMetaKey: false,
+    isControlKey: false,
     editWithValue: '',
     expandableRows: {},
     disabledRows: [],
@@ -71,8 +85,11 @@ export const createWorksheetStore = <Item extends WorksheetItem>() =>
         expandableRows,
         hiddenRows: getHiddenRows(expandableRows, defaultExpandedRows),
       })),
-    setEditingCell: (cell, editWithValue = '') =>
-      set((state) => ({ ...state, editingCell: cell, editWithValue })),
+    setEditingCell: ({ cell, isMetaKey = false, isControlKey = false, editWithValue = '' }) => {
+      set((state) => {
+        return { ...state, editingCell: cell, isMetaKey, isControlKey, editWithValue };
+      });
+    },
     setDisabledRows: (disabledRows) => set((state) => ({ ...state, disabledRows })),
     setHiddenRows: (hiddenRows) => set((state) => ({ ...state, hiddenRows })),
     setOpenModal: (value) => set((state) => ({ ...state, openedModal: value })),

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -594,7 +594,7 @@ describe('keyboard navigation', () => {
     expect(queryByDisplayValue('Control')).not.toBeInTheDocument();
   });
 
-  test('current content in cell is not deleted when copy new text in the cell', async () => {
+  test('current content in cell is not deleted when double cliking and copy new text in the cell', async () => {
     const { getByText, getByDisplayValue } = render(
       <Worksheet columns={columns} items={items} onChange={handleChange} />,
     );

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -553,7 +553,7 @@ describe('keyboard navigation', () => {
   });
 
   test('cell is not editted when key length is greater than 1', async () => {
-    const { getByText, debug, queryByDisplayValue } = render(
+    const { getByText, queryByDisplayValue } = render(
       <Worksheet columns={columns} items={items} onChange={handleChange} />,
     );
 
@@ -564,8 +564,6 @@ describe('keyboard navigation', () => {
 
     expect(getByText('Shoes Name Three')).toBeInTheDocument();
     expect(queryByDisplayValue('capslock')).not.toBeInTheDocument();
-
-    debug(cell);
   });
 
   test('cell is not editted when using Meta key', async () => {

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -552,6 +552,63 @@ describe('keyboard navigation', () => {
     expect(getByDisplayValue('a')).toBeDefined();
   });
 
+  test('cell is not editted when key length is greater than 1', async () => {
+    const { getByText, debug, queryByDisplayValue } = render(
+      <Worksheet columns={columns} items={items} onChange={handleChange} />,
+    );
+
+    const cell = getByText('Shoes Name Three');
+
+    await userEvent.click(cell);
+    await userEvent.keyboard('{capslock}');
+
+    expect(getByText('Shoes Name Three')).toBeInTheDocument();
+    expect(queryByDisplayValue('capslock')).not.toBeInTheDocument();
+
+    debug(cell);
+  });
+
+  test('cell is not editted when using Meta key', async () => {
+    const { getByText, getByDisplayValue, queryByDisplayValue } = render(
+      <Worksheet columns={columns} items={items} onChange={handleChange} />,
+    );
+
+    const cell = getByText('Shoes Name Three');
+
+    await userEvent.click(cell);
+    await userEvent.keyboard('{meta}');
+
+    expect(getByDisplayValue('Shoes Name Three')).toBeDefined();
+    expect(queryByDisplayValue('Meta')).not.toBeInTheDocument();
+  });
+
+  test('cell is not editted when using Control key', async () => {
+    const { getByText, getByDisplayValue, queryByDisplayValue } = render(
+      <Worksheet columns={columns} items={items} onChange={handleChange} />,
+    );
+
+    const cell = getByText('Shoes Name Three');
+
+    await userEvent.click(cell);
+    await userEvent.keyboard('{control}');
+
+    expect(getByDisplayValue('Shoes Name Three')).toBeDefined();
+    expect(queryByDisplayValue('Control')).not.toBeInTheDocument();
+  });
+
+  test('current content in cell is not deleted when copy new text in the cell', async () => {
+    const { getByText, getByDisplayValue } = render(
+      <Worksheet columns={columns} items={items} onChange={handleChange} />,
+    );
+
+    const cell = getByText('Shoes Name Three');
+
+    await userEvent.dblClick(cell);
+    await userEvent.paste('hello');
+
+    expect(getByDisplayValue('Shoes Name Threehello')).toBeDefined();
+  });
+
   test('space starts editing the cell', () => {
     const { getByDisplayValue, getByText, getByRole } = render(
       <Worksheet columns={columns} items={items} onChange={handleChange} />,


### PR DESCRIPTION
## What?
Keys presses fill the field in with the key code in worksheet. 

## Why?
We are passing the key code as an argument in `editSelectedCell` fn when entering info in a cell.

Examples: 
- if we use the `command` key the cell is filled with its corresponding code: 'Meta'
- if we press key `a` the code its `a`

Current solution (patch):
- Checking the length of the key. And check when using Meta and Control to be able to copy content in a cell.

Note: would be good to refactor our current code but might take more time.

## Screenshots/Screen Recordings
Before:

https://user-images.githubusercontent.com/39739180/195959199-bdb4b31d-0d87-4b8d-bb89-85feb8032436.mp4

After


https://user-images.githubusercontent.com/39739180/196284677-91f906ac-3f09-4b4e-8c10-2c67dc210a49.mp4













## Testing/Proof
Test pass
