### PR TITLE
fix(component): fix Chip and MessagingButton width

### DIFF
--- a/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
@@ -534,6 +534,7 @@ exports[`renders close button 1`] = `
   border: none;
   color: #313440;
   height: auto;
+  min-width: auto;
   padding: 0;
 }
 

--- a/packages/big-design/src/components/Button/private.ts
+++ b/packages/big-design/src/components/Button/private.ts
@@ -10,6 +10,7 @@ export const MessagingButton = styled(_StyleableButton)<ButtonProps>`
   border: ${({ theme }) => theme.border.none};
   color: ${({ theme }) => theme.colors.secondary70};
   height: auto;
+  min-width: auto;
   padding: ${({ theme }) => theme.spacing.none};
 
   &:active {

--- a/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
@@ -142,6 +142,7 @@ exports[`renders with close button if onRemove is present 1`] = `
   height: auto;
   padding: 0;
   width: auto;
+  min-width: auto;
 }
 
 @media (min-width:720px) {

--- a/packages/big-design/src/components/Chip/styled.tsx
+++ b/packages/big-design/src/components/Chip/styled.tsx
@@ -15,6 +15,7 @@ export const StyledCloseButton = styled(StyleableButton)`
   height: auto;
   padding: 0;
   width: auto;
+  min-width: auto;
 `;
 
 StyledChip.defaultProps = {

--- a/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
@@ -803,6 +803,7 @@ exports[`renders close button 1`] = `
   border: none;
   color: #313440;
   height: auto;
+  min-width: auto;
   padding: 0;
 }
 

--- a/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
@@ -798,6 +798,7 @@ exports[`renders close button 1`] = `
   border: none;
   color: #313440;
   height: auto;
+  min-width: auto;
   padding: 0;
 }
 

--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -140,6 +140,7 @@ exports[`render open modal 1`] = `
   border: none;
   color: #313440;
   height: auto;
+  min-width: auto;
   padding: 0;
 }
 
@@ -440,6 +441,7 @@ exports[`render open modal without backdrop 1`] = `
   border: none;
   color: #313440;
   height: auto;
+  min-width: auto;
   padding: 0;
 }
 

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -299,14 +299,11 @@ exports[`render pagination component 1`] = `
       class="c0 c3"
     >
       <button
-        aria-activedescendant=""
-        aria-controls=":r0:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
         id=":r0:-toggle-button"
         role="button"
-        tabindex="0"
         type="button"
       >
         <span
@@ -718,14 +715,11 @@ exports[`render pagination component with invalid page info 1`] = `
       class="c0 c3"
     >
       <button
-        aria-activedescendant=""
-        aria-controls=":r4:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
         id=":r4:-toggle-button"
         role="button"
-        tabindex="0"
         type="button"
       >
         <span
@@ -1137,14 +1131,11 @@ exports[`render pagination component with invalid range info 1`] = `
       class="c0 c3"
     >
       <button
-        aria-activedescendant=""
-        aria-controls=":r8:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
         id=":r8:-toggle-button"
         role="button"
-        tabindex="0"
         type="button"
       >
         <span
@@ -1557,14 +1548,11 @@ exports[`render pagination component with no items 1`] = `
       class="c0 c3"
     >
       <button
-        aria-activedescendant=""
-        aria-controls=":rc:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
         id=":rc:-toggle-button"
         role="button"
-        tabindex="0"
         type="button"
       >
         <span

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -314,14 +314,11 @@ exports[`dropdown is not visible if items fit 1`] = `
       class="c0 c6"
     >
       <button
-        aria-activedescendant=""
-        aria-controls=":r2:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
         id=":r2:-toggle-button"
         role="button"
-        tabindex="0"
       >
         <span
           class="c4"
@@ -682,14 +679,11 @@ exports[`it renders the given tabs 1`] = `
       class="c0 c6"
     >
       <button
-        aria-activedescendant=""
-        aria-controls=":r0:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
         id=":r0:-toggle-button"
         role="button"
-        tabindex="0"
       >
         <span
           class="c4"
@@ -1082,14 +1076,11 @@ exports[`only the pills that fit are visible 1`] = `
       class="c0 c6"
     >
       <button
-        aria-activedescendant=""
-        aria-controls=":r8:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
         id=":r8:-toggle-button"
         role="button"
-        tabindex="0"
       >
         <span
           class="c4"
@@ -1481,14 +1472,11 @@ exports[`only the pills that fit are visible 2 1`] = `
       class="c0 c6"
     >
       <button
-        aria-activedescendant=""
-        aria-controls=":ra:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
         id=":ra:-toggle-button"
         role="button"
-        tabindex="0"
       >
         <span
           class="c4"
@@ -1879,14 +1867,11 @@ exports[`renders all the filters if they fit 1`] = `
       class="c0 c6"
     >
       <button
-        aria-activedescendant=""
-        aria-controls=":r6:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
         id=":r6:-toggle-button"
         role="button"
-        tabindex="0"
       >
         <span
           class="c4"
@@ -2264,14 +2249,11 @@ exports[`renders dropdown if items do not fit 1`] = `
       class="c0 c6"
     >
       <button
-        aria-activedescendant=""
-        aria-controls=":r4:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
         id=":r4:-toggle-button"
         role="button"
-        tabindex="0"
       >
         <span
           class="c5"

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -349,14 +349,11 @@ exports[`renders a pagination component 1`] = `
           class="c1 c6"
         >
           <button
-            aria-activedescendant=""
-            aria-controls=":r13:-menu"
             aria-expanded="false"
             aria-haspopup="menu"
             class="c7 c8"
             id=":r13:-toggle-button"
             role="button"
-            tabindex="0"
             type="button"
           >
             <span

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -349,14 +349,11 @@ exports[`pagination renders a pagination component 1`] = `
           class="c1 c6"
         >
           <button
-            aria-activedescendant=""
-            aria-controls=":r13:-menu"
             aria-expanded="false"
             aria-haspopup="menu"
             class="c7 c8"
             id=":r13:-toggle-button"
             role="button"
-            tabindex="0"
             type="button"
           >
             <span


### PR DESCRIPTION
## What?

Fix `Chip`'s `CloseButton` width
Fix `MessagingButton` width

## Why?

Components with `IconOnly` derived from `StyledButton` were displaying incorectly 

## Screenshots/Screen Recordings

InlineMessage
<img width="924" alt="image" src="https://user-images.githubusercontent.com/7959201/213955528-de8427c8-8f25-48dc-b880-0d2d5cc2dc96.png">
<img width="914" alt="image" src="https://user-images.githubusercontent.com/7959201/213955794-ddea8055-8cdf-40fc-9226-7e9113670e12.png">

Message
<img width="924" alt="image" src="https://user-images.githubusercontent.com/7959201/213955578-4457f63e-9d54-46eb-815f-47f1748bc9f3.png">
<img width="912" alt="image" src="https://user-images.githubusercontent.com/7959201/213955759-14603bed-0e88-48d0-a3b4-448fd976a944.png">

Alert
<img width="357" alt="image" src="https://user-images.githubusercontent.com/7959201/213955606-0f87fa1a-e125-4a5a-85f0-43e6edb812a9.png">
<img width="356" alt="image" src="https://user-images.githubusercontent.com/7959201/213955687-77cc099b-92c4-48fc-8752-adba49b6b048.png">

Chip
<img width="440" alt="image" src="https://user-images.githubusercontent.com/7959201/213955636-4ad79fdb-2cb7-4a0c-8ef4-54ce7635e0fd.png">
<img width="433" alt="image" src="https://user-images.githubusercontent.com/7959201/213955658-2988016c-837e-4a1e-85ac-2776a63e202e.png">


## Testing/Proof

Checked visually on latest Chrome and ran tests.
