### PR TITLE
feat(deps): update downshift and apply a11y patterns

### DIFF
--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -38,7 +38,7 @@
     "@popperjs/core": "^2.11.6",
     "@types/react-datepicker": "^4.4.2",
     "date-fns": "2.29.3",
-    "downshift": "6.1.12",
+    "downshift": "7.0.4",
     "focus-trap": "^7.0.0",
     "polished": "^4.0.0",
     "react-beautiful-dnd": "^13.1.1",

--- a/packages/big-design/src/components/Box/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Box/__snapshots__/spec.tsx.snap
@@ -36,6 +36,7 @@ exports[`has individual border props 1`] = `
   box-sizing: border-box;
   border-right: 1px solid #D9DCE9;
   border-bottom: 1px solid #D9DCE9;
+  border-left: 1px solid #D9DCE9;
 }
 
 <div

--- a/packages/big-design/src/components/Box/spec.tsx
+++ b/packages/big-design/src/components/Box/spec.tsx
@@ -55,7 +55,7 @@ test('has border props', () => {
 
 test('has individual border props', () => {
   render(
-    <Box borderBottom="box" borderRight="box">
+    <Box borderBottom="box" borderLeft="box" borderRight="box">
       test
     </Box>,
   );

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -1,5 +1,6 @@
 import { CheckCircleIcon } from '@bigcommerce/big-design-icons';
 import { remCalc } from '@bigcommerce/big-design-theme';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import 'jest-styled-components';
 
@@ -109,7 +110,7 @@ test('dropdown toggle has aria-haspopup', () => {
 
   const toggle = screen.getByRole('button');
 
-  expect(toggle.getAttribute('aria-haspopup')).toBe('listbox');
+  expect(toggle).toHaveAttribute('aria-haspopup', 'menu');
 });
 
 test('dropdown toggle has aria-expanded when dropdown menu is open', async () => {
@@ -117,17 +118,15 @@ test('dropdown toggle has aria-expanded when dropdown menu is open', async () =>
 
   const toggle = screen.getByRole('button');
 
-  await act(async () => {
-    await fireEvent.click(toggle);
-  });
+  await userEvent.click(toggle);
 
-  expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  expect(toggle).toHaveAttribute('aria-expanded', 'true');
 });
 
 test('renders the dropdown menu closed', async () => {
   render(DropdownMock);
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
 
   expect(list).toBeEmptyDOMElement();
 });
@@ -139,13 +138,11 @@ test('opens/closes dropdown menu when toggle is clicked', async () => {
 
   fireEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
 
   expect(list).not.toBeEmptyDOMElement();
 
-  fireEvent.click(toggle);
-
-  await screen.findByRole('listbox');
+  await userEvent.click(toggle);
 
   expect(list).toBeEmptyDOMElement();
 });
@@ -155,12 +152,11 @@ test('dropdown menu has aria-activedescendant', async () => {
 
   const toggle = screen.getByRole('button');
 
-  fireEvent.click(toggle);
+  await userEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
   const options = screen.getAllByRole('option');
 
-  expect(list.getAttribute('aria-activedescendant')).toBe(options[0].id);
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[0].id);
 });
 
 test('dropdown menu should have 4 dropdown items', async () => {
@@ -191,7 +187,7 @@ test('should accept a maxHeight prop', async () => {
 
   fireEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
 
   expect(list).toHaveStyleRule('max-height', remCalc(350));
 });
@@ -203,7 +199,7 @@ test('should default max-height to 250', async () => {
 
   fireEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
 
   expect(list).toHaveStyleRule('max-height', remCalc(250));
 });
@@ -243,7 +239,7 @@ test('first dropdown item should be selected when dropdown is opened', async () 
 
   const options = await screen.findAllByRole('option');
 
-  expect(options[0].getAttribute('aria-selected')).toBe('true');
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[0].id);
 });
 
 test('up/down arrows should change dropdown item selection', async () => {
@@ -251,22 +247,27 @@ test('up/down arrows should change dropdown item selection', async () => {
 
   const toggle = screen.getByRole('button');
 
-  fireEvent.click(toggle);
+  await userEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
   const options = screen.getAllByRole('option');
 
-  fireEvent.keyDown(list, { key: 'ArrowDown' });
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[0].id);
 
-  expect(options[1].getAttribute('aria-selected')).toBe('true');
+  await userEvent.keyboard('{ArrowDown}');
 
-  fireEvent.keyDown(list, { key: 'ArrowUp' });
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[1].id);
 
-  expect(options[0].getAttribute('aria-selected')).toBe('true');
+  await userEvent.keyboard('{ArrowUp}');
 
-  fireEvent.keyDown(list, { key: 'ArrowUp' });
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[0].id);
 
-  expect(options[3].getAttribute('aria-selected')).toBe('true');
+  await userEvent.keyboard('{ArrowUp}');
+
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[3].id);
+
+  await userEvent.keyboard('{ArrowDown}');
+
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[0].id);
 });
 
 test('esc should close menu', async () => {
@@ -274,15 +275,15 @@ test('esc should close menu', async () => {
 
   const toggle = screen.getByRole('button');
 
-  fireEvent.click(toggle);
+  await userEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
 
   expect(list).not.toBeEmptyDOMElement();
 
-  fireEvent.keyDown(list, { key: 'Escape' });
+  await userEvent.keyboard('{Escape}');
 
-  await screen.findByRole('listbox');
+  await screen.findByRole('menu');
 
   expect(list).toBeEmptyDOMElement();
 });
@@ -292,21 +293,19 @@ test('home should select first dropdown item', async () => {
 
   const toggle = screen.getByRole('button');
 
-  fireEvent.click(toggle);
+  await userEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
   const options = screen.getAllByRole('option');
 
-  fireEvent.keyDown(list, { key: 'ArrowDown' });
-  fireEvent.keyDown(list, { key: 'ArrowDown' });
-  fireEvent.keyDown(list, { key: 'ArrowDown' });
+  await userEvent.keyboard('{ArrowDown}');
+  await userEvent.keyboard('{ArrowDown}');
+  await userEvent.keyboard('{ArrowDown}');
 
-  expect(options[3].getAttribute('aria-selected')).toBe('true');
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[3].id);
 
-  fireEvent.keyDown(list, { key: 'Home' });
+  await userEvent.keyboard('{Home}');
 
-  expect(options[0].getAttribute('aria-selected')).toBe('true');
-  expect(list.getAttribute('aria-activedescendant')).toEqual(options[0].id);
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[0].id);
 });
 
 test('end should select last dropdown item', async () => {
@@ -314,17 +313,15 @@ test('end should select last dropdown item', async () => {
 
   const toggle = screen.getByRole('button');
 
-  fireEvent.click(toggle);
+  await userEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
   const options = screen.getAllByRole('option');
 
-  expect(options[0].getAttribute('aria-selected')).toBe('true');
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[0].id);
 
-  fireEvent.keyDown(list, { key: 'End' });
+  await userEvent.keyboard('{End}');
 
-  expect(options[3].getAttribute('aria-selected')).toBe('true');
-  expect(list.getAttribute('aria-activedescendant')).toEqual(options[3].id);
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[3].id);
 });
 
 test('enter should toggle onItemClick', async () => {
@@ -332,18 +329,15 @@ test('enter should toggle onItemClick', async () => {
 
   const toggle = screen.getByRole('button');
 
-  fireEvent.click(toggle);
+  await userEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
   const options = screen.getAllByRole('option');
 
-  fireEvent.keyDown(list, { key: 'ArrowDown' });
+  await userEvent.keyboard('{ArrowDown}');
 
-  expect(options[1].getAttribute('aria-selected')).toBe('true');
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[1].id);
 
-  await act(async () => {
-    await fireEvent.keyDown(list, { key: 'Enter' });
-  });
+  await userEvent.keyboard('{Enter}');
 
   expect(onItemClick).toHaveBeenCalledWith({ content: 'Option 2', onItemClick });
 });
@@ -353,13 +347,11 @@ test('clicking on dropdown items should toggle onItemClick', async () => {
 
   const toggle = screen.getByRole('button');
 
-  fireEvent.click(toggle);
+  await userEvent.click(toggle);
 
   const options = await screen.findAllByRole('option');
 
-  await act(async () => {
-    await fireEvent.click(options[1]);
-  });
+  await userEvent.click(options[1]);
 
   expect(onItemClick).toHaveBeenCalledWith({ content: 'Option 2', onItemClick });
 });
@@ -369,13 +361,13 @@ test('dropdown items should be highlighted when moused over', async () => {
 
   const toggle = screen.getByRole('button');
 
-  fireEvent.click(toggle);
+  await userEvent.click(toggle);
 
   const options = await screen.findAllByRole('option');
 
   fireEvent.mouseOver(options[0]);
 
-  expect(options[0].getAttribute('aria-selected')).toBe('true');
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[0].id);
 });
 
 test('dropdown menu renders 4 link when passed options of type link', async () => {
@@ -397,7 +389,7 @@ test('dropdown menu renders 4 link when passed options of type link', async () =
     await fireEvent.click(toggle);
   });
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
   const options = list.querySelectorAll('a');
 
   expect(options).toHaveLength(4);
@@ -414,7 +406,7 @@ test('items renders icons', async () => {
 
   fireEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
 
   const svgs = list.querySelectorAll('svg');
 
@@ -435,7 +427,7 @@ test('does not forward styles', async () => {
 
   fireEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
 
   expect(list.getElementsByClassName('test')).toHaveLength(0);
   expect(list).not.toHaveStyle('background: red');
@@ -522,7 +514,7 @@ test('no errors expected if all options are disabled', async () => {
 
   fireEvent.click(toggle);
 
-  await screen.findByRole('listbox');
+  await screen.findByRole('menu');
 
   expect(onError).not.toThrow();
 });
@@ -562,16 +554,17 @@ test('group labels are skipped over when using keyboard to navigate options', as
 
   const toggle = screen.getByRole('button');
 
-  fireEvent.click(toggle);
+  await userEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
   const options = screen.getAllByRole('option');
 
-  fireEvent.keyDown(list, { key: 'ArrowDown' });
-  fireEvent.keyDown(list, { key: 'ArrowDown' });
-  fireEvent.keyDown(list, { key: 'ArrowDown' });
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[0].id);
 
-  expect(options[3].getAttribute('aria-selected')).toBe('true');
+  await userEvent.keyboard('{ArrowDown}');
+  await userEvent.keyboard('{ArrowDown}');
+  await userEvent.keyboard('{ArrowDown}');
+
+  expect(toggle).toHaveAttribute('aria-activedescendant', options[3].id);
 });
 
 test('clicking label does not call onItemClick', async () => {
@@ -611,7 +604,7 @@ test('renders appropriate amount of list items', async () => {
 
   fireEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
   const listItems = list.querySelectorAll('li');
 
   expect(listItems).toHaveLength(3);
@@ -624,7 +617,7 @@ test('rendered line separators have correct accessibility properties', async () 
 
   fireEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
   const hrListItems = list.querySelectorAll('hr');
 
   expect(
@@ -642,7 +635,7 @@ test('rendered line separators cannot be focused on', async () => {
 
   fireEvent.click(toggle);
 
-  const list = await screen.findByRole('listbox');
+  const list = await screen.findByRole('menu');
   const hrListItems = list.querySelectorAll('hr');
 
   if (hrListItems.length && hrListItems[0].parentElement) {

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -54,6 +54,17 @@ export const MultiSelect = typedMemo(
 
     const [inputValue, setInputValue] = useState('');
 
+    // aria-labelledby takes presedence over aria-label so we need to strip it out if there is no label
+    // Downshift v7 automatically adds aria-labelledby to props even if there is no label defined
+    // This is a workaround to remove the aria-labelledby if there is no label defined
+    const ariaLabelledBy = useMemo(() => {
+      if (props['aria-label'] && !label) {
+        return { 'aria-labelledby': undefined };
+      }
+
+      return {};
+    }, [label, props]);
+
     const flattenOptions = useCallback((options: MultiSelectProps<T>['options']) => {
       const isGroups = (
         options: Array<SelectOptionGroup<T> | SelectOption<T>>,
@@ -232,7 +243,6 @@ export const MultiSelect = typedMemo(
     );
 
     const {
-      getComboboxProps,
       getInputProps,
       getItemProps,
       getLabelProps,
@@ -351,6 +361,7 @@ export const MultiSelect = typedMemo(
           <Input
             {...getInputProps({
               ...props,
+              ...ariaLabelledBy,
               autoComplete,
               disabled,
               onClick: () => {
@@ -406,6 +417,7 @@ export const MultiSelect = typedMemo(
       );
     }, [
       autoComplete,
+      ariaLabelledBy,
       disabled,
       filterable,
       getInputProps,
@@ -425,7 +437,7 @@ export const MultiSelect = typedMemo(
     return (
       <div>
         {renderLabel}
-        <div {...getComboboxProps()}>{renderInput}</div>
+        {renderInput}
         <Box ref={popperRef} style={styles.popper} {...attributes.poppper} zIndex="popover">
           <List
             action={action}
@@ -433,7 +445,7 @@ export const MultiSelect = typedMemo(
             autoWidth={autoWidth}
             filteredItems={filteredOptions}
             getItemProps={getItemProps}
-            getMenuProps={getMenuProps}
+            getMenuProps={() => getMenuProps({ ...ariaLabelledBy })}
             highlightedIndex={highlightedIndex}
             isOpen={isOpen}
             items={options}

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -227,14 +227,6 @@ test('select accepts custom id', async () => {
   expect(select.id).toBe('testId');
 });
 
-test('combobox has aria-haspopup', async () => {
-  render(MultiSelectMock);
-
-  const combobox = await screen.findByRole('combobox');
-
-  expect(combobox.getAttribute('aria-haspopup')).toBe('listbox');
-});
-
 test('select input has placeholder text', async () => {
   render(MultiSelectMock);
 
@@ -1023,4 +1015,29 @@ test('select action should supports description', async () => {
   await userEvent.click(input);
 
   expect(await screen.findByText('Action Description')).toBeInTheDocument();
+});
+
+describe('aria-labelledby', () => {
+  it('should not be set if using aria-label', async () => {
+    render(<MultiSelect aria-label="Countries" onOptionsChange={onChange} options={mockOptions} />);
+
+    const input = await screen.findByRole('combobox');
+
+    expect(input).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('should set if using label', async () => {
+    render(
+      <MultiSelect
+        label="Countries"
+        labelId="countries"
+        onOptionsChange={onChange}
+        options={mockOptions}
+      />,
+    );
+
+    const input = await screen.findByRole('combobox');
+
+    expect(input).toHaveAttribute('aria-labelledby', 'countries');
+  });
 });

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -299,11 +299,14 @@ exports[`render pagination component 1`] = `
       class="c0 c3"
     >
       <button
+        aria-activedescendant=""
+        aria-controls=":r0:-menu"
         aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby=":r0:-label :r0:-toggle-button"
+        aria-haspopup="menu"
         class="c4 c5"
         id=":r0:-toggle-button"
+        role="button"
+        tabindex="0"
         type="button"
       >
         <span
@@ -338,7 +341,7 @@ exports[`render pagination component 1`] = `
           aria-labelledby=":r0:-label"
           class="c9"
           id=":r0:-menu"
-          role="listbox"
+          role="menu"
           tabindex="-1"
         />
       </div>
@@ -715,11 +718,14 @@ exports[`render pagination component with invalid page info 1`] = `
       class="c0 c3"
     >
       <button
+        aria-activedescendant=""
+        aria-controls=":r4:-menu"
         aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby=":r4:-label :r4:-toggle-button"
+        aria-haspopup="menu"
         class="c4 c5"
         id=":r4:-toggle-button"
+        role="button"
+        tabindex="0"
         type="button"
       >
         <span
@@ -754,7 +760,7 @@ exports[`render pagination component with invalid page info 1`] = `
           aria-labelledby=":r4:-label"
           class="c9"
           id=":r4:-menu"
-          role="listbox"
+          role="menu"
           tabindex="-1"
         />
       </div>
@@ -1131,11 +1137,14 @@ exports[`render pagination component with invalid range info 1`] = `
       class="c0 c3"
     >
       <button
+        aria-activedescendant=""
+        aria-controls=":r8:-menu"
         aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby=":r8:-label :r8:-toggle-button"
+        aria-haspopup="menu"
         class="c4 c5"
         id=":r8:-toggle-button"
+        role="button"
+        tabindex="0"
         type="button"
       >
         <span
@@ -1170,7 +1179,7 @@ exports[`render pagination component with invalid range info 1`] = `
           aria-labelledby=":r8:-label"
           class="c9"
           id=":r8:-menu"
-          role="listbox"
+          role="menu"
           tabindex="-1"
         />
       </div>
@@ -1548,11 +1557,14 @@ exports[`render pagination component with no items 1`] = `
       class="c0 c3"
     >
       <button
+        aria-activedescendant=""
+        aria-controls=":rc:-menu"
         aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby=":rc:-label :rc:-toggle-button"
+        aria-haspopup="menu"
         class="c4 c5"
         id=":rc:-toggle-button"
+        role="button"
+        tabindex="0"
         type="button"
       >
         <span
@@ -1587,7 +1599,7 @@ exports[`render pagination component with no items 1`] = `
           aria-labelledby=":rc:-label"
           class="c9"
           id=":rc:-menu"
-          role="listbox"
+          role="menu"
           tabindex="-1"
         />
       </div>

--- a/packages/big-design/src/components/Pagination/spec.tsx
+++ b/packages/big-design/src/components/Pagination/spec.tsx
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import 'jest-styled-components';
@@ -102,16 +103,21 @@ test('render pagination component while overriding button labels', () => {
     />,
   );
 
-  getByRole('navigation', { name: '[Custom] Pagination' });
-  getByRole('button', { name: '[Custom label] 1-3 of 10' });
-  getByRole('button', { name: '[Custom] Previous page' });
-  getByRole('button', { name: '[Custom] Next page' });
+  const pagination = getByRole('navigation', { name: '[Custom] Pagination' });
+  const dropdown = getByRole('button', { name: '[Custom label] 1-3 of 10' });
+  const prevPage = getByRole('button', { name: '[Custom] Previous page' });
+  const nextPage = getByRole('button', { name: '[Custom] Next page' });
+
+  expect(pagination).toBeInTheDocument();
+  expect(dropdown).toBeInTheDocument();
+  expect(prevPage).toBeInTheDocument();
+  expect(nextPage).toBeInTheDocument();
 });
 
 test('trigger range change', async () => {
   const changePage = jest.fn();
   const changeRange = jest.fn();
-  const { getByText, findByText } = render(
+  const { findByText } = render(
     <Pagination
       currentPage={1}
       itemsPerPage={2}
@@ -122,11 +128,10 @@ test('trigger range change', async () => {
     />,
   );
 
-  fireEvent.click(getByText('1 - 2 of 10'));
-  fireEvent.keyDown(getByText('2'), { key: 'ArrowDown', code: 40 });
-  fireEvent.keyDown(getByText('3'), { key: 'Enter', code: 13 });
-
   const option = await findByText('1 - 2 of 10');
+
+  await userEvent.click(option);
+  await userEvent.keyboard('{ArrowDown}{Enter}');
 
   expect(changeRange).toHaveBeenCalled();
   expect(option).toBeInTheDocument();

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -314,11 +314,14 @@ exports[`dropdown is not visible if items fit 1`] = `
       class="c0 c6"
     >
       <button
+        aria-activedescendant=""
+        aria-controls=":r2:-menu"
         aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby=":r2:-label :r2:-toggle-button"
+        aria-haspopup="menu"
         class="c7 bd-button"
         id=":r2:-toggle-button"
+        role="button"
+        tabindex="0"
       >
         <span
           class="c4"
@@ -356,7 +359,7 @@ exports[`dropdown is not visible if items fit 1`] = `
           aria-labelledby=":r2:-label"
           class="c10"
           id=":r2:-menu"
-          role="listbox"
+          role="menu"
           tabindex="-1"
         />
       </div>
@@ -679,11 +682,14 @@ exports[`it renders the given tabs 1`] = `
       class="c0 c6"
     >
       <button
+        aria-activedescendant=""
+        aria-controls=":r0:-menu"
         aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby=":r0:-label :r0:-toggle-button"
+        aria-haspopup="menu"
         class="c7 bd-button"
         id=":r0:-toggle-button"
+        role="button"
+        tabindex="0"
       >
         <span
           class="c4"
@@ -721,7 +727,7 @@ exports[`it renders the given tabs 1`] = `
           aria-labelledby=":r0:-label"
           class="c10"
           id=":r0:-menu"
-          role="listbox"
+          role="menu"
           tabindex="-1"
         />
       </div>
@@ -1076,11 +1082,14 @@ exports[`only the pills that fit are visible 1`] = `
       class="c0 c6"
     >
       <button
+        aria-activedescendant=""
+        aria-controls=":r8:-menu"
         aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby=":r8:-label :r8:-toggle-button"
+        aria-haspopup="menu"
         class="c7 bd-button"
         id=":r8:-toggle-button"
+        role="button"
+        tabindex="0"
       >
         <span
           class="c4"
@@ -1118,7 +1127,7 @@ exports[`only the pills that fit are visible 1`] = `
           aria-labelledby=":r8:-label"
           class="c10"
           id=":r8:-menu"
-          role="listbox"
+          role="menu"
           tabindex="-1"
         />
       </div>
@@ -1472,11 +1481,14 @@ exports[`only the pills that fit are visible 2 1`] = `
       class="c0 c6"
     >
       <button
+        aria-activedescendant=""
+        aria-controls=":ra:-menu"
         aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby=":ra:-label :ra:-toggle-button"
+        aria-haspopup="menu"
         class="c7 bd-button"
         id=":ra:-toggle-button"
+        role="button"
+        tabindex="0"
       >
         <span
           class="c4"
@@ -1514,7 +1526,7 @@ exports[`only the pills that fit are visible 2 1`] = `
           aria-labelledby=":ra:-label"
           class="c10"
           id=":ra:-menu"
-          role="listbox"
+          role="menu"
           tabindex="-1"
         />
       </div>
@@ -1867,11 +1879,14 @@ exports[`renders all the filters if they fit 1`] = `
       class="c0 c6"
     >
       <button
+        aria-activedescendant=""
+        aria-controls=":r6:-menu"
         aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby=":r6:-label :r6:-toggle-button"
+        aria-haspopup="menu"
         class="c7 bd-button"
         id=":r6:-toggle-button"
+        role="button"
+        tabindex="0"
       >
         <span
           class="c4"
@@ -1909,7 +1924,7 @@ exports[`renders all the filters if they fit 1`] = `
           aria-labelledby=":r6:-label"
           class="c10"
           id=":r6:-menu"
-          role="listbox"
+          role="menu"
           tabindex="-1"
         />
       </div>
@@ -2249,11 +2264,14 @@ exports[`renders dropdown if items do not fit 1`] = `
       class="c0 c6"
     >
       <button
+        aria-activedescendant=""
+        aria-controls=":r4:-menu"
         aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby=":r4:-label :r4:-toggle-button"
+        aria-haspopup="menu"
         class="c7 bd-button"
         id=":r4:-toggle-button"
+        role="button"
+        tabindex="0"
       >
         <span
           class="c5"
@@ -2291,7 +2309,7 @@ exports[`renders dropdown if items do not fit 1`] = `
           aria-labelledby=":r4:-label"
           class="c10"
           id=":r4:-menu"
-          role="listbox"
+          role="menu"
           tabindex="-1"
         />
       </div>

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -53,6 +53,17 @@ export const Select = typedMemo(
 
     const [inputValue, setInputValue] = useState<string | undefined>('');
 
+    // aria-labelledby takes presedence over aria-label so we need to strip it out if there is no label
+    // Downshift v7 automatically adds aria-labelledby to props even if there is no label defined
+    // This is a workaround to remove the aria-labelledby if there is no label defined
+    const ariaLabelledBy = useMemo(() => {
+      if (props['aria-label'] && !label) {
+        return { 'aria-labelledby': undefined };
+      }
+
+      return {};
+    }, [label, props]);
+
     const flattenOptions = useCallback((options: SelectProps<T>['options']) => {
       const isGroups = (
         options: Array<SelectOptionGroup<T> | SelectOption<T>>,
@@ -170,7 +181,6 @@ export const Select = typedMemo(
 
     const {
       closeMenu,
-      getComboboxProps,
       getInputProps,
       getItemProps,
       getLabelProps,
@@ -282,6 +292,7 @@ export const Select = typedMemo(
           <Input
             {...getInputProps({
               ...props,
+              ...ariaLabelledBy,
               autoComplete,
               disabled,
               onClick: () => {
@@ -332,6 +343,7 @@ export const Select = typedMemo(
       );
     }, [
       autoComplete,
+      ariaLabelledBy,
       closeMenu,
       disabled,
       filterable,
@@ -350,14 +362,14 @@ export const Select = typedMemo(
     return (
       <div>
         {renderLabel}
-        <div {...getComboboxProps()}>{renderInput}</div>
+        {renderInput}
         <Box ref={popperRef} style={styles.popper} {...attributes.poppper} zIndex="popover">
           <List
             action={action}
             autoWidth={autoWidth}
             filteredItems={filteredOptions}
             getItemProps={getItemProps}
-            getMenuProps={getMenuProps}
+            getMenuProps={() => getMenuProps({ ...ariaLabelledBy })}
             highlightedIndex={highlightedIndex}
             isOpen={isOpen}
             items={options}

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -189,14 +189,6 @@ test('select accepts custom id', async () => {
   expect(select.id).toBe('testId');
 });
 
-test('combobox has aria-haspopup', async () => {
-  render(SelectMock);
-
-  const combobox = await screen.findByRole('combobox');
-
-  expect(combobox.getAttribute('aria-haspopup')).toBe('listbox');
-});
-
 test('select input has placeholder text', async () => {
   render(SelectMock);
 
@@ -280,17 +272,27 @@ test('esc should close menu', async () => {
 
   const input = screen.getByTestId('select');
 
-  fireEvent.click(input);
+  await userEvent.click(input);
 
   const listbox = await screen.findByRole('listbox');
 
   expect(listbox).not.toBeEmptyDOMElement();
 
-  fireEvent.keyDown(input, { key: 'Escape' });
-
-  await screen.findByRole('listbox');
+  await userEvent.keyboard('{Escape}');
 
   expect(listbox).toBeEmptyDOMElement();
+});
+
+test('select calls onFocus callback', async () => {
+  const onFocus = jest.fn();
+
+  render(<Select onFocus={onFocus} onOptionChange={onChange} options={[]} />);
+
+  const input = screen.getByRole('combobox');
+
+  await userEvent.click(input);
+
+  expect(onFocus).toHaveBeenCalled();
 });
 
 test('select has items', async () => {
@@ -949,4 +951,29 @@ test('select action should supports description', async () => {
   fireEvent.click(input);
 
   expect(await screen.findByText('Action Description')).toBeInTheDocument();
+});
+
+describe('aria-labelledby', () => {
+  it('should not be set if using aria-label', async () => {
+    render(<Select aria-label="Countries" onOptionChange={onChange} options={mockOptions} />);
+
+    const input = await screen.findByRole('combobox');
+
+    expect(input).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('should set if using label', async () => {
+    render(
+      <Select
+        label="Countries"
+        labelId="countries"
+        onOptionChange={onChange}
+        options={mockOptions}
+      />,
+    );
+
+    const input = await screen.findByRole('combobox');
+
+    expect(input).toHaveAttribute('aria-labelledby', 'countries');
+  });
 });

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -349,11 +349,14 @@ exports[`renders a pagination component 1`] = `
           class="c1 c6"
         >
           <button
+            aria-activedescendant=""
+            aria-controls=":r13:-menu"
             aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-labelledby=":r13:-label :r13:-toggle-button"
+            aria-haspopup="menu"
             class="c7 c8"
             id=":r13:-toggle-button"
+            role="button"
+            tabindex="0"
             type="button"
           >
             <span
@@ -388,7 +391,7 @@ exports[`renders a pagination component 1`] = `
               aria-labelledby=":r13:-label"
               class="c12"
               id=":r13:-menu"
-              role="listbox"
+              role="menu"
               tabindex="-1"
             />
           </div>

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -349,11 +349,14 @@ exports[`pagination renders a pagination component 1`] = `
           class="c1 c6"
         >
           <button
+            aria-activedescendant=""
+            aria-controls=":r13:-menu"
             aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-labelledby=":r13:-label :r13:-toggle-button"
+            aria-haspopup="menu"
             class="c7 c8"
             id=":r13:-toggle-button"
+            role="button"
+            tabindex="0"
             type="button"
           >
             <span
@@ -388,7 +391,7 @@ exports[`pagination renders a pagination component 1`] = `
               aria-labelledby=":r13:-label"
               class="c12"
               id=":r13:-menu"
-              role="listbox"
+              role="menu"
               tabindex="-1"
             />
           </div>

--- a/packages/big-design/src/components/Timepicker/spec.tsx
+++ b/packages/big-design/src/components/Timepicker/spec.tsx
@@ -13,7 +13,7 @@ test('should use the passed in ref object if provided', async () => {
   const ref = createRef<HTMLInputElement>();
   const { findByRole } = render(<Timepicker onTimeChange={jest.fn()} ref={ref} />);
 
-  const input = await findByRole('textbox');
+  const input = await findByRole('combobox');
 
   expect(ref.current).toEqual(input);
 });

--- a/packages/configs/jest/jest.config.js
+++ b/packages/configs/jest/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   },
   coverageDirectory: '<rootDir>/coverage',
   testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4815,10 +4815,10 @@ dotenv@~10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
-downshift@6.1.12:
-  version "6.1.12"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.1.12.tgz#f14476b41a6f6fd080c340bad1ddf449f7143f6f"
-  integrity sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==
+downshift@7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-7.0.4.tgz#1ee36db5cb6bb47b67c486ca56e31cd6d685230a"
+  integrity sha512-RUDh8vhgFQRfcjL0ovcN95sw+X6njzaNXi2LxIbvVfvxkxju8wwTl021DVeqZOUkf5sZuXg4m4n3Eaf3DoA88g==
   dependencies:
     "@babel/runtime" "^7.14.8"
     compute-scroll-into-view "^1.0.17"


### PR DESCRIPTION
## What?

Updates `downshift` to the latest major version. This also tackles some a11y improvements for the `Dropdown`, `Select`, and `MultiSelect` components.

## Why?

We want to stay current with the latest ARIA 1.2 spec which this new version of `downshift` adheres to.

## Screenshots/Screen Recordings
N/a?

## Testing/Proof

- Updated Snapshots
- Added new tests to showcase the `aria-labelledby` issue.
- Refactored existing tests to handle a11y updates.