### PR TITLE
feat: convert to react@18 only

### DIFF
--- a/packages/big-design-icons/package.json
+++ b/packages/big-design-icons/package.json
@@ -34,12 +34,11 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@bigcommerce/big-design-theme": "^0.17.0",
-    "react-uid": "^2.3.1"
+    "@bigcommerce/big-design-theme": "^0.17.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "styled-components": "^5.3.5"
   },
   "devDependencies": {

--- a/packages/big-design-icons/scripts/svgr-flags.config.js
+++ b/packages/big-design-icons/scripts/svgr-flags.config.js
@@ -15,16 +15,15 @@ module.exports = {
     // **********************************
     // Auto-generated file, do NOT modify
     // **********************************
-    import React, { forwardRef, memo } from 'react';
+    import React, { forwardRef, memo, useId } from 'react';
     BREAK
 
     import { PrivateIconProps } from '../../base';
-    import { useUniqueId } from '../../utils';
     import { createStyledFlagIcon, FlagIconProps } from '../base';
     BREAK
 
     const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = '${flagName} flag', theme, ...props }) => {
-      const uniqueTitleId = useUniqueId('icon');
+      const uniqueTitleId = useId();
       const titleId = title ? props.titleId || uniqueTitleId : undefined;
       const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/scripts/svgr.config.js
+++ b/packages/big-design-icons/scripts/svgr.config.js
@@ -16,15 +16,14 @@ module.exports = {
     // **********************************
     // Auto-generated file, do NOT modify
     // **********************************
-    import React, { forwardRef, memo } from 'react';
+    import React, { forwardRef, memo, useId } from 'react';
     BREAK
 
     import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-    import { useUniqueId } from '../utils';
     BREAK
 
     const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-      const uniqueTitleId = useUniqueId('icon');
+      const uniqueTitleId = useId();
       const titleId = title ? props.titleId || uniqueTitleId : undefined;
       const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/AddIcon.tsx
+++ b/packages/big-design-icons/src/components/AddIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ArrowBackIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowBackIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/AssignmentIcon.tsx
+++ b/packages/big-design-icons/src/components/AssignmentIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
+++ b/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/BrushIcon.tsx
+++ b/packages/big-design-icons/src/components/BrushIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/CheckCircleIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckCircleIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/CheckIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ChevronRightIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronRightIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/CloseIcon.tsx
+++ b/packages/big-design-icons/src/components/CloseIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/CloudUploadIcon.tsx
+++ b/packages/big-design-icons/src/components/CloudUploadIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/CodeIcon.tsx
+++ b/packages/big-design-icons/src/components/CodeIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ContentCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/ContentCopyIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/DeleteIcon.tsx
+++ b/packages/big-design-icons/src/components/DeleteIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
+++ b/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/EditIcon.tsx
+++ b/packages/big-design-icons/src/components/EditIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ErrorIcon.tsx
+++ b/packages/big-design-icons/src/components/ErrorIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ExpandLessIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandLessIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/FileCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/FileCopyIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/FilterListIcon.tsx
+++ b/packages/big-design-icons/src/components/FilterListIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/FolderIcon.tsx
+++ b/packages/big-design-icons/src/components/FolderIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/GetAppIcon.tsx
+++ b/packages/big-design-icons/src/components/GetAppIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/HomeIcon.tsx
+++ b/packages/big-design-icons/src/components/HomeIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/InfoIcon.tsx
+++ b/packages/big-design-icons/src/components/InfoIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/InsertDriveFileIcon.tsx
+++ b/packages/big-design-icons/src/components/InsertDriveFileIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/InvertColorsIcon.tsx
+++ b/packages/big-design-icons/src/components/InvertColorsIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/KeyboardDoubleArrowLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/KeyboardDoubleArrowLeftIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/LanguageIcon.tsx
+++ b/packages/big-design-icons/src/components/LanguageIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/MenuIcon.tsx
+++ b/packages/big-design-icons/src/components/MenuIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/MoreHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/MoreHorizIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/NotificationsIcon.tsx
+++ b/packages/big-design-icons/src/components/NotificationsIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/OpenInNewIcon.tsx
+++ b/packages/big-design-icons/src/components/OpenInNewIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/PublicIcon.tsx
+++ b/packages/big-design-icons/src/components/PublicIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/ReceiptIcon.tsx
+++ b/packages/big-design-icons/src/components/ReceiptIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/RedoIcon.tsx
+++ b/packages/big-design-icons/src/components/RedoIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/RemoveIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/RestoreIcon.tsx
+++ b/packages/big-design-icons/src/components/RestoreIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/SearchIcon.tsx
+++ b/packages/big-design-icons/src/components/SearchIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/SettingsIcon.tsx
+++ b/packages/big-design-icons/src/components/SettingsIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/StarBorderIcon.tsx
+++ b/packages/big-design-icons/src/components/StarBorderIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/StarHalfIcon.tsx
+++ b/packages/big-design-icons/src/components/StarHalfIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/StarIcon.tsx
+++ b/packages/big-design-icons/src/components/StarIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/StoreIcon.tsx
+++ b/packages/big-design-icons/src/components/StoreIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/SwapHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/SwapHorizIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/UndoIcon.tsx
+++ b/packages/big-design-icons/src/components/UndoIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/VisibilityIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/components/WarningIcon.tsx
+++ b/packages/big-design-icons/src/components/WarningIcon.tsx
@@ -1,13 +1,12 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
-import { useUniqueId } from '../utils';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, ...props }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ACFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ACFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ADFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ADFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AFFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AIFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ALFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ALFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AOFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AQFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ARFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ARFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ASFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ASFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ATFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ATFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AUFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AWFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AXFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/AZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AZFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BBFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BDFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BFFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BHFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BIFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BJFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BLFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BOFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BQFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BSFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BTFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BVFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BWFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BYFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/BZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BZFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CCFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CDFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CEFTAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CEFTAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CFFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CHFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CIFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CKFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CLFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/COFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/COFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CPFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CUFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CVFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CWFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CXFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CYFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/CZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CZFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/DEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/DGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/DJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DJFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/DKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DKFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/DMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/DOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DOFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/DZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DZFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/EAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ECFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ECFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/EEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/EGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/EHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EHFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ERFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ERFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ESCTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESCTFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ESFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ESGAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESGAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ETFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ETFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/EUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EUFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/FIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FIFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/FJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FJFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/FKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FKFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/FMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/FOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FOFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/FRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GBENGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBENGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GBNIRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBNIRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GBSCTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBSCTFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GBWLSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBWLSFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GDFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GFFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GHFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GIFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GLFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GPFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GQFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GSFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GTFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GUFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GWFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/GYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GYFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/HKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HKFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/HMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/HNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/HRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/HTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HTFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/HUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HUFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ICFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ICFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/IDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IDFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/IEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ILFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ILFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/IMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/INFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/INFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/IOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IOFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/IQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IQFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/IRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ISFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ISFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ITFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ITFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/JEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/JMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/JOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JOFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/JPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JPFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KHFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KIFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KPFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KWFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KYFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/KZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KZFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LBFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LCFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LIFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LKFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LSFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LTFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LUFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LVFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/LYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LYFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MCFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MDFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MFFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MHFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MKFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MLFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MOFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MPFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MQFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MSFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MTFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MUFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MVFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MWFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MXFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MYFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/MZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MZFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NCFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NFFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NIFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NLFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NOFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NPFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NUFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/NZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NZFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/OMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/OMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PFFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PHFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PKFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PLFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PSFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PTFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PWFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/PYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PYFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/QAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/QAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/REFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/REFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ROFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ROFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/RSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RSFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/RUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RUFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/RWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RWFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SBFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SCFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SDFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SHFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SIFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SJFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SKFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SLFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SOFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SSFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/STFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/STFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SVFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SXFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SYFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/SZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SZFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TCFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TDFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TFFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/THFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/THFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TJFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TKFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TLFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TOFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TRFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TTFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TVFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TWFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/TZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TZFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/UAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/UGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/UMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/UNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/USFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/USFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/UYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UYFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/UZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UZFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/VAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/VCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VCFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/VEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/VGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VGFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/VIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VIFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/VNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VNFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/VUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VUFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/WFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/WFFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/WSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/WSFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/XKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/XKFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/XXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/XXFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/YEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/YEFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/YTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/YTFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ZAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZAFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ZMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZMFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/flags/components/ZWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZWFlagIcon.tsx
@@ -1,10 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';
-import { useUniqueId } from '../../utils';
 import { createStyledFlagIcon, FlagIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
@@ -13,7 +12,7 @@ const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   theme,
   ...props
 }) => {
-  const uniqueTitleId = useUniqueId('icon');
+  const uniqueTitleId = useId();
   const titleId = title ? props.titleId || uniqueTitleId : undefined;
   const ariaHidden = titleId ? undefined : true;
 

--- a/packages/big-design-icons/src/index.ts
+++ b/packages/big-design-icons/src/index.ts
@@ -1,6 +1,5 @@
 import { IconProps as _IconProps } from './base';
 
 export * from './components';
-export * from './utils';
 export { createStyledIcon } from './base';
 export type IconProps = _IconProps;

--- a/packages/big-design-icons/src/utils/index.ts
+++ b/packages/big-design-icons/src/utils/index.ts
@@ -1,1 +1,0 @@
-export * from './useUniqueId';

--- a/packages/big-design-icons/src/utils/useUniqueId.ts
+++ b/packages/big-design-icons/src/utils/useUniqueId.ts
@@ -1,7 +1,0 @@
-import { useUID } from 'react-uid';
-
-export function useUniqueId(prefix: string) {
-  const uid = useUID();
-
-  return `bd-${prefix}-${uid}`;
-}

--- a/packages/big-design-theme/package.json
+++ b/packages/big-design-theme/package.json
@@ -36,8 +36,8 @@
     "polished": "^4.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "styled-components": "^5.3.5"
   },
   "devDependencies": {

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -44,12 +44,11 @@
     "react-beautiful-dnd": "^13.1.1",
     "react-datepicker": "^4.8.0",
     "react-popper": "^2.3.0",
-    "react-uid": "^2.3.1",
     "zustand": "^4.1.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "styled-components": "^5.3.5"
   },
   "devDependencies": {

--- a/packages/big-design/src/components/AccordionPanel/Accordion/Accordion.tsx
+++ b/packages/big-design/src/components/AccordionPanel/Accordion/Accordion.tsx
@@ -1,7 +1,5 @@
 import { ExpandMoreIcon } from '@bigcommerce/big-design-icons';
-import React, { memo } from 'react';
-
-import { useUniqueId } from '../../../hooks';
+import React, { memo, useId } from 'react';
 
 import { StyledAccordionButton, StyledAccordionContent } from './styled';
 
@@ -16,8 +14,8 @@ export interface AccordionProps {
 
 export const Accordion: React.FC<AccordionProps> = memo(
   ({ children, header, iconLeft, isExpanded, onClick }) => {
-    const accordionId = useUniqueId('accordion');
-    const accordionItemId = useUniqueId('accordion-item');
+    const accordionId = useId();
+    const accordionItemId = useId();
 
     return (
       <>

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -5,10 +5,10 @@ import React, {
   isValidElement,
   LabelHTMLAttributes,
   Ref,
+  useId,
   useMemo,
 } from 'react';
 
-import { useUniqueId } from '../../hooks';
 import { typedMemo, warning } from '../../utils';
 import { FormControlDescription, FormControlDescriptionLinkProps } from '../Form';
 
@@ -50,9 +50,9 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   style,
   ...props
 }) => {
-  const uniqueCheckboxId = useUniqueId('checkbox');
+  const uniqueCheckboxId = useId();
+  const labelId = useId();
   const id = props.id ? props.id : uniqueCheckboxId;
-  const labelId = useUniqueId('checkbox_label');
 
   const renderedLabel = useMemo(() => {
     if (!label) {

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -102,16 +102,16 @@ exports[`render Checkbox checked 1`] = `
 >
   <input
     aria-checked="true"
-    aria-labelledby="bd-checkbox_label-2"
+    aria-labelledby=":r1:"
     checked=""
     class="c1 c2"
-    id="bd-checkbox-1"
+    id=":r0:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
-    for="bd-checkbox-1"
+    for=":r0:"
   >
     <svg
       aria-hidden="true"
@@ -137,8 +137,8 @@ exports[`render Checkbox checked 1`] = `
   >
     <label
       class="c7 c8"
-      for="bd-checkbox-1"
-      id="bd-checkbox_label-2"
+      for=":r0:"
+      id=":r1:"
     >
       Checked
     </label>
@@ -248,18 +248,18 @@ exports[`render Checkbox disabled checked 1`] = `
 >
   <input
     aria-checked="true"
-    aria-labelledby="bd-checkbox_label-2"
+    aria-labelledby=":rg:"
     checked=""
     class="c1 c2"
     disabled=""
-    id="bd-checkbox-1"
+    id=":rf:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
     disabled=""
-    for="bd-checkbox-1"
+    for=":rf:"
   >
     <svg
       aria-hidden="true"
@@ -287,8 +287,8 @@ exports[`render Checkbox disabled checked 1`] = `
       aria-hidden="true"
       class="c7 c8"
       disabled=""
-      for="bd-checkbox-1"
-      id="bd-checkbox_label-2"
+      for=":rf:"
+      id=":rg:"
     >
       Checked
     </label>
@@ -397,17 +397,17 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="bd-checkbox_label-2"
+    aria-labelledby=":rm:"
     class="c1 c2"
     disabled=""
-    id="bd-checkbox-1"
+    id=":rl:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
     disabled=""
-    for="bd-checkbox-1"
+    for=":rl:"
   >
     <svg
       aria-hidden="true"
@@ -435,8 +435,8 @@ exports[`render Checkbox disabled indeterminate 1`] = `
       aria-hidden="true"
       class="c7 c8"
       disabled=""
-      for="bd-checkbox-1"
-      id="bd-checkbox_label-2"
+      for=":rl:"
+      id=":rm:"
     >
       Unchecked
     </label>
@@ -546,17 +546,17 @@ exports[`render Checkbox disabled unchecked 1`] = `
 >
   <input
     aria-checked="false"
-    aria-labelledby="bd-checkbox_label-2"
+    aria-labelledby=":rj:"
     class="c1 c2"
     disabled=""
-    id="bd-checkbox-1"
+    id=":ri:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
     disabled=""
-    for="bd-checkbox-1"
+    for=":ri:"
   >
     <svg
       aria-hidden="true"
@@ -584,8 +584,8 @@ exports[`render Checkbox disabled unchecked 1`] = `
       aria-hidden="true"
       class="c7 c8"
       disabled=""
-      for="bd-checkbox-1"
-      id="bd-checkbox_label-2"
+      for=":ri:"
+      id=":rj:"
     >
       Checked
     </label>
@@ -694,15 +694,15 @@ exports[`render Checkbox indeterminate 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="bd-checkbox_label-2"
+    aria-labelledby=":rd:"
     class="c1 c2"
-    id="bd-checkbox-1"
+    id=":rc:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
-    for="bd-checkbox-1"
+    for=":rc:"
   >
     <svg
       aria-hidden="true"
@@ -728,8 +728,8 @@ exports[`render Checkbox indeterminate 1`] = `
   >
     <label
       class="c7 c8"
-      for="bd-checkbox-1"
-      id="bd-checkbox_label-2"
+      for=":rc:"
+      id=":rd:"
     >
       Unchecked
     </label>
@@ -839,15 +839,15 @@ exports[`render Checkbox unchecked 1`] = `
 >
   <input
     aria-checked="false"
-    aria-labelledby="bd-checkbox_label-2"
+    aria-labelledby=":r4:"
     class="c1 c2"
-    id="bd-checkbox-1"
+    id=":r3:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
-    for="bd-checkbox-1"
+    for=":r3:"
   >
     <svg
       aria-hidden="true"
@@ -873,8 +873,8 @@ exports[`render Checkbox unchecked 1`] = `
   >
     <label
       class="c7 c8"
-      for="bd-checkbox-1"
-      id="bd-checkbox_label-2"
+      for=":r3:"
+      id=":r4:"
     >
       Unchecked
     </label>
@@ -1023,16 +1023,16 @@ exports[`render Checkbox with description object 1`] = `
 >
   <input
     aria-checked="false"
-    aria-labelledby="bd-checkbox_label-2"
+    aria-labelledby=":r7:"
     class="c1 c2"
-    id="bd-checkbox-1"
+    id=":r6:"
     name="test-group"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
-    for="bd-checkbox-1"
+    for=":r6:"
   >
     <svg
       aria-hidden="true"
@@ -1058,8 +1058,8 @@ exports[`render Checkbox with description object 1`] = `
   >
     <label
       class="c7 c8"
-      for="bd-checkbox-1"
-      id="bd-checkbox_label-2"
+      for=":r6:"
+      id=":r7:"
     >
       Unchecked
     </label>
@@ -1196,16 +1196,16 @@ exports[`render Checkbox with description string 1`] = `
 >
   <input
     aria-checked="false"
-    aria-labelledby="bd-checkbox_label-2"
+    aria-labelledby=":ra:"
     class="c1 c2"
-    id="bd-checkbox-1"
+    id=":r9:"
     name="test-group"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
-    for="bd-checkbox-1"
+    for=":r9:"
   >
     <svg
       aria-hidden="true"
@@ -1231,8 +1231,8 @@ exports[`render Checkbox with description string 1`] = `
   >
     <label
       class="c7 c8"
-      for="bd-checkbox-1"
-      id="bd-checkbox_label-2"
+      for=":r9:"
+      id=":ra:"
     >
       Unchecked
     </label>

--- a/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
@@ -175,7 +175,7 @@ exports[`renders with close button if onRemove is present 1`] = `
       class="c5"
     >
       <svg
-        aria-labelledby="bd-icon-1"
+        aria-labelledby=":r0:"
         class="c6"
         fill="currentColor"
         height="24"
@@ -185,7 +185,7 @@ exports[`renders with close button if onRemove is present 1`] = `
         width="24"
       >
         <title
-          id="bd-icon-1"
+          id=":r0:"
         >
           Delete
         </title>

--- a/packages/big-design/src/components/Collapse/Collapse.tsx
+++ b/packages/big-design/src/components/Collapse/Collapse.tsx
@@ -1,7 +1,6 @@
 import { ExpandMoreIcon } from '@bigcommerce/big-design-icons';
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 
-import { useUniqueId } from '../../hooks';
 import { Box } from '../Box';
 
 import { StyledButton } from './styled';
@@ -20,8 +19,8 @@ export const Collapse: React.FC<CollapseProps> = ({
   initiallyOpen = false,
 }) => {
   const [isOpen, setIsOpen] = useState(initiallyOpen);
-  const triggerId = useUniqueId('collapse-title');
-  const panelId = useUniqueId('collapse-panel');
+  const triggerId = useId();
+  const panelId = useId();
 
   const handleTitleClick = () => {
     const nextIsOpen = !isOpen;

--- a/packages/big-design/src/components/Counter/Counter.tsx
+++ b/packages/big-design/src/components/Counter/Counter.tsx
@@ -7,11 +7,11 @@ import React, {
   LabelHTMLAttributes,
   Ref,
   useEffect,
+  useId,
   useMemo,
   useState,
 } from 'react';
 
-import { useUniqueId } from '../../hooks';
 import { typedMemo, warning } from '../../utils';
 import { FormControlDescription, FormControlLabel } from '../Form';
 import { useInputErrors } from '../Form/useInputErrors';
@@ -48,7 +48,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
     ...props
   }) => {
     const [focus, setFocus] = useState(false);
-    const uniqueCounterId = useUniqueId('counter');
+    const uniqueCounterId = useId();
     const id = props.id ? props.id : uniqueCounterId;
     const { errors } = useInputErrors(id, error);
 

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -1,8 +1,15 @@
 import { useSelect, UseSelectState } from 'downshift';
-import React, { cloneElement, isValidElement, memo, useCallback, useMemo, useRef } from 'react';
+import React, {
+  cloneElement,
+  isValidElement,
+  memo,
+  useCallback,
+  useId,
+  useMemo,
+  useRef,
+} from 'react';
 import { usePopper } from 'react-popper';
 
-import { useUniqueId } from '../../hooks';
 import { Box } from '../Box';
 import { List } from '../List';
 
@@ -23,7 +30,7 @@ export const Dropdown = memo(
     style,
     ...props
   }: DropdownProps) => {
-    const dropdownUniqueId = useUniqueId('dropdown');
+    const dropdownUniqueId = useId();
 
     const flattenItems = useCallback((items: DropdownProps['items']) => {
       const isGroups = (

--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -188,7 +188,7 @@ exports[`simple form render 1`] = `
       <div>
         <label
           class="c1 c5"
-          for="bd-input-1"
+          for=":r0:"
         >
           First Name
         </label>
@@ -205,7 +205,7 @@ exports[`simple form render 1`] = `
           >
             <input
               class="c8"
-              id="bd-input-1"
+              id=":r0:"
               placeholder="Placeholder text"
             />
           </div>
@@ -218,7 +218,7 @@ exports[`simple form render 1`] = `
       <div>
         <label
           class="c1 c5"
-          for="bd-input-2"
+          for=":r1:"
         >
           Middle Name
         </label>
@@ -235,7 +235,7 @@ exports[`simple form render 1`] = `
           >
             <input
               class="c8"
-              id="bd-input-2"
+              id=":r1:"
               placeholder="Placeholder text"
             />
           </div>

--- a/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
@@ -931,7 +931,7 @@ exports[`renders close button 1`] = `
         class="c11"
       >
         <svg
-          aria-labelledby="bd-icon-2"
+          aria-labelledby=":ra:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -941,7 +941,7 @@ exports[`renders close button 1`] = `
           width="24"
         >
           <title
-            id="bd-icon-2"
+            id=":ra:"
           >
             Close.
           </title>

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -4,11 +4,11 @@ import React, {
   isValidElement,
   LabelHTMLAttributes,
   Ref,
+  useId,
   useMemo,
   useState,
 } from 'react';
 
-import { useUniqueId } from '../../hooks';
 import { typedMemo, warning } from '../../utils';
 import { Chip, ChipProps } from '../Chip';
 import { FormControlDescription, FormControlLabel } from '../Form';
@@ -43,7 +43,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
   ...props
 }) => {
   const [focus, setFocus] = useState(false);
-  const uniqueInputId = useUniqueId('input');
+  const uniqueInputId = useId();
   const id = props.id ? props.id : uniqueInputId;
   const { errors } = useInputErrors(id, error);
 

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -181,7 +181,7 @@ exports[`renders all together 1`] = `
 <div>
   <label
     class="c0 c1"
-    for="bd-input-1"
+    for=":rp:"
   >
     This is a label
   </label>
@@ -221,7 +221,7 @@ exports[`renders all together 1`] = `
     >
       <input
         class="c7"
-        id="bd-input-1"
+        id=":rp:"
       />
     </div>
     <div

--- a/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
@@ -925,7 +925,7 @@ exports[`renders close button 1`] = `
         class="c11"
       >
         <svg
-          aria-labelledby="bd-icon-2"
+          aria-labelledby=":ra:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -935,7 +935,7 @@ exports[`renders close button 1`] = `
           width="24"
         >
           <title
-            id="bd-icon-2"
+            id=":ra:"
           >
             Close.
           </title>

--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -1,9 +1,8 @@
 import { CloseIcon } from '@bigcommerce/big-design-icons';
 import { createFocusTrap, FocusTrap } from 'focus-trap';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import { useUniqueId } from '../../hooks';
 import { typedMemo } from '../../utils';
 import { Button, ButtonProps } from '../Button';
 import { MessagingButton } from '../Button/private';
@@ -69,7 +68,7 @@ const InternalModal: React.FC<ModalProps> = ({
 }) => {
   const initialBodyOverflowYRef = useRef('');
   const internalTrap = useRef<FocusTrap | null>(null);
-  const headerUniqueId = useUniqueId('modal_header');
+  const headerUniqueId = useId();
   const [modalRef, setModalRef] = useState<HTMLDivElement | null>(null);
 
   const onClickAway = (event: React.MouseEvent) => {

--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -259,7 +259,7 @@ exports[`render open modal 1`] = `
       tabindex="-1"
     >
       <div
-        aria-labelledby="bd-modal_header-1"
+        aria-labelledby=":r0:"
         class="c1 c2 c3"
       >
         <div
@@ -272,7 +272,7 @@ exports[`render open modal 1`] = `
               class="c7"
             >
               <svg
-                aria-labelledby="bd-icon-2"
+                aria-labelledby=":r1:"
                 class="c8"
                 fill="currentColor"
                 height="24"
@@ -282,7 +282,7 @@ exports[`render open modal 1`] = `
                 width="24"
               >
                 <title
-                  id="bd-icon-2"
+                  id=":r1:"
                 >
                   Close
                 </title>
@@ -557,7 +557,7 @@ exports[`render open modal without backdrop 1`] = `
       tabindex="-1"
     >
       <div
-        aria-labelledby="bd-modal_header-1"
+        aria-labelledby=":r2:"
         class="c1 c2 c3"
       >
         <div
@@ -570,7 +570,7 @@ exports[`render open modal without backdrop 1`] = `
               class="c7"
             >
               <svg
-                aria-labelledby="bd-icon-2"
+                aria-labelledby=":r3:"
                 class="c8"
                 fill="currentColor"
                 height="24"
@@ -580,7 +580,7 @@ exports[`render open modal without backdrop 1`] = `
                 width="24"
               >
                 <title
-                  id="bd-icon-2"
+                  id=":r3:"
                 >
                   Close
                 </title>

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -7,13 +7,13 @@ import React, {
   RefObject,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
 } from 'react';
 import { usePopper } from 'react-popper';
 
-import { useUniqueId } from '../../hooks';
 import { typedMemo, warning } from '../../utils';
 import { Box } from '../Box';
 import { FormControlLabel } from '../Form';
@@ -50,7 +50,7 @@ export const MultiSelect = typedMemo(
     ...props
   }: MultiSelectProps<T>): ReturnType<React.FC<MultiSelectProps<T>>> => {
     const defaultRef: RefObject<HTMLInputElement> = createRef();
-    const multiSelectUniqueId = useUniqueId('multi-select');
+    const multiSelectUniqueId = useId();
 
     const [inputValue, setInputValue] = useState('');
 

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -300,9 +300,9 @@ exports[`render pagination component 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="bd-dropdown-1-label bd-dropdown-1-toggle-button"
+        aria-labelledby=":r0:-label :r0:-toggle-button"
         class="c4 c5"
-        id="bd-dropdown-1-toggle-button"
+        id=":r0:-toggle-button"
       >
         <span
           class="c6"
@@ -333,9 +333,9 @@ exports[`render pagination component 1`] = `
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <ul
-          aria-labelledby="bd-dropdown-1-label"
+          aria-labelledby=":r0:-label"
           class="c9"
-          id="bd-dropdown-1-menu"
+          id=":r0:-menu"
           role="listbox"
           tabindex="-1"
         />
@@ -353,7 +353,7 @@ exports[`render pagination component 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby="bd-icon-3"
+          aria-labelledby=":r2:"
           class="c11"
           fill="currentColor"
           height="24"
@@ -363,7 +363,7 @@ exports[`render pagination component 1`] = `
           width="24"
         >
           <title
-            id="bd-icon-3"
+            id=":r2:"
           >
             Previous page
           </title>
@@ -384,7 +384,7 @@ exports[`render pagination component 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby="bd-icon-4"
+          aria-labelledby=":r3:"
           class="c11"
           fill="currentColor"
           height="24"
@@ -394,7 +394,7 @@ exports[`render pagination component 1`] = `
           width="24"
         >
           <title
-            id="bd-icon-4"
+            id=":r3:"
           >
             Next page
           </title>
@@ -712,9 +712,9 @@ exports[`render pagination component with invalid page info 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="bd-dropdown-1-label bd-dropdown-1-toggle-button"
+        aria-labelledby=":r4:-label :r4:-toggle-button"
         class="c4 c5"
-        id="bd-dropdown-1-toggle-button"
+        id=":r4:-toggle-button"
       >
         <span
           class="c6"
@@ -745,9 +745,9 @@ exports[`render pagination component with invalid page info 1`] = `
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <ul
-          aria-labelledby="bd-dropdown-1-label"
+          aria-labelledby=":r4:-label"
           class="c9"
-          id="bd-dropdown-1-menu"
+          id=":r4:-menu"
           role="listbox"
           tabindex="-1"
         />
@@ -765,7 +765,7 @@ exports[`render pagination component with invalid page info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby="bd-icon-3"
+          aria-labelledby=":r6:"
           class="c11"
           fill="currentColor"
           height="24"
@@ -775,7 +775,7 @@ exports[`render pagination component with invalid page info 1`] = `
           width="24"
         >
           <title
-            id="bd-icon-3"
+            id=":r6:"
           >
             Previous page
           </title>
@@ -796,7 +796,7 @@ exports[`render pagination component with invalid page info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby="bd-icon-4"
+          aria-labelledby=":r7:"
           class="c11"
           fill="currentColor"
           height="24"
@@ -806,7 +806,7 @@ exports[`render pagination component with invalid page info 1`] = `
           width="24"
         >
           <title
-            id="bd-icon-4"
+            id=":r7:"
           >
             Next page
           </title>
@@ -1124,9 +1124,9 @@ exports[`render pagination component with invalid range info 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="bd-dropdown-1-label bd-dropdown-1-toggle-button"
+        aria-labelledby=":r8:-label :r8:-toggle-button"
         class="c4 c5"
-        id="bd-dropdown-1-toggle-button"
+        id=":r8:-toggle-button"
       >
         <span
           class="c6"
@@ -1157,9 +1157,9 @@ exports[`render pagination component with invalid range info 1`] = `
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <ul
-          aria-labelledby="bd-dropdown-1-label"
+          aria-labelledby=":r8:-label"
           class="c9"
-          id="bd-dropdown-1-menu"
+          id=":r8:-menu"
           role="listbox"
           tabindex="-1"
         />
@@ -1177,7 +1177,7 @@ exports[`render pagination component with invalid range info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby="bd-icon-3"
+          aria-labelledby=":ra:"
           class="c11"
           fill="currentColor"
           height="24"
@@ -1187,7 +1187,7 @@ exports[`render pagination component with invalid range info 1`] = `
           width="24"
         >
           <title
-            id="bd-icon-3"
+            id=":ra:"
           >
             Previous page
           </title>
@@ -1209,7 +1209,7 @@ exports[`render pagination component with invalid range info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby="bd-icon-4"
+          aria-labelledby=":rb:"
           class="c11"
           fill="currentColor"
           height="24"
@@ -1219,7 +1219,7 @@ exports[`render pagination component with invalid range info 1`] = `
           width="24"
         >
           <title
-            id="bd-icon-4"
+            id=":rb:"
           >
             Next page
           </title>
@@ -1537,9 +1537,9 @@ exports[`render pagination component with no items 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="bd-dropdown-1-label bd-dropdown-1-toggle-button"
+        aria-labelledby=":rc:-label :rc:-toggle-button"
         class="c4 c5"
-        id="bd-dropdown-1-toggle-button"
+        id=":rc:-toggle-button"
       >
         <span
           class="c6"
@@ -1570,9 +1570,9 @@ exports[`render pagination component with no items 1`] = `
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <ul
-          aria-labelledby="bd-dropdown-1-label"
+          aria-labelledby=":rc:-label"
           class="c9"
-          id="bd-dropdown-1-menu"
+          id=":rc:-menu"
           role="listbox"
           tabindex="-1"
         />
@@ -1590,7 +1590,7 @@ exports[`render pagination component with no items 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby="bd-icon-3"
+          aria-labelledby=":re:"
           class="c11"
           fill="currentColor"
           height="24"
@@ -1600,7 +1600,7 @@ exports[`render pagination component with no items 1`] = `
           width="24"
         >
           <title
-            id="bd-icon-3"
+            id=":re:"
           >
             Previous page
           </title>
@@ -1622,7 +1622,7 @@ exports[`render pagination component with no items 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby="bd-icon-4"
+          aria-labelledby=":rf:"
           class="c11"
           fill="currentColor"
           height="24"
@@ -1632,7 +1632,7 @@ exports[`render pagination component with no items 1`] = `
           width="24"
         >
           <title
-            id="bd-icon-4"
+            id=":rf:"
           >
             Next page
           </title>

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -315,15 +315,15 @@ exports[`dropdown is not visible if items fit 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="bd-dropdown-3-label bd-dropdown-3-toggle-button"
+        aria-labelledby=":r2:-label :r2:-toggle-button"
         class="c7 bd-button"
-        id="bd-dropdown-3-toggle-button"
+        id=":r2:-toggle-button"
       >
         <span
           class="c4"
         >
           <svg
-            aria-labelledby="bd-icon-4"
+            aria-labelledby=":r3:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -333,7 +333,7 @@ exports[`dropdown is not visible if items fit 1`] = `
             width="24"
           >
             <title
-              id="bd-icon-4"
+              id=":r3:"
             >
               add
             </title>
@@ -352,9 +352,9 @@ exports[`dropdown is not visible if items fit 1`] = `
         style="position: absolute; left: 0px; top: 0px;"
       >
         <ul
-          aria-labelledby="bd-dropdown-3-label"
+          aria-labelledby=":r2:-label"
           class="c10"
-          id="bd-dropdown-3-menu"
+          id=":r2:-menu"
           role="listbox"
           tabindex="-1"
         />
@@ -679,15 +679,15 @@ exports[`it renders the given tabs 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="bd-dropdown-1-label bd-dropdown-1-toggle-button"
+        aria-labelledby=":r0:-label :r0:-toggle-button"
         class="c7 bd-button"
-        id="bd-dropdown-1-toggle-button"
+        id=":r0:-toggle-button"
       >
         <span
           class="c4"
         >
           <svg
-            aria-labelledby="bd-icon-2"
+            aria-labelledby=":r1:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -697,7 +697,7 @@ exports[`it renders the given tabs 1`] = `
             width="24"
           >
             <title
-              id="bd-icon-2"
+              id=":r1:"
             >
               add
             </title>
@@ -716,9 +716,9 @@ exports[`it renders the given tabs 1`] = `
         style="position: absolute; left: 0px; top: 0px;"
       >
         <ul
-          aria-labelledby="bd-dropdown-1-label"
+          aria-labelledby=":r0:-label"
           class="c10"
-          id="bd-dropdown-1-menu"
+          id=":r0:-menu"
           role="listbox"
           tabindex="-1"
         />
@@ -1075,15 +1075,15 @@ exports[`only the pills that fit are visible 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="bd-dropdown-11-label bd-dropdown-11-toggle-button"
+        aria-labelledby=":r8:-label :r8:-toggle-button"
         class="c7 bd-button"
-        id="bd-dropdown-11-toggle-button"
+        id=":r8:-toggle-button"
       >
         <span
           class="c4"
         >
           <svg
-            aria-labelledby="bd-icon-12"
+            aria-labelledby=":r9:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -1093,7 +1093,7 @@ exports[`only the pills that fit are visible 1`] = `
             width="24"
           >
             <title
-              id="bd-icon-12"
+              id=":r9:"
             >
               add
             </title>
@@ -1112,9 +1112,9 @@ exports[`only the pills that fit are visible 1`] = `
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <ul
-          aria-labelledby="bd-dropdown-11-label"
+          aria-labelledby=":r8:-label"
           class="c10"
-          id="bd-dropdown-11-menu"
+          id=":r8:-menu"
           role="listbox"
           tabindex="-1"
         />
@@ -1470,15 +1470,15 @@ exports[`only the pills that fit are visible 2 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="bd-dropdown-15-label bd-dropdown-15-toggle-button"
+        aria-labelledby=":ra:-label :ra:-toggle-button"
         class="c7 bd-button"
-        id="bd-dropdown-15-toggle-button"
+        id=":ra:-toggle-button"
       >
         <span
           class="c4"
         >
           <svg
-            aria-labelledby="bd-icon-16"
+            aria-labelledby=":rb:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -1488,7 +1488,7 @@ exports[`only the pills that fit are visible 2 1`] = `
             width="24"
           >
             <title
-              id="bd-icon-16"
+              id=":rb:"
             >
               add
             </title>
@@ -1507,9 +1507,9 @@ exports[`only the pills that fit are visible 2 1`] = `
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <ul
-          aria-labelledby="bd-dropdown-15-label"
+          aria-labelledby=":ra:-label"
           class="c10"
-          id="bd-dropdown-15-menu"
+          id=":ra:-menu"
           role="listbox"
           tabindex="-1"
         />
@@ -1864,15 +1864,15 @@ exports[`renders all the filters if they fit 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="bd-dropdown-9-label bd-dropdown-9-toggle-button"
+        aria-labelledby=":r6:-label :r6:-toggle-button"
         class="c7 bd-button"
-        id="bd-dropdown-9-toggle-button"
+        id=":r6:-toggle-button"
       >
         <span
           class="c4"
         >
           <svg
-            aria-labelledby="bd-icon-10"
+            aria-labelledby=":r7:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -1882,7 +1882,7 @@ exports[`renders all the filters if they fit 1`] = `
             width="24"
           >
             <title
-              id="bd-icon-10"
+              id=":r7:"
             >
               add
             </title>
@@ -1901,9 +1901,9 @@ exports[`renders all the filters if they fit 1`] = `
         style="position: absolute; left: 0px; top: 0px;"
       >
         <ul
-          aria-labelledby="bd-dropdown-9-label"
+          aria-labelledby=":r6:-label"
           class="c10"
-          id="bd-dropdown-9-menu"
+          id=":r6:-menu"
           role="listbox"
           tabindex="-1"
         />
@@ -2245,15 +2245,15 @@ exports[`renders dropdown if items do not fit 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="bd-dropdown-5-label bd-dropdown-5-toggle-button"
+        aria-labelledby=":r4:-label :r4:-toggle-button"
         class="c7 bd-button"
-        id="bd-dropdown-5-toggle-button"
+        id=":r4:-toggle-button"
       >
         <span
           class="c5"
         >
           <svg
-            aria-labelledby="bd-icon-6"
+            aria-labelledby=":r5:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -2263,7 +2263,7 @@ exports[`renders dropdown if items do not fit 1`] = `
             width="24"
           >
             <title
-              id="bd-icon-6"
+              id=":r5:"
             >
               add
             </title>
@@ -2282,9 +2282,9 @@ exports[`renders dropdown if items do not fit 1`] = `
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <ul
-          aria-labelledby="bd-dropdown-5-label"
+          aria-labelledby=":r4:-label"
           class="c10"
-          id="bd-dropdown-5-menu"
+          id=":r4:-menu"
           role="listbox"
           tabindex="-1"
         />

--- a/packages/big-design/src/components/Popover/Popover.tsx
+++ b/packages/big-design/src/components/Popover/Popover.tsx
@@ -1,9 +1,8 @@
 import { Modifier, Obj, Placement } from '@popperjs/core';
 import { OffsetModifier } from '@popperjs/core/lib/modifiers/offset';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { usePopper } from 'react-popper';
 
-import { useUniqueId } from '../../hooks';
 import { excludeMarginProps } from '../../mixins';
 import { Box, BoxProps } from '../Box';
 
@@ -40,7 +39,7 @@ export const Popover: React.FC<PopoverProps> = ({
   role = 'dialog',
   ...props
 }) => {
-  const uniquePopoverId = useUniqueId('popover');
+  const uniquePopoverId = useId();
   const rest = excludeMarginProps(props);
 
   useEffect(() => {

--- a/packages/big-design/src/components/Radio/Radio.tsx
+++ b/packages/big-design/src/components/Radio/Radio.tsx
@@ -4,10 +4,10 @@ import React, {
   isValidElement,
   LabelHTMLAttributes,
   Ref,
+  useId,
   useMemo,
 } from 'react';
 
-import { useUniqueId } from '../../hooks';
 import { typedMemo, warning } from '../../utils';
 import { FormControlDescription, FormControlDescriptionLinkProps } from '../Form';
 
@@ -40,9 +40,9 @@ const RawRadio: React.FC<RadioProps & PrivateProps> = ({
   style,
   ...props
 }) => {
-  const uniqueRadioId = useUniqueId('radio');
+  const uniqueRadioId = useId();
+  const labelId = useId();
   const id = props.id ? props.id : uniqueRadioId;
-  const labelId = useUniqueId('radio_label');
 
   const renderedLabel = useMemo(() => {
     if (!label) {

--- a/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
@@ -103,11 +103,11 @@ exports[`render Radio (checked + disabled) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="bd-radio_label-2"
+    aria-labelledby=":r9:"
     checked=""
     class="c1 c2"
     disabled=""
-    id="bd-radio-1"
+    id=":r8:"
     name="test-group"
     type="radio"
   />
@@ -115,7 +115,7 @@ exports[`render Radio (checked + disabled) 1`] = `
     aria-hidden="true"
     class="c3 c4"
     disabled=""
-    for="bd-radio-1"
+    for=":r8:"
   />
   <div
     class="c5"
@@ -124,8 +124,8 @@ exports[`render Radio (checked + disabled) 1`] = `
       aria-hidden="true"
       class="c6 c7"
       disabled=""
-      for="bd-radio-1"
-      id="bd-radio_label-2"
+      for=":r8:"
+      id=":r9:"
     >
       Checked
     </label>
@@ -237,25 +237,25 @@ exports[`render Radio (checked) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="bd-radio_label-2"
+    aria-labelledby=":r1:"
     checked=""
     class="c1 c2"
-    id="bd-radio-1"
+    id=":r0:"
     name="test-group"
     type="radio"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
-    for="bd-radio-1"
+    for=":r0:"
   />
   <div
     class="c5"
   >
     <label
       class="c6 c7"
-      for="bd-radio-1"
-      id="bd-radio_label-2"
+      for=":r0:"
+      id=":r1:"
     >
       Checked
     </label>
@@ -402,24 +402,24 @@ exports[`render Radio (unchecked + description object) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="bd-radio_label-2"
+    aria-labelledby=":r5:"
     class="c1 c2"
-    id="bd-radio-1"
+    id=":r4:"
     name="test-group"
     type="radio"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
-    for="bd-radio-1"
+    for=":r4:"
   />
   <div
     class="c5"
   >
     <label
       class="c6 c7"
-      for="bd-radio-1"
-      id="bd-radio_label-2"
+      for=":r4:"
+      id=":r5:"
     >
       Unchecked
     </label>
@@ -554,24 +554,24 @@ exports[`render Radio (unchecked + description text) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="bd-radio_label-2"
+    aria-labelledby=":r7:"
     class="c1 c2"
-    id="bd-radio-1"
+    id=":r6:"
     name="test-group"
     type="radio"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
-    for="bd-radio-1"
+    for=":r6:"
   />
   <div
     class="c5"
   >
     <label
       class="c6 c7"
-      for="bd-radio-1"
-      id="bd-radio_label-2"
+      for=":r6:"
+      id=":r7:"
     >
       Unchecked
     </label>
@@ -683,10 +683,10 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="bd-radio_label-2"
+    aria-labelledby=":rb:"
     class="c1 c2"
     disabled=""
-    id="bd-radio-1"
+    id=":ra:"
     name="test-group"
     type="radio"
   />
@@ -694,7 +694,7 @@ exports[`render Radio (unchecked + disabled) 1`] = `
     aria-hidden="true"
     class="c3 c4"
     disabled=""
-    for="bd-radio-1"
+    for=":ra:"
   />
   <div
     class="c5"
@@ -703,8 +703,8 @@ exports[`render Radio (unchecked + disabled) 1`] = `
       aria-hidden="true"
       class="c6 c7"
       disabled=""
-      for="bd-radio-1"
-      id="bd-radio_label-2"
+      for=":ra:"
+      id=":rb:"
     >
       Unchecked
     </label>
@@ -812,24 +812,24 @@ exports[`render Radio (unchecked) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby="bd-radio_label-2"
+    aria-labelledby=":r3:"
     class="c1 c2"
-    id="bd-radio-1"
+    id=":r2:"
     name="test-group"
     type="radio"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
-    for="bd-radio-1"
+    for=":r2:"
   />
   <div
     class="c5"
   >
     <label
       class="c6 c7"
-      for="bd-radio-1"
-      id="bd-radio_label-2"
+      for=":r2:"
+      id=":r3:"
     >
       Unchecked
     </label>

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -7,13 +7,13 @@ import React, {
   RefObject,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
 } from 'react';
 import { usePopper } from 'react-popper';
 
-import { useUniqueId } from '../../hooks';
 import { typedMemo, warning } from '../../utils';
 import { Box } from '../Box';
 import { FormControlLabel } from '../Form';
@@ -49,7 +49,7 @@ export const Select = typedMemo(
     ...props
   }: SelectProps<T>): ReturnType<React.FC<SelectProps<T>>> => {
     const defaultRef: RefObject<HTMLInputElement> = createRef();
-    const selectUniqueId = useUniqueId('select');
+    const selectUniqueId = useId();
 
     const [inputValue, setInputValue] = useState<string | undefined>('');
 

--- a/packages/big-design/src/components/Switch/Switch.tsx
+++ b/packages/big-design/src/components/Switch/Switch.tsx
@@ -1,6 +1,5 @@
-import React, { forwardRef, memo, Ref } from 'react';
+import React, { forwardRef, memo, Ref, useId } from 'react';
 
-import { useUniqueId } from '../../hooks';
 import { Flex } from '../Flex';
 
 import { HiddenCheckbox, StyledSwitchLabel } from './styled';
@@ -17,7 +16,7 @@ export const RawSwitch: React.FC<SwitchProps & PrivateProps> = ({
   forwardedRef,
   ...props
 }) => {
-  const uniqueSwitchId = useUniqueId('switch');
+  const uniqueSwitchId = useId();
   const id = props.id ? props.id : uniqueSwitchId;
 
   return (

--- a/packages/big-design/src/components/Switch/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Switch/__snapshots__/spec.tsx.snap
@@ -105,13 +105,13 @@ exports[`render Switch checked 1`] = `
   <input
     checked=""
     class="c2"
-    id="bd-switch-1"
+    id=":r0:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for="bd-switch-1"
+    for=":r0:"
   />
 </div>
 `;
@@ -232,14 +232,14 @@ exports[`render Switch disabled checked 1`] = `
     checked=""
     class="c2"
     disabled=""
-    id="bd-switch-1"
+    id=":r2:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
     disabled=""
-    for="bd-switch-1"
+    for=":r2:"
   />
 </div>
 `;
@@ -362,14 +362,14 @@ exports[`render Switch disabled unchecked 1`] = `
   <input
     class="c2"
     disabled=""
-    id="bd-switch-1"
+    id=":r3:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
     disabled=""
-    for="bd-switch-1"
+    for=":r3:"
   />
 </div>
 `;
@@ -481,13 +481,13 @@ exports[`render Switch unchecked 1`] = `
 >
   <input
     class="c2"
-    id="bd-switch-1"
+    id=":r1:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for="bd-switch-1"
+    for=":r1:"
   />
 </div>
 `;

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -3,9 +3,9 @@ import {
   ArrowUpwardIcon,
   BaselineHelpIcon,
 } from '@bigcommerce/big-design-icons';
-import React, { memo, RefObject, TableHTMLAttributes } from 'react';
+import React, { memo, RefObject, TableHTMLAttributes, useId } from 'react';
 
-import { useComponentSize, useUniqueId } from '../../../hooks';
+import { useComponentSize } from '../../../hooks';
 import { typedMemo } from '../../../utils';
 import { Box } from '../../Box';
 import { Tooltip } from '../../Tooltip';
@@ -52,7 +52,7 @@ const InternalHeaderCell = <T extends TableItem>({
 }: HeaderCellProps<T>) => {
   const { align = 'left', isSortable, width, tooltip } = column;
   const actionsSize = useComponentSize(actionsRef);
-  const tooltipId = useUniqueId('table-header-tooltip');
+  const tooltipId = useId();
 
   const renderSortIcon = () => {
     if (!isSorted) {

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -1,7 +1,7 @@
-import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useId, useRef, useState } from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 
-import { useEventCallback, useUniqueId } from '../../hooks';
+import { useEventCallback } from '../../hooks';
 import { MarginProps } from '../../mixins';
 import { typedMemo } from '../../utils';
 
@@ -37,7 +37,7 @@ const InternalTable = <T extends TableItem>(
   } = props;
 
   const actionsRef = useRef<HTMLDivElement>(null);
-  const uniqueTableId = useUniqueId('table');
+  const uniqueTableId = useId();
   const tableIdRef = useRef(id || uniqueTableId);
   const isSelectable = Boolean(selectable);
   const [selectedItems, setSelectedItems] = useState<Set<T>>(new Set());

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -330,7 +330,7 @@ exports[`renders a pagination component 1`] = `
 }
 
 <div
-  aria-controls="bd-table-1"
+  aria-controls=":r12:"
   class="c0"
 >
   <div
@@ -350,9 +350,9 @@ exports[`renders a pagination component 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="bd-dropdown-2-label bd-dropdown-2-toggle-button"
+            aria-labelledby=":r13:-label :r13:-toggle-button"
             class="c7 c8"
-            id="bd-dropdown-2-toggle-button"
+            id=":r13:-toggle-button"
           >
             <span
               class="c9"
@@ -383,9 +383,9 @@ exports[`renders a pagination component 1`] = `
             style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
           >
             <ul
-              aria-labelledby="bd-dropdown-2-label"
+              aria-labelledby=":r13:-label"
               class="c12"
-              id="bd-dropdown-2-menu"
+              id=":r13:-menu"
               role="listbox"
               tabindex="-1"
             />
@@ -403,7 +403,7 @@ exports[`renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby="bd-icon-4"
+              aria-labelledby=":r15:"
               class="c14"
               fill="currentColor"
               height="24"
@@ -413,7 +413,7 @@ exports[`renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id="bd-icon-4"
+                id=":r15:"
               >
                 Previous page
               </title>
@@ -434,7 +434,7 @@ exports[`renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby="bd-icon-5"
+              aria-labelledby=":r16:"
               class="c14"
               fill="currentColor"
               height="24"
@@ -444,7 +444,7 @@ exports[`renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id="bd-icon-5"
+                id=":r16:"
               >
                 Next page
               </title>
@@ -559,7 +559,7 @@ exports[`renders a simple table 1`] = `
 
 <table
   class="c0"
-  id="bd-table-1"
+  id=":r0:"
 >
   <thead
     class=""
@@ -929,7 +929,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls="bd-table-1"
+  aria-controls=":r1i:"
   class="c0"
 >
   <div
@@ -943,15 +943,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby="bd-checkbox_label-3"
+          aria-labelledby=":r1k:"
           class="c6 c7"
-          id="bd-checkbox-2"
+          id=":r1j:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for="bd-checkbox-2"
+          for=":r1j:"
         >
           <svg
             aria-hidden="true"
@@ -977,9 +977,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c12 c13"
-            for="bd-checkbox-2"
+            for=":r1j:"
             hidden=""
-            id="bd-checkbox_label-3"
+            id=":r1k:"
           >
             Select All
           </label>

--- a/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
@@ -3,9 +3,9 @@ import {
   ArrowUpwardIcon,
   BaselineHelpIcon,
 } from '@bigcommerce/big-design-icons';
-import React, { memo, RefObject, TableHTMLAttributes } from 'react';
+import React, { memo, RefObject, TableHTMLAttributes, useId } from 'react';
 
-import { useComponentSize, useUniqueId } from '../../../hooks';
+import { useComponentSize } from '../../../hooks';
 import { typedMemo } from '../../../utils';
 import { Box } from '../../Box';
 import { Tooltip } from '../../Tooltip';
@@ -52,7 +52,7 @@ const InternalHeaderCell = <T extends TableItem>({
 }: HeaderCellProps<T>) => {
   const { align = 'left', isSortable, width, tooltip } = column;
   const actionsSize = useComponentSize(actionsRef);
-  const tooltipId = useUniqueId('table-header-tooltip');
+  const tooltipId = useId();
 
   const renderSortIcon = () => {
     if (!isSorted) {

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -1,7 +1,6 @@
-import React, { memo, useCallback, useRef, useState } from 'react';
+import React, { memo, useCallback, useId, useRef, useState } from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 
-import { useUniqueId } from '../../hooks';
 import { MarginProps } from '../../mixins';
 import { typedMemo } from '../../utils';
 
@@ -44,7 +43,7 @@ const InternalTableNext = <T extends TableItem>(
   } = props;
 
   const actionsRef = useRef<HTMLDivElement>(null);
-  const uniqueTableId = useUniqueId('table');
+  const uniqueTableId = useId();
   const tableIdRef = useRef(id || uniqueTableId);
   const [headerCellWidths, setHeaderCellWidths] = useState<Array<number | string>>([]);
   const headerCellIconRef = useRef<HTMLTableCellElement>(null);

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -330,7 +330,7 @@ exports[`pagination renders a pagination component 1`] = `
 }
 
 <div
-  aria-controls="bd-table-1"
+  aria-controls=":r12:"
   class="c0"
 >
   <div
@@ -350,9 +350,9 @@ exports[`pagination renders a pagination component 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="bd-dropdown-2-label bd-dropdown-2-toggle-button"
+            aria-labelledby=":r13:-label :r13:-toggle-button"
             class="c7 c8"
-            id="bd-dropdown-2-toggle-button"
+            id=":r13:-toggle-button"
           >
             <span
               class="c9"
@@ -383,9 +383,9 @@ exports[`pagination renders a pagination component 1`] = `
             style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
           >
             <ul
-              aria-labelledby="bd-dropdown-2-label"
+              aria-labelledby=":r13:-label"
               class="c12"
-              id="bd-dropdown-2-menu"
+              id=":r13:-menu"
               role="listbox"
               tabindex="-1"
             />
@@ -403,7 +403,7 @@ exports[`pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby="bd-icon-4"
+              aria-labelledby=":r15:"
               class="c14"
               fill="currentColor"
               height="24"
@@ -413,7 +413,7 @@ exports[`pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id="bd-icon-4"
+                id=":r15:"
               >
                 Previous page
               </title>
@@ -434,7 +434,7 @@ exports[`pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby="bd-icon-5"
+              aria-labelledby=":r16:"
               class="c14"
               fill="currentColor"
               height="24"
@@ -444,7 +444,7 @@ exports[`pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id="bd-icon-5"
+                id=":r16:"
               >
                 Next page
               </title>
@@ -559,7 +559,7 @@ exports[`renders a simple table 1`] = `
 
 <table
   class="c0"
-  id="bd-table-1"
+  id=":r0:"
 >
   <thead
     class=""
@@ -989,7 +989,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls="bd-table-1"
+  aria-controls=":r6b:"
   class="c0"
 >
   <div
@@ -1003,15 +1003,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby="bd-checkbox_label-3"
+          aria-labelledby=":r6d:"
           class="c6 c7"
-          id="bd-checkbox-2"
+          id=":r6c:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for="bd-checkbox-2"
+          for=":r6c:"
         >
           <svg
             aria-hidden="true"
@@ -1037,9 +1037,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c12 c13"
-            for="bd-checkbox-2"
+            for=":r6c:"
             hidden=""
-            id="bd-checkbox_label-3"
+            id=":r6d:"
           >
             Select All
           </label>
@@ -1283,7 +1283,7 @@ exports[`selectable renders selectable actions, checkboxes when having parent ro
 }
 
 <div
-  aria-controls="bd-table-1"
+  aria-controls=":r71:"
   class="c0"
 >
   <div
@@ -1297,15 +1297,15 @@ exports[`selectable renders selectable actions, checkboxes when having parent ro
       >
         <input
           aria-checked="false"
-          aria-labelledby="bd-checkbox_label-3"
+          aria-labelledby=":r73:"
           class="c6 c7"
-          id="bd-checkbox-2"
+          id=":r72:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for="bd-checkbox-2"
+          for=":r72:"
         >
           <svg
             aria-hidden="true"
@@ -1331,9 +1331,9 @@ exports[`selectable renders selectable actions, checkboxes when having parent ro
         >
           <label
             class="c12 c13"
-            for="bd-checkbox-2"
+            for=":r72:"
             hidden=""
-            id="bd-checkbox_label-3"
+            id=":r73:"
           >
             Select All
           </label>

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -4,10 +4,10 @@ import React, {
   isValidElement,
   LabelHTMLAttributes,
   Ref,
+  useId,
   useMemo,
 } from 'react';
 
-import { useUniqueId } from '../../hooks';
 import { typedMemo, warning } from '../../utils';
 import { FormControlDescription, FormControlLabel } from '../Form';
 import { useInputErrors } from '../Form/useInputErrors';
@@ -39,7 +39,7 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
   resize = true,
   ...props
 }) => {
-  const uniqueTextareaId = useUniqueId('textarea');
+  const uniqueTextareaId = useId();
   const id = props.id ? props.id : uniqueTextareaId;
   const { errors } = useInputErrors(id, error);
   const MAX_ROWS = 7;

--- a/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
@@ -105,7 +105,7 @@ exports[`renders all together 1`] = `
 <div>
   <label
     class="c0 c1"
-    for="bd-textarea-1"
+    for=":rp:"
   >
     This is a label
   </label>
@@ -119,7 +119,7 @@ exports[`renders all together 1`] = `
   >
     <textarea
       class="c4"
-      id="bd-textarea-1"
+      id=":rp:"
       rows="3"
     />
   </span>

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -71,16 +71,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby="bd-checkbox_label-2"
+                aria-labelledby=":r1:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id="bd-checkbox-1"
+                id=":r0:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for="bd-checkbox-1"
+                for=":r0:"
               >
                 <svg
                   aria-hidden="true"
@@ -107,9 +107,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for="bd-checkbox-1"
+                  for=":r0:"
                   hidden=""
-                  id="bd-checkbox_label-2"
+                  id=":r1:"
                 >
                   Checked
                 </label>
@@ -201,16 +201,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby="bd-checkbox_label-5"
+                aria-labelledby=":r4:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id="bd-checkbox-4"
+                id=":r3:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for="bd-checkbox-4"
+                for=":r3:"
               >
                 <svg
                   aria-hidden="true"
@@ -237,9 +237,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for="bd-checkbox-4"
+                  for=":r3:"
                   hidden=""
-                  id="bd-checkbox_label-5"
+                  id=":r4:"
                 >
                   Checked
                 </label>
@@ -331,15 +331,15 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="false"
-                aria-labelledby="bd-checkbox_label-8"
+                aria-labelledby=":r7:"
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id="bd-checkbox-7"
+                id=":r6:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 eeOlTF"
-                for="bd-checkbox-7"
+                for=":r6:"
               >
                 <svg
                   aria-hidden="true"
@@ -366,9 +366,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for="bd-checkbox-7"
+                  for=":r6:"
                   hidden=""
-                  id="bd-checkbox_label-8"
+                  id=":r7:"
                 >
                   Unchecked
                 </label>
@@ -458,16 +458,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby="bd-checkbox_label-11"
+                aria-labelledby=":ra:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id="bd-checkbox-10"
+                id=":r9:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for="bd-checkbox-10"
+                for=":r9:"
               >
                 <svg
                   aria-hidden="true"
@@ -494,9 +494,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for="bd-checkbox-10"
+                  for=":r9:"
                   hidden=""
-                  id="bd-checkbox_label-11"
+                  id=":ra:"
                 >
                   Checked
                 </label>
@@ -585,15 +585,15 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxContainer-sc-s1u0st-1 BPzxd"
             >
               <input
-                aria-labelledby="bd-checkbox_label-14"
+                aria-labelledby=":rd:"
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id="bd-checkbox-13"
+                id=":rc:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 eeOlTF"
-                for="bd-checkbox-13"
+                for=":rc:"
               >
                 <svg
                   aria-hidden="true"
@@ -620,9 +620,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for="bd-checkbox-13"
+                  for=":rc:"
                   hidden=""
-                  id="bd-checkbox_label-14"
+                  id=":rd:"
                 >
                   Unchecked
                 </label>
@@ -708,16 +708,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby="bd-checkbox_label-17"
+                aria-labelledby=":rg:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id="bd-checkbox-16"
+                id=":rf:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for="bd-checkbox-16"
+                for=":rf:"
               >
                 <svg
                   aria-hidden="true"
@@ -744,9 +744,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for="bd-checkbox-16"
+                  for=":rf:"
                   hidden=""
-                  id="bd-checkbox_label-17"
+                  id=":rg:"
                 >
                   Checked
                 </label>
@@ -838,15 +838,15 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="false"
-                aria-labelledby="bd-checkbox_label-20"
+                aria-labelledby=":rj:"
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id="bd-checkbox-19"
+                id=":ri:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 eeOlTF"
-                for="bd-checkbox-19"
+                for=":ri:"
               >
                 <svg
                   aria-hidden="true"
@@ -873,9 +873,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for="bd-checkbox-19"
+                  for=":ri:"
                   hidden=""
-                  id="bd-checkbox_label-20"
+                  id=":rj:"
                 >
                   Unchecked
                 </label>
@@ -967,16 +967,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby="bd-checkbox_label-23"
+                aria-labelledby=":rm:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id="bd-checkbox-22"
+                id=":rl:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for="bd-checkbox-22"
+                for=":rl:"
               >
                 <svg
                   aria-hidden="true"
@@ -1003,9 +1003,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for="bd-checkbox-22"
+                  for=":rl:"
                   hidden=""
-                  id="bd-checkbox_label-23"
+                  id=":rm:"
                 >
                   Checked
                 </label>
@@ -1097,16 +1097,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby="bd-checkbox_label-26"
+                aria-labelledby=":rp:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id="bd-checkbox-25"
+                id=":ro:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for="bd-checkbox-25"
+                for=":ro:"
               >
                 <svg
                   aria-hidden="true"
@@ -1133,9 +1133,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for="bd-checkbox-25"
+                  for=":ro:"
                   hidden=""
-                  id="bd-checkbox_label-26"
+                  id=":rp:"
                 >
                   Checked
                 </label>

--- a/packages/big-design/src/hooks/index.ts
+++ b/packages/big-design/src/hooks/index.ts
@@ -3,6 +3,5 @@ export * from './useDidUpdate';
 export * from './useEventCallback';
 export * from './useIsomorphicLayoutEffect';
 export * from './useRafState';
-export * from './useUniqueId';
 export * from './useWindowResizeListener';
 export * from './useWindowSize';

--- a/packages/big-design/src/hooks/useUniqueId.ts
+++ b/packages/big-design/src/hooks/useUniqueId.ts
@@ -1,7 +1,0 @@
-import { useUID } from 'react-uid';
-
-export function useUniqueId(prefix: string) {
-  const uid = useUID();
-
-  return `bd-${prefix}-${uid}`;
-}

--- a/packages/big-design/tests/utils.tsx
+++ b/packages/big-design/tests/utils.tsx
@@ -1,13 +1,8 @@
 import { render, RenderOptions } from '@testing-library/react';
 import React from 'react';
-import { UIDReset } from 'react-uid';
-
-const BigDesignWrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  return <UIDReset>{children}</UIDReset>;
-};
 
 const customRender = (ui: React.ReactElement<unknown>, options: RenderOptions = {}) =>
-  render(ui, { wrapper: BigDesignWrapper, ...options });
+  render(ui, options);
 
 // re-export everything
 // eslint-disable-next-line import/export

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -32,7 +32,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-live": "^3.1.1",
-    "react-uid": "^2.3.1",
     "styled-components": "^5.3.5"
   },
   "devDependencies": {

--- a/packages/docs/pages/_app.tsx
+++ b/packages/docs/pages/_app.tsx
@@ -10,7 +10,6 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import Script from 'next/script';
 import React, { useEffect } from 'react';
-import { UIDFork, UIDReset } from 'react-uid';
 import { ThemeProvider } from 'styled-components';
 
 import { BetaRibbon, SideNav, StoryWrapper } from '../components';
@@ -90,44 +89,40 @@ const App = ({ Component, pageProps }) => {
           />
         </>
       )}
-      <UIDReset>
-        <UIDFork>
-          <ThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
+        <>
+          <GlobalStyles />
+          <AlertsManager manager={alertsManager} />
+          {router.query.noNav ? (
+            <Component {...pageProps} />
+          ) : (
             <>
-              <GlobalStyles />
-              <AlertsManager manager={alertsManager} />
-              {router.query.noNav ? (
-                <Component {...pageProps} />
-              ) : (
-                <>
-                  <Grid
-                    backgroundColor="secondary10"
-                    gridGap="0"
-                    gridTemplate={gridTemplate}
-                    style={{ minHeight: '100%' }}
-                  >
-                    <GridItem gridArea="nav" paddingTop="medium">
-                      <SideNav />
-                    </GridItem>
-                    <GridItem
-                      gridArea="main"
-                      marginHorizontal={{ mobile: 'small', tablet: 'xxLarge' }}
-                      marginVertical="medium"
-                      paddingTop="large"
-                      style={{ maxWidth: '100%' }}
-                    >
-                      <StoryWrapper>
-                        <Component {...pageProps} />
-                      </StoryWrapper>
-                    </GridItem>
-                  </Grid>
-                  <BetaRibbon />
-                </>
-              )}
+              <Grid
+                backgroundColor="secondary10"
+                gridGap="0"
+                gridTemplate={gridTemplate}
+                style={{ minHeight: '100%' }}
+              >
+                <GridItem gridArea="nav" paddingTop="medium">
+                  <SideNav />
+                </GridItem>
+                <GridItem
+                  gridArea="main"
+                  marginHorizontal={{ mobile: 'small', tablet: 'xxLarge' }}
+                  marginVertical="medium"
+                  paddingTop="large"
+                  style={{ maxWidth: '100%' }}
+                >
+                  <StoryWrapper>
+                    <Component {...pageProps} />
+                  </StoryWrapper>
+                </GridItem>
+              </Grid>
+              <BetaRibbon />
             </>
-          </ThemeProvider>
-        </UIDFork>
-      </UIDReset>
+          )}
+        </>
+      </ThemeProvider>
     </>
   );
 };

--- a/packages/docs/pages/icons.tsx
+++ b/packages/docs/pages/icons.tsx
@@ -30,19 +30,14 @@ import React, { Fragment, useEffect, useState } from 'react';
 import { Code, CodePreview, CodeSnippet, ContentRoutingTabs, List, NextLink } from '../components';
 import { FlagIconPropTable, IconPropTable } from '../PropTables';
 
-type BigDesignIcons = Omit<
-  typeof import('@bigcommerce/big-design-icons'),
-  'createStyledIcon' | 'useUniqueId'
->;
+type BigDesignIcons = Omit<typeof import('@bigcommerce/big-design-icons'), 'createStyledIcon'>;
 
 const IconsPage = () => {
   const [icons, setIcons] = useState<BigDesignIcons | Record<string, unknown>>({});
 
   useEffect(() => {
     const fetchIcons = async () => {
-      const { createStyledIcon, useUniqueId, ...iconsModule } = await import(
-        '@bigcommerce/big-design-icons'
-      );
+      const { createStyledIcon, ...iconsModule } = await import('@bigcommerce/big-design-icons');
 
       setIcons(iconsModule);
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8688,13 +8688,6 @@ react-test-renderer@^18.2.0:
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.0"
 
-react-uid@^2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.2.tgz#09107543bb3184b53ca70275adb919217b94974d"
-  integrity sha512-oeaoT4YOjsqHdrEJoO8SONNNBsoGh7AJPbsNqRK6Dv8UMdctWxA4ncj9gAA/Odki5g0GZaDSR7HydBJ8HxwgNg==
-  dependencies:
-    tslib "^2.0.0"
-
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -9693,7 +9686,7 @@ tslib@^1.10.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
+tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
## What?

Converts BigDesign to be `react@18` only.

ℹ️ Reviewing by commit will be helpful!

BREAKING CHANGE:
Requires `react@18` or higher.

## Why?
So we can get the benefits of SSR react using the new `useId` hooks.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

- Flipped on strict mode to test if there were some concurrency issues, but didn't look like it. Had to flip back off because `react-beautiful-dnd` doesn't work with strict mode.
- Manual tested some components
- Updated snapshots
