### PR TITLE
feat(component): add description to Panel

### DIFF
--- a/packages/big-design/src/components/AccordionPanel/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/AccordionPanel/__snapshots__/spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`it renders accordion panel header 1`] = `
 <h2
-  class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 fVcMKm bJUVLc"
+  class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 diIXBE bJUVLc"
 >
   Accordion Panel Header
 </h2>

--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -1,9 +1,11 @@
-import React, { forwardRef, HTMLAttributes, memo, Ref } from 'react';
+import React, { forwardRef, HTMLAttributes, isValidElement, memo, Ref } from 'react';
 
 import { MarginProps } from '../../mixins';
 import { excludePaddingProps } from '../../mixins/paddings/paddings';
+import { warning } from '../../utils';
 import { Button, ButtonProps } from '../Button';
 import { Flex } from '../Flex';
+import { Text } from '../Typography';
 
 import { StyledH2, StyledPanel } from './styled';
 
@@ -17,6 +19,7 @@ export interface PanelAction extends Omit<ButtonProps, 'children'> {
 
 export interface PanelProps extends HTMLAttributes<HTMLElement>, MarginProps {
   children?: React.ReactNode;
+  description?: React.ReactNode;
   header?: string;
   headerId?: string;
   action?: PanelAction;
@@ -24,7 +27,7 @@ export interface PanelProps extends HTMLAttributes<HTMLElement>, MarginProps {
 
 export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRef, ...props }) => {
   const filteredProps = excludePaddingProps(props);
-  const { action, children, header, headerId, ...rest } = filteredProps;
+  const { action, children, description, header, headerId, ...rest } = filteredProps;
 
   const renderHeader = () => {
     if (!header && !action) {
@@ -37,10 +40,30 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
 
     return (
       <Flex flexDirection="row">
-        {Boolean(header) && <StyledH2 id={headerId}>{header}</StyledH2>}
+        {Boolean(header) && (
+          <StyledH2 id={headerId} marginBottom={description ? 'xxSmall' : 'medium'}>
+            {header}
+          </StyledH2>
+        )}
         {action && <Button {...action}>{action.text}</Button>}
       </Flex>
     );
+  };
+
+  const renderDescription = () => {
+    if (!description) {
+      return null;
+    }
+
+    if (typeof description === 'string') {
+      return <Text color="secondary60">{description}</Text>;
+    }
+
+    if (isValidElement(description)) {
+      return description;
+    }
+
+    warning('description must be either a string or a ReactNode.');
   };
 
   return (
@@ -53,6 +76,7 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
       shadow="raised"
     >
       {renderHeader()}
+      {renderDescription()}
       {children}
     </StyledPanel>
   );

--- a/packages/big-design/src/components/Panel/spec.tsx
+++ b/packages/big-design/src/components/Panel/spec.tsx
@@ -4,6 +4,8 @@ import 'jest-styled-components';
 
 import { fireEvent, render, screen } from '@test/utils';
 
+import { Text } from '../Typography';
+
 import { Panel } from './Panel';
 
 test('render panel', () => {
@@ -52,6 +54,42 @@ test('renders a header and action', () => {
 
   expect(actionButton).toBeInTheDocument();
   expect(actionButton.textContent).toBe('Test Action');
+});
+
+describe('description', () => {
+  test('renders string description', async () => {
+    render(
+      <Panel action={{ text: 'Test Action' }} description="Test Description" header="Test Header">
+        Dolore proident eiusmod sint est enim laboris anim minim quis ut adipisicing consectetur
+        officia ex. Ipsum eiusmod fugiat amet pariatur culpa tempor aliquip tempor nisi. Irure esse
+        deserunt nostrud ipsum id adipisicing enim velit labore. Nulla exercitation laborum laboris
+        Lorem irure sit esse nulla mollit aliquip consectetur velit
+      </Panel>,
+    );
+
+    const description = await screen.findByText('Test Description');
+
+    expect(description).toBeInTheDocument();
+  });
+
+  test('renders ReactNode description', async () => {
+    render(
+      <Panel
+        action={{ text: 'Test Action' }}
+        description={<Text>Test Description</Text>}
+        header="Test Header"
+      >
+        Dolore proident eiusmod sint est enim laboris anim minim quis ut adipisicing consectetur
+        officia ex. Ipsum eiusmod fugiat amet pariatur culpa tempor aliquip tempor nisi. Irure esse
+        deserunt nostrud ipsum id adipisicing enim velit labore. Nulla exercitation laborum laboris
+        Lorem irure sit esse nulla mollit aliquip consectetur velit
+      </Panel>,
+    );
+
+    const description = await screen.findByText('Test Description');
+
+    expect(description).toBeInTheDocument();
+  });
 });
 
 test('action options get forwarded to button', () => {

--- a/packages/docs/PropTables/PanelPropTable.tsx
+++ b/packages/docs/PropTables/PanelPropTable.tsx
@@ -31,6 +31,11 @@ const panelProps: Prop[] = [
       </>
     ),
   },
+  {
+    name: 'description',
+    types: ['string', 'React.ReactNode'],
+    description: 'Appends a description.',
+  },
 ];
 
 export const PanelPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/PanelPropTable.tsx
+++ b/packages/docs/PropTables/PanelPropTable.tsx
@@ -34,7 +34,7 @@ const panelProps: Prop[] = [
   {
     name: 'description',
     types: ['string', 'React.ReactNode'],
-    description: 'Appends a description.',
+    description: 'Appends a description below the header and action.',
   },
 ];
 

--- a/packages/docs/pages/panel.tsx
+++ b/packages/docs/pages/panel.tsx
@@ -33,6 +33,7 @@ const PanelPage = () => {
                 // Do some action
               },
             }}
+            description="This is the panel's optional description."
             header="Panel header"
           >
             <Text>


### PR DESCRIPTION
## What?

Add description to Panel component. Resolves #1109.

## How?

I opted to allow the description a `string` or as a `ReactNode`. This will allow the flexibility to include links in the description. Let me know if we want to showcase the "custom" ReactNode functionality.

Should we include more do's and don'ts for this prop? @bigcommerce/product-design 

## Screenshots/Screen Recordings

![screencapture-localhost-3000-panel-2023-02-01-15_08_10](https://user-images.githubusercontent.com/196129/216163951-dec547e4-bc52-494b-bba3-d4fc6bbe09c6.png)

Without description (remains the same):
<img width="733" alt="Screenshot 2023-02-01 at 4 32 48 PM" src="https://user-images.githubusercontent.com/196129/216178990-d88b9b7d-3f54-449d-a4aa-894c2de310f7.png">

## Testing/Proof

Unit tests
