### PR TITLE
fix(component): fix table-next column alignment

### DIFF
--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -18,8 +18,8 @@ interface PrivateProps {
 }
 
 const ALIGN_MAP: Record<string, FlexedProps['justifyContent']> = {
-  right: 'flex-start',
-  left: 'flex-end',
+  left: 'flex-start',
+  right: 'flex-end',
   center: 'center',
 };
 

--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -5,6 +5,7 @@ import { typedMemo } from '../../../utils';
 import { MessagingButton } from '../../Button/private';
 import { Checkbox } from '../../Checkbox';
 import { Flex } from '../../Flex';
+import { FlexedProps } from '../../Flex/types';
 import { DataCell } from '../DataCell';
 import { OnItemSelectFn } from '../hooks';
 import { TableColumn, TableItem, TableSelectable } from '../types';
@@ -15,6 +16,12 @@ import { useRowState } from './useRowState';
 interface PrivateProps {
   forwardedRef?: React.Ref<HTMLTableRowElement>;
 }
+
+const ALIGN_MAP: Record<string, FlexedProps['justifyContent']> = {
+  right: 'flex-start',
+  left: 'flex-end',
+  center: 'center',
+};
 
 export interface RowProps<T> extends TableHTMLAttributes<HTMLTableRowElement> {
   childrenRows?: T[];
@@ -154,7 +161,11 @@ const InternalRow = <T extends TableItem>({
               verticalAlign={verticalAlign}
               width={isDragging ? cellWidth : width}
             >
-              <Flex alignItems="center" flexDirection="row">
+              <Flex
+                alignItems="center"
+                flexDirection="row"
+                justifyContent={align && ALIGN_MAP[align]}
+              >
                 {/* @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544 */}
                 <CellContent {...item} />
               </Flex>


### PR DESCRIPTION
## What?
Fix horizontal alignment for columns by adding missing props to the flex component.

## Screenshots/Screen Recordings

**Note:** both examples have `align === right` for the `stock` column.

**Before fix:**
<img width="1144" alt="Screenshot 2022-12-01 at 16 28 50" src="https://user-images.githubusercontent.com/9980803/205079502-9e3b4b90-d04a-47e6-99b8-1f305e882cdc.png">

**After fix:**
<img width="1116" alt="Screenshot 2022-12-01 at 16 29 39" src="https://user-images.githubusercontent.com/9980803/205079567-dbeed8f3-bbd9-4d68-82c7-307266773fcb.png">


## Testing/Proof
Locally.
