### PR TITLE
chore(component): make ButtonGroup trigger a type button

### DIFF
--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -118,6 +118,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(({ actions, ...wrapp
             <StyledButton
               borderRadius={actionsState.every(({ isVisible }) => !isVisible)}
               iconOnly={<MoreHorizIcon title="more" />}
+              type="button"
               variant="secondary"
             />
           }

--- a/packages/big-design/src/components/ButtonGroup/spec.tsx
+++ b/packages/big-design/src/components/ButtonGroup/spec.tsx
@@ -128,3 +128,20 @@ test('dropdown item on click callback receives synthetic event', async () => {
 
   expect(mockOnClick).toHaveBeenCalledWith(expect.objectContaining({ target: button }));
 });
+
+test('dropdown trigger is type button', async () => {
+  render(
+    <ButtonGroup
+      actions={[
+        { text: 'button 1' },
+        { text: 'button 2' },
+        { text: 'button 3' },
+        { text: 'button 4' },
+      ]}
+    />,
+  );
+
+  const trigger = await screen.findByRole('button', { name: 'more' });
+
+  expect(trigger).toHaveAttribute('type', 'button');
+});


### PR DESCRIPTION
## What?
Adds `type=button` to the ButtonGroup dropdown trigger.

## Why?
When we render a `ButtonGroup` inside of a form and the user clicks on the dropdown trigger it submits the form as we can't pass a type button to the trigger.

## Screenshots/Screen Recordings
n/a

## Testing/Proof
Unit
