### PR TITLE
chore: cleanup test logs and add jest-fail-on-console

### DIFF
--- a/packages/big-design-theme/jest.config.js
+++ b/packages/big-design-theme/jest.config.js
@@ -2,6 +2,7 @@ const defaultJestConfig = require('@bigcommerce/configs/jest');
 
 module.exports = {
   ...defaultJestConfig,
+  setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
   coverageThreshold: {
     global: {
       statements: 100,

--- a/packages/big-design-theme/package.json
+++ b/packages/big-design-theme/package.json
@@ -55,6 +55,7 @@
     "babel-plugin-styled-components": "^2.0.7",
     "jest": "^29.0.3",
     "jest-environment-jsdom": "^29.4.1",
+    "jest-fail-on-console": "^3.1.1",
     "jest-styled-components": "^7.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/big-design-theme/setupTests.ts
+++ b/packages/big-design-theme/setupTests.ts
@@ -1,0 +1,3 @@
+import failOnConsole from 'jest-fail-on-console';
+
+failOnConsole();

--- a/packages/big-design-theme/tsconfig.json
+++ b/packages/big-design-theme/tsconfig.json
@@ -8,6 +8,6 @@
     "module": "esnext",
     "target": "esnext"
   },
-  "include": ["src"],
+  "include": ["src", "setupTests.ts"],
   "exclude": ["dist"],
 }

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -76,6 +76,7 @@
     "babel-plugin-styled-components": "^2.0.7",
     "jest": "^29.0.3",
     "jest-environment-jsdom": "^29.4.1",
+    "jest-fail-on-console": "^3.1.1",
     "jest-styled-components": "^7.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/big-design/setupTests.ts
+++ b/packages/big-design/setupTests.ts
@@ -1,4 +1,7 @@
 import '@testing-library/jest-dom/extend-expect';
+import failOnConsole from 'jest-fail-on-console';
+
+failOnConsole();
 
 jest.mock('./src/utils', () => ({
   ...jest.requireActual<any>('./src/utils'),

--- a/packages/big-design/src/components/Counter/spec.tsx
+++ b/packages/big-design/src/components/Counter/spec.tsx
@@ -57,25 +57,31 @@ const counterMock = ({
   />
 );
 
-test('forwards ref', () => {
+test('forwards ref', async () => {
   const ref = createRef<HTMLInputElement>();
-  const { container } = render(counterMock({ ref, ...requiredAttributes }));
-  const counter = container.querySelector('input');
+
+  render(counterMock({ ref, ...requiredAttributes }));
+
+  const counter = await screen.findByRole('textbox');
 
   expect(ref.current).toBe(counter);
 });
 
-test('renders a counter as an input tag', () => {
-  const { container } = render(counterMock(requiredAttributes));
+test('renders a counter as an input tag', async () => {
+  render(counterMock(requiredAttributes));
 
-  expect(container.querySelector('input')).toBeInTheDocument();
+  const counter = await screen.findByRole('textbox');
+
+  expect(counter).toBeInTheDocument();
 });
 
-test('renders a counter with matched label', () => {
-  const { queryByLabelText } = render(counterMock({ label: 'Test Label', ...requiredAttributes }));
+test('renders a counter with matched label', async () => {
+  render(counterMock({ label: 'Test Label', ...requiredAttributes }));
+
+  const label = await screen.findByLabelText<HTMLLabelElement>('Test Label');
 
   // This one checks for matching id and htmlFor
-  expect(queryByLabelText('Test Label')).toBeInTheDocument();
+  expect(label).toBeInTheDocument();
 });
 
 test('create unique ids if not provided', async () => {
@@ -117,25 +123,27 @@ test('respects provided labelId', async () => {
   expect(label.id).toBe('test');
 });
 
-test('renders a description', () => {
+test('renders a description', async () => {
   const descriptionText = 'This is a description';
-  const { queryByText } = render(
-    counterMock({ description: descriptionText, ...requiredAttributes }),
-  );
 
-  expect(queryByText(descriptionText)).toBeInTheDocument();
+  render(counterMock({ description: descriptionText, ...requiredAttributes }));
+
+  const description = await screen.findByText(descriptionText);
+
+  expect(description).toBeInTheDocument();
 });
 
-test('renders an error', () => {
+test('renders an error', async () => {
   const errorText = 'This is an error';
-  const { queryByText } = render(
-    <FormGroup>{counterMock({ error: errorText, ...requiredAttributes })}</FormGroup>,
-  );
 
-  expect(queryByText(errorText)).toBeInTheDocument();
+  render(<FormGroup>{counterMock({ error: errorText, ...requiredAttributes })}</FormGroup>);
+
+  const error = await screen.findByText(errorText);
+
+  expect(error).toBeInTheDocument();
 });
 
-test('accepts a Label Component', () => {
+test('accepts a Label Component', async () => {
   const CustomLabel = (
     <FormControlLabel>
       This is a custom Label
@@ -145,9 +153,11 @@ test('accepts a Label Component', () => {
     </FormControlLabel>
   );
 
-  const { queryByTestId } = render(counterMock({ label: CustomLabel, ...requiredAttributes }));
+  render(counterMock({ label: CustomLabel, ...requiredAttributes }));
 
-  expect(queryByTestId('test')).toBeInTheDocument();
+  const label = await screen.findByTestId('test');
+
+  expect(label).toBeInTheDocument();
 });
 
 test('does not accept non-Label Components', () => {
@@ -160,12 +170,14 @@ test('does not accept non-Label Components', () => {
     </div>
   );
 
-  const { queryByTestId } = render(counterMock({ label: NotALabel, ...requiredAttributes }));
+  render(counterMock({ label: NotALabel, ...requiredAttributes }));
 
-  expect(queryByTestId('test')).not.toBeInTheDocument();
+  const maybeLabel = screen.queryByTestId('test');
+
+  expect(maybeLabel).not.toBeInTheDocument();
 });
 
-test('accepts a Description Component', () => {
+test('accepts a Description Component', async () => {
   const CustomDescription = (
     <FormControlDescription>
       This is a custom Description
@@ -175,11 +187,11 @@ test('accepts a Description Component', () => {
     </FormControlDescription>
   );
 
-  const { queryByTestId } = render(
-    counterMock({ description: CustomDescription, ...requiredAttributes }),
-  );
+  render(counterMock({ description: CustomDescription, ...requiredAttributes }));
 
-  expect(queryByTestId('test')).toBeInTheDocument();
+  const description = await screen.findByTestId('test');
+
+  expect(description).toBeInTheDocument();
 });
 
 test('does not accept non-Description Components', () => {
@@ -192,14 +204,14 @@ test('does not accept non-Description Components', () => {
     </div>
   );
 
-  const { queryByTestId } = render(
-    counterMock({ description: NotADescription, ...requiredAttributes }),
-  );
+  render(counterMock({ description: NotADescription, ...requiredAttributes }));
 
-  expect(queryByTestId('test')).not.toBeInTheDocument();
+  const maybeDescription = screen.queryByTestId('test');
+
+  expect(maybeDescription).not.toBeInTheDocument();
 });
 
-test('accepts an Error Component', () => {
+test('accepts an Error Component', async () => {
   const CustomError = (
     <FormControlError>
       This is a custom Error Component
@@ -209,11 +221,11 @@ test('accepts an Error Component', () => {
     </FormControlError>
   );
 
-  const { queryByTestId } = render(
-    <FormGroup>{counterMock({ error: CustomError, ...requiredAttributes })}</FormGroup>,
-  );
+  render(<FormGroup>{counterMock({ error: CustomError, ...requiredAttributes })}</FormGroup>);
 
-  expect(queryByTestId('test')).toBeInTheDocument();
+  const error = await screen.findByTestId('test');
+
+  expect(error).toBeInTheDocument();
 });
 
 test('does not accept non-Error Components', () => {
@@ -226,11 +238,11 @@ test('does not accept non-Error Components', () => {
     </div>
   );
 
-  const { queryByTestId } = render(
-    <FormGroup>{counterMock({ error: NotAnError, ...requiredAttributes })}</FormGroup>,
-  );
+  render(<FormGroup>{counterMock({ error: NotAnError, ...requiredAttributes })}</FormGroup>);
 
-  expect(queryByTestId('test')).not.toBeInTheDocument();
+  const maybeError = screen.queryByTestId('test');
+
+  expect(maybeError).not.toBeInTheDocument();
 });
 
 test('renders both the add and subtract icons', () => {
@@ -241,18 +253,18 @@ test('renders both the add and subtract icons', () => {
   expect(buttons).toHaveLength(2);
 });
 
-test('buttons are disabled when value hits max or min', () => {
-  const { getAllByRole, rerender } = render(counterMock({ ...requiredAttributes, value: 0 }));
+test('buttons are disabled when value hits max or min', async () => {
+  const { rerender } = render(counterMock({ ...requiredAttributes, value: 0 }));
 
-  const buttons = getAllByRole('button');
+  const [decreaseButton, increaseButton] = await screen.findAllByRole('button');
 
-  expect(buttons[0]).toHaveProperty('disabled', true);
-  expect(buttons[1]).toHaveProperty('disabled', false);
+  expect(decreaseButton).toHaveProperty('disabled', true);
+  expect(increaseButton).toHaveProperty('disabled', false);
 
   rerender(counterMock({ ...requiredAttributes, value: 10 }));
 
-  expect(buttons[0]).toHaveProperty('disabled', false);
-  expect(buttons[1]).toHaveProperty('disabled', true);
+  expect(decreaseButton).toHaveProperty('disabled', false);
+  expect(increaseButton).toHaveProperty('disabled', true);
 });
 
 test('value prop only accepts whole numbers', async () => {
@@ -262,19 +274,20 @@ test('value prop only accepts whole numbers', async () => {
 });
 
 test('value increases when increase or decrease icons are clicked', async () => {
-  const { container } = render(counterMock(requiredAttributes));
+  render(counterMock(requiredAttributes));
 
-  const counter = await screen.findByDisplayValue<HTMLInputElement>('5');
+  const counter = await screen.findByRole('textbox');
 
-  const icons = container.getElementsByTagName('svg');
+  expect(counter).toHaveValue('5');
 
-  expect(counter.value).toBe('5');
+  const decreaseButton = await screen.findByRole('button', { name: 'Decrease count' });
+  const increaseButton = await screen.findByRole('button', { name: 'Increase count' });
 
-  await userEvent.click(icons[1]);
+  await userEvent.click(increaseButton);
 
   expect(handleChange).toHaveBeenCalledWith(6);
 
-  await userEvent.click(icons[0]);
+  await userEvent.click(decreaseButton);
 
   expect(handleChange).toHaveBeenCalledWith(4);
 });
@@ -282,12 +295,11 @@ test('value increases when increase or decrease icons are clicked', async () => 
 test('value increases and decreases with arrow keypresses', async () => {
   render(counterMock(requiredAttributes));
 
-  const counter = screen.getByDisplayValue<HTMLInputElement>('5');
+  const counter = await screen.findByRole('textbox');
 
-  counter.focus();
+  expect(counter).toHaveValue('5');
 
-  expect(counter.value).toBe('5');
-
+  await userEvent.click(counter);
   await userEvent.keyboard('{arrowUp}');
 
   expect(handleChange).toHaveBeenCalledWith(6);
@@ -298,11 +310,11 @@ test('value increases and decreases with arrow keypresses', async () => {
 });
 
 test('value is set to 0 when pressing Escape', async () => {
-  const { getByDisplayValue } = render(counterMock(requiredAttributes));
+  render(counterMock(requiredAttributes));
 
-  const counter = getByDisplayValue('5');
+  const counter = await screen.findByRole('textbox');
 
-  expect(counter.getAttribute('value')).toBe('5');
+  expect(counter).toHaveValue('5');
 
   await userEvent.type(counter, '{escape}');
 
@@ -310,11 +322,11 @@ test('value is set to 0 when pressing Escape', async () => {
 });
 
 test('value does not change when pressing Enter', async () => {
-  const { getByDisplayValue } = render(counterMock(requiredAttributes));
+  render(counterMock(requiredAttributes));
 
-  const counter = getByDisplayValue('5');
+  const counter = await screen.findByRole('textbox');
 
-  expect(counter.getAttribute('value')).toBe('5');
+  expect(counter).toHaveValue('5');
 
   await userEvent.type(counter, '{enter}');
 
@@ -322,35 +334,38 @@ test('value does not change when pressing Enter', async () => {
 });
 
 test('provided onCountChange function is called on value change', async () => {
-  const { getByTitle } = render(counterMock(requiredAttributes));
+  render(counterMock(requiredAttributes));
 
-  const increase = getByTitle('Increase count');
+  const increase = await screen.findByRole('button', { name: 'Increase count' });
 
   await userEvent.click(increase);
 
   expect(handleChange).toHaveBeenCalledWith(6);
 });
 
-test('error shows with valid string', () => {
+test('error shows with valid string', async () => {
   const error = 'Error';
-  const { container, rerender } = render(
+  const { rerender } = render(
     <FormGroup>{counterMock({ error: '', ...requiredAttributes })}</FormGroup>,
   );
 
-  expect(container.querySelector('[class*="StyledError"]')).not.toBeInTheDocument();
+  let errorText = screen.queryByText(error);
+
+  expect(errorText).not.toBeInTheDocument();
 
   rerender(<FormGroup>{counterMock({ error, ...requiredAttributes })}</FormGroup>);
 
-  expect(container.querySelector('[class*="StyledError"]')).toBeInTheDocument();
+  errorText = await screen.findByText(error);
+
+  expect(errorText).toBeInTheDocument();
 });
 
 test('error shows when an array of strings', () => {
   const errors = ['Error 0', 'Error 1'];
-  const { getByText } = render(
-    <FormGroup>{counterMock({ error: errors, ...requiredAttributes })}</FormGroup>,
-  );
 
-  errors.forEach((error) => expect(getByText(error)).toBeInTheDocument());
+  render(<FormGroup>{counterMock({ error: errors, ...requiredAttributes })}</FormGroup>);
+
+  errors.forEach((error) => expect(screen.getByText(error)).toBeInTheDocument());
 });
 
 test('error shows when an array of Errors', () => {
@@ -360,11 +375,10 @@ test('error shows when an array of Errors', () => {
       Error
     </FormControlError>
   ));
-  const { getByTestId } = render(
-    <FormGroup>{counterMock({ error: errors, ...requiredAttributes })}</FormGroup>,
-  );
 
-  testIds.forEach((id) => expect(getByTestId(id)).toBeInTheDocument());
+  render(<FormGroup>{counterMock({ error: errors, ...requiredAttributes })}</FormGroup>);
+
+  testIds.forEach((id) => expect(screen.getByTestId(id)).toBeInTheDocument());
 });
 
 test('input counter value does not change when using it inside a form', async () => {
@@ -379,7 +393,7 @@ test('input counter value does not change when using it inside a form', async ()
     </Form>,
   );
 
-  const input = await screen.findByDisplayValue<HTMLInputElement>('5');
+  const input = await screen.findByRole('textbox');
 
   await userEvent.type(input, '{enter}');
 
@@ -394,7 +408,9 @@ describe('error does not show when invalid type', () => {
       <FormGroup>{counterMock({ error, ...requiredAttributes })}</FormGroup>,
     );
 
-    expect(queryByTestId('err')).not.toBeInTheDocument();
+    const maybeError = queryByTestId('err');
+
+    expect(maybeError).not.toBeInTheDocument();
   });
 
   test('array of elements', () => {
@@ -410,7 +426,9 @@ describe('error does not show when invalid type', () => {
       <FormGroup>{counterMock({ error: errors, ...requiredAttributes })}</FormGroup>,
     );
 
-    expect(queryByTestId('err')).not.toBeInTheDocument();
+    const maybeError = queryByTestId('err');
+
+    expect(maybeError).not.toBeInTheDocument();
   });
 });
 

--- a/packages/big-design/src/components/Pagination/spec.tsx
+++ b/packages/big-design/src/components/Pagination/spec.tsx
@@ -82,13 +82,14 @@ test('render pagination component with no items', async () => {
   expect(pagination).toMatchSnapshot();
 });
 
-test('render pagination component while overriding button labels', () => {
+test('render pagination component while overriding button labels', async () => {
   const getRangeLabel = (first: number, last: number, totalItems: number) => {
     return `[Custom label] ${first}-${last} of ${totalItems}`;
   };
   const changePage = jest.fn();
   const changeRange = jest.fn();
-  const { getByRole } = render(
+
+  render(
     <Pagination
       currentPage={1}
       getRangeLabel={getRangeLabel}
@@ -103,10 +104,10 @@ test('render pagination component while overriding button labels', () => {
     />,
   );
 
-  const pagination = getByRole('navigation', { name: '[Custom] Pagination' });
-  const dropdown = getByRole('button', { name: '[Custom label] 1-3 of 10' });
-  const prevPage = getByRole('button', { name: '[Custom] Previous page' });
-  const nextPage = getByRole('button', { name: '[Custom] Next page' });
+  const pagination = await screen.findByRole('navigation', { name: '[Custom] Pagination' });
+  const dropdown = await screen.findByRole('button', { name: '[Custom label] 1-3 of 10' });
+  const prevPage = await screen.findByRole('button', { name: '[Custom] Previous page' });
+  const nextPage = await screen.findByRole('button', { name: '[Custom] Next page' });
 
   expect(pagination).toBeInTheDocument();
   expect(dropdown).toBeInTheDocument();

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -354,11 +354,10 @@ test('select items should be filterable', async () => {
   render(SelectMock);
 
   const input = screen.getByTestId('select');
-  const button = await screen.findByLabelText('toggle menu');
 
-  await fireEvent.click(button);
+  await userEvent.tripleClick(input);
 
-  await fireEvent.change(input, { target: { value: 'c' } });
+  await userEvent.keyboard('c');
 
   const options = await screen.findAllByRole('option');
 
@@ -369,17 +368,17 @@ test('select should select the filtered item', async () => {
   render(SelectMock);
 
   const input = screen.getByTestId('select');
-  const button = await screen.findByLabelText('toggle menu');
 
-  await fireEvent.click(button);
+  await userEvent.tripleClick(input);
+  await userEvent.keyboard('c');
 
-  await fireEvent.change(input, { target: { value: 'c' } });
+  expect(input).toHaveValue('c');
 
   const options = await screen.findAllByRole('option');
 
   expect(options).toHaveLength(2);
 
-  await fireEvent.keyDown(input, { key: 'Enter' });
+  await userEvent.keyboard('{Enter}');
 
   expect(input.getAttribute('value')).toBe('Canada');
 });
@@ -893,9 +892,7 @@ test('grouped select should render group labels, render uppercased', async () =>
 
   const button = await screen.findByLabelText('toggle menu');
 
-  await act(async () => {
-    fireEvent.click(button);
-  });
+  await userEvent.click(button);
 
   const label1 = screen.getByText('Label 1');
   const label2 = screen.getByText('Label 2');

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event';
 import React, { CSSProperties } from 'react';
 import 'jest-styled-components';
 
@@ -201,7 +202,7 @@ test('renders a pagination component', async () => {
   const onItemsPerPageChange = jest.fn();
   const onPageChange = jest.fn();
 
-  const { container, findByRole, getByTitle } = render(
+  const { container, findByTitle } = render(
     <Table
       columns={[
         { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
@@ -226,22 +227,22 @@ test('renders a pagination component', async () => {
     />,
   );
 
-  fireEvent.click(getByTitle('Next page'));
+  const nextPage = await findByTitle('Next page');
 
-  await findByRole('table');
+  await userEvent.click(nextPage);
 
   expect(onPageChange).toHaveBeenCalledWith(2);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('renders a pagination component with custom button labels', () => {
+test('renders a pagination component with custom button labels', async () => {
   const getRangeLabel = (first: number, last: number, totalItems: number) => {
     return `[Custom label] ${first}-${last} of ${totalItems}`;
   };
   const onItemsPerPageChange = jest.fn();
   const onPageChange = jest.fn();
 
-  const { getByRole } = render(
+  const { findByRole } = render(
     <Table
       columns={[
         { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
@@ -270,10 +271,15 @@ test('renders a pagination component with custom button labels', () => {
     />,
   );
 
-  getByRole('navigation', { name: '[Custom] Pagination' });
-  getByRole('button', { name: '[Custom label] 1-3 of 5' });
-  getByRole('button', { name: '[Custom] Previous page' });
-  getByRole('button', { name: '[Custom] Next page' });
+  const navigation = await findByRole('navigation', { name: '[Custom] Pagination' });
+  const paginationDropdown = await findByRole('button', { name: '[Custom label] 1-3 of 5' });
+  const previousButtonPage = await findByRole('button', { name: '[Custom] Previous page' });
+  const nextButtonPage = await findByRole('button', { name: '[Custom] Next page' });
+
+  expect(navigation).toBeVisible();
+  expect(paginationDropdown).toBeVisible();
+  expect(previousButtonPage).toBeVisible();
+  expect(nextButtonPage).toBeVisible();
 });
 
 describe('selectable', () => {

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -226,7 +226,7 @@ describe('pagination', () => {
     const onItemsPerPageChange = jest.fn();
     const onPageChange = jest.fn();
 
-    const { container, findByRole, getByTitle } = render(
+    const { container, findByTitle } = render(
       <TableNext
         columns={[
           { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
@@ -252,22 +252,22 @@ describe('pagination', () => {
       />,
     );
 
-    fireEvent.click(getByTitle('Next page'));
+    const nextPage = await findByTitle('Next page');
 
-    await findByRole('table');
+    await userEvent.click(nextPage);
 
     expect(onPageChange).toHaveBeenCalledWith(2);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('renders a pagination component with custom button labels', () => {
+  test('renders a pagination component with custom button labels', async () => {
     const getRangeLabel = (first: number, last: number, totalItems: number) => {
       return `[Custom label] ${first}-${last} of ${totalItems}`;
     };
     const onItemsPerPageChange = jest.fn();
     const onPageChange = jest.fn();
 
-    const { getByRole } = render(
+    const { findByRole } = render(
       <TableNext
         columns={[
           { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
@@ -297,10 +297,10 @@ describe('pagination', () => {
       />,
     );
 
-    const navigation = getByRole('navigation', { name: '[Custom] Pagination' });
-    const paginationDropdown = getByRole('button', { name: '[Custom label] 1-3 of 5' });
-    const previousButtonPage = getByRole('button', { name: '[Custom] Previous page' });
-    const nextButtonPage = getByRole('button', { name: '[Custom] Next page' });
+    const navigation = await findByRole('navigation', { name: '[Custom] Pagination' });
+    const paginationDropdown = await findByRole('button', { name: '[Custom label] 1-3 of 5' });
+    const previousButtonPage = await findByRole('button', { name: '[Custom] Previous page' });
+    const nextButtonPage = await findByRole('button', { name: '[Custom] Next page' });
 
     expect(navigation).toBeVisible();
     expect(paginationDropdown).toBeVisible();
@@ -634,7 +634,7 @@ describe('pagination', () => {
     });
   });
 
-  test("selected expandable rows doesn't count towards total selected items", () => {
+  test("selected expandable rows doesn't count towards total selected items", async () => {
     const items = [
       { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
       { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
@@ -679,7 +679,7 @@ describe('pagination', () => {
       />,
     );
 
-    const selectedItems = screen.getByText('3/5');
+    const selectedItems = await screen.findByText('3/5');
 
     expect(selectedItems).toBeInTheDocument();
   });

--- a/packages/big-design/src/utils/warning/spec.ts
+++ b/packages/big-design/src/utils/warning/spec.ts
@@ -1,17 +1,18 @@
 import { warning } from './warning';
 
-const consoleError = jest.spyOn(console, 'warn').mockImplementation(jest.fn);
-
 jest.mock('./warning', () => ({
   ...jest.requireActual<any>('./warning'),
 }));
 
 test('warning should throw a console.error', () => {
+  jest.spyOn(console, 'warn').mockImplementation();
   warning('test error');
 
-  expect(consoleError).toHaveBeenCalledTimes(1);
+  // eslint-disable-next-line no-console
+  expect(console.warn).toHaveBeenCalledTimes(1);
 
   warning('test error');
 
-  expect(consoleError).toHaveBeenCalledTimes(2);
+  // eslint-disable-next-line no-console
+  expect(console.warn).toHaveBeenCalledTimes(2);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6478,6 +6478,13 @@ jest-environment-node@^29.5.0:
     jest-mock "^29.5.0"
     jest-util "^29.5.0"
 
+jest-fail-on-console@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/jest-fail-on-console/-/jest-fail-on-console-3.1.1.tgz#4ca0d0cc8f11675e8e9f52159a37a6602a7e6c09"
+  integrity sha512-g9HGhKcWOz8lHeZhLCXGg+RD/7upngiKkkBrHimsO/tGB0qi++QZffOgybjeI2bDW1qgdFiJJEG6t/WeTlfmOw==
+  dependencies:
+    chalk "^4.1.0"
+
 jest-get-type@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.4.3.tgz#1ab7a5207c995161100b5187159ca82dd48b3dd5"


### PR DESCRIPTION
## What?

Cleans up the all the error and warnings logs from our test suites. Also added `jest-fail-on-console` to prevent this from happening in the future.

## Why?

To make it 💅 

## Testing/Proof

Pretty test suite 😮 
![Screenshot 2023-04-06 at 10 56 13](https://user-images.githubusercontent.com/10539418/230421286-5fbc7ded-67dc-4765-b018-eb1b6dd53b9f.png)

`jest-fail-on-error` test:
![Screenshot 2023-04-06 at 11 05 16](https://user-images.githubusercontent.com/10539418/230421310-7972cd53-c561-49fa-9471-4d1cba5979f4.png)
