### PR TITLE
Enable child row selection in TableNext

### DIFF
--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -1,11 +1,17 @@
-import React, { RefObject } from 'react';
+import React, { Dispatch, RefObject, SetStateAction } from 'react';
 
 import { typedMemo } from '../../../utils';
 import { FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
 import { SelectAll } from '../SelectAll';
 import { TablePagination } from '../TablePagination';
-import { TableExpandable, TableItem, TablePaginationProps, TableSelectable } from '../types';
+import {
+  TableExpandable,
+  TableItem,
+  TablePaginationProps,
+  TableProps,
+  TableSelectable,
+} from '../types';
 
 import { StyledFlex } from './styled';
 
@@ -14,13 +20,16 @@ export interface ActionsProps<T> {
   forwardedRef: RefObject<HTMLDivElement>;
   itemName?: string;
   items: T[];
-  isExpandable: boolean;
   pagination?: TablePaginationProps;
   selectedItems: TableSelectable['selectedItems'];
   stickyHeader?: boolean;
   tableId: string;
-  expandedRowSelector?: TableExpandable<T>['expandedRowSelector'];
+  getChildren?: TableExpandable<T>['getChildren'];
   onSelectionChange?: TableSelectable['onSelectionChange'];
+  getRowId: NonNullable<TableProps<T>['getRowId']>;
+  setSelectedParentRowsCrossPages: Dispatch<SetStateAction<Set<string>>>;
+  selectedParentRowsCrossPages: Set<string>;
+  isChildrenRowsSelectable?: boolean;
 }
 
 const InternalActions = <T extends TableItem>({
@@ -32,9 +41,12 @@ const InternalActions = <T extends TableItem>({
   selectedItems,
   stickyHeader,
   tableId,
-  isExpandable,
-  expandedRowSelector,
+  getChildren,
   onSelectionChange,
+  getRowId,
+  setSelectedParentRowsCrossPages,
+  selectedParentRowsCrossPages,
+  isChildrenRowsSelectable,
   ...props
 }: ActionsProps<T>) => {
   const isSelectable = typeof onSelectionChange === 'function';
@@ -70,10 +82,15 @@ const InternalActions = <T extends TableItem>({
     >
       {isSelectable && (
         <SelectAll
+          getChildren={getChildren}
+          getRowId={getRowId}
+          isChildrenRowsSelectable={isChildrenRowsSelectable}
           items={items}
           onChange={onSelectionChange}
           pagination={pagination}
           selectedItems={selectedItems}
+          selectedParentRowsCrossPages={selectedParentRowsCrossPages}
+          setSelectedParentRowsCrossPages={setSelectedParentRowsCrossPages}
           totalItems={totalItems}
         />
       )}

--- a/packages/big-design/src/components/TableNext/Row/spec.tsx
+++ b/packages/big-design/src/components/TableNext/Row/spec.tsx
@@ -6,7 +6,6 @@ import { render, screen } from '@test/utils';
 import { TableColumn } from '../types';
 
 import { Row } from './Row';
-import { useRowState } from './useRowState';
 
 interface Item {
   sku: string;
@@ -25,39 +24,23 @@ const defaultColumns: Array<TableColumn<Item>> = [
 
 test('renders a table row', async () => {
   render(
-    <Row
-      columns={defaultColumns}
-      headerCellWidths={[]}
-      isDraggable={false}
-      item={item}
-      parentRowIndex={0}
-      selectedItems={{}}
-    />,
+    <table>
+      <tbody>
+        <Row
+          childrenRowsIds={[]}
+          columns={defaultColumns}
+          headerCellWidths={[]}
+          isDraggable={false}
+          item={item}
+          onItemSelect={() => jest.fn}
+          parentRowId="0"
+          selectedItems={{}}
+        />
+      </tbody>
+    </table>,
   );
 
   const name = await screen.findByRole('row', { name: /Smith Journal 13/i });
 
   expect(name).toBeVisible();
-});
-
-test('row state callbacks execute argument callback', () => {
-  const onExpandedRow = jest.fn();
-  const onItemSelect = jest.fn();
-
-  const { onChange, onExpandedChange } = useRowState({
-    childrenRows: [],
-    isParentRow: true,
-    isSelected: false,
-    onExpandedRow,
-    onItemSelect,
-    parentRowIndex: 0,
-  });
-
-  onChange();
-
-  expect(onItemSelect).toHaveBeenCalled();
-
-  onExpandedChange();
-
-  expect(onExpandedRow).toHaveBeenCalled();
 });

--- a/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
@@ -1,18 +1,29 @@
-import React from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 
 import { Checkbox } from '../../Checkbox';
 import { Flex, FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
-import { TableItem, TablePaginationProps, TableSelectable } from '../types';
+import {
+  TableExpandable,
+  TableItem,
+  TablePaginationProps,
+  TableProps,
+  TableSelectable,
+} from '../types';
 
 import { useSelectAllState } from './useSelectAllState';
 
 export interface SelectAllProps<T> {
+  getChildren?: TableExpandable<T>['getChildren'];
   items: T[];
   onChange?: TableSelectable['onSelectionChange'];
   selectedItems: TableSelectable['selectedItems'];
   totalItems: number;
   pagination?: TablePaginationProps;
+  getRowId: NonNullable<TableProps<T>['getRowId']>;
+  setSelectedParentRowsCrossPages: Dispatch<SetStateAction<Set<string>>>;
+  selectedParentRowsCrossPages: Set<string>;
+  isChildrenRowsSelectable?: boolean;
 }
 
 export const SelectAll = <T extends TableItem>(props: SelectAllProps<T>) => {

--- a/packages/big-design/src/components/TableNext/SelectAll/helpers.ts
+++ b/packages/big-design/src/components/TableNext/SelectAll/helpers.ts
@@ -1,65 +1,179 @@
 import { getPagedIndex } from '../helpers';
-import { TableSelectable } from '../types';
+import { TableExpandable, TableSelectable } from '../types';
 
 import { SelectAllProps } from './SelectAll';
 
 type SelectAllRowsArg<T> = Omit<SelectAllProps<T>, 'onChange'>;
 
-export function getTotalSelectedItems(selectedItems: TableSelectable['selectedItems']) {
-  return Object.keys(selectedItems).filter((key) => !key.includes('.')).length;
+export function getChildrenRows<T>(parentRow: T, getChildren?: TableExpandable<T>['getChildren']) {
+  const isGetChildrenUsed = getChildren !== undefined;
+
+  if (!isGetChildrenUsed) {
+    return [];
+  }
+
+  return getChildren(parentRow) ?? [];
 }
 
-export function areAllInPageSelected<T>({ items, selectedItems, pagination }: SelectAllRowsArg<T>) {
-  if (items.length <= 0) {
+export function areAllInPageSelected<T>({
+  items,
+  selectedItems,
+  getChildren,
+  pagination,
+  getRowId,
+  isChildrenRowsSelectable,
+}: SelectAllRowsArg<T>) {
+  if (items.length === 0) {
     return false;
   }
 
-  return items.every((_, parentRowIndex) => {
+  return items.every((parentRow, parentRowIndex) => {
     const pagedIndex = getPagedIndex(parentRowIndex, pagination);
+    const childrenRows: T[] = isChildrenRowsSelectable
+      ? getChildrenRows(parentRow, getChildren)
+      : [];
+    const childrenRowsIds: string[] = childrenRows.map((childRow, childRowIndex) => {
+      return getRowId(childRow, pagedIndex, childRowIndex);
+    });
+    const parentRowId = getRowId(parentRow, pagedIndex);
 
-    return selectedItems[pagedIndex] !== undefined;
+    if (childrenRowsIds.length === 0) {
+      return selectedItems[parentRowId];
+    }
+
+    return areAllParentsAndChildrenSelected(selectedItems, childrenRowsIds, parentRowId);
   });
 }
 
 export function areSomeInPageSelected<T>({
   items,
   selectedItems,
+  getChildren,
   pagination,
+  getRowId,
+  isChildrenRowsSelectable,
 }: SelectAllRowsArg<T>): boolean {
   if (items.length <= 0) {
     return false;
   }
 
-  return items.some((_, parentRowIndex) => {
+  return items.some((parentRow, parentRowIndex) => {
     const pagedIndex = getPagedIndex(parentRowIndex, pagination);
+    const childrenRows: T[] = isChildrenRowsSelectable
+      ? getChildrenRows(parentRow, getChildren)
+      : [];
+    const childrenRowsIds: string[] = childrenRows.map((childRow, childRowIndex) => {
+      return getRowId(childRow, pagedIndex, childRowIndex);
+    });
+    const parentRowId = getRowId(parentRow, pagedIndex);
 
-    return selectedItems[pagedIndex] !== undefined;
+    if (childrenRowsIds.length === 0) {
+      return selectedItems[parentRowId] !== undefined;
+    }
+
+    return areSomeParentsAndChildrenSelected(selectedItems, childrenRowsIds, parentRowId);
   });
 }
 
+function areAllParentsAndChildrenSelected(
+  selectedItems: TableSelectable['selectedItems'],
+  childrenRowsIds: string[],
+  parentRowId: string,
+) {
+  const allChildrenRowsSelected = childrenRowsIds.every((childRowId) => {
+    return selectedItems[childRowId];
+  });
+
+  return selectedItems[parentRowId] !== undefined && allChildrenRowsSelected;
+}
+
+function areSomeParentsAndChildrenSelected(
+  selectedItems: TableSelectable['selectedItems'],
+  childrenRowsIds: string[],
+  parentRowId: string,
+) {
+  const someChildrenRowsInPageSelected = childrenRowsIds.some((childRowId) => {
+    return selectedItems[childRowId] !== undefined;
+  });
+
+  return selectedItems[parentRowId] !== undefined && someChildrenRowsInPageSelected;
+}
+
 function deselectAllOnCurrentPage<T>(params: SelectAllRowsArg<T>) {
-  const { items, selectedItems, pagination } = params;
+  const {
+    items,
+    selectedItems,
+    pagination,
+    getRowId,
+    getChildren,
+    setSelectedParentRowsCrossPages,
+    isChildrenRowsSelectable,
+  } = params;
 
-  const filteredSelectedItems = Object.keys(selectedItems)
-    .filter((selectedKey) => {
-      const item = items.find(
-        (_, index) => getPagedIndex(index, pagination) === parseInt(selectedKey, 10),
-      );
+  const newSelectedItems = { ...selectedItems };
 
-      return !item;
-    })
-    .map<[string, true]>((key) => [key, true]);
+  items.forEach((item, index) => {
+    const pagedIndex = getPagedIndex(index, pagination);
+    const parentRowId = getRowId(item, pagedIndex);
 
-  return Object.fromEntries(filteredSelectedItems);
+    setSelectedParentRowsCrossPages((prevSelectedParentRowsCrossPages) => {
+      const newSet = new Set([...prevSelectedParentRowsCrossPages]);
+
+      newSet.delete(parentRowId);
+
+      return newSet;
+    });
+
+    delete newSelectedItems[parentRowId];
+
+    const childrenRows = isChildrenRowsSelectable ? getChildrenRows(item, getChildren) : [];
+
+    childrenRows.forEach((childRow, childRowIndex) => {
+      const childRowId = getRowId(childRow, pagedIndex, childRowIndex);
+
+      delete newSelectedItems[childRowId];
+    });
+  });
+
+  return newSelectedItems;
 }
 
 function selectAllOnCurrentPage<T>(params: SelectAllRowsArg<T>) {
-  const { items, selectedItems, pagination } = params;
-
-  const newSelectedItems = items.map((_, parentRowIndex) => {
+  const {
+    items,
+    selectedItems,
+    getChildren,
+    pagination,
+    getRowId,
+    setSelectedParentRowsCrossPages,
+    isChildrenRowsSelectable,
+  } = params;
+  const newSelectedItems = items.map((parentRow, parentRowIndex) => {
     const pagedIndex = getPagedIndex(parentRowIndex, pagination);
+    const childrenRows: T[] = isChildrenRowsSelectable
+      ? getChildrenRows(parentRow, getChildren)
+      : [];
+    const parentRowId = getRowId(parentRow, pagedIndex);
 
-    return [[`${pagedIndex}`, true]];
+    setSelectedParentRowsCrossPages((prevSelectedParentRowsCrossPages) => {
+      const newSet = new Set([...prevSelectedParentRowsCrossPages]);
+
+      newSet.add(parentRowId);
+
+      return newSet;
+    });
+
+    if (childrenRows.length) {
+      const newSelectedChildrenRows = childrenRows.map<[string, true]>((child, childRowIndex) => {
+        const childRowId = getRowId(child, pagedIndex, childRowIndex);
+
+        return [`${childRowId}`, true];
+      });
+
+      return [[`${parentRowId}`, true], ...newSelectedChildrenRows];
+    }
+
+    return [[`${parentRowId}`, true]];
   });
 
   return { ...selectedItems, ...Object.fromEntries(newSelectedItems.flat()) };

--- a/packages/big-design/src/components/TableNext/SelectAll/useSelectAllState.ts
+++ b/packages/big-design/src/components/TableNext/SelectAll/useSelectAllState.ts
@@ -1,17 +1,12 @@
-import {
-  areAllInPageSelected,
-  areSomeInPageSelected,
-  getSelectAllState,
-  getTotalSelectedItems,
-} from './helpers';
+import { areAllInPageSelected, areSomeInPageSelected, getSelectAllState } from './helpers';
 import { SelectAllProps } from './SelectAll';
 
 export const useSelectAllState = <T>(props: SelectAllProps<T>) => {
-  const { selectedItems, onChange } = props;
+  const { onChange } = props;
 
   const allInPageSelected = areAllInPageSelected(props);
   const someInPageSelected = areSomeInPageSelected(props);
-  const totalSelectedItems = getTotalSelectedItems(selectedItems);
+  const totalSelectedItems = props.selectedParentRowsCrossPages.size;
   const label = allInPageSelected ? 'Deselect All' : 'Select All';
 
   const handleSelectAll = () => {

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -39,6 +39,13 @@ const InternalTableNext = <T extends TableItem>(
     stickyHeader,
     style,
     onRowDrop,
+    getRowId = (_item, parentRowIndex, childRowIndex) => {
+      if (childRowIndex !== undefined) {
+        return `${parentRowIndex}.${childRowIndex}`;
+      }
+
+      return `${parentRowIndex}`;
+    },
     ...rest
   } = props;
 
@@ -47,8 +54,15 @@ const InternalTableNext = <T extends TableItem>(
   const tableIdRef = useRef(id || uniqueTableId);
   const [headerCellWidths, setHeaderCellWidths] = useState<Array<number | string>>([]);
   const headerCellIconRef = useRef<HTMLTableCellElement>(null);
-  const { isSelectable, onItemSelect, selectedItems } = useSelectable(selectable);
-  const { expandedRows, expandedRowSelector, isExpandable, onExpandedRow, setExpandedRows } =
+  const {
+    isSelectable,
+    onItemSelect,
+    selectedItems,
+    isChildrenRowsSelectable,
+    setSelectedParentRowsCrossPages,
+    selectedParentRowsCrossPages,
+  } = useSelectable(selectable);
+  const { expandedRows, getChildren, isExpandable, onExpandedRow, setExpandedRows } =
     useExpandable(expandable);
 
   const onSortClick = useCallback(
@@ -128,7 +142,7 @@ const InternalTableNext = <T extends TableItem>(
         )}
         {isSelectable && <HeaderCheckboxCell actionsRef={actionsRef} stickyHeader={stickyHeader} />}
 
-        {expandedRowSelector !== undefined && (
+        {getChildren !== undefined && (
           <ExpandableHeaderCell actionsRef={actionsRef} headerCellIconRef={headerCellIconRef} />
         )}
 
@@ -176,11 +190,13 @@ const InternalTableNext = <T extends TableItem>(
                     {...provided.dragHandleProps}
                     {...provided.draggableProps}
                     columns={columns}
-                    expandedRowSelector={expandedRowSelector}
                     expandedRows={expandedRows}
+                    getChildren={getChildren}
                     getItemKey={getItemKey}
                     getLoadMoreAction={expandable?.getLoadMoreAction}
+                    getRowId={getRowId}
                     headerCellWidths={headerCellWidths}
+                    isChildrenRowsSelectable={isChildrenRowsSelectable}
                     isExpandable={isExpandable}
                     isSelectable={isSelectable}
                     item={item}
@@ -214,12 +230,14 @@ const InternalTableNext = <T extends TableItem>(
           return (
             <RowContainer
               columns={columns}
-              expandedRowSelector={expandedRowSelector}
               expandedRows={expandedRows}
+              getChildren={getChildren}
               getItemKey={getItemKey}
               getLoadMoreAction={expandable?.getLoadMoreAction}
+              getRowId={getRowId}
               headerCellWidths={headerCellWidths}
               headerless={headerless}
+              isChildrenRowsSelectable={isChildrenRowsSelectable}
               isExpandable={isExpandable}
               isSelectable={isSelectable}
               item={item}
@@ -247,14 +265,17 @@ const InternalTableNext = <T extends TableItem>(
       {shouldRenderActions() && (
         <Actions
           customActions={actions}
-          expandedRowSelector={expandedRowSelector}
           forwardedRef={actionsRef}
-          isExpandable={isExpandable}
+          getChildren={getChildren}
+          getRowId={getRowId}
+          isChildrenRowsSelectable={isChildrenRowsSelectable}
           itemName={itemName}
           items={items}
           onSelectionChange={selectable && selectable.onSelectionChange}
           pagination={pagination}
           selectedItems={selectedItems}
+          selectedParentRowsCrossPages={selectedParentRowsCrossPages}
+          setSelectedParentRowsCrossPages={setSelectedParentRowsCrossPages}
           stickyHeader={stickyHeader}
           tableId={tableIdRef.current}
         />

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -996,7 +996,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls=":r6b:"
+  aria-controls=":r6t:"
   class="c0"
 >
   <div
@@ -1010,15 +1010,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r6d:"
+          aria-labelledby=":r6v:"
           class="c6 c7"
-          id=":r6c:"
+          id=":r6u:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r6c:"
+          for=":r6u:"
         >
           <svg
             aria-hidden="true"
@@ -1044,9 +1044,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c12 c13"
-            for=":r6c:"
+            for=":r6u:"
             hidden=""
-            id=":r6d:"
+            id=":r6v:"
           >
             Select All
           </label>
@@ -1071,7 +1071,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 </div>
 `;
 
-exports[`selectable renders selectable actions, checkboxes when having parent rows and children rows 1`] = `
+exports[`selectable selectable by default (isChildrenRowsSelectable prop is not used or is set to false) when isChildrenRowsSelectable prop is not used or is set to false, as default renders checkboxes just for parent rows 1`] = `
 .c10 {
   vertical-align: middle;
   height: 1.5rem;
@@ -1290,7 +1290,7 @@ exports[`selectable renders selectable actions, checkboxes when having parent ro
 }
 
 <div
-  aria-controls=":r71:"
+  aria-controls=":r7j:"
   class="c0"
 >
   <div
@@ -1304,15 +1304,15 @@ exports[`selectable renders selectable actions, checkboxes when having parent ro
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r73:"
+          aria-labelledby=":r7l:"
           class="c6 c7"
-          id=":r72:"
+          id=":r7k:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r72:"
+          for=":r7k:"
         >
           <svg
             aria-hidden="true"
@@ -1338,9 +1338,303 @@ exports[`selectable renders selectable actions, checkboxes when having parent ro
         >
           <label
             class="c12 c13"
-            for=":r72:"
+            for=":r7k:"
             hidden=""
-            id=":r73:"
+            id=":r7l:"
+          >
+            Select All
+          </label>
+        </div>
+      </div>
+      <p
+        class="c14"
+      >
+        5
+      </p>
+    </div>
+  </div>
+  <div
+    class="c15 c2"
+  >
+    <p
+      class="c16"
+    >
+      Product
+    </p>
+  </div>
+</div>
+`;
+
+exports[`selectable selectable by not default (isChildrenRowsSelectable prop is used and it is set to true renders checkboxes for parent rows and children rows) 1`] = `
+.c10 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c1 {
+  margin-right: 0.25rem;
+  box-sizing: border-box;
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c15 {
+  margin-right: 1rem;
+  box-sizing: border-box;
+}
+
+.c4 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c12 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c12:last-child {
+  margin-bottom: 0;
+}
+
+.c14 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin-left: 0.75rem;
+}
+
+.c14:last-child {
+  margin-bottom: 0;
+}
+
+.c16 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0;
+}
+
+.c16:last-child {
+  margin-bottom: 0;
+}
+
+.c13 {
+  cursor: pointer;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11 {
+  margin-left: 0.5rem;
+}
+
+.c5 {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c9 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
+  transition-property: border-color,background,box-shadow,color,opacity;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #FFFFFF;
+  box-sizing: border-box;
+  border: 1px solid #D9DCE9;
+  border-color: #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 1.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-bottom: 0.125rem;
+  margin-top: 0.125rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1.25rem;
+}
+
+.c9:hover {
+  border-color: #B4BAD1;
+}
+
+.c6:focus + .c8 {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c9 svg {
+  opacity: 0;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: stretch;
+  -webkit-justify-content: stretch;
+  -ms-flex-pack: stretch;
+  justify-content: stretch;
+  background-color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0.75rem 1.5rem;
+}
+
+@media (min-width:720px) {
+
+}
+
+@media (min-width:720px) {
+
+}
+
+<div
+  aria-controls=":rba:"
+  class="c0"
+>
+  <div
+    class="c1 c2"
+  >
+    <div
+      class="c3 c4"
+    >
+      <div
+        class="c5"
+      >
+        <input
+          aria-checked="false"
+          aria-labelledby=":rbc:"
+          class="c6 c7"
+          id=":rbb:"
+          type="checkbox"
+        />
+        <label
+          aria-hidden="true"
+          class="c8 c9"
+          for=":rbb:"
+        >
+          <svg
+            aria-hidden="true"
+            class="c10"
+            fill="currentColor"
+            height="24"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M0 0h24v24H0V0z"
+              fill="none"
+            />
+            <path
+              d="M9 16.17L5.53 12.7a.996.996 0 10-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 10-1.41-1.41L9 16.17z"
+            />
+          </svg>
+        </label>
+        <div
+          class="c11"
+        >
+          <label
+            class="c12 c13"
+            for=":rbb:"
+            hidden=""
+            id=":rbc:"
           >
             Select All
           </label>

--- a/packages/big-design/src/components/TableNext/hooks/useExpandable/useExpandable.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useExpandable/useExpandable.ts
@@ -7,27 +7,27 @@ export const useExpandable = <T>(expandable?: TableExpandable<T>) => {
   const [expandedRows, setExpandedRows] = useState<TableExpandable<T>['expandedRows']>({});
   const isExpandable = Boolean(expandable);
 
-  const expandedItemsEventCallback = useEventCallback((parentRowIndex: number | null) => {
-    if (!expandable || parentRowIndex === null) {
+  const expandedItemsEventCallback = useEventCallback((parentRowId: string) => {
+    if (!expandable || parentRowId === null) {
       return;
     }
 
     const { onExpandedChange } = expandable;
 
-    const isExpandedRow = expandedRows[parentRowIndex] !== undefined;
+    const isExpandedRow = expandedRows[parentRowId] !== undefined;
 
     if (isExpandedRow) {
-      const newExpandedRows = Object.entries(expandedRows).filter(
-        ([key]) => key !== `${parentRowIndex}`,
-      );
+      const newExpandedRows = Object.entries(expandedRows).filter(([key]) => {
+        return key !== `${parentRowId}`;
+      });
 
-      onExpandedChange(Object.fromEntries(newExpandedRows), parentRowIndex);
+      onExpandedChange(Object.fromEntries(newExpandedRows), parentRowId);
     } else {
       const newExpandedRows = { ...expandedRows };
 
-      newExpandedRows[parentRowIndex] = true;
+      newExpandedRows[parentRowId] = true;
 
-      onExpandedChange(newExpandedRows, parentRowIndex);
+      onExpandedChange(newExpandedRows, parentRowId);
     }
   });
 
@@ -39,7 +39,7 @@ export const useExpandable = <T>(expandable?: TableExpandable<T>) => {
 
   return {
     expandedRows,
-    expandedRowSelector: expandable?.expandedRowSelector,
+    getChildren: expandable?.getChildren,
     isExpandable,
     onExpandedRow: isExpandable ? expandedItemsEventCallback : undefined,
     setExpandedRows,

--- a/packages/big-design/src/components/TableNext/hooks/useSelectable/helpers.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useSelectable/helpers.ts
@@ -1,56 +1,281 @@
+import { Dispatch, SetStateAction } from 'react';
+
 import { TableSelectable } from '../../types';
 
-export interface SelectRowArg<T> {
-  childrenRows?: T[];
-  childRowIndex?: number;
-  isExpandable?: boolean;
+export interface SelectRowArg {
   isTheOnlySelectedChildRow?: boolean;
-  parentRowIndex: number;
   selectedItems: TableSelectable['selectedItems'];
   isParentRow?: boolean;
+  parentRowId: string;
+  setSelectedParentRowsCrossPages: Dispatch<SetStateAction<Set<string>>>;
+  childRowId?: string;
+  isChildrenRowsSelectable?: TableSelectable['isChildrenRowsSelectable'];
+  childrenRowsIds: string[];
 }
 
-export function selectParentRow<T>({
-  parentRowIndex,
+export function selectParentRow({
   selectedItems,
-}: SelectRowArg<T>): TableSelectable['selectedItems'] {
-  const isSelectedParent = selectedItems[parentRowIndex] !== undefined;
+  setSelectedParentRowsCrossPages,
+  childRowId,
+  parentRowId,
+  isChildrenRowsSelectable,
+  childrenRowsIds,
+}: SelectRowArg): TableSelectable['selectedItems'] {
+  const isSelectedParent = selectedItems[parentRowId] !== undefined;
 
   if (isSelectedParent) {
     const newSelectedItems = unselectParent({
-      parentRowIndex,
       selectedItems,
+      setSelectedParentRowsCrossPages,
+      childRowId,
+      parentRowId,
+      isChildrenRowsSelectable,
+      childrenRowsIds,
     });
 
     return newSelectedItems;
   }
 
   const newSelectedItems = selectParent({
-    parentRowIndex,
     selectedItems,
+    parentRowId,
+    setSelectedParentRowsCrossPages,
+    childRowId,
+    isChildrenRowsSelectable,
+    childrenRowsIds,
   });
 
   return newSelectedItems;
 }
 
-function unselectParent<T>({
-  parentRowIndex,
+function unselectParent({
   selectedItems,
-}: SelectRowArg<T>): TableSelectable['selectedItems'] {
+  parentRowId,
+  setSelectedParentRowsCrossPages,
+  childRowId,
+  isChildrenRowsSelectable,
+  childrenRowsIds,
+}: SelectRowArg): TableSelectable['selectedItems'] {
+  const hasChildrenRows = Boolean(childrenRowsIds.length);
+
+  // If parent has children, unselect it's childrenRows
+  if (hasChildrenRows && isChildrenRowsSelectable) {
+    const newSelectedItems = unselectParentAndChildren({
+      selectedItems,
+      parentRowId,
+      setSelectedParentRowsCrossPages,
+      childRowId,
+      childrenRowsIds,
+    });
+
+    return newSelectedItems;
+  }
+
+  setSelectedParentRowsCrossPages((prevSelectedParentsRowsCrossPages) => {
+    const newSet = new Set([...prevSelectedParentsRowsCrossPages]);
+
+    newSet.delete(parentRowId);
+
+    return newSet;
+  });
+
   // Unselect the parent row
-  const newSelectedItems = Object.entries(selectedItems).filter(
-    ([key]) => key !== `${parentRowIndex}`,
-  );
+  const newSelectedItems = Object.entries(selectedItems).filter(([key]) => {
+    return key !== parentRowId;
+  });
 
   return Object.fromEntries(newSelectedItems);
 }
 
-function selectParent<T>({
-  parentRowIndex,
+function unselectParentAndChildren({
   selectedItems,
-}: SelectRowArg<T>): TableSelectable['selectedItems'] {
+  parentRowId,
+  setSelectedParentRowsCrossPages,
+  childrenRowsIds,
+}: SelectRowArg) {
+  setSelectedParentRowsCrossPages((prevSelectedParentsRowsCrossPages) => {
+    const newSet = new Set([...prevSelectedParentsRowsCrossPages]);
+
+    newSet.delete(parentRowId);
+
+    return newSet;
+  });
+
+  const newSelectedItems = { ...selectedItems };
+
+  delete newSelectedItems[parentRowId];
+
+  childrenRowsIds?.forEach((childRowId) => {
+    delete newSelectedItems[childRowId];
+  });
+
+  return newSelectedItems;
+}
+
+function selectParent({
+  selectedItems,
+  parentRowId,
+  setSelectedParentRowsCrossPages,
+  childRowId,
+  isChildrenRowsSelectable,
+  childrenRowsIds,
+}: SelectRowArg): TableSelectable['selectedItems'] {
+  const hasChildrenRows = Boolean(childrenRowsIds.length);
+
+  // If parent has children, select it's childrenRows
+  if (hasChildrenRows && isChildrenRowsSelectable) {
+    const newSelectedItems = selectParentAndChildren({
+      selectedItems,
+      parentRowId,
+      childRowId,
+      setSelectedParentRowsCrossPages,
+      childrenRowsIds,
+    });
+
+    return newSelectedItems;
+  }
+
+  setSelectedParentRowsCrossPages((prevSelectedParentsRowsCrossPages) => {
+    const newSet = new Set([...prevSelectedParentsRowsCrossPages]);
+
+    newSet.add(parentRowId);
+
+    return newSet;
+  });
+
   return {
     ...selectedItems,
-    [parentRowIndex]: true,
+    [parentRowId]: true,
   };
+}
+
+function selectParentAndChildren({
+  selectedItems,
+  parentRowId,
+  setSelectedParentRowsCrossPages,
+  childrenRowsIds,
+}: SelectRowArg) {
+  setSelectedParentRowsCrossPages((prevSelectedParentsRowsCrossPages) => {
+    const newSet = new Set([...prevSelectedParentsRowsCrossPages]);
+
+    newSet.add(parentRowId);
+
+    return newSet;
+  });
+
+  const newSelectedItems = { ...selectedItems };
+
+  newSelectedItems[parentRowId] = true;
+
+  childrenRowsIds?.forEach((childRowId) => {
+    newSelectedItems[childRowId] = true;
+  });
+
+  return newSelectedItems;
+}
+
+export function selectChildRow({
+  childRowId,
+  isTheOnlySelectedChildRow,
+  selectedItems,
+  parentRowId,
+  setSelectedParentRowsCrossPages,
+  childrenRowsIds,
+}: SelectRowArg): TableSelectable['selectedItems'] {
+  const isSelectedParent = selectedItems[parentRowId] !== undefined;
+
+  if (!isSelectedParent) {
+    const newSelectedItems = selectChild({
+      selectedItems,
+      parentRowId,
+      childRowId,
+      setSelectedParentRowsCrossPages,
+      childrenRowsIds,
+    });
+
+    return newSelectedItems;
+  }
+
+  const isSelectedChild = childRowId !== undefined && selectedItems[childRowId];
+
+  if (isSelectedChild) {
+    const newSelectedItems = unselectChild({
+      selectedItems,
+      isTheOnlySelectedChildRow,
+      setSelectedParentRowsCrossPages,
+      parentRowId,
+      childRowId,
+      childrenRowsIds,
+    });
+
+    return newSelectedItems;
+  }
+
+  // Parent is selected (partially) but child is not selected.
+  const newSelectedItems = { ...selectedItems };
+
+  newSelectedItems[`${childRowId}`] = true;
+
+  return newSelectedItems;
+}
+
+function selectChild({
+  selectedItems,
+  parentRowId,
+  setSelectedParentRowsCrossPages,
+  childRowId,
+}: SelectRowArg): TableSelectable['selectedItems'] {
+  const newSelectedItems = { ...selectedItems };
+
+  setSelectedParentRowsCrossPages((prevSelectedParentsRowsCrossPages) => {
+    const newSet = new Set([...prevSelectedParentsRowsCrossPages]);
+
+    newSet.add(parentRowId);
+
+    return newSet;
+  });
+
+  newSelectedItems[`${parentRowId}`] = true;
+  newSelectedItems[`${childRowId}`] = true;
+
+  return newSelectedItems;
+}
+
+function unselectChild({
+  selectedItems,
+  isTheOnlySelectedChildRow,
+  setSelectedParentRowsCrossPages,
+  parentRowId,
+  childRowId,
+}: SelectRowArg) {
+  const newSelectedItems = Object.entries(selectedItems)
+    .filter(([key]) => key !== `${childRowId}`)
+    .filter(([key]) => {
+      // Unselect the parent row if it's the only selected child.
+      if (isTheOnlySelectedChildRow) {
+        setSelectedParentRowsCrossPages((prevSelectedParentsRowsCrossPages) => {
+          const newSet = new Set([...prevSelectedParentsRowsCrossPages]);
+
+          newSet.delete(parentRowId);
+
+          return newSet;
+        });
+
+        return key !== `${parentRowId}`;
+      }
+
+      return true;
+    });
+
+  return Object.fromEntries(newSelectedItems);
+}
+
+export function getTotalSelectedChildRows({ selectedItems, childrenRowsIds }: SelectRowArg) {
+  return childrenRowsIds?.reduce((acc, childRowId) => {
+    if (selectedItems[childRowId] !== undefined) {
+      return acc + 1;
+    }
+
+    return acc;
+  }, 0);
 }

--- a/packages/big-design/src/components/TableNext/hooks/useSelectable/useSelectable.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useSelectable/useSelectable.ts
@@ -3,21 +3,48 @@ import { useEffect, useState } from 'react';
 import { useEventCallback } from '../../../../hooks';
 import { TableSelectable } from '../../types';
 
-import { selectParentRow, SelectRowArg } from './helpers';
+import {
+  getTotalSelectedChildRows,
+  selectChildRow,
+  selectParentRow,
+  SelectRowArg,
+} from './helpers';
 
-interface OnItemSelectFnArg<T> extends Omit<SelectRowArg<T>, 'childRowIndex' | 'selectedItems'> {
-  parentRowIndex: number;
+interface OnItemSelectFnArg
+  extends Omit<SelectRowArg, 'selectedItems' | 'setSelectedParentRowsCrossPages'> {
   isParentRow: boolean;
+  parentRowId: string;
+  childRowId?: string;
+  childrenRowsIds: string[];
 }
 
-export type OnItemSelectFn = <T>({ isParentRow, parentRowIndex }: OnItemSelectFnArg<T>) => void;
+export type OnItemSelectFn = ({
+  isParentRow,
+  parentRowId,
+  childRowId,
+  childrenRowsIds,
+}: OnItemSelectFnArg) => void;
 
 export const useSelectable = (selectable?: TableSelectable) => {
   const isSelectable = Boolean(selectable);
+  const isChildrenRowsSelectable = selectable?.isChildrenRowsSelectable ?? false;
   const [selectedItems, setSelectedItems] = useState<TableSelectable['selectedItems']>({});
+  const [selectedParentRowsCrossPages, setSelectedParentRowsCrossPages] = useState<Set<string>>(
+    () => {
+      const initialSelectedParentRows = selectable?.initialSelectedParentRows ?? [];
+
+      if (initialSelectedParentRows.length) {
+        const initialSelectedParentRowsCrossPages = new Set(initialSelectedParentRows);
+
+        return new Set(initialSelectedParentRowsCrossPages);
+      }
+
+      return new Set();
+    },
+  );
 
   const onItemSelectEventCallback: OnItemSelectFn = useEventCallback(
-    ({ isParentRow, parentRowIndex }) => {
+    ({ isParentRow, parentRowId, childRowId, childrenRowsIds }) => {
       if (!selectable) {
         return;
       }
@@ -26,8 +53,34 @@ export const useSelectable = (selectable?: TableSelectable) => {
 
       if (isParentRow) {
         const newSelectedItems = selectParentRow({
-          parentRowIndex,
           selectedItems,
+          setSelectedParentRowsCrossPages,
+          parentRowId,
+          childRowId,
+          isChildrenRowsSelectable,
+          childrenRowsIds,
+        });
+
+        onSelectionChange(newSelectedItems);
+      } else {
+        const totalSelectedChildRows = getTotalSelectedChildRows({
+          selectedItems,
+          parentRowId,
+          setSelectedParentRowsCrossPages,
+          childRowId,
+          childrenRowsIds,
+        });
+
+        const isTheOnlySelectedChildRow = totalSelectedChildRows === 1;
+
+        const newSelectedItems = selectChildRow({
+          isTheOnlySelectedChildRow,
+          selectedItems,
+          parentRowId,
+          setSelectedParentRowsCrossPages,
+          childRowId,
+          isChildrenRowsSelectable,
+          childrenRowsIds,
         });
 
         onSelectionChange(newSelectedItems);
@@ -45,5 +98,8 @@ export const useSelectable = (selectable?: TableSelectable) => {
     isSelectable,
     onItemSelect: isSelectable ? onItemSelectEventCallback : undefined,
     selectedItems,
+    isChildrenRowsSelectable,
+    selectedParentRowsCrossPages,
+    setSelectedParentRowsCrossPages,
   };
 };

--- a/packages/big-design/src/components/TableNext/types.ts
+++ b/packages/big-design/src/components/TableNext/types.ts
@@ -8,6 +8,8 @@ import { TableColumnDisplayProps } from './mixins';
 export interface TableSelectable {
   selectedItems: Record<string, true>;
   onSelectionChange(selectedItems: Record<string, true>): void;
+  isChildrenRowsSelectable?: boolean;
+  initialSelectedParentRows?: string[];
 }
 export interface LoadMoreAction {
   isLoading: boolean;
@@ -15,12 +17,12 @@ export interface LoadMoreAction {
   text: string;
 }
 
-type LoadMoreActionCallback = (parentRowIndex: number) => LoadMoreAction | undefined;
+type LoadMoreActionCallback = (parentRowId: string) => LoadMoreAction | undefined;
 
 export interface TableExpandable<T> {
   expandedRows: Record<string, true>;
-  expandedRowSelector: (item: T) => T[] | undefined;
-  onExpandedChange(expandedItems: Record<string, true>, expandedIndex: number): void;
+  getChildren: (item: T) => T[] | undefined;
+  onExpandedChange(expandedRows: Record<string, true>, expandedRowId: string): void;
   getLoadMoreAction?: LoadMoreActionCallback;
 }
 
@@ -68,4 +70,5 @@ export interface TableProps<T> extends TableHTMLAttributes<HTMLTableElement> {
   selectable?: TableSelectable;
   sortable?: TableSortable<T>;
   stickyHeader?: boolean;
+  getRowId?: (item: T, parentRowIndex: number, childRowIndex?: number) => string;
 }


### PR DESCRIPTION
## What?
1. Enable child row selection  (isChildrenRowsSelectable)
2. Get rows by and identifier (getRowId)
3. Add and update props. (initialSelectedParentRows, expandedRowSelector)

Note: Please review by commit.

## Why?
1. Let the user decide to make all the children selectable in a table or not.
2. Let the user decide how to retrieve the selected rows and expanded rows by an identifier (the  default is gonna by indexes)
3. Based on the new changes of how to retrieve selected rows, it was necessary to add initialSelectedParentRows prop to identify the initial selected parent rows across pages, since when using pagination not all the items are passed to the component, it is just passes the current items by page. 
Also, update expandedRowSelector prop name to getChildren since it better describes the purpose of it.

New props:
`isChildrenRowsSelectable`:
  - type: boolean
  - description: enables child row selection. If the prop is not used, by default child rows are not enabled
  - example: 
  
  ```
    selectable={
       isChildrenRowsSelectable: true
    }
  ```
  
`getRowId`:
  - type: (item: T, parentRowId: number, childRowId: number) => string
  - description: a way to identify a row by a unique id, sku, etc. Note: The default is by indexes.
  - example: If all the items contains a unique identifier (example, id, sku, etc) , the user would need to provide a callback function in to the prop:
   
   ```ts
   const children = [{name: 'child 1', id: 'id-child1'}, {name: 'child 2',  id: 'id-child2'}]
   const items = [{name: 'item 1', id: 'id-item1', children}]
   getRowById: {(item) => item.id}
   
   // Result after selecting all items
   {
      id-item1: true,
      id-child1: true,
      id-child2: true
   }

   // if getRowId is not used, the default selected items would be:
   
   {
       0: true
       0.0: true
       0.1: true
    }
   ```

`initialSelectedParentRows`
  -type: string[]
  -description: This helps the component to internally count the all the total selected parent rows selected cross pages.
  -example: 
  
  ```
   const [selectedItems, onSelectionChange] = useState<Record<string, true>>({0: true,  20: true, 20.0:  true});
   selectable: {
       selectedItems,
       initialSelectedParentRows: ['0', '20']
   }
  ```
  
 Updated props:

 `expandedRowSelector`
  - what changed: Only the name,  NOTE: the usage of this prop didn't change, it's still the same
  - new name: getChildren.
  - description: this prop helps table next to retrieve children from an item by passing a callback function.
  - example:
  ```ts
  expandable={{
        getChildren: ({ children }) => {
          if (children) {
            return children;
          }

          return undefined;
        },
      }}
  ```
  
Code example:

```tsx
import { TableNext } from '@bigcommerce/big-design/src/components/TableNext';
import React, { useEffect, useState } from 'react';

interface Item {
  name: string;
  id: string;
  age: number;
  children?: Item[];
}

const itemsWithChilds = new Array(25).fill(undefined).map<Item>((_, index) => ({
  name: `Hello ${index}`,
  id: `id-${index}`,
  age: index + 1,
  children: [
    { name: `Child ${index}`, id: `id-${index}-0`, age: index + 1 },
    { name: `Child ${index}`, id: `id-${index}-1`, age: index + 2 },
  ],
}));

const itemWithNoChild = new Array(1).fill(undefined).map<Item>((_, index) => ({
  name: `Hello item with no child`,
  id: `id-item-with-no-child`,
  age: index + 1,
}));

const items = [...itemWithNoChild, ...itemsWithChilds];

const DevPage = () => {
  const [currentPage, onPageChange] = useState(1);
  const [itemsPerPage, onItemsPerPageChange] = useState(10);
  const [selectedItems, onSelectionChange] = useState<Record<string, true>>({
    'id-1': true,
    'id-1-0': true,
    'id-2': true,
    'id-13': true,
    'id-13-0': true,
  });
  const [pagedItems, setPagedItems] = useState<typeof items>([]);
  const [expandedRows, onExpandedChange] = useState({});

  useEffect(() => {
    setPagedItems(
      items.filter(
        (_item, index) =>
          index >= (currentPage - 1) * itemsPerPage && index < currentPage * itemsPerPage,
      ),
    );
  }, [currentPage, itemsPerPage]);

  return (
    <TableNext
      columns={[
        { hash: 'name', header: 'Name', render: ({ name }) => name },
        { hash: 'age', header: 'Age', render: ({ age }) => age },
      ]}
      expandable={{
        expandedRows,
        onExpandedChange,
        getChildren: ({ children }) => {
          if (children) {
            return children;
          }

          return undefined;
        },
      }}
      itemName="Worlds"
      items={pagedItems}
      keyField="sku"
      pagination={{
        currentPage,
        onPageChange,
        itemsPerPage,
        totalItems: items.length,
        onItemsPerPageChange,
        itemsPerPageOptions: [10, 20, 30],
      }}
      selectable={{
        onSelectionChange,
        selectedItems,
        isChildrenRowsSelectable: true,
        initialSelectedParentRows: ['id-1', 'id-13'],
      }}
      getRowId={(item) => {
        return item.id;
      }}
    />
  );
};

export default DevPage;
```
## Screenshots/Screen Recordings
Children are selectable. Selecting children by a unique identifier (id):


https://user-images.githubusercontent.com/39739180/211925719-b1ea96e2-a805-4dda-be98-c10a504201f3.mp4




https://user-images.githubusercontent.com/39739180/211927411-d0bab745-4702-4fd9-a0f6-24da7751074e.mp4



Parent are just selectable. Selecting parents by default (indexes):


https://user-images.githubusercontent.com/39739180/211925950-0d51d79d-b883-4384-8c5d-9d9ae5874df1.mp4



## Testing/Proof
Tests pass
