### PR TITLE
Remove child selection from TableNext

### DIFF
--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -70,8 +70,6 @@ const InternalActions = <T extends TableItem>({
     >
       {isSelectable && (
         <SelectAll
-          expandedRowSelector={expandedRowSelector}
-          isExpandable={isExpandable}
           items={items}
           onChange={onSelectionChange}
           pagination={pagination}

--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -57,31 +57,20 @@ const InternalRow = <T extends TableItem>({
   isParentRow = false,
   ...rest
 }: RowProps<T> & PrivateProps) => {
-  const { hasChildrenRows, isChecked, isIndeterminate, label, onChange, onExpandedChange } =
-    useRowState({
-      childRowIndex,
-      childrenRows,
-      isExpandable,
-      isParentRow,
-      isSelected,
-      onExpandedRow,
-      onItemSelect,
-      selectedItems,
-      parentRowIndex,
-    });
+  const { hasChildrenRows, isChecked, label, onChange, onExpandedChange } = useRowState({
+    childrenRows,
+    isParentRow,
+    isSelected,
+    onExpandedRow,
+    onItemSelect,
+    parentRowIndex,
+  });
 
   const renderSelectDataCell = () => {
     if (isSelectable && isParentRow) {
       return (
         <DataCell isCheckbox={true} isExpandable={isExpandable} key="data-checkbox" width={10}>
-          <Checkbox
-            checked={isChecked}
-            hiddenLabel
-            isIndeterminate={isIndeterminate}
-            label={label}
-            onChange={onChange}
-            width={0}
-          />
+          <Checkbox checked={isChecked} hiddenLabel label={label} onChange={onChange} width={0} />
         </DataCell>
       );
     }
@@ -166,17 +155,7 @@ const InternalRow = <T extends TableItem>({
               width={isDragging ? cellWidth : width}
             >
               <Flex alignItems="center" flexDirection="row">
-                {columnIndex === 0 && isExpandable && isSelectable && !isParentRow && (
-                  <Checkbox
-                    checked={isSelected}
-                    hiddenLabel
-                    label={label}
-                    onChange={onChange}
-                    width={0}
-                  />
-                )}
-                {/*
-          // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
+                {/* @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
                 <CellContent {...item} />
               </Flex>
             </DataCell>

--- a/packages/big-design/src/components/TableNext/Row/spec.tsx
+++ b/packages/big-design/src/components/TableNext/Row/spec.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import 'jest-styled-components';
+
+import { render, screen } from '@test/utils';
+
+import { TableColumn } from '../types';
+
+import { Row } from './Row';
+import { useRowState } from './useRowState';
+
+interface Item {
+  sku: string;
+  name: string;
+  stock: number;
+  children?: Item[];
+}
+
+const item = { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 };
+
+const defaultColumns: Array<TableColumn<Item>> = [
+  { hash: 'sku', header: 'Sku', render: ({ sku }) => sku },
+  { hash: 'name', header: 'Name', render: ({ name }) => name },
+  { hash: 'stock', header: 'Stock', render: ({ stock }) => stock },
+];
+
+test('renders a table row', async () => {
+  render(
+    <Row
+      columns={defaultColumns}
+      headerCellWidths={[]}
+      isDraggable={false}
+      item={item}
+      parentRowIndex={0}
+      selectedItems={{}}
+    />,
+  );
+
+  const name = await screen.findByRole('row', { name: /Smith Journal 13/i });
+
+  expect(name).toBeVisible();
+});
+
+test('row state callbacks execute argument callback', () => {
+  const onExpandedRow = jest.fn();
+  const onItemSelect = jest.fn();
+
+  const { onChange, onExpandedChange } = useRowState({
+    childrenRows: [],
+    isParentRow: true,
+    isSelected: false,
+    onExpandedRow,
+    onItemSelect,
+    parentRowIndex: 0,
+  });
+
+  onChange();
+
+  expect(onItemSelect).toHaveBeenCalled();
+
+  onExpandedChange();
+
+  expect(onExpandedRow).toHaveBeenCalled();
+});

--- a/packages/big-design/src/components/TableNext/Row/useRowState.ts
+++ b/packages/big-design/src/components/TableNext/Row/useRowState.ts
@@ -1,25 +1,19 @@
 import { OnItemSelectFn } from '../hooks';
-import { TableSelectable } from '../types';
 
 interface UseRowStateProps<T> {
   childRowIndex?: number;
   childrenRows?: T[];
-  isExpandable: boolean;
   isParentRow: boolean;
   isSelected?: boolean;
-  selectedItems: TableSelectable['selectedItems'];
   onExpandedRow?(parentRowIndex: number | null): void;
   onItemSelect?: OnItemSelectFn;
   parentRowIndex: number;
 }
 
 export const useRowState = <T>({
-  childRowIndex,
   childrenRows,
-  isExpandable,
   isParentRow,
   isSelected,
-  selectedItems,
   onExpandedRow,
   onItemSelect,
   parentRowIndex,
@@ -27,10 +21,7 @@ export const useRowState = <T>({
   const onChange = () => {
     if (onItemSelect) {
       onItemSelect({
-        childRowIndex: childRowIndex ?? null,
-        childrenRows: childrenRows ?? [],
         isParentRow,
-        isExpandable,
         parentRowIndex,
       });
     }
@@ -44,28 +35,11 @@ export const useRowState = <T>({
 
   const hasChildrenRows = Array.isArray(childrenRows);
 
-  const allChildrenRowsSelected =
-    isExpandable &&
-    childrenRows?.every((_childRow, childRowIndex) => {
-      return selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
-    });
-
-  const someChildrenRowsSelected =
-    isExpandable &&
-    childrenRows?.some((_childRow, childRowIndex) => {
-      return selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
-    });
-
   const label = isSelected ? `Selected` : `Unselected`;
-
-  const isChecked = isExpandable && hasChildrenRows ? allChildrenRowsSelected : isSelected;
-
-  const isIndeterminate = isExpandable && hasChildrenRows ? someChildrenRowsSelected : undefined;
 
   return {
     hasChildrenRows,
-    isChecked,
-    isIndeterminate,
+    isChecked: isSelected,
     label,
     onChange,
     onExpandedChange,

--- a/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
+++ b/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
@@ -72,8 +72,6 @@ const InternalRowContainer = <T extends TableItem>({
         isExpanded &&
         childrenRows?.map((childRow: T, childRowIndex: number) => {
           const key = getItemKey(childRow, childRowIndex);
-          const isChildRowSelected =
-            selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
 
           return (
             <Row
@@ -85,11 +83,9 @@ const InternalRowContainer = <T extends TableItem>({
               isDragging={false}
               isExpandable={isExpandable}
               isParentRow={false}
-              isSelectable={isSelectable}
-              isSelected={isChildRowSelected}
+              isSelectable={isSelectable} // for rendering extra cells
               item={childRow}
               key={key}
-              onItemSelect={onItemSelect}
               parentRowIndex={parentRowIndex}
               selectedItems={selectedItems}
               showDragIcon={showDragIcon}

--- a/packages/big-design/src/components/TableNext/RowContainer/spec.ts
+++ b/packages/big-design/src/components/TableNext/RowContainer/spec.ts
@@ -1,0 +1,49 @@
+import { TableColumn } from '../types';
+
+import { calculateColSpan } from './helpers';
+
+interface Item {
+  sku: string;
+  name: string;
+  stock: number;
+  children?: Item[];
+}
+
+const columns: Array<TableColumn<Item>> = [
+  { hash: 'sku', header: 'Sku', render: ({ sku }) => sku },
+  { hash: 'name', header: 'Name', render: ({ name }) => name },
+  { hash: 'stock', header: 'Stock', render: ({ stock }) => stock },
+];
+
+test('should increment for draggable row', () => {
+  const totalColSpans = calculateColSpan({
+    columns,
+    isExpandable: false,
+    isDraggable: true,
+    isSelectable: false,
+  });
+
+  expect(totalColSpans).toBe(4);
+});
+
+test('should increment for expandable row', () => {
+  const totalColSpans = calculateColSpan({
+    columns,
+    isExpandable: true,
+    isDraggable: false,
+    isSelectable: false,
+  });
+
+  expect(totalColSpans).toBe(4);
+});
+
+test('should increment for selectable row', () => {
+  const totalColSpans = calculateColSpan({
+    columns,
+    isExpandable: false,
+    isDraggable: false,
+    isSelectable: true,
+  });
+
+  expect(totalColSpans).toBe(4);
+});

--- a/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
@@ -3,13 +3,11 @@ import React from 'react';
 import { Checkbox } from '../../Checkbox';
 import { Flex, FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
-import { TableExpandable, TableItem, TablePaginationProps, TableSelectable } from '../types';
+import { TableItem, TablePaginationProps, TableSelectable } from '../types';
 
 import { useSelectAllState } from './useSelectAllState';
 
 export interface SelectAllProps<T> {
-  expandedRowSelector?: TableExpandable<T>['expandedRowSelector'];
-  isExpandable: boolean;
   items: T[];
   onChange?: TableSelectable['onSelectionChange'];
   selectedItems: TableSelectable['selectedItems'];

--- a/packages/big-design/src/components/TableNext/hooks/useSelectable/helpers.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useSelectable/helpers.ts
@@ -11,8 +11,6 @@ export interface SelectRowArg<T> {
 }
 
 export function selectParentRow<T>({
-  childrenRows,
-  isExpandable,
   parentRowIndex,
   selectedItems,
 }: SelectRowArg<T>): TableSelectable['selectedItems'] {
@@ -20,8 +18,6 @@ export function selectParentRow<T>({
 
   if (isSelectedParent) {
     const newSelectedItems = unselectParent({
-      childrenRows,
-      isExpandable,
       parentRowIndex,
       selectedItems,
     });
@@ -30,8 +26,6 @@ export function selectParentRow<T>({
   }
 
   const newSelectedItems = selectParent({
-    childrenRows,
-    isExpandable,
     parentRowIndex,
     selectedItems,
   });
@@ -40,23 +34,9 @@ export function selectParentRow<T>({
 }
 
 function unselectParent<T>({
-  childrenRows,
-  isExpandable,
   parentRowIndex,
   selectedItems,
 }: SelectRowArg<T>): TableSelectable['selectedItems'] {
-  const hasChildrenRows = isExpandable && childrenRows !== undefined;
-
-  // If parent has children, unselect it's childrenRows
-  if (hasChildrenRows) {
-    const newSelectedItems = unselectParentAndChildren({
-      selectedItems,
-      parentRowIndex,
-    });
-
-    return newSelectedItems;
-  }
-
   // Unselect the parent row
   const newSelectedItems = Object.entries(selectedItems).filter(
     ([key]) => key !== `${parentRowIndex}`,
@@ -65,137 +45,12 @@ function unselectParent<T>({
   return Object.fromEntries(newSelectedItems);
 }
 
-function unselectParentAndChildren<T>({ selectedItems, parentRowIndex }: SelectRowArg<T>) {
-  const newSelectedItems = Object.entries(selectedItems).filter(([key]) => {
-    const [parentIndex] = key.split('.').map((key) => parseInt(key, 10));
-
-    return parentIndex !== parentRowIndex;
-  });
-
-  return Object.fromEntries(newSelectedItems);
-}
-
 function selectParent<T>({
-  childrenRows,
-  isExpandable,
   parentRowIndex,
   selectedItems,
 }: SelectRowArg<T>): TableSelectable['selectedItems'] {
-  const hasChildrenRows = isExpandable && childrenRows !== undefined;
-
-  // If parent has children, select it's childrenRows
-  if (hasChildrenRows) {
-    const newSelectedItems = selectParentAndChildren({
-      selectedItems,
-      childrenRows,
-      parentRowIndex,
-    });
-
-    return newSelectedItems;
-  }
-
   return {
     ...selectedItems,
     [parentRowIndex]: true,
   };
-}
-
-function selectParentAndChildren<T>({
-  selectedItems,
-  childrenRows = [],
-  parentRowIndex,
-}: SelectRowArg<T>) {
-  const newSelectedItems = { ...selectedItems };
-
-  newSelectedItems[parentRowIndex] = true;
-
-  for (let index = 0; index < childrenRows.length; index++) {
-    const childRowIndex = index;
-
-    newSelectedItems[`${parentRowIndex}.${childRowIndex}`] = true;
-  }
-
-  return newSelectedItems;
-}
-
-export function selectChildRow<T>({
-  childRowIndex,
-  isTheOnlySelectedChildRow,
-  selectedItems,
-  parentRowIndex,
-}: SelectRowArg<T>): TableSelectable['selectedItems'] {
-  const isSelectedParent = selectedItems[parentRowIndex] !== undefined;
-
-  if (!isSelectedParent) {
-    const newSelectedItems = selectChild({ childRowIndex, parentRowIndex, selectedItems });
-
-    return newSelectedItems;
-  }
-
-  const isSelectedChild = selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined;
-
-  if (isSelectedChild) {
-    const newSelectedItems = unselectChild({
-      selectedItems,
-      parentRowIndex,
-      childRowIndex,
-      isTheOnlySelectedChildRow,
-    });
-
-    return newSelectedItems;
-  }
-
-  // SelectedParent but child is not selected.
-  const newSelectedItems = { ...selectedItems };
-
-  newSelectedItems[`${parentRowIndex}.${childRowIndex}`] = true;
-
-  return newSelectedItems;
-}
-
-function selectChild<T>({
-  childRowIndex,
-  parentRowIndex,
-  selectedItems,
-}: SelectRowArg<T>): TableSelectable['selectedItems'] {
-  const newSelectedItems = { ...selectedItems };
-
-  newSelectedItems[`${parentRowIndex}`] = true;
-  newSelectedItems[`${parentRowIndex}.${childRowIndex}`] = true;
-
-  return newSelectedItems;
-}
-
-function unselectChild<T>({
-  selectedItems,
-  parentRowIndex,
-  childRowIndex,
-  isTheOnlySelectedChildRow,
-}: SelectRowArg<T>) {
-  const newSelectedItems = Object.entries(selectedItems)
-    .filter(([key]) => key !== `${parentRowIndex}.${childRowIndex}`)
-    .filter(([key]) => {
-      // Remove the parent row if it's the only selected child.
-      if (isTheOnlySelectedChildRow) {
-        return key !== `${parentRowIndex}`;
-      }
-
-      return true;
-    });
-
-  return Object.fromEntries(newSelectedItems);
-}
-
-export function getTotalSelectedChildRows<T>({
-  childrenRows,
-  parentRowIndex,
-  selectedItems,
-}: SelectRowArg<T>) {
-  return childrenRows?.reduce((acc, _childRow, childRowIndex) => {
-    if (selectedItems[`${parentRowIndex}.${childRowIndex}`] !== undefined) {
-      return acc + 1;
-    }
-
-    return acc;
-  }, 0);
 }

--- a/packages/big-design/src/components/TableNext/hooks/useSelectable/useSelectable.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useSelectable/useSelectable.ts
@@ -3,32 +3,21 @@ import { useEffect, useState } from 'react';
 import { useEventCallback } from '../../../../hooks';
 import { TableSelectable } from '../../types';
 
-import {
-  getTotalSelectedChildRows,
-  selectChildRow,
-  selectParentRow,
-  SelectRowArg,
-} from './helpers';
+import { selectParentRow, SelectRowArg } from './helpers';
 
 interface OnItemSelectFnArg<T> extends Omit<SelectRowArg<T>, 'childRowIndex' | 'selectedItems'> {
-  childRowIndex: number | null;
+  parentRowIndex: number;
   isParentRow: boolean;
 }
 
-export type OnItemSelectFn = <T>({
-  childRowIndex,
-  childrenRows,
-  isParentRow,
-  isExpandable,
-  parentRowIndex,
-}: OnItemSelectFnArg<T>) => void;
+export type OnItemSelectFn = <T>({ isParentRow, parentRowIndex }: OnItemSelectFnArg<T>) => void;
 
 export const useSelectable = (selectable?: TableSelectable) => {
   const isSelectable = Boolean(selectable);
   const [selectedItems, setSelectedItems] = useState<TableSelectable['selectedItems']>({});
 
   const onItemSelectEventCallback: OnItemSelectFn = useEventCallback(
-    ({ childRowIndex, childrenRows, isParentRow, isExpandable, parentRowIndex }) => {
+    ({ isParentRow, parentRowIndex }) => {
       if (!selectable) {
         return;
       }
@@ -37,25 +26,6 @@ export const useSelectable = (selectable?: TableSelectable) => {
 
       if (isParentRow) {
         const newSelectedItems = selectParentRow({
-          childrenRows,
-          isExpandable,
-          parentRowIndex,
-          selectedItems,
-        });
-
-        onSelectionChange(newSelectedItems);
-      } else if (childRowIndex !== null) {
-        const totalSelectedChildRows = getTotalSelectedChildRows({
-          childrenRows,
-          parentRowIndex,
-          selectedItems,
-        });
-
-        const isTheOnlySelectedChildRow = totalSelectedChildRows === 1;
-
-        const newSelectedItems = selectChildRow({
-          childRowIndex,
-          isTheOnlySelectedChildRow,
           parentRowIndex,
           selectedItems,
         });


### PR DESCRIPTION
## What?

Removes child row selection from TableNext

## Why?
We want to come up with a better pattern for child selection, and child selection was causing some issues in current implementations using this new component. 

## Screenshots/Screen Recordings
<img width="1001" alt="Screen Shot 2022-10-26 at 10 40 31 AM" src="https://user-images.githubusercontent.com/99345561/198072772-7651edee-4f54-400b-afa3-1d5d8029c5b2.png">


## Testing/Proof

Parent row selection still functions and child rows are read only
