### PR TITLE
fix(component): add border-radius back to Panel component

### DIFF
--- a/packages/big-design/src/components/AccordionPanel/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/AccordionPanel/__snapshots__/spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`it renders accordion panel header 1`] = `
 <h2
-  class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-0 kEGvNd gRjkZy"
+  class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 kEGvNd fjdBDH"
 >
   Accordion Panel Header
 </h2>

--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -2,11 +2,10 @@ import React, { forwardRef, HTMLAttributes, memo, Ref } from 'react';
 
 import { MarginProps } from '../../mixins';
 import { excludePaddingProps } from '../../mixins/paddings/paddings';
-import { Box } from '../Box';
 import { Button, ButtonProps } from '../Button';
 import { Flex } from '../Flex';
 
-import { StyledH2 } from './styled';
+import { StyledH2, StyledPanel } from './styled';
 
 interface PrivateProps {
   forwardedRef: Ref<HTMLDivElement>;
@@ -45,18 +44,17 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
   };
 
   return (
-    <Box
+    <StyledPanel
       marginBottom="medium"
       {...rest}
       backgroundColor="white"
-      borderRadius="none"
       padding={{ mobile: 'medium', tablet: 'xLarge' }}
       ref={forwardedRef}
       shadow="raised"
     >
       {renderHeader()}
       {children}
-    </Box>
+    </StyledPanel>
   );
 });
 

--- a/packages/big-design/src/components/Panel/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Panel/__snapshots__/spec.tsx.snap
@@ -7,6 +7,9 @@ exports[`render panel 1`] = `
   background-color: #FFFFFF;
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+}
+
+.c1 {
   border-radius: 0;
 }
 
@@ -22,8 +25,14 @@ exports[`render panel 1`] = `
   }
 }
 
+@media (min-width:720px) {
+  .c1 {
+    border-radius: 0.25rem;
+  }
+}
+
 <div
-  class="c0"
+  class="c0 c1"
 >
   Dolore proident eiusmod sint est enim laboris anim minim quis ut adipisicing consectetur officia ex. Ipsum eiusmod fugiat amet pariatur culpa tempor aliquip tempor nisi. Irure esse deserunt nostrud ipsum id adipisicing enim velit labore. Nulla exercitation laborum laboris Lorem irure sit esse nulla mollit aliquip consectetur velit
 </div>

--- a/packages/big-design/src/components/Panel/spec.tsx
+++ b/packages/big-design/src/components/Panel/spec.tsx
@@ -2,7 +2,7 @@ import { theme } from '@bigcommerce/big-design-theme';
 import React, { createRef } from 'react';
 import 'jest-styled-components';
 
-import { fireEvent, render } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { Panel } from './Panel';
 
@@ -123,4 +123,22 @@ test('forwards headerId to heading', () => {
   );
 
   expect(getByText('Test Header')).toHaveAttribute('id', 'test-header');
+});
+
+test('applies the right border radius values', async () => {
+  render(
+    <Panel role="region">
+      Dolore proident eiusmod sint est enim laboris anim minim quis ut adipisicing consectetur
+      officia ex. Ipsum eiusmod fugiat amet pariatur culpa tempor aliquip tempor nisi. Irure esse
+      deserunt nostrud ipsum id adipisicing enim velit labore. Nulla exercitation laborum laboris
+      Lorem irure sit esse nulla mollit aliquip consectetur velit
+    </Panel>,
+  );
+
+  const panel = await screen.findByRole('region');
+
+  expect(panel).toHaveStyleRule('border-radius', `${theme.borderRadius.none}`);
+  expect(panel).toHaveStyleRule('border-radius', theme.borderRadius.normal, {
+    media: `(min-width:${theme.breakpointValues.tablet})`,
+  });
 });

--- a/packages/big-design/src/components/Panel/styled.tsx
+++ b/packages/big-design/src/components/Panel/styled.tsx
@@ -1,7 +1,16 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
+import { Box } from '../Box';
 import { StyleableH2 } from '../Typography/private';
+
+export const StyledPanel = styled(Box)`
+  border-radius: ${({ theme }) => theme.borderRadius.none};
+
+  ${({ theme }) => theme.breakpoints.tablet} {
+    border-radius: ${({ theme }) => theme.borderRadius.normal};
+  }
+`;
 
 export const StyledH2 = styled(StyleableH2)`
   flex-grow: 1;
@@ -12,4 +21,5 @@ export const StyledH2 = styled(StyleableH2)`
   }
 `;
 
+StyledPanel.defaultProps = { theme: defaultTheme };
 StyledH2.defaultProps = { theme: defaultTheme };


### PR DESCRIPTION
## What?

Adds the border radius back to the `Panel` component on tablet+ screens.

## Why?

This was a regression from https://github.com/bigcommerce/big-design/pull/962. The panel shouldn't have a border radius only on mobile devices.

Fixes #1031

## Screenshots/Screen Recordings

![screencapture-localhost-3000-panel-2022-10-27-10_04_45](https://user-images.githubusercontent.com/10539418/198326755-d7340491-32b8-44c6-b696-e2bb7122c7ef.png)

## Testing/Proof

Updated tests and snapshots.
