### PR TITLE
fix(component): prevent focus from opening menu in selects

### DIFF
--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -38,7 +38,7 @@
     "@popperjs/core": "^2.11.6",
     "@types/react-datepicker": "^4.4.2",
     "date-fns": "2.29.3",
-    "downshift": "7.2.0",
+    "downshift": "7.2.1",
     "focus-trap": "^7.0.0",
     "polished": "^4.0.0",
     "react-beautiful-dnd": "^13.1.1",

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -166,6 +166,12 @@ export const MultiSelect = typedMemo(
         case useCombobox.stateChangeTypes.InputBlur:
           return { ...actionAndChanges.changes, inputValue: '' };
 
+        case useCombobox.stateChangeTypes.InputFocus:
+          return {
+            ...actionAndChanges.changes,
+            isOpen: false, // keep the menu closed when input gets focused.
+          };
+
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick: {
           if (!actionAndChanges.changes.selectedItem) {

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -281,6 +281,18 @@ test('multi select menu opens/closes when input button is clicked', async () => 
   expect(listbox).toBeEmptyDOMElement();
 });
 
+test('menu should not open on focus', async () => {
+  render(MultiSelectMock);
+
+  await userEvent.tab();
+  await userEvent.tab();
+  await userEvent.tab();
+
+  const listbox = await screen.findByRole('listbox');
+
+  expect(listbox).toBeEmptyDOMElement();
+});
+
 test('esc should close menu', async () => {
   render(MultiSelectMock);
 

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -174,6 +174,12 @@ export const Select = typedMemo(
             inputValue: selectedOption ? selectedOption.content : '',
           };
 
+        case useCombobox.stateChangeTypes.InputFocus:
+          return {
+            ...actionAndChanges.changes,
+            isOpen: false, // keep the menu closed when input gets focused.
+          };
+
         default:
           return actionAndChanges.changes;
       }

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -267,6 +267,16 @@ test('select menu opens/closes when input button is clicked', async () => {
   expect(listbox).toBeEmptyDOMElement();
 });
 
+test('menu should not open on focus', async () => {
+  render(SelectMock);
+
+  await userEvent.tab();
+
+  const listbox = await screen.findByRole('listbox');
+
+  expect(listbox).toBeEmptyDOMElement();
+});
+
 test('esc should close menu', async () => {
   render(SelectMock);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4815,10 +4815,10 @@ dotenv@~10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
-downshift@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-7.2.0.tgz#f2a2777253a8ca26ca56c38caa8e75f76a6ab346"
-  integrity sha512-dEn1Sshe7iTelUhmdbmiJhtIiwIBxBV8p15PuvEBh0qZcHXZnEt0geuCIIkCL4+ooaKRuLE0Wc+Fz9SwWuBIyg==
+downshift@7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-7.2.1.tgz#5cca2e4089357ce1cec30207d2c0776f10dacad5"
+  integrity sha512-P39LrMwHEkeiOeMoVE+Nv01AMSXzFQG2b5tsSGOG0zi99qMgOEN4RBHNfQuYgYUwV1uDJeKUhOvIZoQQ/r27NA==
   dependencies:
     "@babel/runtime" "^7.14.8"
     compute-scroll-into-view "^2.0.4"


### PR DESCRIPTION
## What?
Bump of `downshift` to `7.x` enabled by default the opening of the menu when the input was focused. This reverts that behavior.

## Screenshots/Screen Recordings
![Kapture 2023-02-21 at 11 04 27](https://user-images.githubusercontent.com/196129/220412024-0fe693c0-3cca-4822-bfc5-17d43d289e16.gif)

## Testing/Proof

Unit test + local.
