### PR TITLE
feat(component): add sub-rows indicators for worksheet

### DIFF
--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -15,6 +15,8 @@ import {
 import { StyledCell } from './styled';
 
 interface CellProps<Item> extends TCell<Item> {
+  isLastChild: boolean;
+  isChild: boolean;
   options?: WorksheetSelectableColumn<Item>['config']['options'];
   rowId: number | string;
   formatting?: WorksheetTextColumn<Item>['formatting'];
@@ -32,6 +34,8 @@ const InternalCell = <T extends WorksheetItem>({
   rowId,
   validation,
   value,
+  isChild,
+  isLastChild,
 }: CellProps<T>) => {
   const cell: TCell<T> = useMemo(
     () => ({ columnIndex, disabled, hash, rowIndex, type, value }),
@@ -189,7 +193,9 @@ const InternalCell = <T extends WorksheetItem>({
 
   return (
     <StyledCell
+      isChild={isChild}
       isEdited={isEdited}
+      isLastChild={isLastChild}
       isSelected={isSelected}
       isValid={isValid}
       onClick={handleClick}

--- a/packages/big-design/src/components/Worksheet/Cell/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/styled.tsx
@@ -4,6 +4,8 @@ import styled, { css } from 'styled-components';
 import { Cell, WorksheetItem } from '../types';
 
 interface StyledCellProps<Item> {
+  isLastChild: boolean;
+  isChild: boolean;
   isEdited?: boolean;
   isSelected?: boolean;
   isValid?: boolean;
@@ -15,7 +17,9 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
   border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} solid ${theme.colors.secondary30}`};
   box-sizing: border-box;
   padding: ${({ theme, type }) =>
-    type === 'select' ? 0 : `${theme.helpers.remCalc(6)} ${theme.helpers.remCalc(17)}`};
+    type === 'select' || type === 'toggle'
+      ? 0
+      : `${theme.helpers.remCalc(6)} ${theme.helpers.remCalc(17)}`};
   text-align: ${({ type }) => {
     switch (type) {
       case 'number':
@@ -30,8 +34,33 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
   }};
   user-select: none;
 
-  ${({ isSelected }) =>
+  ${({ type }) =>
+    type === 'toggle' &&
+    css`
+      position: relative;
+      border-color: ${({ theme }) =>
+        `${theme.colors.white} ${theme.colors.white} ${theme.colors.white} ${theme.colors.secondary30}`};
+    `}
+
+  ${({ type, isChild }) =>
+    type === 'toggle' &&
+    !isChild &&
+    css`
+      border-color: ${({ theme }) =>
+        `${theme.colors.secondary30} ${theme.colors.white} ${theme.colors.secondary30} ${theme.colors.secondary30}`};
+    `}
+
+
+    ${({ type, isLastChild }) =>
+    type === 'toggle' &&
+    isLastChild &&
+    css`
+      border-bottom-color: ${({ theme }) => `${theme.colors.secondary30}`};
+    `}
+
+  ${({ type, isSelected }) =>
     isSelected &&
+    type !== 'toggle' &&
     css`
       border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} double ${theme.colors.primary}`};
     `}
@@ -53,6 +82,32 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
     white-space: inherit;
     word-break: break-word;
   }
+
+  ${({ type, isChild, isLastChild }) =>
+    type === 'toggle' &&
+    isChild &&
+    css`
+      &::before {
+        content: '';
+        display: block;
+        top: 0;
+        height: ${isLastChild ? '50%' : '100%'};
+        left: 50%;
+        width: ${({ theme }) => `${theme.helpers.remCalc(1)}`};
+        position: absolute;
+        background-color: ${({ theme }) => `${theme.colors.secondary30}`};
+      }
+      &::after {
+        content: '';
+        display: block;
+        top: 50%;
+        left: 50%;
+        width: 50%;
+        height: ${({ theme }) => `${theme.helpers.remCalc(1)}`};
+        position: absolute;
+        background-color: ${({ theme }) => `${theme.colors.secondary30}`};
+      }
+    `}
 `;
 
 StyledCell.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/Row/Row.tsx
+++ b/packages/big-design/src/components/Worksheet/Row/Row.tsx
@@ -61,8 +61,18 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
     [],
   );
 
+  const isLastChild = useMemo(
+    () =>
+      expandableRows
+        ? Object.values(expandableRows)
+            .reduce((accum, item) => [...accum, item[item.length - 1]], [])
+            .includes(row.id)
+        : false,
+    [expandableRows, row.id],
+  );
+
   return (
-    <StyledTableRow isChild={isChild} isExpanded={!isChild || isExpanded}>
+    <StyledTableRow isExpanded={!isChild || isExpanded}>
       <RowStatus rowIndex={rowIndex} />
       {columns.map((column, columnIndex) => (
         <Cell
@@ -70,6 +80,8 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
           disabled={column.disabled || isDisabled}
           formatting={hasFormatting(column) ? column.formatting : undefined}
           hash={column.hash}
+          isChild={isChild}
+          isLastChild={isLastChild}
           key={`${rowIndex}-${columnIndex}`}
           options={column.type === 'select' ? column.config.options : undefined}
           rowId={row.id}

--- a/packages/big-design/src/components/Worksheet/Row/styled.ts
+++ b/packages/big-design/src/components/Worksheet/Row/styled.ts
@@ -1,10 +1,8 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
-export const StyledTableRow = styled.tr<{ isChild: boolean; isExpanded: boolean }>`
+export const StyledTableRow = styled.tr<{ isExpanded: boolean }>`
   display: ${({ isExpanded }) => (isExpanded ? 'table-row' : 'none')};
-  background-color: ${({ theme, isChild }) =>
-    isChild ? theme.colors.secondary10 : theme.colors.white};
 `;
 
 StyledTableRow.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -68,7 +68,7 @@ const InternalWorksheet = typedMemo(
     // Add a column for the toggle components
     const expandedColumns: Array<InternalWorksheetColumn<T>> = useMemo(() => {
       return expandableRows
-        ? [{ hash: '', header: '', type: 'toggle', width: 50 }, ...columns]
+        ? [{ hash: '', header: '', type: 'toggle', width: 32 }, ...columns]
         : columns;
     }, [columns, expandableRows]);
 
@@ -172,6 +172,7 @@ const InternalWorksheet = typedMemo(
       <UpdateItemsProvider items={rows}>
         <StyledBox>
           <Table
+            hasExpandableRows={Boolean(expandableRows)}
             hasStaticWidth={tableHasStaticWidth}
             minWidth={minWidth}
             onKeyDown={handleKeyDown}

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`renders worksheet 1`] = `
   class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledBox-sc-16rzzpq-2 hEsHBI"
 >
   <table
-    class="styled__Table-sc-16rzzpq-0 lcEKdF"
+    class="styled__Table-sc-16rzzpq-0 dihcXA"
     tabindex="0"
   >
     <thead>
@@ -14,31 +14,31 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-1aacki0-0 jTecwD"
         />
         <th
-          class="styled__Header-sc-16rzzpq-1 kXfxBV"
+          class="styled__Header-sc-16rzzpq-1 tWleT"
         >
           Product name
            
         </th>
         <th
-          class="styled__Header-sc-16rzzpq-1 hpccrq"
+          class="styled__Header-sc-16rzzpq-1 dqwjjU"
         >
           Visible on storefront
            
         </th>
         <th
-          class="styled__Header-sc-16rzzpq-1 kXfxBV"
+          class="styled__Header-sc-16rzzpq-1 tWleT"
         >
           Other field
            
         </th>
         <th
-          class="styled__Header-sc-16rzzpq-1 kXfxBV"
+          class="styled__Header-sc-16rzzpq-1 tWleT"
         >
           Other field
            
         </th>
         <th
-          class="styled__Header-sc-16rzzpq-1 exSgRY"
+          class="styled__Header-sc-16rzzpq-1 iqHMUa"
         >
           Number field
            
@@ -75,13 +75,13 @@ exports[`renders worksheet 1`] = `
     </thead>
     <tbody>
       <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 TFqyL"
+        class="styled__StyledTableRow-sc-1bzgr3l-0 iVAweo"
       >
         <td
           class="styled__Status-sc-1aacki0-0 jTecwD"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -93,7 +93,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 jrERuW"
+          class="styled__StyledCell-sc-1bt06ph-0 Suqfr"
           type="checkbox"
         >
           <div
@@ -151,7 +151,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -163,7 +163,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="modal"
         >
           <div
@@ -192,7 +192,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 kJefLh"
+          class="styled__StyledCell-sc-1bt06ph-0 hJijTQ"
           type="number"
         >
           <p
@@ -205,13 +205,13 @@ exports[`renders worksheet 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 TFqyL"
+        class="styled__StyledTableRow-sc-1bzgr3l-0 iVAweo"
       >
         <td
           class="styled__Status-sc-1aacki0-0 jTecwD"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -223,7 +223,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 jrERuW"
+          class="styled__StyledCell-sc-1bt06ph-0 Suqfr"
           type="checkbox"
         >
           <div
@@ -281,7 +281,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -293,7 +293,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="modal"
         >
           <div
@@ -322,7 +322,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 kJefLh"
+          class="styled__StyledCell-sc-1bt06ph-0 hJijTQ"
           type="number"
         >
           <p
@@ -335,13 +335,13 @@ exports[`renders worksheet 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 TFqyL"
+        class="styled__StyledTableRow-sc-1bzgr3l-0 iVAweo"
       >
         <td
           class="styled__Status-sc-1aacki0-0 jTecwD"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -353,7 +353,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 jrERuW"
+          class="styled__StyledCell-sc-1bt06ph-0 Suqfr"
           type="checkbox"
         >
           <div
@@ -410,7 +410,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -420,7 +420,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="modal"
         >
           <div
@@ -449,7 +449,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 kJefLh"
+          class="styled__StyledCell-sc-1bt06ph-0 hJijTQ"
           type="number"
         >
           <p
@@ -462,13 +462,13 @@ exports[`renders worksheet 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 TFqyL"
+        class="styled__StyledTableRow-sc-1bzgr3l-0 iVAweo"
       >
         <td
           class="styled__Status-sc-1aacki0-0 jTecwD"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -480,7 +480,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 jrERuW"
+          class="styled__StyledCell-sc-1bt06ph-0 Suqfr"
           type="checkbox"
         >
           <div
@@ -538,7 +538,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -550,7 +550,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="modal"
         >
           <div
@@ -579,7 +579,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 kJefLh"
+          class="styled__StyledCell-sc-1bt06ph-0 hJijTQ"
           type="number"
         >
           <p
@@ -592,13 +592,13 @@ exports[`renders worksheet 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 TFqyL"
+        class="styled__StyledTableRow-sc-1bzgr3l-0 iVAweo"
       >
         <td
           class="styled__Status-sc-1aacki0-0 kGNgfN"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 MHtCo"
+          class="styled__StyledCell-sc-1bt06ph-0 bLpbvx"
           type="text"
         >
           <p
@@ -608,7 +608,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 jrERuW"
+          class="styled__StyledCell-sc-1bt06ph-0 Suqfr"
           type="checkbox"
         >
           <div
@@ -664,7 +664,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -674,7 +674,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="modal"
         >
           <div
@@ -701,7 +701,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 iCVJtP"
+          class="styled__StyledCell-sc-1bt06ph-0 dwaAsi"
           type="number"
         >
           <p
@@ -712,13 +712,13 @@ exports[`renders worksheet 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 TFqyL"
+        class="styled__StyledTableRow-sc-1bzgr3l-0 iVAweo"
       >
         <td
           class="styled__Status-sc-1aacki0-0 jTecwD"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -730,7 +730,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 jrERuW"
+          class="styled__StyledCell-sc-1bt06ph-0 Suqfr"
           type="checkbox"
         >
           <div
@@ -788,7 +788,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -800,7 +800,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="modal"
         >
           <div
@@ -829,7 +829,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 kJefLh"
+          class="styled__StyledCell-sc-1bt06ph-0 hJijTQ"
           type="number"
         >
           <p
@@ -842,13 +842,13 @@ exports[`renders worksheet 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 TFqyL"
+        class="styled__StyledTableRow-sc-1bzgr3l-0 iVAweo"
       >
         <td
           class="styled__Status-sc-1aacki0-0 kGNgfN"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -860,7 +860,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 jrERuW"
+          class="styled__StyledCell-sc-1bt06ph-0 Suqfr"
           type="checkbox"
         >
           <div
@@ -917,7 +917,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -929,7 +929,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="modal"
         >
           <div
@@ -958,7 +958,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 iCVJtP"
+          class="styled__StyledCell-sc-1bt06ph-0 dwaAsi"
           type="number"
         >
           <p
@@ -971,13 +971,13 @@ exports[`renders worksheet 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 TFqyL"
+        class="styled__StyledTableRow-sc-1bzgr3l-0 iVAweo"
       >
         <td
           class="styled__Status-sc-1aacki0-0 jTecwD"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -989,7 +989,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 jrERuW"
+          class="styled__StyledCell-sc-1bt06ph-0 Suqfr"
           type="checkbox"
         >
           <div
@@ -1047,7 +1047,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -1059,7 +1059,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="modal"
         >
           <div
@@ -1088,7 +1088,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 kJefLh"
+          class="styled__StyledCell-sc-1bt06ph-0 hJijTQ"
           type="number"
         >
           <p
@@ -1101,13 +1101,13 @@ exports[`renders worksheet 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 TFqyL"
+        class="styled__StyledTableRow-sc-1bzgr3l-0 iVAweo"
       >
         <td
           class="styled__Status-sc-1aacki0-0 jTecwD"
         />
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -1119,7 +1119,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 jrERuW"
+          class="styled__StyledCell-sc-1bt06ph-0 Suqfr"
           type="checkbox"
         >
           <div
@@ -1177,7 +1177,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="text"
         >
           <p
@@ -1189,7 +1189,7 @@ exports[`renders worksheet 1`] = `
           </p>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 euavmG"
+          class="styled__StyledCell-sc-1bt06ph-0 buYWID"
           type="modal"
         >
           <div
@@ -1218,7 +1218,7 @@ exports[`renders worksheet 1`] = `
           </div>
         </td>
         <td
-          class="styled__StyledCell-sc-1bt06ph-0 kJefLh"
+          class="styled__StyledCell-sc-1bt06ph-0 hJijTQ"
           type="number"
         >
           <p

--- a/packages/big-design/src/components/Worksheet/editors/ToggleEditor/ToggleEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ToggleEditor/ToggleEditor.tsx
@@ -1,7 +1,6 @@
 import { ChevronRightIcon, ExpandMoreIcon } from '@bigcommerce/big-design-icons';
 import React, { memo, useEffect } from 'react';
 
-import { Flex } from '../../../Flex';
 import { useExpandable, useWorksheetStore } from '../../hooks';
 
 import { StyledExpandButton } from './styled';
@@ -25,29 +24,33 @@ const InternalToggleEditor = ({ rowId, toggle }: ToggleEditorProps) => {
     setEditingCell({ cell: null });
   }, [hasExpanded, isExpandable, onToggle, setEditingCell, toggle]);
 
-  return isExpandable ? (
-    <Flex justifyContent="center">
-      {hasExpanded ? (
-        <StyledExpandButton
-          iconOnly={<ExpandMoreIcon />}
-          onClick={() => {
-            onToggle(true);
-          }}
-          title="toggle row expanded"
-          variant="subtle"
-        />
-      ) : (
-        <StyledExpandButton
-          iconOnly={<ChevronRightIcon />}
-          onClick={() => {
-            onToggle(false);
-          }}
-          title="toggle row expanded"
-          variant="subtle"
-        />
-      )}
-    </Flex>
-  ) : null;
+  if (!isExpandable) {
+    return null;
+  }
+
+  if (hasExpanded) {
+    return (
+      <StyledExpandButton
+        iconOnly={<ExpandMoreIcon color="secondary60" />}
+        onClick={() => {
+          onToggle(true);
+        }}
+        title="toggle row expanded"
+        variant="subtle"
+      />
+    );
+  }
+
+  return (
+    <StyledExpandButton
+      iconOnly={<ChevronRightIcon color="secondary60" />}
+      onClick={() => {
+        onToggle(false);
+      }}
+      title="toggle row expanded"
+      variant="subtle"
+    />
+  );
 };
 
 export const ToggleEditor = memo(InternalToggleEditor);

--- a/packages/big-design/src/components/Worksheet/editors/ToggleEditor/styled.ts
+++ b/packages/big-design/src/components/Worksheet/editors/ToggleEditor/styled.ts
@@ -4,8 +4,22 @@ import styled from 'styled-components';
 import { StyleableButton } from '../../../Button/private';
 
 export const StyledExpandButton = styled(StyleableButton)`
-  height: ${({ theme }) => theme.spacing.large};
-  width: ${({ theme }) => theme.spacing.xxSmall};
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 100%;
+  min-width: ${({ theme }) => `${theme.helpers.remCalc(32)}`};
+  border-radius: 0;
+
+  &:focus {
+    box-shadow: none;
+  }
+
+  &:hover {
+    svg {
+      color: ${({ theme }) => `${theme.colors.primary}`};
+    }
+  }
 `;
 
 StyledExpandButton.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/styled.tsx
@@ -1,11 +1,15 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Box } from '../Box';
 
 import { InternalWorksheetColumn } from './types';
 
-export const Table = styled.table<{ minWidth?: number; hasStaticWidth: boolean }>`
+export const Table = styled.table<{
+  minWidth?: number;
+  hasStaticWidth: boolean;
+  hasExpandableRows: boolean;
+}>`
   border-collapse: collapse;
   border-spacing: 0;
   min-width: ${({ minWidth, hasStaticWidth }) =>
@@ -16,13 +20,33 @@ export const Table = styled.table<{ minWidth?: number; hasStaticWidth: boolean }
   &:focus {
     outline: none;
   }
+
+  ${({ hasExpandableRows }) =>
+    hasExpandableRows &&
+    css`
+      & > thead > tr {
+        & > th:nth-of-type(2) {
+          padding-left: ${({ theme }) => theme.spacing.xSmall};
+        }
+      }
+
+      & > tbody > tr {
+        & > td:nth-of-type(3) {
+          padding-left: ${({ theme }) => theme.spacing.xSmall};
+        }
+      }
+    `}
 `;
+
+Table.defaultProps = { theme: defaultTheme };
 
 export const Header = styled.th<{
   columnType: InternalWorksheetColumn<unknown>['type'];
   columnWidth: InternalWorksheetColumn<unknown>['width'];
 }>`
   border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} solid ${theme.colors.secondary30}`};
+  border-right-color: ${({ theme, columnType }) =>
+    columnType === 'toggle' ? `${theme.colors.white}` : `${theme.colors.secondary30}`};
   box-sizing: border-box;
   color: ${({ theme }) => theme.colors.secondary60};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};


### PR DESCRIPTION
## What?
1. Add sub-rows indicators for the worksheet.
2. Changes in the worksheet according to the new guidelines.

## Why?
The guidelines is updated.

## Screenshots/Screen Recordings
<img width="752" alt="Screenshot 2023-01-25 at 14 01 20" src="https://user-images.githubusercontent.com/84462142/214559103-f339679c-d812-4340-b2a9-7d24dbd95585.png">



## Testing/Proof

Locally.
