### PR TITLE
feat(component): add custom rendering for text/number  cells (worksheet)

### DIFF
--- a/packages/big-design/src/components/Worksheet/Row/Row.tsx
+++ b/packages/big-design/src/components/Worksheet/Row/Row.tsx
@@ -65,6 +65,15 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
     [],
   );
 
+  const hasRender = useCallback(
+    (
+      column: InternalWorksheetColumn<T>,
+    ): column is WorksheetTextColumn<T> | WorksheetNumberColumn<T> => {
+      return column.type === 'text' || column.type === 'number';
+    },
+    [],
+  );
+
   const isLastChild = useMemo(
     () =>
       expandableRows
@@ -89,6 +98,7 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
           key={`${rowIndex}-${columnIndex}`}
           nextRowValue={(nextRow && nextRow[column.hash]) || ''}
           options={column.type === 'select' ? column.config.options : undefined}
+          render={hasRender(column) ? column.render : undefined}
           rowId={row.id}
           rowIndex={rowIndex}
           type={column.type ?? 'text'}

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -71,6 +71,12 @@ exports[`renders worksheet 1`] = `
             </svg>
           </span>
         </th>
+        <th
+          class="styled__Header-sc-16rzzpq-1 NXQqy"
+        >
+          Number field 2
+           
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -218,6 +224,20 @@ exports[`renders worksheet 1`] = `
           >
             $50.00
           </p>
+          <div
+            aria-label="Autofill handler"
+            class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
+          />
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 jthdlh"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 lbbxgf"
+            color="secondary70"
+            title=""
+          />
           <div
             aria-label="Autofill handler"
             class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
@@ -373,6 +393,20 @@ exports[`renders worksheet 1`] = `
             class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
           />
         </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 jthdlh"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 lbbxgf"
+            color="secondary70"
+            title=""
+          />
+          <div
+            aria-label="Autofill handler"
+            class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
+          />
+        </td>
       </tr>
       <tr
         class="styled__StyledTableRow-sc-1bzgr3l-0 emkOGW"
@@ -515,6 +549,20 @@ exports[`renders worksheet 1`] = `
           >
             $50.00
           </p>
+          <div
+            aria-label="Autofill handler"
+            class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
+          />
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 jthdlh"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 lbbxgf"
+            color="secondary70"
+            title=""
+          />
           <div
             aria-label="Autofill handler"
             class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
@@ -670,6 +718,20 @@ exports[`renders worksheet 1`] = `
             class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
           />
         </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 jthdlh"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 lbbxgf"
+            color="secondary70"
+            title=""
+          />
+          <div
+            aria-label="Autofill handler"
+            class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
+          />
+        </td>
       </tr>
       <tr
         class="styled__StyledTableRow-sc-1bzgr3l-0 emkOGW"
@@ -798,6 +860,20 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="styled__StyledCell-sc-1bt06ph-0 bUdYFr"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 lbbxgf"
+            color="secondary70"
+            title=""
+          />
+          <div
+            aria-label="Autofill handler"
+            class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
+          />
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 jthdlh"
           type="number"
         >
           <p
@@ -960,6 +1036,20 @@ exports[`renders worksheet 1`] = `
             class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
           />
         </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 jthdlh"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 lbbxgf"
+            color="secondary70"
+            title=""
+          />
+          <div
+            aria-label="Autofill handler"
+            class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
+          />
+        </td>
       </tr>
       <tr
         class="styled__StyledTableRow-sc-1bzgr3l-0 emkOGW"
@@ -1104,6 +1194,20 @@ exports[`renders worksheet 1`] = `
           >
             $49.00
           </p>
+          <div
+            aria-label="Autofill handler"
+            class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
+          />
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 jthdlh"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 lbbxgf"
+            color="secondary70"
+            title=""
+          />
           <div
             aria-label="Autofill handler"
             class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
@@ -1259,6 +1363,20 @@ exports[`renders worksheet 1`] = `
             class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
           />
         </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 jthdlh"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 lbbxgf"
+            color="secondary70"
+            title=""
+          />
+          <div
+            aria-label="Autofill handler"
+            class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
+          />
+        </td>
       </tr>
       <tr
         class="styled__StyledTableRow-sc-1bzgr3l-0 emkOGW"
@@ -1404,6 +1522,20 @@ exports[`renders worksheet 1`] = `
           >
             $50.00
           </p>
+          <div
+            aria-label="Autofill handler"
+            class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"
+          />
+        </td>
+        <td
+          class="styled__StyledCell-sc-1bt06ph-0 jthdlh"
+          type="number"
+        >
+          <p
+            class="styled__StyledSmall-sc-tqnj75-6 lbbxgf"
+            color="secondary70"
+            title=""
+          />
           <div
             aria-label="Autofill handler"
             class="styled__AutoFillHandler-sc-1bt06ph-1 hXNuWA"

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -15,6 +15,7 @@ interface Product {
   otherField: string;
   otherField2: number;
   numberField: number;
+  numberField2: number;
 }
 
 const TreeComponent = (
@@ -86,6 +87,12 @@ const columns: Array<WorksheetColumn<Product>> = [
     validation: (value: number) => value >= 50,
     formatting: (value: number) => `$${value}.00`,
     width: 90,
+  },
+  {
+    hash: 'numberField2',
+    header: 'Number field 2',
+    type: 'number',
+    render: (value) => <button>-{value}-</button>,
   },
 ];
 
@@ -558,6 +565,35 @@ describe('formatting', () => {
     );
 
     expect(getAllByText('$50.00')).toHaveLength(7);
+  });
+});
+
+describe('render', () => {
+  test('provides custom template values', () => {
+    const items = [
+      {
+        id: 1,
+        productName: 'Name 1',
+        visibleOnStorefront: true,
+        otherField: 'Other field',
+        otherField2: 1,
+        numberField: 50,
+        numberField2: 333,
+      },
+      {
+        id: 2,
+        productName: 'Name 2',
+        visibleOnStorefront: true,
+        otherField: 'Other field',
+        otherField2: 2,
+        numberField: 50,
+        numberField2: 333,
+      },
+    ];
+
+    render(<Worksheet columns={columns} items={items} onChange={handleChange} />);
+
+    expect(screen.getAllByRole('button', { name: /-333-/i })).toHaveLength(2);
   });
 });
 

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -48,14 +48,21 @@ interface WorksheetBaseColumn<Item> {
   validation?(value: Item[keyof Item] | ''): boolean;
 }
 
+interface RenderingOptions {
+  row: WorksheetItem;
+  disabled: boolean;
+}
+
 export interface WorksheetTextColumn<Item> extends WorksheetBaseColumn<Item> {
   type?: 'text';
   formatting?(value: Item[keyof Item] | ''): string;
+  render?(value: Item[keyof Item] | '', options: RenderingOptions): React.ReactNode;
 }
 
 export interface WorksheetNumberColumn<Item> extends WorksheetBaseColumn<Item> {
   type: 'number';
   formatting?(value: Item[keyof Item] | ''): string;
+  render?(value: Item[keyof Item] | '', options: RenderingOptions): React.ReactNode;
 }
 
 export interface WorksheetCheckboxColumn<Item> extends WorksheetBaseColumn<Item> {

--- a/packages/docs/PropTables/WorksheetPropTable.tsx
+++ b/packages/docs/PropTables/WorksheetPropTable.tsx
@@ -127,6 +127,11 @@ const worksheetTextColumnProps: Prop[] = [
     description: 'Used to format the value of a cell.',
   },
   {
+    name: 'render',
+    types: '(value: any, options: { row: any; disabled: boolean; }) => React.ReactNode',
+    description: 'Used to provide the custom template of a cell.',
+  },
+  {
     name: 'validation',
     types: '(value: any) => boolean',
     description: 'Will set a cell as invalid if it returns false.',
@@ -172,6 +177,11 @@ const worksheetNumberColumnProps: Prop[] = [
     name: 'formatting',
     types: '(value: any) => string',
     description: 'Used to format the value of a cell.',
+  },
+  {
+    name: 'render',
+    types: '(value: any, options: { row: any; disabled: boolean; }) => React.ReactNode',
+    description: 'Used to provide the custom template of a cell.',
   },
   {
     name: 'validation',

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -1,4 +1,12 @@
-import { H1, Panel, StatefulTree, Text, Worksheet, WorksheetColumn } from '@bigcommerce/big-design';
+import {
+  Badge,
+  H1,
+  Panel,
+  StatefulTree,
+  Text,
+  Worksheet,
+  WorksheetColumn,
+} from '@bigcommerce/big-design';
 import React from 'react';
 
 import {
@@ -289,7 +297,10 @@ const WorksheetPage = () => {
                       {
                         hash: 'productName',
                         header: 'Product name',
+                        type: 'text',
                         validation: (value) => !!value,
+                        render: (value) =>
+                          value === 'Product 3' ? <Badge label={String(value)} /> : value,
                       },
                       { hash: 'otherField', header: 'Other field' },
                     ];


### PR DESCRIPTION
## What?

Add custom renderer for `text` and number fields. (worksheet)

## Why?
To be able to provide a custom template within the cell if needed.
<img width="291" alt="Screenshot 2023-03-28 at 22 29 09" src="https://user-images.githubusercontent.com/84462142/228346691-fd66250d-0a90-40d6-91b0-d016e7c3892d.png">

## Screenshots/Screen Recordings
<img width="735" alt="Screenshot 2023-03-28 at 22 30 55" src="https://user-images.githubusercontent.com/84462142/228347048-21cb876c-ea1d-4fe6-badb-c0cb919184ed.png">

<img width="743" alt="Screenshot 2023-03-28 at 19 54 38" src="https://user-images.githubusercontent.com/84462142/228347131-f115ed53-fa52-419b-94ec-99dd439aafd4.png">


## Testing/Proof

Locally + UT
