### PR TITLE
fix(component): combobox can have an accessible name when no label is provided to MultiSelect

### DIFF
--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -257,6 +257,15 @@ export const MultiSelect = typedMemo(
       stateReducer: handleStateReducer,
     });
 
+    let comboboxProps = getComboboxProps();
+
+    if (!label && props['aria-label']) {
+      comboboxProps = {
+        ...comboboxProps,
+        'aria-label': props['aria-label'],
+      };
+    }
+
     // Popper
     const referenceRef = useRef(null);
     const popperRef = useRef(null);
@@ -425,7 +434,7 @@ export const MultiSelect = typedMemo(
     return (
       <div>
         {renderLabel}
-        <div {...getComboboxProps()}>{renderInput}</div>
+        <div {...comboboxProps}>{renderInput}</div>
         <Box ref={popperRef} style={styles.popper} {...attributes.poppper} zIndex="popover">
           <List
             action={action}

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -1,6 +1,6 @@
 import { ArrowBackIcon, ArrowForwardIcon, DeleteIcon } from '@bigcommerce/big-design-icons';
 import { remCalc } from '@bigcommerce/big-design-theme';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'jest-styled-components';
 import React, { createRef } from 'react';
@@ -57,6 +57,19 @@ const MultiSelectMock = (
     data-testid="multi-select"
     error="Required"
     label="Countries"
+    onClose={onClose}
+    onOpen={onOpen}
+    onOptionsChange={onChange}
+    options={mockOptions}
+    placeholder="Choose country"
+    required
+    value={['us', 'mx']}
+  />
+);
+
+const VisuallyHiddenLabelMultiSelectMock = (
+  <MultiSelect
+    aria-label="Countries"
     onClose={onClose}
     onOpen={onOpen}
     onOptionsChange={onChange}
@@ -1023,4 +1036,16 @@ test('select action should supports description', async () => {
   await userEvent.click(input);
 
   expect(await screen.findByText('Action Description')).toBeInTheDocument();
+});
+
+test('combobox and input can have accessible names without a visible label', async () => {
+  render(VisuallyHiddenLabelMultiSelectMock);
+
+  const combobox = await screen.findByRole('combobox', { name: 'Countries' });
+
+  expect(combobox).toBeInTheDocument();
+
+  const input = await within(combobox).findByRole('textbox', { name: 'Countries' });
+
+  expect(input).toBeInTheDocument();
 });


### PR DESCRIPTION
## What?

The aria-label prop is used by both the `input` and descendent `combobox` elements when the label prop is missing. Currently only the `input` has aria props passed to it.

## Why?

In the promotions editor we have a MultiSelect without a label. The purpose of the dropdown is already clear from the surrounding context.
![image](https://user-images.githubusercontent.com/109577044/207506264-a9127650-5196-4f00-ab86-4c6b9300e75e.png)
But currently there is no way to give the `combobox` an accessible name for screen readers etc.
![image](https://user-images.githubusercontent.com/109577044/207506757-60406796-ba7f-4832-afcd-7d5e4ed17f30.png)


## Screenshots/Screen Recordings
![image](https://user-images.githubusercontent.com/109577044/207507045-a80d3d59-da38-47a4-8b2c-0bb574937547.png)


## Testing/Proof

Added jest test for accessing combobox via role and name.
Confirm browser compatibility on doc screenshot shared above.