### PR TITLE
feat(component): allow fullWidth on inline form fields

### DIFF
--- a/packages/big-design/src/components/Form/Form.tsx
+++ b/packages/big-design/src/components/Form/Form.tsx
@@ -4,6 +4,7 @@ import { MarginProps } from '../../mixins';
 import { typedMemo } from '../../utils';
 
 import { StyledForm } from './styled';
+import { FormContext } from './useFormContext';
 
 interface PrivateProps {
   forwardedRef: Ref<HTMLFormElement>;
@@ -14,9 +15,13 @@ export type FormProps = React.FormHTMLAttributes<HTMLFormElement> &
     fullWidth?: boolean;
   };
 
-const StyleableForm: React.FC<PrivateProps & FormProps> = ({ forwardedRef, ...props }) => (
-  <StyledForm {...props} ref={forwardedRef} />
-);
+const StyleableForm: React.FC<PrivateProps & FormProps> = ({ forwardedRef, ...props }) => {
+  return (
+    <FormContext.Provider value={{ fullWidth: props.fullWidth }}>
+      <StyledForm {...props} ref={forwardedRef} />
+    </FormContext.Provider>
+  );
+};
 
 export const Form = typedMemo(
   forwardRef<HTMLFormElement, FormProps>(({ className, style, ...props }, ref) => (

--- a/packages/big-design/src/components/Form/Group/Group.tsx
+++ b/packages/big-design/src/components/Form/Group/Group.tsx
@@ -13,6 +13,7 @@ import { warning } from '../../../utils';
 import { Checkbox } from '../../Checkbox';
 import { Radio } from '../../Radio';
 import { FormControlError } from '../Error';
+import { useFormContext } from '../useFormContext';
 
 import { StyledError, StyledGroup, StyledInlineGroup } from './styled';
 
@@ -33,6 +34,7 @@ interface Context {
 export const FormGroupContext = createContext<Context>({});
 
 export const FormGroup: React.FC<GroupProps> = (props) => {
+  const { fullWidth } = useFormContext();
   const [inputErrors, setInputErrors] = useState<Errors>({});
 
   const { children, errors: groupErrors } = props;
@@ -61,7 +63,7 @@ export const FormGroup: React.FC<GroupProps> = (props) => {
   return (
     <FormGroupContext.Provider value={contextValue}>
       {inline ? (
-        <StyledInlineGroup childrenCount={childrenCount}>
+        <StyledInlineGroup childrenCount={childrenCount} fullWidth={fullWidth}>
           {children}
           {renderErrors()}
         </StyledInlineGroup>

--- a/packages/big-design/src/components/Form/Group/styled.tsx
+++ b/packages/big-design/src/components/Form/Group/styled.tsx
@@ -5,6 +5,7 @@ import { Flex } from '../../Flex';
 
 interface StyledProps {
   childrenCount?: number;
+  fullWidth?: boolean;
 }
 
 const SharedGroupStyles = css`
@@ -29,20 +30,20 @@ export const StyledInlineGroup = styled.div<StyledProps>`
   ${SharedGroupStyles};
 
   ${({ theme }) => theme.breakpoints.tablet} {
-    ${({ childrenCount, theme }) =>
+    ${({ childrenCount, fullWidth, theme }) =>
       childrenCount === 2 &&
       css`
-        grid-template-columns: repeat(2, ${theme.helpers.remCalc(200)});
+        grid-template-columns: repeat(2, ${fullWidth ? '1fr' : theme.helpers.remCalc(200)});
 
         ${StyledError} {
           grid-column: 1 / 3;
         }
       `}
 
-    ${({ childrenCount, theme }) =>
+    ${({ childrenCount, fullWidth, theme }) =>
       childrenCount === 3 &&
       css`
-        grid-template-columns: repeat(3, ${theme.helpers.remCalc(128)});
+        grid-template-columns: repeat(3, ${fullWidth ? '1fr' : theme.helpers.remCalc(128)});
 
         ${StyledError} {
           grid-column: 1 / 4;

--- a/packages/big-design/src/components/Form/useFormContext.ts
+++ b/packages/big-design/src/components/Form/useFormContext.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+interface FormContextProps {
+  fullWidth?: boolean;
+}
+
+export const FormContext = createContext<FormContextProps>({});
+
+export const useFormContext = () => {
+  const context = useContext(FormContext);
+
+  if (!context) {
+    throw new Error('useFormContext must be used within a FormContext');
+  }
+
+  return context;
+};


### PR DESCRIPTION
## What?

Allows fullWidth inline form fields. Fixes #660

## Why?

To add consistency with the rest of form fields that have full width enabled.

## Screenshots/Screen Recordings

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="945" alt="Screen Shot 2022-11-02 at 21 09 20" src="https://user-images.githubusercontent.com/10539418/199635634-4520c14b-83e3-4f6a-a56c-5f0f2fcc82a6.png"/>
	<td><img width="945" alt="Screen Shot 2022-11-02 at 21 08 49" src="https://user-images.githubusercontent.com/10539418/199635646-3636de20-d2ec-4685-8f86-108a9387a92b.png" />
</table>

## Testing/Proof

Manually tested in the browser.
