### PR TITLE
fix(component): prevent selectedItem from being set on Dropdown blur

### DIFF
--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -82,6 +82,9 @@ export const Dropdown = memo(
 
           return changes;
 
+        case useSelect.stateChangeTypes.ToggleButtonBlur:
+          return { ...changes, selectedItem: null };
+
         default:
           return changes;
       }

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -658,3 +658,17 @@ test('items should supports description', async () => {
 
   expect(description).toBeInTheDocument();
 });
+
+test("dropdown toggle doesn't trigger onItemClick", async () => {
+  render(DropdownMock);
+
+  const toggle = screen.getByRole('button');
+
+  await userEvent.click(toggle);
+
+  expect(onItemClick).not.toHaveBeenCalled();
+
+  await userEvent.click(document.body);
+
+  expect(onItemClick).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## What/Why?

We (as in @deini) noticed that the `Dropdown` was triggering `onItemClick` whenever we blurred away from the dropdown menu. Downshift [adds a `selectedItem`](https://github.com/downshift-js/downshift/blob/master/src/hooks/useSelect/reducer.js#L150-L158) whenever the highlighted index is `>=0` (which ours is `0` by default). This causes the `onSelectedItemChange` function to trigger causing `onItemClick` to run when the dropdown is blurred.

## Screenshots/Screen Recordings

Replicated issue:

https://user-images.githubusercontent.com/10539418/230143812-e4cf58ff-a6bf-4277-955e-0c30d225f1e1.mp4


## Testing/Proof

Added new tests to the component and ensured coverage was met.
