### PR TITLE
fix(component): add type button to StyledAccordionButton (1022)

### DIFF
--- a/packages/big-design/src/components/AccordionPanel/Accordion/Accordion.tsx
+++ b/packages/big-design/src/components/AccordionPanel/Accordion/Accordion.tsx
@@ -29,6 +29,7 @@ export const Accordion: React.FC<AccordionProps> = memo(
           id={accordionId}
           isExpanded={isExpanded}
           onClick={onClick}
+          type="button"
           variant="subtle"
         >
           {header}


### PR DESCRIPTION
## What?

Fixes an issue that when accordion headers are clicked, they fire the 'enter' event, causing forms to submit. See issue https://github.com/bigcommerce/big-design/issues/1022

## Testing/Proof

Tested by adding type='button' to the StyledAccordionButton props and then clicking the attribute header.  
