### PR TITLE
feat(component): add cell selection with a keyboard

### DIFF
--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -64,7 +64,7 @@ const InternalWorksheet = typedMemo(
       useMemo(() => (state) => state.invalidCells, []),
     );
 
-    const { handleKeyDown } = useKeyEvents();
+    const { handleKeyDown, handleKeyUp } = useKeyEvents();
 
     // Add a column for the toggle components
     const expandedColumns: Array<InternalWorksheetColumn<T>> = useMemo(() => {
@@ -179,6 +179,7 @@ const InternalWorksheet = typedMemo(
             hasStaticWidth={tableHasStaticWidth}
             minWidth={minWidth}
             onKeyDown={handleKeyDown}
+            onKeyUp={handleKeyUp}
             ref={tableRef}
             tabIndex={0}
           >

--- a/packages/big-design/src/components/Worksheet/hooks/useWorksheetStore/useWorksheetStore.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useWorksheetStore/useWorksheetStore.ts
@@ -21,6 +21,7 @@ export interface BaseState<Item> {
   editedCells: Array<Cell<Item>>;
   editingCell: Cell<Item> | null;
   isMetaKey: boolean;
+  isShiftPressed: boolean;
   isAutoFillActive: boolean;
   isSelectingActive: boolean;
   isBlockedFillOut: boolean;
@@ -50,6 +51,7 @@ export interface BaseState<Item> {
     isControlKey,
     editWithValue,
   }: SetEditingCellArgs<Item>) => void;
+  setShiftPressed: (ShiftPressed: boolean) => void;
   setDisabledRows: (disabledRows: DisabledRows) => void;
   setHiddenRows: (hiddenRow: Array<string | number>) => void;
   setOpenModal: (value: keyof Item | null) => void;
@@ -68,6 +70,7 @@ export const createWorksheetStore = <Item extends WorksheetItem>() =>
     editedCells: [],
     editingCell: null,
     isMetaKey: false,
+    isShiftPressed: false,
     isAutoFillActive: false,
     isSelectingActive: false,
     isBlockedFillOut: false,
@@ -101,6 +104,7 @@ export const createWorksheetStore = <Item extends WorksheetItem>() =>
         return { ...state, editingCell: cell, isMetaKey, isControlKey, editWithValue };
       });
     },
+    setShiftPressed: (isShiftPressed: boolean) => set((state) => ({ ...state, isShiftPressed })),
     setDisabledRows: (disabledRows) => set((state) => ({ ...state, disabledRows })),
     setHiddenRows: (hiddenRows) => set((state) => ({ ...state, hiddenRows })),
     setOpenModal: (value) => set((state) => ({ ...state, openedModal: value })),

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -256,6 +256,56 @@ describe('selection', () => {
       `background-color: ${theme.colors.primary}`,
     );
   });
+
+  test('selects cells on selecting range', async () => {
+    render(<Worksheet columns={columns} items={items} onChange={handleChange} />);
+
+    const firstRowElement = await screen.findByText('Shoes Name Three');
+    const firstCell = firstRowElement.parentElement;
+    const lastRowElement = await screen.findByText('Shoes Name One');
+    const lastCell = lastRowElement.parentElement;
+
+    if (firstCell) {
+      await userEvent.click(firstCell);
+    }
+
+    await userEvent.keyboard('{Shift>}');
+
+    if (lastCell) {
+      await userEvent.click(lastCell);
+    }
+
+    expect(firstCell).toHaveStyle(`border-color: ${theme.colors.primary}`);
+    expect(firstCell?.parentElement?.firstChild).toHaveStyle(
+      `background-color: ${theme.colors.primary}`,
+    );
+
+    expect(lastCell).toHaveStyle(`border-bottom-color: ${theme.colors.primary}`);
+    expect(lastCell).toHaveStyle(`border-top-color: ${theme.colors.secondary30}`);
+  });
+
+  test('selects cells with arrow keys', async () => {
+    render(<Worksheet columns={columns} items={items} onChange={handleChange} />);
+
+    const firstRowElement = await screen.findByText('Shoes Name Three');
+    const firstCell = firstRowElement.parentElement;
+    const lastRowElement = await screen.findByText('Shoes Name One');
+    const lastCell = lastRowElement.parentElement;
+
+    if (firstCell) {
+      await userEvent.click(firstCell);
+    }
+
+    await userEvent.keyboard('{Shift>}{ArrowDown>2}{/Shift}');
+
+    expect(firstCell).toHaveStyle(`border-color: ${theme.colors.primary}`);
+    expect(firstCell?.parentElement?.firstChild).toHaveStyle(
+      `background-color: ${theme.colors.primary}`,
+    );
+
+    expect(lastCell).toHaveStyle(`border-bottom-color: ${theme.colors.primary}`);
+    expect(lastCell).toHaveStyle(`border-top-color: ${theme.colors.secondary30}`);
+  });
 });
 
 describe('edition', () => {
@@ -375,6 +425,10 @@ describe('edition', () => {
     const button = await screen.findByLabelText('Autofill handler');
 
     expect(button).toBeInTheDocument();
+
+    fireEvent.mouseDown(button);
+
+    expect(await screen.findAllByText('Shoes Name Three')).toHaveLength(1);
 
     fireEvent.doubleClick(button);
 
@@ -579,6 +633,22 @@ describe('keyboard navigation', () => {
     fireEvent.keyDown(worksheet, { key: 'Enter' });
 
     expect(getByDisplayValue('Shoes Name Three')).toBeDefined();
+  });
+
+  test('tab finish editing the cell', () => {
+    const { getByDisplayValue, getByText, getByRole } = render(
+      <Worksheet columns={columns} items={items} onChange={handleChange} />,
+    );
+
+    const worksheet = getByRole('table');
+    const cell = getByText('Shoes Name Three');
+
+    fireEvent.click(cell);
+    fireEvent.keyDown(worksheet, { key: 'a' });
+
+    expect(getByDisplayValue('a')).toBeDefined();
+
+    fireEvent.keyDown(cell, { key: 'Tab' });
   });
 
   test('typing starts editing the cell', () => {


### PR DESCRIPTION
## What? Why?

1. Implement the selection of multiple cells in a row using Shift+arrow buttons.
2. Implement the selection of multiple cells in a row within a column by holding SHIFT and clicking on the first and the last cells in the selection.

## Screenshots/Screen Recordings

https://user-images.githubusercontent.com/84462142/226999149-65a2b457-abb1-4577-86af-8a2b7bf4e1e8.mov



## Testing/Proof
Locally + UT
