### PR TITLE
feat(component): add tooltip for Input and Select components

### DIFF
--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -218,7 +218,7 @@ exports[`simple form render 1`] = `
       <div>
         <label
           class="c1 c5"
-          for=":r1:"
+          for=":r2:"
         >
           Middle Name
         </label>
@@ -235,7 +235,7 @@ exports[`simple form render 1`] = `
           >
             <input
               class="c8"
-              id=":r1:"
+              id=":r2:"
               placeholder="Placeholder text"
             />
           </div>

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -1,3 +1,4 @@
+import { BaselineHelpIcon } from '@bigcommerce/big-design-icons';
 import React, {
   cloneElement,
   forwardRef,
@@ -10,9 +11,11 @@ import React, {
 } from 'react';
 
 import { typedMemo, warning } from '../../utils';
+import { Box } from '../Box';
 import { Chip, ChipProps } from '../Chip';
 import { FormControlDescription, FormControlLabel } from '../Form';
 import { useInputErrors } from '../Form/useInputErrors';
+import { Tooltip } from '../Tooltip';
 
 import { StyledIconWrapper, StyledInput, StyledInputContent, StyledInputWrapper } from './styled';
 
@@ -24,6 +27,7 @@ export interface Props {
   iconRight?: React.ReactNode;
   label?: React.ReactChild;
   labelId?: string;
+  tooltip?: string;
 }
 
 interface PrivateProps {
@@ -40,10 +44,12 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
   forwardedRef,
   label,
   labelId,
+  tooltip,
   ...props
 }) => {
   const [focus, setFocus] = useState(false);
   const uniqueInputId = useId();
+  const tooltipId = useId();
   const id = props.id ? props.id : uniqueInputId;
   const { errors } = useInputErrors(id, error);
 
@@ -137,9 +143,36 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
     return chips.map((chip) => <Chip {...chip} key={chip.label} marginBottom="none" />);
   }, [chips]);
 
+  const renderedTooltip = useMemo(() => {
+    if (typeof tooltip === 'string' && tooltip.length > 0) {
+      return (
+        <Tooltip
+          id={tooltipId}
+          placement="right"
+          trigger={
+            <Box as="span" marginLeft="xxSmall">
+              <BaselineHelpIcon
+                aria-describedby={tooltipId}
+                color="secondary50"
+                marginBottom="small"
+                size="medium"
+                title="Hover or focus for additional context."
+              />
+            </Box>
+          }
+        >
+          {tooltip}
+        </Tooltip>
+      );
+    }
+
+    return null;
+  }, [tooltip, tooltipId]);
+
   return (
     <div>
       {renderedLabel}
+      {renderedTooltip}
       {renderedDescription}
       <StyledInputWrapper disabled={disabled} error={errors} focus={focus}>
         {renderedIconLeft}

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -181,7 +181,7 @@ exports[`renders all together 1`] = `
 <div>
   <label
     class="c0 c1"
-    for=":rp:"
+    for=":r1c:"
   >
     This is a label
   </label>
@@ -221,7 +221,7 @@ exports[`renders all together 1`] = `
     >
       <input
         class="c7"
-        id=":rp:"
+        id=":r1c:"
       />
     </div>
     <div

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -3,7 +3,7 @@ import { theme } from '@bigcommerce/big-design-theme';
 import React, { createRef } from 'react';
 import 'jest-styled-components';
 
-import { render, screen } from '@test/utils';
+import { fireEvent, render, screen } from '@test/utils';
 
 import { warning } from '../../utils';
 import { FormControlDescription, FormControlError, FormControlLabel, FormGroup } from '../Form';
@@ -356,4 +356,22 @@ test('appends (optional) text to label if input is not required', () => {
   const label = container.querySelector('label');
 
   expect(label).toHaveStyleRule('content', "' (optional)'", { modifier: '::after' });
+});
+
+describe('Input tooltip', () => {
+  test('renders with tooltip icon', () => {
+    render(<Input label="Test Label" tooltip="Info about input" />);
+
+    expect(screen.getByTitle('Hover or focus for additional context.')).toBeTruthy();
+  });
+
+  test('renders tooltip when hovering on icon', () => {
+    render(<Input label="Test Label" tooltip="Info about input" />);
+
+    fireEvent.mouseOver(screen.getByTitle('Hover or focus for additional context.'));
+
+    const result = screen.getByText('Info about input');
+
+    expect(result).toBeInTheDocument();
+  });
 });

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -1,3 +1,4 @@
+import { BaselineHelpIcon } from '@bigcommerce/big-design-icons';
 import { useCombobox, UseComboboxState, UseComboboxStateChangeOptions } from 'downshift';
 import React, {
   cloneElement,
@@ -22,6 +23,7 @@ import { List } from '../List';
 import { SelectOption, SelectOptionGroup, SelectProps } from '../Select';
 import { DropdownButton, StyledDropdownIcon, StyledInputContainer } from '../Select/styled';
 import { SelectAction } from '../Select/types';
+import { Tooltip } from '../Tooltip';
 
 export const Select = typedMemo(
   <T,>({
@@ -46,10 +48,12 @@ export const Select = typedMemo(
     required,
     style,
     value,
+    tooltip,
     ...props
   }: SelectProps<T>): ReturnType<React.FC<SelectProps<T>>> => {
     const defaultRef: RefObject<HTMLInputElement> = createRef();
     const selectUniqueId = useId();
+    const tooltipId = useId();
 
     const [inputValue, setInputValue] = useState<string | undefined>('');
 
@@ -365,9 +369,36 @@ export const Select = typedMemo(
       selectedItem,
     ]);
 
+    const renderedTooltip = useMemo(() => {
+      if (typeof tooltip === 'string' && tooltip.length > 0) {
+        return (
+          <Tooltip
+            id={tooltipId}
+            placement="right"
+            trigger={
+              <Box as="span" marginLeft="xxSmall">
+                <BaselineHelpIcon
+                  aria-describedby={tooltipId}
+                  color="secondary50"
+                  marginBottom="small"
+                  size="medium"
+                  title="Hover or focus for additional context."
+                />
+              </Box>
+            }
+          >
+            {tooltip}
+          </Tooltip>
+        );
+      }
+
+      return null;
+    }, [tooltip, tooltipId]);
+
     return (
       <div>
         {renderLabel}
+        {renderedTooltip}
         {renderInput}
         <Box ref={popperRef} style={styles.popper} {...attributes.poppper} zIndex="popover">
           <List

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -987,3 +987,37 @@ describe('aria-labelledby', () => {
     expect(input).toHaveAttribute('aria-labelledby', 'countries');
   });
 });
+
+describe('Select tooltip', () => {
+  test('renders with tooltip icon', () => {
+    render(
+      <Select
+        label="Countries"
+        labelId="countries"
+        onOptionChange={onChange}
+        options={mockOptions}
+        tooltip="Info about select"
+      />,
+    );
+
+    expect(screen.getByTitle('Hover or focus for additional context.')).toBeTruthy();
+  });
+
+  test('renders tooltip when hovering on icon', () => {
+    render(
+      <Select
+        label="Countries"
+        labelId="countries"
+        onOptionChange={onChange}
+        options={mockOptions}
+        tooltip="Info about select"
+      />,
+    );
+
+    fireEvent.mouseOver(screen.getByTitle('Hover or focus for additional context.'));
+
+    const result = screen.getByText('Info about select');
+
+    expect(result).toBeInTheDocument();
+  });
+});

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -13,6 +13,7 @@ interface BaseSelect extends Omit<React.HTMLAttributes<HTMLInputElement>, 'child
   filterable?: boolean;
   inputRef?: RefObject<HTMLInputElement> | React.Ref<HTMLInputElement>;
   label?: React.ReactChild;
+  tooltip?: string;
   labelId?: string;
   maxHeight?: number;
   name?: string;

--- a/packages/docs/PropTables/InputPropTable.tsx
+++ b/packages/docs/PropTables/InputPropTable.tsx
@@ -57,6 +57,11 @@ const inputProps: Prop[] = [
       </>
     ),
   },
+  {
+    name: 'tooltip',
+    types: 'string',
+    description: 'Tooltip for the input.',
+  },
 ];
 
 export const InputPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/SelectPropTable.tsx
+++ b/packages/docs/PropTables/SelectPropTable.tsx
@@ -153,6 +153,11 @@ const selectProps: Prop[] = [
     types: 'any ',
     description: <>Modifies the current selected value of the field.</>,
   },
+  {
+    name: 'tooltip',
+    types: 'string',
+    description: 'Tooltip for the select.',
+  },
 ];
 
 const selectOptionProps: Prop[] = [


### PR DESCRIPTION
## What?

Add a tooltip for `Input` and `Select` components.

## Why?

To be able to provide an extended description of the field.

## Screenshots/Screen Recordings
<img width="526" alt="Screenshot 2023-03-06 at 11 26 18" src="https://user-images.githubusercontent.com/84462142/223069867-0b15edf7-144b-40db-8b12-7a9142767914.png">
<img width="493" alt="Screenshot 2023-03-06 at 11 11 41" src="https://user-images.githubusercontent.com/84462142/223069889-b7939478-c365-4608-8392-6741091985f4.png">


## Testing/Proof

Locally + UT.
