### PR TITLE
feat(component): add header tooltip for worksheet component

### DIFF
--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -66,7 +66,6 @@ const InternalHeaderCell = <T extends TableItem>({
     );
   };
 
-  // TODO: Update this. Return early if we don't have tooltip.
   const renderTooltip = () => {
     if (typeof tooltip === 'string' && tooltip.length > 0) {
       return (

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -1,7 +1,18 @@
-import React, { createContext, createRef, useEffect, useMemo, useRef } from 'react';
+import { BaselineHelpIcon } from '@bigcommerce/big-design-icons';
+import React, {
+  createContext,
+  createRef,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+} from 'react';
 import { StoreApi } from 'zustand';
 
 import { typedMemo } from '../../utils';
+import { Box } from '../Box';
+import { Tooltip } from '../Tooltip';
 
 import { UpdateItemsProvider } from './context';
 import { BaseState, createWorksheetStore, useKeyEvents, useWorksheetStore } from './hooks';
@@ -31,6 +42,7 @@ const InternalWorksheet = typedMemo(
     const tableRef = createRef<HTMLTableElement>();
     const shouldBeTriggeredOnChange = useRef(false);
     const { store, useStore } = useWorksheetStore();
+    const tooltipId = useId();
 
     const setRows = useStore(store, (state) => state.setRows);
     const setColumns = useStore(store, (state) => state.setColumns);
@@ -89,6 +101,33 @@ const InternalWorksheet = typedMemo(
       }
     }, [invalidCells, onErrors, rows]);
 
+    const getRenderedTooltip = useCallback(
+      (tooltip?: string) => {
+        if (typeof tooltip === 'string' && tooltip.length > 0) {
+          return (
+            <Tooltip
+              id={tooltipId}
+              placement="right"
+              trigger={
+                <Box as="span" marginLeft="xxSmall">
+                  <BaselineHelpIcon
+                    aria-describedby={tooltipId}
+                    size="medium"
+                    title="Hover or focus for additional context."
+                  />
+                </Box>
+              }
+            >
+              {tooltip}
+            </Tooltip>
+          );
+        }
+
+        return null;
+      },
+      [tooltipId],
+    );
+
     const renderedHeaders = useMemo(
       () => (
         <thead>
@@ -96,13 +135,13 @@ const InternalWorksheet = typedMemo(
             <Status />
             {expandedColumns.map((column, index) => (
               <Header columnType={column.type} columnWidth={column.width || 'auto'} key={index}>
-                {column.header}
+                {column.header} {getRenderedTooltip(column.tooltip)}
               </Header>
             ))}
           </tr>
         </thead>
       ),
-      [expandedColumns],
+      [expandedColumns, getRenderedTooltip],
     );
 
     const tableHasStaticWidth = useMemo(

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -17,26 +17,59 @@ exports[`renders worksheet 1`] = `
           class="styled__Header-sc-16rzzpq-1 kXfxBV"
         >
           Product name
+           
         </th>
         <th
           class="styled__Header-sc-16rzzpq-1 LXhSu"
         >
           Visible on storefront
+           
         </th>
         <th
           class="styled__Header-sc-16rzzpq-1 kXfxBV"
         >
           Other field
+           
         </th>
         <th
           class="styled__Header-sc-16rzzpq-1 kXfxBV"
         >
           Other field
+           
         </th>
         <th
           class="styled__Header-sc-16rzzpq-1 exSgRY"
         >
           Number field
+           
+          <span
+            class="styled__StyledBox-sc-sj5f1m-0 ZcIoi"
+          >
+            <svg
+              aria-describedby=":r0:"
+              aria-labelledby=":r1:"
+              class="base__StyledIcon-sc-a9u0e1-0 keWbN"
+              fill="currentColor"
+              height="24"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <title
+                id=":r1:"
+              >
+                Hover or focus for additional context.
+              </title>
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+              />
+            </svg>
+          </span>
         </th>
       </tr>
     </thead>
@@ -71,16 +104,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r1:"
+                aria-labelledby=":r3:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id=":r0:"
+                id=":r2:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for=":r0:"
+                for=":r2:"
               >
                 <svg
                   aria-hidden="true"
@@ -107,9 +140,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for=":r0:"
+                  for=":r2:"
                   hidden=""
-                  id=":r1:"
+                  id=":r3:"
                 >
                   Checked
                 </label>
@@ -201,16 +234,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r4:"
+                aria-labelledby=":r6:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id=":r3:"
+                id=":r5:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for=":r3:"
+                for=":r5:"
               >
                 <svg
                   aria-hidden="true"
@@ -237,9 +270,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for=":r3:"
+                  for=":r5:"
                   hidden=""
-                  id=":r4:"
+                  id=":r6:"
                 >
                   Checked
                 </label>
@@ -331,15 +364,15 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="false"
-                aria-labelledby=":r7:"
+                aria-labelledby=":r9:"
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id=":r6:"
+                id=":r8:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 eeOlTF"
-                for=":r6:"
+                for=":r8:"
               >
                 <svg
                   aria-hidden="true"
@@ -366,9 +399,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for=":r6:"
+                  for=":r8:"
                   hidden=""
-                  id=":r7:"
+                  id=":r9:"
                 >
                   Unchecked
                 </label>
@@ -458,16 +491,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":ra:"
+                aria-labelledby=":rc:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id=":r9:"
+                id=":rb:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for=":r9:"
+                for=":rb:"
               >
                 <svg
                   aria-hidden="true"
@@ -494,9 +527,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for=":r9:"
+                  for=":rb:"
                   hidden=""
-                  id=":ra:"
+                  id=":rc:"
                 >
                   Checked
                 </label>
@@ -585,15 +618,15 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxContainer-sc-s1u0st-1 BPzxd"
             >
               <input
-                aria-labelledby=":rd:"
+                aria-labelledby=":rf:"
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id=":rc:"
+                id=":re:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 eeOlTF"
-                for=":rc:"
+                for=":re:"
               >
                 <svg
                   aria-hidden="true"
@@ -620,9 +653,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for=":rc:"
+                  for=":re:"
                   hidden=""
-                  id=":rd:"
+                  id=":rf:"
                 >
                   Unchecked
                 </label>
@@ -708,16 +741,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":rg:"
+                aria-labelledby=":ri:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id=":rf:"
+                id=":rh:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for=":rf:"
+                for=":rh:"
               >
                 <svg
                   aria-hidden="true"
@@ -744,9 +777,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for=":rf:"
+                  for=":rh:"
                   hidden=""
-                  id=":rg:"
+                  id=":ri:"
                 >
                   Checked
                 </label>
@@ -838,15 +871,15 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="false"
-                aria-labelledby=":rj:"
+                aria-labelledby=":rl:"
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id=":ri:"
+                id=":rk:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 eeOlTF"
-                for=":ri:"
+                for=":rk:"
               >
                 <svg
                   aria-hidden="true"
@@ -873,9 +906,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for=":ri:"
+                  for=":rk:"
                   hidden=""
-                  id=":rj:"
+                  id=":rl:"
                 >
                   Unchecked
                 </label>
@@ -967,16 +1000,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":rm:"
+                aria-labelledby=":ro:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id=":rl:"
+                id=":rn:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for=":rl:"
+                for=":rn:"
               >
                 <svg
                   aria-hidden="true"
@@ -1003,9 +1036,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for=":rl:"
+                  for=":rn:"
                   hidden=""
-                  id=":rm:"
+                  id=":ro:"
                 >
                   Checked
                 </label>
@@ -1097,16 +1130,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":rp:"
+                aria-labelledby=":rr:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
-                id=":ro:"
+                id=":rq:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 bgzSTq"
-                for=":ro:"
+                for=":rq:"
               >
                 <svg
                   aria-hidden="true"
@@ -1133,9 +1166,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz foLSRl"
-                  for=":ro:"
+                  for=":rq:"
                   hidden=""
-                  id=":rp:"
+                  id=":rr:"
                 >
                   Checked
                 </label>

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -81,6 +81,7 @@ const columns: Array<WorksheetColumn<Product>> = [
   {
     hash: 'numberField',
     header: 'Number field',
+    tooltip: 'Info about number field',
     type: 'number',
     validation: (value: number) => value >= 50,
     formatting: (value: number) => `$${value}.00`,
@@ -1221,5 +1222,27 @@ describe('column widths', () => {
     expect(productNameColumn).toHaveStyle('width: auto');
     expect(visibleOnStorefrontColumn).toHaveStyle('width: 80px');
     expect(numberFieldColumn).toHaveStyle('width: 90px');
+  });
+});
+
+describe('Header tooltip', () => {
+  test('renders column with tooltip icon', () => {
+    const { getByTitle } = render(
+      <Worksheet columns={columns} items={items} onChange={handleChange} />,
+    );
+
+    expect(getByTitle('Hover or focus for additional context.')).toBeTruthy();
+  });
+
+  test('renders tooltip when hovering on icon', async () => {
+    const { getByTitle } = render(
+      <Worksheet columns={columns} items={items} onChange={handleChange} />,
+    );
+
+    await userEvent.hover(getByTitle('Hover or focus for additional context.'));
+
+    const result = screen.getByText('Info about number field');
+
+    expect(result).toBeInTheDocument();
   });
 });

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -44,6 +44,7 @@ interface WorksheetBaseColumn<Item> {
   hash: keyof Item;
   header: string;
   width?: string | number;
+  tooltip?: string;
   validation?(value: Item[keyof Item] | ''): boolean;
 }
 

--- a/packages/docs/PropTables/WorksheetPropTable.tsx
+++ b/packages/docs/PropTables/WorksheetPropTable.tsx
@@ -141,6 +141,11 @@ const worksheetTextColumnProps: Prop[] = [
     types: ['string', 'number'],
     description: 'Sets column width.',
   },
+  {
+    name: 'tooltip',
+    types: 'string',
+    description: 'Tooltip for the worksheet column header.',
+  },
 ];
 
 const worksheetNumberColumnProps: Prop[] = [
@@ -183,6 +188,11 @@ const worksheetNumberColumnProps: Prop[] = [
     types: ['string', 'number'],
     description: 'Sets column width.',
   },
+  {
+    name: 'tooltip',
+    types: 'string',
+    description: 'Tooltip for the worksheet column header.',
+  },
 ];
 
 const worksheetCheckboxColumnProps: Prop[] = [
@@ -219,6 +229,11 @@ const worksheetCheckboxColumnProps: Prop[] = [
     name: 'width',
     types: ['string', 'number'],
     description: 'Sets column width.',
+  },
+  {
+    name: 'tooltip',
+    types: 'string',
+    description: 'Tooltip for the worksheet column header.',
   },
 ];
 
@@ -284,6 +299,11 @@ const worksheetSelectableColumnProps: Prop[] = [
     types: ['string', 'number'],
     description: 'Sets column width.',
   },
+  {
+    name: 'tooltip',
+    types: 'string',
+    description: 'Tooltip for the worksheet column header.',
+  },
 ];
 
 const worksheetModalColumnProps: Prop[] = [
@@ -346,6 +366,11 @@ const worksheetModalColumnProps: Prop[] = [
     name: 'width',
     types: ['string', 'number'],
     description: 'Sets column width.',
+  },
+  {
+    name: 'tooltip',
+    types: 'string',
+    description: 'Tooltip for the worksheet column header.',
   },
 ];
 

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -137,6 +137,7 @@ const WorksheetPage = () => {
                         header: 'Product name',
                         validation: (value) => !!value,
                         width: 200,
+                        tooltip: 'Tooltip text',
                       },
                       { hash: 'isVisible', header: 'Visible', type: 'checkbox', width: 80 },
                       { hash: 'otherField', header: 'Other field' },


### PR DESCRIPTION
## What?

Added header tooltip for worksheet component.

Refactored rendering of the tooltip for the Table component.
(packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx)

## Why?

To be able to leave a short description of the column.

## Screenshots/Screen Recordings
<img width="832" alt="Screenshot 2023-01-11 at 12 16 27" src="https://user-images.githubusercontent.com/84462142/211781304-2a376985-8e65-4864-b9c9-9323fe1452e0.png">



## Testing/Proof

Locally + UT.
