### PR TITLE
feat(component): add notation for worksheet cells

### DIFF
--- a/packages/big-design/src/components/Worksheet/Cell/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/styled.tsx
@@ -1,4 +1,4 @@
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { Colors, theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { Cell, WorksheetItem } from '../types';
@@ -147,5 +147,19 @@ export const AutoFillHandler = styled.div<{ isVisible: boolean }>`
   display: none;
 `;
 
+export const CellNote = styled.div<{ color: keyof Colors }>`
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+
+  border-bottom: 8px solid ${({ theme, color }) => theme.colors[color]};
+  position: absolute;
+  top -1px;
+  right: -5px;
+  transform: rotate(45deg)
+`;
+
 StyledCell.defaultProps = { theme: defaultTheme };
 AutoFillHandler.defaultProps = { theme: defaultTheme };
+CellNote.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/Row/Row.tsx
+++ b/packages/big-design/src/components/Worksheet/Row/Row.tsx
@@ -88,6 +88,7 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
           isLastChild={isLastChild}
           key={`${rowIndex}-${columnIndex}`}
           nextRowValue={(nextRow && nextRow[column.hash]) || ''}
+          notation={column.notation}
           options={column.type === 'select' ? column.config.options : undefined}
           rowId={row.id}
           rowIndex={rowIndex}

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -108,16 +108,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r3:"
+                aria-labelledby=":r5:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 esYNiS"
-                id=":r2:"
+                id=":r4:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 hRAiAt"
-                for=":r2:"
+                for=":r4:"
               >
                 <svg
                   aria-hidden="true"
@@ -144,9 +144,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 eargYo rtDwa"
-                  for=":r2:"
+                  for=":r4:"
                   hidden=""
-                  id=":r3:"
+                  id=":r5:"
                 >
                   Checked
                 </label>
@@ -258,16 +258,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r6:"
+                aria-labelledby=":rd:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 esYNiS"
-                id=":r5:"
+                id=":rc:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 hRAiAt"
-                for=":r5:"
+                for=":rc:"
               >
                 <svg
                   aria-hidden="true"
@@ -294,9 +294,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 eargYo rtDwa"
-                  for=":r5:"
+                  for=":rc:"
                   hidden=""
-                  id=":r6:"
+                  id=":rd:"
                 >
                   Checked
                 </label>
@@ -408,15 +408,15 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="false"
-                aria-labelledby=":r9:"
+                aria-labelledby=":rl:"
                 class="styled__HiddenCheckbox-sc-s1u0st-2 esYNiS"
-                id=":r8:"
+                id=":rk:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 dJjwwe"
-                for=":r8:"
+                for=":rk:"
               >
                 <svg
                   aria-hidden="true"
@@ -443,9 +443,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 eargYo rtDwa"
-                  for=":r8:"
+                  for=":rk:"
                   hidden=""
-                  id=":r9:"
+                  id=":rl:"
                 >
                   Unchecked
                 </label>
@@ -555,16 +555,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":rc:"
+                aria-labelledby=":rt:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 esYNiS"
-                id=":rb:"
+                id=":rs:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 hRAiAt"
-                for=":rb:"
+                for=":rs:"
               >
                 <svg
                   aria-hidden="true"
@@ -591,9 +591,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 eargYo rtDwa"
-                  for=":rb:"
+                  for=":rs:"
                   hidden=""
-                  id=":rc:"
+                  id=":rt:"
                 >
                   Checked
                 </label>
@@ -702,15 +702,15 @@ exports[`renders worksheet 1`] = `
               class="styled__CheckboxContainer-sc-s1u0st-1 dhAZEO"
             >
               <input
-                aria-labelledby=":rf:"
+                aria-labelledby=":r15:"
                 class="styled__HiddenCheckbox-sc-s1u0st-2 esYNiS"
-                id=":re:"
+                id=":r14:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 dJjwwe"
-                for=":re:"
+                for=":r14:"
               >
                 <svg
                   aria-hidden="true"
@@ -737,9 +737,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 eargYo rtDwa"
-                  for=":re:"
+                  for=":r14:"
                   hidden=""
-                  id=":rf:"
+                  id=":r15:"
                 >
                   Unchecked
                 </label>
@@ -845,16 +845,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":ri:"
+                aria-labelledby=":r1d:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 esYNiS"
-                id=":rh:"
+                id=":r1c:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 hRAiAt"
-                for=":rh:"
+                for=":r1c:"
               >
                 <svg
                   aria-hidden="true"
@@ -881,9 +881,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 eargYo rtDwa"
-                  for=":rh:"
+                  for=":r1c:"
                   hidden=""
-                  id=":ri:"
+                  id=":r1d:"
                 >
                   Checked
                 </label>
@@ -995,15 +995,15 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="false"
-                aria-labelledby=":rl:"
+                aria-labelledby=":r1l:"
                 class="styled__HiddenCheckbox-sc-s1u0st-2 esYNiS"
-                id=":rk:"
+                id=":r1k:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 dJjwwe"
-                for=":rk:"
+                for=":r1k:"
               >
                 <svg
                   aria-hidden="true"
@@ -1030,9 +1030,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 eargYo rtDwa"
-                  for=":rk:"
+                  for=":r1k:"
                   hidden=""
-                  id=":rl:"
+                  id=":r1l:"
                 >
                   Unchecked
                 </label>
@@ -1144,16 +1144,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":ro:"
+                aria-labelledby=":r1t:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 esYNiS"
-                id=":rn:"
+                id=":r1s:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 hRAiAt"
-                for=":rn:"
+                for=":r1s:"
               >
                 <svg
                   aria-hidden="true"
@@ -1180,9 +1180,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 eargYo rtDwa"
-                  for=":rn:"
+                  for=":r1s:"
                   hidden=""
-                  id=":ro:"
+                  id=":r1t:"
                 >
                   Checked
                 </label>
@@ -1294,16 +1294,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":rr:"
+                aria-labelledby=":r25:"
                 checked=""
                 class="styled__HiddenCheckbox-sc-s1u0st-2 esYNiS"
-                id=":rq:"
+                id=":r24:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="styled__StyledCheckbox-sc-s1u0st-3 hRAiAt"
-                for=":rq:"
+                for=":r24:"
               >
                 <svg
                   aria-hidden="true"
@@ -1330,9 +1330,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 eargYo rtDwa"
-                  for=":rq:"
+                  for=":r24:"
                   hidden=""
-                  id=":rr:"
+                  id=":r25:"
                 >
                   Checked
                 </label>

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -69,7 +69,13 @@ const TreeComponent = (
 };
 
 const columns: Array<WorksheetColumn<Product>> = [
-  { hash: 'productName', header: 'Product name', validation: (value: string) => !!value },
+  {
+    hash: 'productName',
+    header: 'Product name',
+    validation: (value: string) => !!value,
+    notation: (value) =>
+      value === 'Shoes Name One Edit' ? { color: 'danger20', description: 'Text' } : undefined,
+  },
   { hash: 'visibleOnStorefront', header: 'Visible on storefront', type: 'checkbox', width: 80 },
   { hash: 'otherField', header: 'Other field', width: 'auto' },
   {
@@ -558,6 +564,25 @@ describe('formatting', () => {
     );
 
     expect(getAllByText('$50.00')).toHaveLength(7);
+  });
+});
+
+describe('notation', () => {
+  test('indicates the cell', () => {
+    const { getByDisplayValue, getByText, getByRole } = render(
+      <Worksheet columns={columns} items={items} onChange={handleChange} />,
+    );
+
+    const cell = getByText('Shoes Name One');
+
+    fireEvent.doubleClick(cell);
+
+    const input = getByDisplayValue('Shoes Name One');
+
+    fireEvent.change(input, { target: { value: 'Shoes Name One Edit' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(getByRole('note')).toBeInTheDocument();
   });
 });
 

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -1,3 +1,4 @@
+import { Colors } from '@bigcommerce/big-design-theme';
 import React from 'react';
 
 import { SelectOption } from '../Select';
@@ -24,6 +25,11 @@ export interface WorksheetError<Item extends WorksheetItem> {
   errors: Array<keyof Item>;
 }
 
+export interface NotationConfig {
+  color: keyof Colors;
+  description: string;
+}
+
 export type WorksheetColumn<Item> =
   | WorksheetTextColumn<Item>
   | WorksheetNumberColumn<Item>
@@ -46,6 +52,7 @@ interface WorksheetBaseColumn<Item> {
   width?: string | number;
   tooltip?: string;
   validation?(value: Item[keyof Item] | ''): boolean;
+  notation?(value: Item[keyof Item] | '', row: WorksheetItem): NotationConfig | undefined;
 }
 
 export interface WorksheetTextColumn<Item> extends WorksheetBaseColumn<Item> {

--- a/packages/docs/PropTables/WorksheetPropTable.tsx
+++ b/packages/docs/PropTables/WorksheetPropTable.tsx
@@ -132,6 +132,12 @@ const worksheetTextColumnProps: Prop[] = [
     description: 'Will set a cell as invalid if it returns false.',
   },
   {
+    name: 'notation',
+    types: '(value: any, row: any; }) => { color: keyof Colors; description: string; } | undefined',
+    description:
+      'Used to provide a way to show additional notes/comments/instructions on a particular cell.',
+  },
+  {
     name: 'disable',
     types: 'boolean',
     description: 'Disables cell manipulation for the entire column.',
@@ -179,6 +185,12 @@ const worksheetNumberColumnProps: Prop[] = [
     description: 'Function to test the validity of the cell.',
   },
   {
+    name: 'notation',
+    types: '(value: any, row: any; }) => { color: keyof Colors; description: string; } | undefined',
+    description:
+      'Used to provide a way to show additional notes/comments/instructions on a particular cell.',
+  },
+  {
     name: 'disable',
     types: 'boolean',
     description: 'Disables cell manipulation for the entire column.',
@@ -221,6 +233,12 @@ const worksheetCheckboxColumnProps: Prop[] = [
     description: 'Function to test the validity of the cell.',
   },
   {
+    name: 'notation',
+    types: '(value: any, row: any; }) => { color: keyof Colors; description: string; } | undefined',
+    description:
+      'Used to provide a way to show additional notes/comments/instructions on a particular cell.',
+  },
+  {
     name: 'disable',
     types: 'boolean',
     description: 'Disables cell manipulation for the entire column.',
@@ -261,6 +279,12 @@ const worksheetSelectableColumnProps: Prop[] = [
     name: 'validation',
     types: '(value: any) => boolean',
     description: 'Function to test the validity of the cell.',
+  },
+  {
+    name: 'notation',
+    types: '(value: any, row: any; }) => { color: keyof Colors; description: string; } | undefined',
+    description:
+      'Used to provide a way to show additional notes/comments/instructions on a particular cell.',
   },
   {
     name: 'config',
@@ -335,6 +359,12 @@ const worksheetModalColumnProps: Prop[] = [
     name: 'validation',
     types: '(value: any) => boolean',
     description: 'Function to test the validity of the cell.',
+  },
+  {
+    name: 'notation',
+    types: '(value: any, row: any; }) => { color: keyof Colors; description: string; } | undefined',
+    description:
+      'Used to provide a way to show additional notes/comments/instructions on a particular cell.',
   },
   {
     name: 'config',

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -136,6 +136,27 @@ const WorksheetPage = () => {
                         hash: 'productName',
                         header: 'Product name',
                         validation: (value) => !!value,
+                        notation: (value) => {
+                          switch (value) {
+                            case 'Product 1':
+                              return {
+                                color: 'danger',
+                                description: 'Change value to 2',
+                              };
+
+                            case '2':
+                              return {
+                                color: 'warning40',
+                                description: 'To make it green change it to 3',
+                              };
+
+                            case '3':
+                              return {
+                                color: 'success',
+                                description: 'Value is equal 3',
+                              };
+                          }
+                        },
                         width: 200,
                         tooltip: 'Tooltip text',
                       },


### PR DESCRIPTION
## What?

Add notation for worksheet cells

- It should be applicable to a cell of any type.
- The indicator color should be customizable within the BigDesign color palette.
- The message should be customizable.
- The indicator position is always the same – the top right corner.
- The tooltip position by default should be on the right of the indicator and automatically adjusted if it doesn’t fit the screen.

## Why?

To be able to provide a way to show additional notes/comments/instructions on a particular cell level.
## Screenshots/Screen Recordings


https://user-images.githubusercontent.com/84462142/231280748-fc82a7ce-c25c-4d72-8b73-2cb0a3cfb537.mov



## Testing/Proof

Locally + UT
