### PR TITLE
feat(component): localize components

### DIFF
--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -46,7 +46,7 @@ const excludeIconProps = ({
 }: ButtonProps & Pick<ButtonGroupAction, 'text'>): ButtonGroupAction => actionProps;
 
 export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
-  ({ actions, localization = { more: 'more' }, ...wrapperProps }) => {
+  ({ actions, localization, ...wrapperProps }) => {
     const parentRef = createRef<HTMLDivElement>();
     const dropdownRef = createRef<HTMLDivElement>();
     const [isMenuVisible, setIsMenuVisible] = useState(false);
@@ -123,7 +123,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
             toggle={
               <StyledButton
                 borderRadius={actionsState.every(({ isVisible }) => !isVisible)}
-                iconOnly={<MoreHorizIcon title={localization.more} />}
+                iconOnly={<MoreHorizIcon title={localization?.more || 'more'} />}
                 type="button"
                 variant="secondary"
               />
@@ -131,7 +131,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
           />
         </StyledFlexItem>
       ),
-      [actionsState, dropdownRef, isMenuVisible, localization.more],
+      [actionsState, dropdownRef, isMenuVisible, localization?.more],
     );
 
     const renderedActions = useMemo(

--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -23,8 +23,13 @@ export interface ButtonGroupAction
   icon?: React.ReactElement;
 }
 
+interface Localization {
+  more: string;
+}
+
 export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement>, MarginProps {
   actions: ButtonGroupAction[];
+  localization?: Localization;
 }
 
 interface ActionsState {
@@ -40,146 +45,148 @@ const excludeIconProps = ({
   ...actionProps
 }: ButtonProps & Pick<ButtonGroupAction, 'text'>): ButtonGroupAction => actionProps;
 
-export const ButtonGroup: React.FC<ButtonGroupProps> = memo(({ actions, ...wrapperProps }) => {
-  const parentRef = createRef<HTMLDivElement>();
-  const dropdownRef = createRef<HTMLDivElement>();
-  const [isMenuVisible, setIsMenuVisible] = useState(false);
-  const [actionsState, setActionsState] = useState<ActionsState[]>([]);
+export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
+  ({ actions, localization = { more: 'more' }, ...wrapperProps }) => {
+    const parentRef = createRef<HTMLDivElement>();
+    const dropdownRef = createRef<HTMLDivElement>();
+    const [isMenuVisible, setIsMenuVisible] = useState(false);
+    const [actionsState, setActionsState] = useState<ActionsState[]>([]);
 
-  useEffect(() => {
-    setActionsState(
-      actions.map((action) => ({
-        isVisible: true,
-        action: excludeIconProps(action),
-        ref: createRef<HTMLDivElement>(),
-      })),
-    );
-  }, [actions]);
+    useEffect(() => {
+      setActionsState(
+        actions.map((action) => ({
+          isVisible: true,
+          action: excludeIconProps(action),
+          ref: createRef<HTMLDivElement>(),
+        })),
+      );
+    }, [actions]);
 
-  const hideOverflowedActions = useCallback(() => {
-    const parentWidth = parentRef.current?.offsetWidth ?? 0;
-    const dropdownWidth = dropdownRef.current?.offsetWidth ?? 0;
+    const hideOverflowedActions = useCallback(() => {
+      const parentWidth = parentRef.current?.offsetWidth ?? 0;
+      const dropdownWidth = dropdownRef.current?.offsetWidth ?? 0;
 
-    let remainingWidth = parentWidth;
+      let remainingWidth = parentWidth;
 
-    const nextState = actionsState.map((stateObj) => {
-      const actionWidth = stateObj.ref.current?.offsetWidth;
+      const nextState = actionsState.map((stateObj) => {
+        const actionWidth = stateObj.ref.current?.offsetWidth;
 
-      if (!actionWidth) {
-        return stateObj;
-      }
+        if (!actionWidth) {
+          return stateObj;
+        }
 
-      if (stateObj.action.actionType === 'destructive') {
+        if (stateObj.action.actionType === 'destructive') {
+          return { ...stateObj, isVisible: false };
+        }
+
+        if (remainingWidth - actionWidth > dropdownWidth) {
+          remainingWidth -= actionWidth;
+
+          return { ...stateObj, isVisible: true };
+        }
+
         return { ...stateObj, isVisible: false };
+      });
+
+      const visibleActions = actionsState.filter(({ isVisible }) => isVisible);
+      const nextVisibleActions = nextState.filter(({ isVisible }) => isVisible);
+
+      if (visibleActions.length !== nextVisibleActions.length) {
+        setActionsState(nextState);
       }
+    }, [actionsState, dropdownRef, parentRef]);
 
-      if (remainingWidth - actionWidth > dropdownWidth) {
-        remainingWidth -= actionWidth;
+    const renderedDropdown = useMemo(
+      () => (
+        <StyledFlexItem
+          data-testid="buttongroup-dropdown"
+          isVisible={isMenuVisible}
+          ref={dropdownRef}
+          role="listitem"
+        >
+          <Dropdown
+            items={actionsState
+              .filter(({ isVisible }) => !isVisible)
+              .map(({ action, ref }) => ({
+                actionType: action.actionType,
+                content: action.text,
+                disabled: action.disabled,
+                onItemClick: () => {
+                  if (ref.current) {
+                    ref.current.getElementsByTagName('button')[0].click();
+                  }
+                },
+                hash: action.text.toLowerCase(),
+                icon: action.icon,
+              }))}
+            placement="bottom-end"
+            toggle={
+              <StyledButton
+                borderRadius={actionsState.every(({ isVisible }) => !isVisible)}
+                iconOnly={<MoreHorizIcon title={localization.more} />}
+                type="button"
+                variant="secondary"
+              />
+            }
+          />
+        </StyledFlexItem>
+      ),
+      [actionsState, dropdownRef, isMenuVisible, localization.more],
+    );
 
-        return { ...stateObj, isVisible: true };
+    const renderedActions = useMemo(
+      () =>
+        [...actionsState]
+          .reverse()
+          .sort(({ isVisible }) => (isVisible ? -1 : 1))
+          .map(({ action, isVisible, ref }, key) => {
+            const { text, icon, ...buttonProps } = action;
+
+            return (
+              <StyledFlexItem
+                data-testid="buttongroup-item"
+                isVisible={isVisible}
+                key={key}
+                ref={ref}
+                role="listitem"
+              >
+                <StyledButton {...buttonProps} variant="secondary">
+                  {text}
+                </StyledButton>
+              </StyledFlexItem>
+            );
+          }),
+      [actionsState],
+    );
+
+    useEffect(() => {
+      const nextIsMenuVisible = actionsState.some(({ isVisible }) => !isVisible);
+
+      if (nextIsMenuVisible !== isMenuVisible) {
+        setIsMenuVisible(nextIsMenuVisible);
       }
+    }, [actionsState, isMenuVisible]);
 
-      return { ...stateObj, isVisible: false };
+    useEffect(() => {
+      hideOverflowedActions();
+    }, [actions, parentRef, hideOverflowedActions]);
+
+    useWindowResizeListener(() => {
+      hideOverflowedActions();
     });
 
-    const visibleActions = actionsState.filter(({ isVisible }) => isVisible);
-    const nextVisibleActions = nextState.filter(({ isVisible }) => isVisible);
-
-    if (visibleActions.length !== nextVisibleActions.length) {
-      setActionsState(nextState);
-    }
-  }, [actionsState, dropdownRef, parentRef]);
-
-  const renderedDropdown = useMemo(
-    () => (
-      <StyledFlexItem
-        data-testid="buttongroup-dropdown"
-        isVisible={isMenuVisible}
-        ref={dropdownRef}
-        role="listitem"
+    return actions.length > 0 ? (
+      <Flex
+        {...wrapperProps}
+        data-testid="buttongroup-wrapper"
+        flexDirection="row"
+        flexWrap="nowrap"
+        ref={parentRef}
+        role="list"
       >
-        <Dropdown
-          items={actionsState
-            .filter(({ isVisible }) => !isVisible)
-            .map(({ action, ref }) => ({
-              actionType: action.actionType,
-              content: action.text,
-              disabled: action.disabled,
-              onItemClick: () => {
-                if (ref.current) {
-                  ref.current.getElementsByTagName('button')[0].click();
-                }
-              },
-              hash: action.text.toLowerCase(),
-              icon: action.icon,
-            }))}
-          placement="bottom-end"
-          toggle={
-            <StyledButton
-              borderRadius={actionsState.every(({ isVisible }) => !isVisible)}
-              iconOnly={<MoreHorizIcon title="more" />}
-              type="button"
-              variant="secondary"
-            />
-          }
-        />
-      </StyledFlexItem>
-    ),
-    [actionsState, dropdownRef, isMenuVisible],
-  );
-
-  const renderedActions = useMemo(
-    () =>
-      [...actionsState]
-        .reverse()
-        .sort(({ isVisible }) => (isVisible ? -1 : 1))
-        .map(({ action, isVisible, ref }, key) => {
-          const { text, icon, ...buttonProps } = action;
-
-          return (
-            <StyledFlexItem
-              data-testid="buttongroup-item"
-              isVisible={isVisible}
-              key={key}
-              ref={ref}
-              role="listitem"
-            >
-              <StyledButton {...buttonProps} variant="secondary">
-                {text}
-              </StyledButton>
-            </StyledFlexItem>
-          );
-        }),
-    [actionsState],
-  );
-
-  useEffect(() => {
-    const nextIsMenuVisible = actionsState.some(({ isVisible }) => !isVisible);
-
-    if (nextIsMenuVisible !== isMenuVisible) {
-      setIsMenuVisible(nextIsMenuVisible);
-    }
-  }, [actionsState, isMenuVisible]);
-
-  useEffect(() => {
-    hideOverflowedActions();
-  }, [actions, parentRef, hideOverflowedActions]);
-
-  useWindowResizeListener(() => {
-    hideOverflowedActions();
-  });
-
-  return actions.length > 0 ? (
-    <Flex
-      {...wrapperProps}
-      data-testid="buttongroup-wrapper"
-      flexDirection="row"
-      flexWrap="nowrap"
-      ref={parentRef}
-      role="list"
-    >
-      {renderedActions}
-      {renderedDropdown}
-    </Flex>
-  ) : null;
-});
+        {renderedActions}
+        {renderedDropdown}
+      </Flex>
+    ) : null;
+  },
+);

--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -27,6 +27,10 @@ interface Localization {
   more: string;
 }
 
+const defaultLocalization: Localization = {
+  more: 'more',
+};
+
 export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement>, MarginProps {
   actions: ButtonGroupAction[];
   localization?: Localization;
@@ -46,7 +50,7 @@ const excludeIconProps = ({
 }: ButtonProps & Pick<ButtonGroupAction, 'text'>): ButtonGroupAction => actionProps;
 
 export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
-  ({ actions, localization, ...wrapperProps }) => {
+  ({ actions, localization = defaultLocalization, ...wrapperProps }) => {
     const parentRef = createRef<HTMLDivElement>();
     const dropdownRef = createRef<HTMLDivElement>();
     const [isMenuVisible, setIsMenuVisible] = useState(false);
@@ -123,7 +127,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
             toggle={
               <StyledButton
                 borderRadius={actionsState.every(({ isVisible }) => !isVisible)}
-                iconOnly={<MoreHorizIcon title={localization?.more || 'more'} />}
+                iconOnly={<MoreHorizIcon title={localization.more} />}
                 type="button"
                 variant="secondary"
               />
@@ -131,7 +135,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
           />
         </StyledFlexItem>
       ),
-      [actionsState, dropdownRef, isMenuVisible, localization?.more],
+      [actionsState, dropdownRef, isMenuVisible, localization.more],
     );
 
     const renderedActions = useMemo(

--- a/packages/big-design/src/components/ButtonGroup/spec.tsx
+++ b/packages/big-design/src/components/ButtonGroup/spec.tsx
@@ -145,3 +145,21 @@ test('dropdown trigger is type button', async () => {
 
   expect(trigger).toHaveAttribute('type', 'button');
 });
+
+test('renders localized labels', async () => {
+  render(
+    <ButtonGroup
+      actions={[
+        { text: 'button 1' },
+        { text: 'button 2' },
+        { text: 'button 3' },
+        { text: 'button 4' },
+      ]}
+      localization={{ more: 'mas' }}
+    />,
+  );
+
+  const trigger = await screen.findByRole('button', { name: 'mas' });
+
+  expect(trigger).toBeVisible();
+});

--- a/packages/big-design/src/components/Counter/Counter.tsx
+++ b/packages/big-design/src/components/Counter/Counter.tsx
@@ -47,11 +47,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
     forwardedRef,
     label,
     labelId,
-    localization = {
-      decreaseCount: 'Decrease count',
-      increaseCount: 'Increase count',
-      optional: 'optional',
-    },
+    localization,
     description,
     error,
     disabled,
@@ -161,7 +157,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
           <FormControlLabel
             htmlFor={id}
             id={labelId}
-            optionalLabel={localization.optional}
+            optionalLabel={localization?.optional}
             renderOptional={!props.required}
           >
             {label}
@@ -180,7 +176,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
       }
 
       warning('label must be either a string or a FormControlLabel component.');
-    }, [id, label, labelId, localization.optional, props.required]);
+    }, [id, label, labelId, localization?.optional, props.required]);
 
     const renderedDescription = useMemo(() => {
       if (!description) {
@@ -205,7 +201,9 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
         <StyledCounterWrapper disabled={disabled} error={errors} focus={focus}>
           <StyledCounterButton
             disabled={disabled || value <= Number(min)}
-            iconOnly={<RemoveCircleOutlineIcon title={localization.decreaseCount} />}
+            iconOnly={
+              <RemoveCircleOutlineIcon title={localization?.decreaseCount || 'Decrease count'} />
+            }
             onClick={handleDecrease}
             type="button"
           />
@@ -223,7 +221,9 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
           />
           <StyledCounterButton
             disabled={disabled || value >= Number(max)}
-            iconOnly={<AddCircleOutlineIcon title={localization.increaseCount} />}
+            iconOnly={
+              <AddCircleOutlineIcon title={localization?.increaseCount || 'Increase count'} />
+            }
             onClick={handleIncrease}
             type="button"
           />

--- a/packages/big-design/src/components/Counter/Counter.tsx
+++ b/packages/big-design/src/components/Counter/Counter.tsx
@@ -18,11 +18,18 @@ import { useInputErrors } from '../Form/useInputErrors';
 
 import { StyledCounterButton, StyledCounterInput, StyledCounterWrapper } from './styled';
 
+interface Localization {
+  decreaseCount: string;
+  increaseCount: string;
+  optional: string;
+}
+
 export interface CounterProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: React.ReactNode;
   labelId?: string;
   description?: React.ReactNode;
   error?: React.ReactNode | React.ReactNode[];
+  localization?: Localization;
   value: number;
   step?: number;
   onCountChange(count: number): void;
@@ -40,6 +47,11 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
     forwardedRef,
     label,
     labelId,
+    localization = {
+      decreaseCount: 'Decrease count',
+      increaseCount: 'Increase count',
+      optional: 'optional',
+    },
     description,
     error,
     disabled,
@@ -75,7 +87,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
     };
 
     const handleIncrease = () => {
-      if (value + step > max) {
+      if (value + step > Number(max)) {
         return;
       }
 
@@ -90,7 +102,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
     };
 
     const handleDecrease = () => {
-      if (value - step < min) {
+      if (value - step < Number(min)) {
         return;
       }
 
@@ -115,7 +127,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
         onCountChange(Math.round(newValue));
       }
 
-      if (newValue >= min && newValue <= max) {
+      if (newValue >= Number(min) && newValue <= Number(max)) {
         onCountChange(newValue);
       }
     };
@@ -146,7 +158,12 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
 
       if (typeof label === 'string') {
         return (
-          <FormControlLabel htmlFor={id} id={labelId} renderOptional={!props.required}>
+          <FormControlLabel
+            htmlFor={id}
+            id={labelId}
+            optionalLabel={localization.optional}
+            renderOptional={!props.required}
+          >
             {label}
           </FormControlLabel>
         );
@@ -163,7 +180,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
       }
 
       warning('label must be either a string or a FormControlLabel component.');
-    }, [id, label, labelId, props.required]);
+    }, [id, label, labelId, localization.optional, props.required]);
 
     const renderedDescription = useMemo(() => {
       if (!description) {
@@ -187,8 +204,8 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
         {renderedDescription}
         <StyledCounterWrapper disabled={disabled} error={errors} focus={focus}>
           <StyledCounterButton
-            disabled={disabled || value <= min}
-            iconOnly={<RemoveCircleOutlineIcon title="Decrease count" />}
+            disabled={disabled || value <= Number(min)}
+            iconOnly={<RemoveCircleOutlineIcon title={localization.decreaseCount} />}
             onClick={handleDecrease}
             type="button"
           />
@@ -205,8 +222,8 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
             value={value}
           />
           <StyledCounterButton
-            disabled={disabled || value >= max}
-            iconOnly={<AddCircleOutlineIcon title="Increase count" />}
+            disabled={disabled || value >= Number(max)}
+            iconOnly={<AddCircleOutlineIcon title={localization.increaseCount} />}
             onClick={handleIncrease}
             type="button"
           />

--- a/packages/big-design/src/components/Counter/Counter.tsx
+++ b/packages/big-design/src/components/Counter/Counter.tsx
@@ -24,6 +24,12 @@ interface Localization {
   optional: string;
 }
 
+const defaultLocalization: Localization = {
+  decreaseCount: 'Decrease count',
+  increaseCount: 'Increase count',
+  optional: 'optional',
+};
+
 export interface CounterProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: React.ReactNode;
   labelId?: string;
@@ -47,7 +53,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
     forwardedRef,
     label,
     labelId,
-    localization,
+    localization = defaultLocalization,
     description,
     error,
     disabled,
@@ -157,7 +163,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
           <FormControlLabel
             htmlFor={id}
             id={labelId}
-            optionalLabel={localization?.optional}
+            localization={{ optional: localization.optional }}
             renderOptional={!props.required}
           >
             {label}
@@ -176,7 +182,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
       }
 
       warning('label must be either a string or a FormControlLabel component.');
-    }, [id, label, labelId, localization?.optional, props.required]);
+    }, [id, label, labelId, localization.optional, props.required]);
 
     const renderedDescription = useMemo(() => {
       if (!description) {
@@ -201,9 +207,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
         <StyledCounterWrapper disabled={disabled} error={errors} focus={focus}>
           <StyledCounterButton
             disabled={disabled || value <= Number(min)}
-            iconOnly={
-              <RemoveCircleOutlineIcon title={localization?.decreaseCount || 'Decrease count'} />
-            }
+            iconOnly={<RemoveCircleOutlineIcon title={localization.decreaseCount} />}
             onClick={handleDecrease}
             type="button"
           />
@@ -221,9 +225,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
           />
           <StyledCounterButton
             disabled={disabled || value >= Number(max)}
-            iconOnly={
-              <AddCircleOutlineIcon title={localization?.increaseCount || 'Increase count'} />
-            }
+            iconOnly={<AddCircleOutlineIcon title={localization.increaseCount} />}
             onClick={handleIncrease}
             type="button"
           />

--- a/packages/big-design/src/components/Counter/spec.tsx
+++ b/packages/big-design/src/components/Counter/spec.tsx
@@ -33,6 +33,7 @@ const counterMock = ({
   ref,
   label = 'Label',
   labelId = '',
+  localization,
   id = '',
   error = '',
   description = '',
@@ -49,6 +50,7 @@ const counterMock = ({
     id={id}
     label={label}
     labelId={labelId}
+    localization={localization}
     max={max}
     min={min}
     onCountChange={onCountChange}
@@ -437,4 +439,27 @@ test('appends (optional) text to label if input is not required', () => {
   const label = container.querySelector('label');
 
   expect(label).toHaveStyleRule('content', "' (optional)'", { modifier: '::after' });
+});
+
+test('renders localized labels', async () => {
+  const { container } = render(
+    counterMock({
+      ...requiredAttributes,
+      localization: {
+        decreaseCount: 'Decrementar cuenta',
+        increaseCount: 'Incrementar cuenta',
+        optional: 'opcional',
+      },
+    }),
+  );
+
+  const label = container.querySelector('label');
+
+  expect(label).toHaveStyleRule('content', "' (opcional)'", { modifier: '::after' });
+
+  const decreaseButton = await screen.findByRole('button', { name: 'Decrementar cuenta' });
+  const increaseButton = await screen.findByRole('button', { name: 'Incrementar cuenta' });
+
+  expect(decreaseButton).toBeInTheDocument();
+  expect(increaseButton).toBeInTheDocument();
 });

--- a/packages/big-design/src/components/Datepicker/Datepicker.tsx
+++ b/packages/big-design/src/components/Datepicker/Datepicker.tsx
@@ -3,6 +3,7 @@ import { default as ReactDatePicker, registerLocale } from 'react-datepicker';
 
 import { createLocalizationProvider } from '../../utils';
 import { Input } from '../Input';
+import { InputLocalization } from '../Input/Input';
 
 import Header from './Header';
 import { StyledDatepicker } from './styled';
@@ -12,6 +13,7 @@ interface Props {
   error?: React.ReactNode;
   label?: string;
   locale?: string;
+  localization?: InputLocalization;
   onDateChange(date: string): void;
 }
 
@@ -28,6 +30,7 @@ const RawDatepicker: React.FC<DatepickerProps & PrivateProps> = ({
   forwardedRef,
   label,
   locale = 'en-US',
+  localization,
   min,
   max,
   onDateChange,
@@ -37,9 +40,9 @@ const RawDatepicker: React.FC<DatepickerProps & PrivateProps> = ({
   ...props
 }) => {
   const [selected, setSelected] = useState<Date>();
-  const localization = createLocalizationProvider(locale);
+  const localizationProvider = createLocalizationProvider(locale);
 
-  registerLocale(locale, localization);
+  registerLocale(locale, localizationProvider);
 
   const updateDate = (value: Date) => onDateChange(value ? value.toISOString() : value);
 
@@ -56,7 +59,7 @@ const RawDatepicker: React.FC<DatepickerProps & PrivateProps> = ({
       <ReactDatePicker
         calendarClassName="bc-datepicker"
         className="calendar-input"
-        customInput={<Input error={error} label={label} {...props} />}
+        customInput={<Input error={error} label={label} localization={localization} {...props} />}
         dateFormat={dateFormat || 'EE, dd MMM, yyyy'}
         disabled={disabled}
         locale={locale}
@@ -76,7 +79,7 @@ const RawDatepicker: React.FC<DatepickerProps & PrivateProps> = ({
             date={date}
             decreaseMonth={decreaseMonth}
             increaseMonth={increaseMonth}
-            months={localization.monthsLong}
+            months={localizationProvider.monthsLong}
             nextMonthButtonDisabled={nextMonthButtonDisabled}
             prevMonthButtonDisabled={prevMonthButtonDisabled}
           />

--- a/packages/big-design/src/components/Datepicker/spec.tsx
+++ b/packages/big-design/src/components/Datepicker/spec.tsx
@@ -115,3 +115,18 @@ test('dates after max date passed are disabled', async () => {
 
   expect(disabledDate?.classList.contains('react-datepicker__day--disabled')).toBe(true);
 });
+
+test('renders localized labels', () => {
+  const { container } = render(
+    <Datepicker
+      data-testid="datepicker"
+      label="Test label"
+      localization={{ optional: 'opcional' }}
+      onDateChange={jest.fn()}
+    />,
+  );
+
+  const label = container.querySelector('label');
+
+  expect(label).toHaveStyleRule('content', "' (opcional)'", { modifier: '::after' });
+});

--- a/packages/big-design/src/components/Form/Label/Label.tsx
+++ b/packages/big-design/src/components/Form/Label/Label.tsx
@@ -2,11 +2,22 @@ import React, { LabelHTMLAttributes } from 'react';
 
 import { StyledLabel } from './styled';
 
-export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
-  renderOptional?: boolean;
-  optionalLabel?: string;
+interface Localization {
+  optional: string;
 }
 
-export const FormControlLabel: React.FC<LabelProps> = ({ className, style, ...props }) => (
-  <StyledLabel {...props} />
-);
+const defaultLocalization = {
+  optional: 'optional',
+};
+
+export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+  renderOptional?: boolean;
+  localization?: Localization;
+}
+
+export const FormControlLabel: React.FC<LabelProps> = ({
+  className,
+  localization = defaultLocalization,
+  style,
+  ...props
+}) => <StyledLabel localization={localization} {...props} />;

--- a/packages/big-design/src/components/Form/Label/Label.tsx
+++ b/packages/big-design/src/components/Form/Label/Label.tsx
@@ -4,6 +4,7 @@ import { StyledLabel } from './styled';
 
 export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
   renderOptional?: boolean;
+  optionalLabel?: string;
 }
 
 export const FormControlLabel: React.FC<LabelProps> = ({ className, style, ...props }) => (

--- a/packages/big-design/src/components/Form/Label/Label.tsx
+++ b/packages/big-design/src/components/Form/Label/Label.tsx
@@ -2,17 +2,17 @@ import React, { LabelHTMLAttributes } from 'react';
 
 import { StyledLabel } from './styled';
 
-interface Localization {
+export interface LabelLocalization {
   optional: string;
 }
 
-const defaultLocalization: Localization = {
+const defaultLocalization: LabelLocalization = {
   optional: 'optional',
 };
 
 export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
   renderOptional?: boolean;
-  localization?: Localization;
+  localization?: LabelLocalization;
 }
 
 export const FormControlLabel: React.FC<LabelProps> = ({

--- a/packages/big-design/src/components/Form/Label/Label.tsx
+++ b/packages/big-design/src/components/Form/Label/Label.tsx
@@ -6,7 +6,7 @@ interface Localization {
   optional: string;
 }
 
-const defaultLocalization = {
+const defaultLocalization: Localization = {
   optional: 'optional',
 };
 

--- a/packages/big-design/src/components/Form/Label/spec.tsx
+++ b/packages/big-design/src/components/Form/Label/spec.tsx
@@ -25,3 +25,14 @@ test('appends (optional) text when renderOptional', () => {
 
   expect(label).toHaveStyleRule('content', "' (optional)'", { modifier: '::after' });
 });
+
+test('appends custom (optional) text when passed', () => {
+  const { container } = render(
+    <FormControlLabel optionalLabel="Custom optional" renderOptional>
+      This is a label
+    </FormControlLabel>,
+  );
+  const label = container.querySelector('label');
+
+  expect(label).toHaveStyleRule('content', "' (custom optional)'", { modifier: '::after' });
+});

--- a/packages/big-design/src/components/Form/Label/spec.tsx
+++ b/packages/big-design/src/components/Form/Label/spec.tsx
@@ -28,11 +28,11 @@ test('appends (optional) text when renderOptional', () => {
 
 test('appends custom (optional) text when passed', () => {
   const { container } = render(
-    <FormControlLabel optionalLabel="Custom optional" renderOptional>
+    <FormControlLabel localization={{ optional: 'Custom optional' }} renderOptional>
       This is a label
     </FormControlLabel>,
   );
   const label = container.querySelector('label');
 
-  expect(label).toHaveStyleRule('content', "' (custom optional)'", { modifier: '::after' });
+  expect(label).toHaveStyleRule('content', "' (Custom optional)'", { modifier: '::after' });
 });

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -19,12 +19,12 @@ export const StyledLabel = styled<
   display: inline-block;
   margin-bottom: ${({ theme }: StyledLabelArgument) => theme.spacing.xxSmall};
 
-  ${({ theme, renderOptional, optionalLabel }: StyledLabelArgument) =>
+  ${({ theme, renderOptional, localization }: StyledLabelArgument) =>
     renderOptional &&
     css`
       &::after {
         color: ${theme.colors.secondary60};
-        content: ' (${optionalLabel?.toLowerCase() ?? 'optional'})';
+        content: ' (${localization?.optional})';
         font-weight: ${theme.typography.fontWeight.regular};
       }
     `}

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -4,10 +4,11 @@ import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
 import { StyleableH4 } from '../../Typography/private';
 import { HeadingProps } from '../../Typography/types';
 
-import { LabelProps } from './Label';
+import { LabelLocalization, LabelProps } from './Label';
 
-interface StyledLabelArgument extends LabelProps {
+interface StyledLabelArgument extends Omit<LabelProps, 'localization'> {
   theme: DefaultTheme;
+  localization: LabelLocalization;
 }
 
 export const StyledLabel = styled<
@@ -24,7 +25,7 @@ export const StyledLabel = styled<
     css`
       &::after {
         color: ${theme.colors.secondary60};
-        content: ' (${localization?.optional})';
+        content: ' (${localization.optional})';
         font-weight: ${theme.typography.fontWeight.regular};
       }
     `}

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -24,7 +24,7 @@ export const StyledLabel = styled<
     css`
       &::after {
         color: ${theme.colors.secondary60};
-        content: ' (${optionalLabel ?? 'optional'})';
+        content: ' (${optionalLabel?.toLowerCase() ?? 'optional'})';
         font-weight: ${theme.typography.fontWeight.regular};
       }
     `}

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -19,12 +19,12 @@ export const StyledLabel = styled<
   display: inline-block;
   margin-bottom: ${({ theme }: StyledLabelArgument) => theme.spacing.xxSmall};
 
-  ${({ theme, renderOptional }: StyledLabelArgument) =>
+  ${({ theme, renderOptional, optionalLabel }: StyledLabelArgument) =>
     renderOptional &&
     css`
       &::after {
         color: ${theme.colors.secondary60};
-        content: ' (optional)';
+        content: ' (${optionalLabel ?? 'optional'})';
         font-weight: ${theme.typography.fontWeight.regular};
       }
     `}

--- a/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
+++ b/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
@@ -16,10 +16,18 @@ import {
   StyledMessageItem,
 } from './styled';
 
-export type InlineMessageProps = SharedMessagingProps & MarginProps;
+interface Localization {
+  close: string;
+}
+
+interface LocalizationProp {
+  localization?: Localization;
+}
+
+export type InlineMessageProps = SharedMessagingProps & MarginProps & LocalizationProp;
 
 export const InlineMessage: React.FC<InlineMessageProps> = memo(
-  ({ className, style, header, ...props }) => {
+  ({ className, style, header, localization = { close: 'Close' }, ...props }) => {
     const filteredProps = excludePaddingProps(props);
     const icon = useMemo(() => props.type && getMessagingIcon(props.type, true), [props.type]);
 
@@ -68,7 +76,7 @@ export const InlineMessage: React.FC<InlineMessageProps> = memo(
         {props.onClose && (
           <GridItem>
             <MessagingButton
-              iconOnly={<CloseIcon size="medium" title="Close." />}
+              iconOnly={<CloseIcon size="medium" title={localization.close} />}
               onClick={props.onClose}
             />
           </GridItem>

--- a/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
+++ b/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
@@ -16,16 +16,16 @@ import {
   StyledMessageItem,
 } from './styled';
 
-interface Localization {
+export interface InlineMessageLocalization {
   close: string;
 }
 
-const defaultLocalization: Localization = {
+const defaultLocalization: InlineMessageLocalization = {
   close: 'Close',
 };
 
 export type InlineMessageProps = SharedMessagingProps &
-  MarginProps & { localization?: Localization };
+  MarginProps & { localization?: InlineMessageLocalization };
 
 export const InlineMessage: React.FC<InlineMessageProps> = memo(
   ({ className, style, header, localization = defaultLocalization, ...props }) => {

--- a/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
+++ b/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
@@ -17,17 +17,13 @@ import {
 } from './styled';
 
 interface Localization {
-  close: string;
+  localization?: { close: string };
 }
 
-interface LocalizationProp {
-  localization?: Localization;
-}
+export type InlineMessageProps = SharedMessagingProps & MarginProps;
 
-export type InlineMessageProps = SharedMessagingProps & MarginProps & LocalizationProp;
-
-export const InlineMessage: React.FC<InlineMessageProps> = memo(
-  ({ className, style, header, localization = { close: 'Close' }, ...props }) => {
+export const InlineMessage: React.FC<InlineMessageProps & Localization> = memo(
+  ({ className, style, header, localization, ...props }) => {
     const filteredProps = excludePaddingProps(props);
     const icon = useMemo(() => props.type && getMessagingIcon(props.type, true), [props.type]);
 
@@ -76,7 +72,7 @@ export const InlineMessage: React.FC<InlineMessageProps> = memo(
         {props.onClose && (
           <GridItem>
             <MessagingButton
-              iconOnly={<CloseIcon size="medium" title={localization.close} />}
+              iconOnly={<CloseIcon size="medium" title={localization?.close || 'Close'} />}
               onClick={props.onClose}
             />
           </GridItem>

--- a/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
+++ b/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
@@ -17,13 +17,18 @@ import {
 } from './styled';
 
 interface Localization {
-  localization?: { close: string };
+  close: string;
 }
 
-export type InlineMessageProps = SharedMessagingProps & MarginProps;
+const defaultLocalization: Localization = {
+  close: 'Close',
+};
 
-export const InlineMessage: React.FC<InlineMessageProps & Localization> = memo(
-  ({ className, style, header, localization, ...props }) => {
+export type InlineMessageProps = SharedMessagingProps &
+  MarginProps & { localization?: Localization };
+
+export const InlineMessage: React.FC<InlineMessageProps> = memo(
+  ({ className, style, header, localization = defaultLocalization, ...props }) => {
     const filteredProps = excludePaddingProps(props);
     const icon = useMemo(() => props.type && getMessagingIcon(props.type, true), [props.type]);
 
@@ -72,7 +77,7 @@ export const InlineMessage: React.FC<InlineMessageProps & Localization> = memo(
         {props.onClose && (
           <GridItem>
             <MessagingButton
-              iconOnly={<CloseIcon size="medium" title={localization?.close || 'Close'} />}
+              iconOnly={<CloseIcon size="medium" title={localization.close} />}
               onClick={props.onClose}
             />
           </GridItem>

--- a/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
@@ -945,7 +945,7 @@ exports[`renders close button 1`] = `
           <title
             id=":ra:"
           >
-            Close.
+            Close
           </title>
           <path
             d="M0 0h24v24H0V0z"

--- a/packages/big-design/src/components/InlineMessage/spec.tsx
+++ b/packages/big-design/src/components/InlineMessage/spec.tsx
@@ -153,3 +153,17 @@ test('renders actions', () => {
 
   expect(onClick).toHaveBeenCalledTimes(2);
 });
+
+test('renders localized labels', async () => {
+  render(
+    <InlineMessage
+      localization={{ close: 'Cerrar' }}
+      messages={[{ text: 'Success' }]}
+      onClose={() => null}
+    />,
+  );
+
+  const button = await screen.findByRole('button', { name: 'Cerrar' });
+
+  expect(button).toBeInTheDocument();
+});

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -16,6 +16,10 @@ import { useInputErrors } from '../Form/useInputErrors';
 
 import { StyledIconWrapper, StyledInput, StyledInputContent, StyledInputWrapper } from './styled';
 
+export interface InputLocalization {
+  optional: string;
+}
+
 export interface Props {
   chips?: ChipProps[];
   description?: React.ReactChild;
@@ -24,6 +28,7 @@ export interface Props {
   iconRight?: React.ReactNode;
   label?: React.ReactChild;
   labelId?: string;
+  localization?: InputLocalization;
 }
 
 interface PrivateProps {
@@ -40,6 +45,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
   forwardedRef,
   label,
   labelId,
+  localization = { optional: 'optional' },
   ...props
 }) => {
   const [focus, setFocus] = useState(false);
@@ -70,7 +76,12 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
 
     if (typeof label === 'string') {
       return (
-        <FormControlLabel htmlFor={id} id={labelId} renderOptional={!props.required}>
+        <FormControlLabel
+          htmlFor={id}
+          id={labelId}
+          optionalLabel={localization.optional}
+          renderOptional={!props.required}
+        >
           {label}
         </FormControlLabel>
       );
@@ -87,7 +98,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
     }
 
     warning('label must be either a string or a FormControlLabel component.');
-  }, [id, label, labelId, props.required]);
+  }, [id, label, labelId, localization.optional, props.required]);
 
   const renderedDescription = useMemo(() => {
     if (!description) {

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -79,7 +79,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
         <FormControlLabel
           htmlFor={id}
           id={labelId}
-          optionalLabel={localization?.optional}
+          localization={localization}
           renderOptional={!props.required}
         >
           {label}
@@ -98,7 +98,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
     }
 
     warning('label must be either a string or a FormControlLabel component.');
-  }, [id, label, labelId, localization?.optional, props.required]);
+  }, [id, label, labelId, localization, props.required]);
 
   const renderedDescription = useMemo(() => {
     if (!description) {

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -45,7 +45,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
   forwardedRef,
   label,
   labelId,
-  localization = { optional: 'optional' },
+  localization,
   ...props
 }) => {
   const [focus, setFocus] = useState(false);
@@ -79,7 +79,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
         <FormControlLabel
           htmlFor={id}
           id={labelId}
-          optionalLabel={localization.optional}
+          optionalLabel={localization?.optional}
           renderOptional={!props.required}
         >
           {label}
@@ -98,7 +98,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
     }
 
     warning('label must be either a string or a FormControlLabel component.');
-  }, [id, label, labelId, localization.optional, props.required]);
+  }, [id, label, labelId, localization?.optional, props.required]);
 
   const renderedDescription = useMemo(() => {
     if (!description) {

--- a/packages/big-design/src/components/Input/spec.tsx
+++ b/packages/big-design/src/components/Input/spec.tsx
@@ -357,3 +357,12 @@ test('appends (optional) text to label if input is not required', () => {
 
   expect(label).toHaveStyleRule('content', "' (optional)'", { modifier: '::after' });
 });
+
+test('renders localized labels', () => {
+  const { container } = render(
+    <Input label="Test Label" localization={{ optional: 'opcional' }} />,
+  );
+  const label = container.querySelector('label');
+
+  expect(label).toHaveStyleRule('content', "' (opcional)'", { modifier: '::after' });
+});

--- a/packages/big-design/src/components/Message/Message.tsx
+++ b/packages/big-design/src/components/Message/Message.tsx
@@ -16,65 +16,75 @@ import {
   StyledMessageItem,
 } from './styled';
 
-export type MessageProps = SharedMessagingProps & MarginProps;
+interface Localization {
+  close: string;
+}
 
-export const Message: React.FC<MessageProps> = memo(({ className, style, header, ...props }) => {
-  const filteredProps = excludePaddingProps(props);
-  const icon = useMemo(() => props.type && getMessagingIcon(props.type), [props.type]);
+interface LocalizationProp {
+  localization?: Localization;
+}
 
-  const renderedMessages = useMemo(
-    () =>
-      props.messages.map(({ text, link }, index) => (
-        <Box key={index}>
-          <StyledMessageItem>{text}</StyledMessageItem>{' '}
-          {link && <StyledLink {...link}>{link.text}</StyledLink>}
-        </Box>
-      )),
-    [props.messages],
-  );
+export type MessageProps = SharedMessagingProps & MarginProps & LocalizationProp;
 
-  const renderedHeader = useMemo(() => header && <StyledHeader>{header}</StyledHeader>, [header]);
+export const Message: React.FC<MessageProps> = memo(
+  ({ className, localization = { close: 'Close' }, style, header, ...props }) => {
+    const filteredProps = excludePaddingProps(props);
+    const icon = useMemo(() => props.type && getMessagingIcon(props.type), [props.type]);
 
-  const renderedActions = useMemo(
-    () =>
-      props.actions && (
-        <StyledActionsWrapper flexDirection="row" flexWrap="wrap" marginTop="xSmall">
-          {props.actions.map(({ text, variant = 'secondary', ...actionProps }, index) => (
-            <Button
-              {...excludeMarginProps(actionProps)}
-              key={index}
-              marginBottom="xSmall"
-              marginHorizontal="xxSmall"
-              mobileWidth="auto"
-              variant={getActionVariant(variant)}
-            >
-              {text}
-            </Button>
-          ))}
-        </StyledActionsWrapper>
-      ),
-    [props.actions],
-  );
+    const renderedMessages = useMemo(
+      () =>
+        props.messages.map(({ text, link }, index) => (
+          <Box key={index}>
+            <StyledMessageItem>{text}</StyledMessageItem>{' '}
+            {link && <StyledLink {...link}>{link.text}</StyledLink>}
+          </Box>
+        )),
+      [props.messages],
+    );
 
-  return (
-    <StyledMessage {...filteredProps} backgroundColor="white" role="alert">
-      <GridItem gridArea="icon">{icon}</GridItem>
-      <GridItem gridArea="messages">
-        {renderedHeader}
-        {renderedMessages}
-        {renderedActions}
-      </GridItem>
-      {props.onClose && (
-        <GridItem>
-          <MessagingButton
-            iconOnly={<CloseIcon size="large" title="Close." />}
-            onClick={props.onClose}
-          />
+    const renderedHeader = useMemo(() => header && <StyledHeader>{header}</StyledHeader>, [header]);
+
+    const renderedActions = useMemo(
+      () =>
+        props.actions && (
+          <StyledActionsWrapper flexDirection="row" flexWrap="wrap" marginTop="xSmall">
+            {props.actions.map(({ text, variant = 'secondary', ...actionProps }, index) => (
+              <Button
+                {...excludeMarginProps(actionProps)}
+                key={index}
+                marginBottom="xSmall"
+                marginHorizontal="xxSmall"
+                mobileWidth="auto"
+                variant={getActionVariant(variant)}
+              >
+                {text}
+              </Button>
+            ))}
+          </StyledActionsWrapper>
+        ),
+      [props.actions],
+    );
+
+    return (
+      <StyledMessage {...filteredProps} backgroundColor="white" role="alert">
+        <GridItem gridArea="icon">{icon}</GridItem>
+        <GridItem gridArea="messages">
+          {renderedHeader}
+          {renderedMessages}
+          {renderedActions}
         </GridItem>
-      )}
-    </StyledMessage>
-  );
-});
+        {props.onClose && (
+          <GridItem>
+            <MessagingButton
+              iconOnly={<CloseIcon size="large" title={localization.close} />}
+              onClick={props.onClose}
+            />
+          </GridItem>
+        )}
+      </StyledMessage>
+    );
+  },
+);
 
 Message.defaultProps = {
   messages: [],

--- a/packages/big-design/src/components/Message/Message.tsx
+++ b/packages/big-design/src/components/Message/Message.tsx
@@ -17,13 +17,17 @@ import {
 } from './styled';
 
 interface Localization {
-  localization?: { close: string };
+  close: string;
 }
 
-export type MessageProps = SharedMessagingProps & MarginProps;
+const defaultLocalization: Localization = {
+  close: 'Close',
+};
 
-export const Message: React.FC<MessageProps & Localization> = memo(
-  ({ className, localization = { close: 'Close' }, style, header, ...props }) => {
+export type MessageProps = SharedMessagingProps & MarginProps & { localization?: Localization };
+
+export const Message: React.FC<MessageProps> = memo(
+  ({ className, localization = defaultLocalization, style, header, ...props }) => {
     const filteredProps = excludePaddingProps(props);
     const icon = useMemo(() => props.type && getMessagingIcon(props.type), [props.type]);
 

--- a/packages/big-design/src/components/Message/Message.tsx
+++ b/packages/big-design/src/components/Message/Message.tsx
@@ -17,16 +17,12 @@ import {
 } from './styled';
 
 interface Localization {
-  close: string;
+  localization?: { close: string };
 }
 
-interface LocalizationProp {
-  localization?: Localization;
-}
+export type MessageProps = SharedMessagingProps & MarginProps;
 
-export type MessageProps = SharedMessagingProps & MarginProps & LocalizationProp;
-
-export const Message: React.FC<MessageProps> = memo(
+export const Message: React.FC<MessageProps & Localization> = memo(
   ({ className, localization = { close: 'Close' }, style, header, ...props }) => {
     const filteredProps = excludePaddingProps(props);
     const icon = useMemo(() => props.type && getMessagingIcon(props.type), [props.type]);

--- a/packages/big-design/src/components/Message/Message.tsx
+++ b/packages/big-design/src/components/Message/Message.tsx
@@ -16,15 +16,16 @@ import {
   StyledMessageItem,
 } from './styled';
 
-interface Localization {
+export interface MessageLocalization {
   close: string;
 }
 
-const defaultLocalization: Localization = {
+const defaultLocalization: MessageLocalization = {
   close: 'Close',
 };
 
-export type MessageProps = SharedMessagingProps & MarginProps & { localization?: Localization };
+export type MessageProps = SharedMessagingProps &
+  MarginProps & { localization?: MessageLocalization };
 
 export const Message: React.FC<MessageProps> = memo(
   ({ className, localization = defaultLocalization, style, header, ...props }) => {

--- a/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
@@ -939,7 +939,7 @@ exports[`renders close button 1`] = `
           <title
             id=":ra:"
           >
-            Close.
+            Close
           </title>
           <path
             d="M0 0h24v24H0V0z"

--- a/packages/big-design/src/components/Message/spec.tsx
+++ b/packages/big-design/src/components/Message/spec.tsx
@@ -149,3 +149,17 @@ test('renders actions', () => {
 
   expect(onClick).toHaveBeenCalledTimes(2);
 });
+
+test('renders localized labels', async () => {
+  render(
+    <Message
+      localization={{ close: 'Cerrar' }}
+      messages={[{ text: 'Success' }]}
+      onClose={() => null}
+    />,
+  );
+
+  const button = await screen.findByRole('button', { name: 'Cerrar' });
+
+  expect(button).toBeInTheDocument();
+});

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -36,6 +36,7 @@ export const MultiSelect = typedMemo(
     inputRef,
     label,
     labelId,
+    localization = { optional: 'optional' },
     maxHeight,
     onClose,
     onOpen,
@@ -330,7 +331,11 @@ export const MultiSelect = typedMemo(
 
       if (typeof label === 'string') {
         return (
-          <FormControlLabel {...getLabelProps()} renderOptional={!required}>
+          <FormControlLabel
+            {...getLabelProps()}
+            optionalLabel={localization.optional}
+            renderOptional={!required}
+          >
             {label}
           </FormControlLabel>
         );
@@ -344,7 +349,7 @@ export const MultiSelect = typedMemo(
       }
 
       warning('label must be either a string or a FormControlLabel component.');
-    }, [getLabelProps, label, required]);
+    }, [getLabelProps, label, localization.optional, required]);
 
     const renderToggle = useMemo(() => {
       return (

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -36,7 +36,7 @@ export const MultiSelect = typedMemo(
     inputRef,
     label,
     labelId,
-    localization = { optional: 'optional' },
+    localization,
     maxHeight,
     onClose,
     onOpen,
@@ -333,7 +333,7 @@ export const MultiSelect = typedMemo(
         return (
           <FormControlLabel
             {...getLabelProps()}
-            optionalLabel={localization.optional}
+            optionalLabel={localization?.optional}
             renderOptional={!required}
           >
             {label}
@@ -349,7 +349,7 @@ export const MultiSelect = typedMemo(
       }
 
       warning('label must be either a string or a FormControlLabel component.');
-    }, [getLabelProps, label, localization.optional, required]);
+    }, [getLabelProps, label, localization?.optional, required]);
 
     const renderToggle = useMemo(() => {
       return (

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -333,7 +333,7 @@ export const MultiSelect = typedMemo(
         return (
           <FormControlLabel
             {...getLabelProps()}
-            optionalLabel={localization?.optional}
+            localization={localization}
             renderOptional={!required}
           >
             {label}
@@ -349,7 +349,7 @@ export const MultiSelect = typedMemo(
       }
 
       warning('label must be either a string or a FormControlLabel component.');
-    }, [getLabelProps, label, localization?.optional, required]);
+    }, [getLabelProps, label, localization, required]);
 
     const renderToggle = useMemo(() => {
       return (

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -1063,6 +1063,28 @@ test('select action should supports description', async () => {
   expect(await screen.findByText('Action Description')).toBeInTheDocument();
 });
 
+test('renders localized labels', async () => {
+  render(
+    <MultiSelect
+      label="Countries"
+      localization={{ optional: 'opcional' }}
+      onOptionsChange={onChange}
+      options={[
+        { value: 'us', content: 'United States' },
+        { value: 'mx', content: 'Mexico' },
+        { value: 'ca', content: 'Canada' },
+        { value: 'en', content: 'England' },
+        { value: 'fr', content: 'France', disabled: true },
+      ]}
+      placeholder="Choose country"
+    />,
+  );
+
+  const label = await screen.findByText('Countries');
+
+  expect(label).toHaveStyleRule('content', "' (opcional)'", { modifier: '::after' });
+});
+
 describe('aria-labelledby', () => {
   it('should not be set if using aria-label', async () => {
     render(<MultiSelect aria-label="Countries" onOptionsChange={onChange} options={mockOptions} />);

--- a/packages/big-design/src/components/MultiSelect/types.ts
+++ b/packages/big-design/src/components/MultiSelect/types.ts
@@ -2,6 +2,7 @@ import { Placement } from '@popperjs/core';
 import React, { RefObject } from 'react';
 
 import { InputProps } from '../Input';
+import { InputLocalization } from '../Input/Input';
 import { SelectAction, SelectOption } from '../Select';
 import { SelectOptionGroup } from '../Select/types';
 
@@ -16,6 +17,7 @@ interface BaseSelect extends Omit<React.HTMLAttributes<HTMLInputElement>, 'child
   inputRef?: RefObject<HTMLInputElement> | React.Ref<HTMLInputElement>;
   label?: React.ReactChild;
   labelId?: string;
+  localization?: InputLocalization;
   maxHeight?: number;
   name?: string;
   placement?: Placement;

--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -12,10 +12,14 @@ import { Flex, FlexItem } from '../Flex';
 import { StyledButton } from './styled';
 
 export interface PaginationLocalization {
-  of: string;
   previousPage: string;
   nextPage: string;
 }
+
+const defaultLocalization: PaginationLocalization = {
+  previousPage: 'Previous page',
+  nextPage: 'Next page',
+};
 
 export interface PaginationProps extends MarginProps {
   currentPage: number;
@@ -29,17 +33,12 @@ export interface PaginationProps extends MarginProps {
   getRangeLabel?(start: number, end: number, totalItems: number): string;
 }
 
-const defaultGetRangeLabel = (
-  start: number,
-  end: number,
-  totalItems: number,
-  of = 'of',
-): string => {
+const defaultGetRangeLabel = (start: number, end: number, totalItems: number): string => {
   if (start === end) {
-    return `${start} ${of} ${totalItems}`;
+    return `${start} of ${totalItems}`;
   }
 
-  return `${start} - ${end} ${of} ${totalItems}`;
+  return `${start} - ${end} of ${totalItems}`;
 };
 
 export const Pagination: React.FC<PaginationProps> = memo(
@@ -51,7 +50,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
     onPageChange,
     onItemsPerPageChange,
     label = 'pagination',
-    localization,
+    localization = defaultLocalization,
     getRangeLabel = defaultGetRangeLabel,
   }) => {
     const [maxPages, setMaxPages] = useState(Math.max(1, Math.ceil(totalItems / itemsPerPage)));
@@ -131,7 +130,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
                 type="button"
                 variant="subtle"
               >
-                {getRangeLabel(itemRange.start, itemRange.end, totalItems, localization?.of)}
+                {getRangeLabel(itemRange.start, itemRange.end, totalItems)}
               </StyledButton>
             }
           />
@@ -139,7 +138,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
         <FlexItem>
           <StyledButton
             disabled={currentPage <= 1}
-            iconOnly={<ChevronLeftIcon title={localization?.previousPage || 'Previous page'} />}
+            iconOnly={<ChevronLeftIcon title={localization.previousPage} />}
             onClick={handlePageDecrease}
             type="button"
             variant="subtle"
@@ -147,7 +146,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
 
           <StyledButton
             disabled={currentPage >= maxPages}
-            iconOnly={<ChevronRightIcon title={localization?.nextPage || 'Next page'} />}
+            iconOnly={<ChevronRightIcon title={localization.nextPage} />}
             onClick={handlePageIncrease}
             type="button"
             variant="subtle"

--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -11,7 +11,7 @@ import { Flex, FlexItem } from '../Flex';
 
 import { StyledButton } from './styled';
 
-interface Localization {
+export interface PaginationLocalization {
   of: string;
   previousPage: string;
   nextPage: string;
@@ -25,7 +25,7 @@ export interface PaginationProps extends MarginProps {
   onPageChange(page: number): void;
   onItemsPerPageChange(range: number): void;
   label?: string;
-  localization?: Localization;
+  localization?: PaginationLocalization;
   getRangeLabel?(start: number, end: number, totalItems: number): string;
 }
 
@@ -33,7 +33,7 @@ const defaultGetRangeLabel = (
   start: number,
   end: number,
   totalItems: number,
-  localization: Localization,
+  localization: PaginationLocalization,
 ): string => {
   if (start === end) {
     return `${start} ${localization.of} ${totalItems}`;

--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -11,6 +11,12 @@ import { Flex, FlexItem } from '../Flex';
 
 import { StyledButton } from './styled';
 
+interface Localization {
+  of: string;
+  previousPage: string;
+  nextPage: string;
+}
+
 export interface PaginationProps extends MarginProps {
   currentPage: number;
   itemsPerPage: number;
@@ -19,17 +25,21 @@ export interface PaginationProps extends MarginProps {
   onPageChange(page: number): void;
   onItemsPerPageChange(range: number): void;
   label?: string;
-  previousLabel?: string;
-  nextLabel?: string;
+  localization?: Localization;
   getRangeLabel?(start: number, end: number, totalItems: number): string;
 }
 
-const defaultGetRangeLabel = (start: number, end: number, totalItems: number): string => {
+const defaultGetRangeLabel = (
+  start: number,
+  end: number,
+  totalItems: number,
+  localization: Localization,
+): string => {
   if (start === end) {
-    return `${start} of ${totalItems}`;
+    return `${start} ${localization.of} ${totalItems}`;
   }
 
-  return `${start} - ${end} of ${totalItems}`;
+  return `${start} - ${end} ${localization.of} ${totalItems}`;
 };
 
 export const Pagination: React.FC<PaginationProps> = memo(
@@ -41,8 +51,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
     onPageChange,
     onItemsPerPageChange,
     label = 'pagination',
-    previousLabel = 'Previous page',
-    nextLabel = 'Next page',
+    localization = { of: 'of', previousPage: 'Previous page', nextPage: 'Next page' },
     getRangeLabel = defaultGetRangeLabel,
   }) => {
     const [maxPages, setMaxPages] = useState(Math.max(1, Math.ceil(totalItems / itemsPerPage)));
@@ -122,7 +131,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
                 type="button"
                 variant="subtle"
               >
-                {getRangeLabel(itemRange.start, itemRange.end, totalItems)}
+                {getRangeLabel(itemRange.start, itemRange.end, totalItems, localization)}
               </StyledButton>
             }
           />
@@ -130,7 +139,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
         <FlexItem>
           <StyledButton
             disabled={currentPage <= 1}
-            iconOnly={<ChevronLeftIcon title={previousLabel} />}
+            iconOnly={<ChevronLeftIcon title={localization.previousPage} />}
             onClick={handlePageDecrease}
             type="button"
             variant="subtle"
@@ -138,7 +147,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
 
           <StyledButton
             disabled={currentPage >= maxPages}
-            iconOnly={<ChevronRightIcon title={nextLabel} />}
+            iconOnly={<ChevronRightIcon title={localization.nextPage} />}
             onClick={handlePageIncrease}
             type="button"
             variant="subtle"

--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -33,13 +33,13 @@ const defaultGetRangeLabel = (
   start: number,
   end: number,
   totalItems: number,
-  localization: PaginationLocalization,
+  of = 'of',
 ): string => {
   if (start === end) {
-    return `${start} ${localization.of} ${totalItems}`;
+    return `${start} ${of} ${totalItems}`;
   }
 
-  return `${start} - ${end} ${localization.of} ${totalItems}`;
+  return `${start} - ${end} ${of} ${totalItems}`;
 };
 
 export const Pagination: React.FC<PaginationProps> = memo(
@@ -51,7 +51,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
     onPageChange,
     onItemsPerPageChange,
     label = 'pagination',
-    localization = { of: 'of', previousPage: 'Previous page', nextPage: 'Next page' },
+    localization,
     getRangeLabel = defaultGetRangeLabel,
   }) => {
     const [maxPages, setMaxPages] = useState(Math.max(1, Math.ceil(totalItems / itemsPerPage)));
@@ -131,7 +131,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
                 type="button"
                 variant="subtle"
               >
-                {getRangeLabel(itemRange.start, itemRange.end, totalItems, localization)}
+                {getRangeLabel(itemRange.start, itemRange.end, totalItems, localization?.of)}
               </StyledButton>
             }
           />
@@ -139,7 +139,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
         <FlexItem>
           <StyledButton
             disabled={currentPage <= 1}
-            iconOnly={<ChevronLeftIcon title={localization.previousPage} />}
+            iconOnly={<ChevronLeftIcon title={localization?.previousPage || 'Previous page'} />}
             onClick={handlePageDecrease}
             type="button"
             variant="subtle"
@@ -147,7 +147,7 @@ export const Pagination: React.FC<PaginationProps> = memo(
 
           <StyledButton
             disabled={currentPage >= maxPages}
-            iconOnly={<ChevronRightIcon title={localization.nextPage} />}
+            iconOnly={<ChevronRightIcon title={localization?.nextPage || 'Next page'} />}
             onClick={handlePageIncrease}
             type="button"
             variant="subtle"

--- a/packages/big-design/src/components/Pagination/spec.tsx
+++ b/packages/big-design/src/components/Pagination/spec.tsx
@@ -96,7 +96,7 @@ test('render pagination component while overriding button labels', async () => {
       itemsPerPage={3}
       itemsPerPageOptions={[2, 3, 5]}
       label="[Custom] Pagination"
-      localization={{ of: 'de', previousPage: 'Pagina previa', nextPage: 'Pagina siguiente' }}
+      localization={{ previousPage: 'Pagina previa', nextPage: 'Pagina siguiente' }}
       onItemsPerPageChange={changeRange}
       onPageChange={changePage}
       totalItems={10}
@@ -206,10 +206,13 @@ test('renders localized labels', async () => {
   render(
     <Pagination
       currentPage={1}
+      getRangeLabel={(start: number, end: number, totalItems: number): string => {
+        return `${start} - ${end} de ${totalItems}`;
+      }}
       itemsPerPage={3}
       itemsPerPageOptions={[2, 3, 5]}
       label="Paginacion"
-      localization={{ of: 'de', previousPage: 'Pagina previa', nextPage: 'Pagina siguiente' }}
+      localization={{ previousPage: 'Pagina previa', nextPage: 'Pagina siguiente' }}
       onItemsPerPageChange={changeRange}
       onPageChange={changePage}
       totalItems={10}

--- a/packages/big-design/src/components/Pagination/spec.tsx
+++ b/packages/big-design/src/components/Pagination/spec.tsx
@@ -96,18 +96,17 @@ test('render pagination component while overriding button labels', async () => {
       itemsPerPage={3}
       itemsPerPageOptions={[2, 3, 5]}
       label="[Custom] Pagination"
-      nextLabel="[Custom] Next page"
+      localization={{ of: 'de', previousPage: 'Pagina previa', nextPage: 'Pagina siguiente' }}
       onItemsPerPageChange={changeRange}
       onPageChange={changePage}
-      previousLabel="[Custom] Previous page"
       totalItems={10}
     />,
   );
 
   const pagination = await screen.findByRole('navigation', { name: '[Custom] Pagination' });
   const dropdown = await screen.findByRole('button', { name: '[Custom label] 1-3 of 10' });
-  const prevPage = await screen.findByRole('button', { name: '[Custom] Previous page' });
-  const nextPage = await screen.findByRole('button', { name: '[Custom] Next page' });
+  const prevPage = await screen.findByRole('button', { name: 'Pagina previa' });
+  const nextPage = await screen.findByRole('button', { name: 'Pagina siguiente' });
 
   expect(pagination).toBeInTheDocument();
   expect(dropdown).toBeInTheDocument();
@@ -198,4 +197,32 @@ test('trigger page increase', async () => {
 
   expect(changePage).toHaveBeenCalled();
   expect(title).toBeInTheDocument();
+});
+
+test('renders localized labels', async () => {
+  const changePage = jest.fn();
+  const changeRange = jest.fn();
+
+  render(
+    <Pagination
+      currentPage={1}
+      itemsPerPage={3}
+      itemsPerPageOptions={[2, 3, 5]}
+      label="Paginacion"
+      localization={{ of: 'de', previousPage: 'Pagina previa', nextPage: 'Pagina siguiente' }}
+      onItemsPerPageChange={changeRange}
+      onPageChange={changePage}
+      totalItems={10}
+    />,
+  );
+
+  const pagination = await screen.findByRole('navigation', { name: 'Paginacion' });
+  const dropdown = await screen.findByRole('button', { name: '1 - 3 de 10' });
+  const prevPage = await screen.findByRole('button', { name: 'Pagina previa' });
+  const nextPage = await screen.findByRole('button', { name: 'Pagina siguiente' });
+
+  expect(pagination).toBeInTheDocument();
+  expect(dropdown).toBeInTheDocument();
+  expect(prevPage).toBeInTheDocument();
+  expect(nextPage).toBeInTheDocument();
 });

--- a/packages/big-design/src/components/Search/Search.tsx
+++ b/packages/big-design/src/components/Search/Search.tsx
@@ -9,7 +9,7 @@ import { Input } from '../Input';
 import { SearchProps } from './types';
 
 export const Search: React.FC<SearchProps> = ({
-  localization = { search: 'Search' },
+  localization,
   value,
   onChange,
   onSubmit,
@@ -33,17 +33,17 @@ export const Search: React.FC<SearchProps> = ({
         <FlexItem flexGrow={1} marginRight="small">
           <Input
             {...props}
-            aria-label={ariaLabel ?? localization.search}
+            aria-label={ariaLabel ?? (localization?.search || 'Search')}
             autoComplete={autoComplete}
             iconLeft={<SearchIcon color="secondary50" />}
             onChange={onChange}
-            placeholder={placeholder ?? localization.search}
+            placeholder={placeholder ?? (localization?.search || 'Search')}
             type="search"
             value={value}
           />
         </FlexItem>
         <Button mobileWidth="auto" type="submit" variant="secondary">
-          {localization.search}
+          {localization?.search || 'Search'}
         </Button>
       </Flex>
     </Form>

--- a/packages/big-design/src/components/Search/Search.tsx
+++ b/packages/big-design/src/components/Search/Search.tsx
@@ -9,11 +9,12 @@ import { Input } from '../Input';
 import { SearchProps } from './types';
 
 export const Search: React.FC<SearchProps> = ({
+  localization = { search: 'Search' },
   value,
   onChange,
   onSubmit,
-  placeholder = 'Search',
-  'aria-label': ariaLabel = 'Search',
+  placeholder,
+  'aria-label': ariaLabel,
   autoComplete = 'off',
   ...props
 }) => {
@@ -32,17 +33,17 @@ export const Search: React.FC<SearchProps> = ({
         <FlexItem flexGrow={1} marginRight="small">
           <Input
             {...props}
-            aria-label={ariaLabel}
+            aria-label={ariaLabel ?? localization.search}
             autoComplete={autoComplete}
             iconLeft={<SearchIcon color="secondary50" />}
             onChange={onChange}
-            placeholder={placeholder}
+            placeholder={placeholder ?? localization.search}
             type="search"
             value={value}
           />
         </FlexItem>
         <Button mobileWidth="auto" type="submit" variant="secondary">
-          Search
+          {localization.search}
         </Button>
       </Flex>
     </Form>

--- a/packages/big-design/src/components/Search/Search.tsx
+++ b/packages/big-design/src/components/Search/Search.tsx
@@ -6,10 +6,14 @@ import { Flex, FlexItem } from '../Flex';
 import { Form } from '../Form';
 import { Input } from '../Input';
 
-import { SearchProps } from './types';
+import { SearchLocalization, SearchProps } from './types';
+
+const defaultLocalization: SearchLocalization = {
+  search: 'Search',
+};
 
 export const Search: React.FC<SearchProps> = ({
-  localization,
+  localization = defaultLocalization,
   value,
   onChange,
   onSubmit,
@@ -33,17 +37,17 @@ export const Search: React.FC<SearchProps> = ({
         <FlexItem flexGrow={1} marginRight="small">
           <Input
             {...props}
-            aria-label={ariaLabel ?? (localization?.search || 'Search')}
+            aria-label={ariaLabel ?? localization.search}
             autoComplete={autoComplete}
             iconLeft={<SearchIcon color="secondary50" />}
             onChange={onChange}
-            placeholder={placeholder ?? (localization?.search || 'Search')}
+            placeholder={placeholder ?? localization.search}
             type="search"
             value={value}
           />
         </FlexItem>
         <Button mobileWidth="auto" type="submit" variant="secondary">
-          {localization?.search || 'Search'}
+          {localization.search}
         </Button>
       </Flex>
     </Form>

--- a/packages/big-design/src/components/Search/spec.tsx
+++ b/packages/big-design/src/components/Search/spec.tsx
@@ -41,3 +41,20 @@ test('Search input has autocomplete=off', async () => {
 
   expect(input.getAttribute('autocomplete')).toBe('off');
 });
+
+test('renders localized labels', async () => {
+  render(
+    <Search
+      localization={{ search: 'Buscar' }}
+      onChange={jest.fn()}
+      onSubmit={jest.fn()}
+      value=""
+    />,
+  );
+
+  const input = screen.getByLabelText('Buscar');
+  const button = screen.getByRole('button', { name: /buscar/i });
+
+  expect(input).toBeInTheDocument();
+  expect(button).toBeInTheDocument();
+});

--- a/packages/big-design/src/components/Search/types.ts
+++ b/packages/big-design/src/components/Search/types.ts
@@ -3,7 +3,12 @@ import { InputHTMLAttributes } from 'react';
 import { FormProps } from '../Form';
 import { InputProps } from '../Input';
 
+interface Localization {
+  search: string;
+}
+
 export interface SearchProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onSubmit'> {
+  localization?: Localization;
   value: InputProps['value'];
   onChange: InputProps['onChange'];
   onSubmit: FormProps['onSubmit'];

--- a/packages/big-design/src/components/Search/types.ts
+++ b/packages/big-design/src/components/Search/types.ts
@@ -3,12 +3,12 @@ import { InputHTMLAttributes } from 'react';
 import { FormProps } from '../Form';
 import { InputProps } from '../Input';
 
-interface Localization {
+export interface SearchLocalization {
   search: string;
 }
 
 export interface SearchProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onSubmit'> {
-  localization?: Localization;
+  localization?: SearchLocalization;
   value: InputProps['value'];
   onChange: InputProps['onChange'];
   onSubmit: FormProps['onSubmit'];

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -264,7 +264,7 @@ export const Select = typedMemo(
         return (
           <FormControlLabel
             {...getLabelProps()}
-            optionalLabel={localization?.optional}
+            localization={localization}
             renderOptional={!required}
           >
             {label}
@@ -280,7 +280,7 @@ export const Select = typedMemo(
       }
 
       warning('label must be either a string or a FormControlLabel component.');
-    }, [getLabelProps, label, localization?.optional, required]);
+    }, [getLabelProps, label, localization, required]);
 
     const renderToggle = useMemo(() => {
       return (

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -35,6 +35,7 @@ export const Select = typedMemo(
     inputRef,
     label,
     labelId,
+    localization = { optional: 'optional' },
     maxHeight,
     onClose,
     onOpen,
@@ -261,7 +262,11 @@ export const Select = typedMemo(
 
       if (typeof label === 'string') {
         return (
-          <FormControlLabel {...getLabelProps()} renderOptional={!required}>
+          <FormControlLabel
+            {...getLabelProps()}
+            optionalLabel={localization?.optional}
+            renderOptional={!required}
+          >
             {label}
           </FormControlLabel>
         );
@@ -275,7 +280,7 @@ export const Select = typedMemo(
       }
 
       warning('label must be either a string or a FormControlLabel component.');
-    }, [getLabelProps, label, required]);
+    }, [getLabelProps, label, localization?.optional, required]);
 
     const renderToggle = useMemo(() => {
       return (
@@ -344,25 +349,27 @@ export const Select = typedMemo(
             })}
             iconLeft={selectedItem?.icon}
             iconRight={renderToggle}
+            localization={localization}
           />
         </StyledInputContainer>
       );
     }, [
-      autoComplete,
-      ariaLabelledBy,
-      closeMenu,
-      disabled,
-      filterable,
       getInputProps,
-      getInputRef,
-      isOpen,
-      onOptionChange,
-      openMenu,
-      placeholder,
       props,
-      renderToggle,
+      ariaLabelledBy,
+      autoComplete,
+      disabled,
+      placeholder,
+      getInputRef,
+      filterable,
       required,
-      selectedItem,
+      selectedItem?.icon,
+      renderToggle,
+      localization,
+      isOpen,
+      openMenu,
+      onOptionChange,
+      closeMenu,
     ]);
 
     return (

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -35,7 +35,7 @@ export const Select = typedMemo(
     inputRef,
     label,
     labelId,
-    localization = { optional: 'optional' },
+    localization,
     maxHeight,
     onClose,
     onOpen,

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -979,6 +979,28 @@ test('select action should supports description', async () => {
   expect(await screen.findByText('Action Description')).toBeInTheDocument();
 });
 
+test('renders localized labels', async () => {
+  render(
+    <Select
+      label="Countries"
+      localization={{ optional: 'opcional' }}
+      onOptionChange={onChange}
+      options={[
+        { value: 'us', content: 'United States' },
+        { value: 'mx', content: 'Mexico' },
+        { value: 'ca', content: 'Canada' },
+        { value: 'en', content: 'England' },
+        { value: 'fr', content: 'France', disabled: true },
+      ]}
+      placeholder="Choose country"
+    />,
+  );
+
+  const label = await screen.findByText('Countries');
+
+  expect(label).toHaveStyleRule('content', "' (opcional)'", { modifier: '::after' });
+});
+
 describe('aria-labelledby', () => {
   it('should not be set if using aria-label', async () => {
     render(<Select aria-label="Countries" onOptionChange={onChange} options={mockOptions} />);

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -2,6 +2,7 @@ import { Placement } from '@popperjs/core';
 import React, { LiHTMLAttributes, RefObject } from 'react';
 
 import { InputProps } from '../Input';
+import { InputLocalization } from '../Input/Input';
 
 interface BaseSelect extends Omit<React.HTMLAttributes<HTMLInputElement>, 'children' | 'value'> {
   action?: SelectAction;
@@ -14,6 +15,7 @@ interface BaseSelect extends Omit<React.HTMLAttributes<HTMLInputElement>, 'child
   inputRef?: RefObject<HTMLInputElement> | React.Ref<HTMLInputElement>;
   label?: React.ReactChild;
   labelId?: string;
+  localization?: InputLocalization;
   maxHeight?: number;
   name?: string;
   placement?: Placement;

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -85,7 +85,7 @@ const InternalStatefulTable = <T extends TableItem>({
   itemName,
   items = [],
   keyField,
-  localization: localizationProp,
+  localization: localizationProp = defaultLocalization,
   getRangeLabel,
   onSelectionChange,
   onRowDrop,

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import { useDidUpdate } from '../../hooks';
 import { typedMemo } from '../../utils';
 import { Box } from '../Box';
+import { PaginationProps } from '../Pagination';
 import { PaginationLocalization } from '../Pagination/Pagination';
 import { PillTabItem, PillTabs, PillTabsProps } from '../PillTabs';
 import { Search } from '../Search';
@@ -22,6 +23,12 @@ type Localization =
   | PaginationLocalization
   | SearchLocalization
   | (PaginationLocalization & SearchLocalization);
+
+const defaultLocalization: Localization = {
+  nextPage: 'Next page',
+  previousPage: 'Previous page',
+  search: 'Search',
+};
 
 export interface StatefulTablePillTabFilter<T> {
   pillTabs: PillTabItem[];
@@ -54,6 +61,7 @@ export interface StatefulTableProps<T>
   selectable?: boolean;
   defaultSelected?: T[];
   search?: boolean;
+  getRangeLabel?: PaginationProps['getRangeLabel'];
   onRowDrop?(items: T[]): void;
   onSelectionChange?: TableSelectable<T>['onSelectionChange'];
 }
@@ -77,7 +85,8 @@ const InternalStatefulTable = <T extends TableItem>({
   itemName,
   items = [],
   keyField,
-  localization: localizationObj,
+  localization: localizationProp,
+  getRangeLabel,
   onSelectionChange,
   onRowDrop,
   search,
@@ -87,14 +96,7 @@ const InternalStatefulTable = <T extends TableItem>({
   stickyHeader = false,
   ...rest
 }: StatefulTableProps<T>): React.ReactElement<StatefulTableProps<T>> => {
-  // Merge localization and set defaults to make sure prop exists no matter what type
-  const localization = {
-    of: 'of',
-    nextPage: 'Next page',
-    previousPage: 'Previous page',
-    search: 'Search',
-    ...localizationObj,
-  };
+  const localization = { ...defaultLocalization, ...localizationProp };
 
   const reducer = useMemo(() => createReducer<T>(), []);
   const reducerInit = useMemo(() => createReducerInit<T>(), []);
@@ -153,20 +155,20 @@ const InternalStatefulTable = <T extends TableItem>({
             onItemsPerPageChange,
             onPageChange,
             localization: {
-              of: localization.of,
               previousPage: localization.previousPage,
               nextPage: localization.nextPage,
             },
+            getRangeLabel,
           }
         : undefined,
     [
       pagination,
       state.pagination,
+      getRangeLabel,
       onItemsPerPageChange,
       onPageChange,
-      localization?.of,
-      localization?.previousPage,
-      localization?.nextPage,
+      localization.previousPage,
+      localization.nextPage,
     ],
   );
 

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -87,6 +87,7 @@ const InternalStatefulTable = <T extends TableItem>({
   stickyHeader = false,
   ...rest
 }: StatefulTableProps<T>): React.ReactElement<StatefulTableProps<T>> => {
+  // Merge localization and set defaults to make sure prop exists no matter what type
   const localization = {
     of: 'of',
     nextPage: 'Next page',

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -3,8 +3,10 @@ import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import { useDidUpdate } from '../../hooks';
 import { typedMemo } from '../../utils';
 import { Box } from '../Box';
+import { PaginationLocalization } from '../Pagination/Pagination';
 import { PillTabItem, PillTabs, PillTabsProps } from '../PillTabs';
 import { Search } from '../Search';
+import { SearchLocalization } from '../Search/types';
 import {
   Table,
   TableColumn,
@@ -15,6 +17,11 @@ import {
 } from '../Table';
 
 import { createReducer, createReducerInit } from './reducer';
+
+type Localization =
+  | PaginationLocalization
+  | SearchLocalization
+  | (PaginationLocalization & SearchLocalization);
 
 export interface StatefulTablePillTabFilter<T> {
   pillTabs: PillTabItem[];
@@ -31,9 +38,17 @@ export interface StatefulTableColumn<T> extends Omit<TableColumn<T>, 'isSortable
 export interface StatefulTableProps<T>
   extends Omit<
     TableProps<T>,
-    'columns' | 'pagination' | 'filters' | 'search' | 'selectable' | 'sortable' | 'onRowDrop'
+    | 'columns'
+    | 'pagination'
+    | 'filters'
+    | 'search'
+    | 'selectable'
+    | 'sortable'
+    | 'onRowDrop'
+    | 'localization'
   > {
   columns: Array<StatefulTableColumn<T>>;
+  localization?: Localization;
   pagination?: boolean;
   filters?: StatefulTablePillTabFilter<T>;
   selectable?: boolean;
@@ -62,6 +77,7 @@ const InternalStatefulTable = <T extends TableItem>({
   itemName,
   items = [],
   keyField,
+  localization: localizationObj,
   onSelectionChange,
   onRowDrop,
   search,
@@ -71,6 +87,14 @@ const InternalStatefulTable = <T extends TableItem>({
   stickyHeader = false,
   ...rest
 }: StatefulTableProps<T>): React.ReactElement<StatefulTableProps<T>> => {
+  const localization = {
+    of: 'of',
+    nextPage: 'Next page',
+    previousPage: 'Previous page',
+    search: 'Search',
+    ...localizationObj,
+  };
+
   const reducer = useMemo(() => createReducer<T>(), []);
   const reducerInit = useMemo(() => createReducerInit<T>(), []);
   const sortable = useMemo(
@@ -121,8 +145,28 @@ const InternalStatefulTable = <T extends TableItem>({
   );
 
   const paginationOptions = useMemo(
-    () => (pagination ? { ...state.pagination, onItemsPerPageChange, onPageChange } : undefined),
-    [pagination, state.pagination, onItemsPerPageChange, onPageChange],
+    () =>
+      pagination
+        ? {
+            ...state.pagination,
+            onItemsPerPageChange,
+            onPageChange,
+            localization: {
+              of: localization.of,
+              previousPage: localization.previousPage,
+              nextPage: localization.nextPage,
+            },
+          }
+        : undefined,
+    [
+      pagination,
+      state.pagination,
+      onItemsPerPageChange,
+      onPageChange,
+      localization?.of,
+      localization?.previousPage,
+      localization?.nextPage,
+    ],
   );
 
   const selectableOptions = useMemo(
@@ -199,7 +243,7 @@ const InternalStatefulTable = <T extends TableItem>({
 
     return (
       <Box marginBottom="medium">
-        <Search {...searchProps} />
+        <Search localization={{ search: localization.search }} {...searchProps} />
       </Box>
     );
   };

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -556,9 +556,11 @@ describe('test search in the StatefulTable', () => {
 test('renders localized labels', async () => {
   render(
     getSimpleTable({
+      getRangeLabel: (start: number, end: number, totalItems: number): string => {
+        return `${start} - ${end} de ${totalItems}`;
+      },
       pagination: true,
       localization: {
-        of: 'de',
         nextPage: 'Pagina siguiente',
         previousPage: 'Pagina previa',
         search: 'Buscar',

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -552,3 +552,28 @@ describe('test search in the StatefulTable', () => {
     expect(rows).toHaveLength(105);
   });
 });
+
+test('renders localized labels', async () => {
+  render(
+    getSimpleTable({
+      pagination: true,
+      localization: {
+        of: 'de',
+        nextPage: 'Pagina siguiente',
+        previousPage: 'Pagina previa',
+        search: 'Buscar',
+      },
+      search: true,
+    }),
+  );
+
+  const input = screen.getByLabelText('Buscar');
+  const dropdown = await screen.findByRole('button', { name: '1 - 25 de 104' });
+  const prevPage = await screen.findByRole('button', { name: 'Pagina previa' });
+  const nextPage = await screen.findByRole('button', { name: 'Pagina siguiente' });
+
+  expect(input).toBeInTheDocument();
+  expect(dropdown).toBeInTheDocument();
+  expect(prevPage).toBeInTheDocument();
+  expect(nextPage).toBeInTheDocument();
+});

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -18,8 +18,10 @@ export interface HeaderCellProps<T>
   extends TableHTMLAttributes<HTMLTableCellElement>,
     TableColumnDisplayProps {
   actionsRef: RefObject<HTMLDivElement>;
+  ascendingOrderLabel?: string;
   children?: React.ReactNode;
   column: TableColumn<T>;
+  descendingOrderLabel?: string;
   id: string;
   hide?: boolean;
   isSorted?: boolean;
@@ -40,8 +42,10 @@ export interface DragIconCellProps {
 
 const InternalHeaderCell = <T extends TableItem>({
   actionsRef,
+  ascendingOrderLabel = 'Ascending order',
   children,
   column,
+  descendingOrderLabel = 'Desceding order',
   display,
   hide = false,
   id,
@@ -60,9 +64,9 @@ const InternalHeaderCell = <T extends TableItem>({
     }
 
     return sortDirection === 'ASC' ? (
-      <ArrowUpwardIcon data-testid="asc-icon" size="medium" title="Ascending order" />
+      <ArrowUpwardIcon data-testid="asc-icon" size="medium" title={ascendingOrderLabel} />
     ) : (
-      <ArrowDownwardIcon data-testid="desc-icon" size="medium" title="Descending order" />
+      <ArrowDownwardIcon data-testid="desc-icon" size="medium" title={descendingOrderLabel} />
     );
   };
 

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -19,11 +19,6 @@ interface Localization {
   descendingOrder: string;
 }
 
-const defaultLocalization: Localization = {
-  ascendingOrder: 'Ascending order',
-  descendingOrder: 'Descending order',
-};
-
 export interface HeaderCellProps<T>
   extends TableHTMLAttributes<HTMLTableCellElement>,
     TableColumnDisplayProps {
@@ -33,7 +28,7 @@ export interface HeaderCellProps<T>
   id: string;
   hide?: boolean;
   isSorted?: boolean;
-  localization?: Localization;
+  localization: Localization;
   sortDirection?: 'ASC' | 'DESC';
   stickyHeader?: boolean;
   onSortClick?(column: TableColumn<T>): void;
@@ -57,7 +52,7 @@ const InternalHeaderCell = <T extends TableItem>({
   hide = false,
   id,
   isSorted,
-  localization = defaultLocalization,
+  localization,
   onSortClick,
   sortDirection,
   stickyHeader,

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -14,17 +14,26 @@ import { TableColumn, TableItem } from '../types';
 
 import { StyledFlex, StyledTableHeaderCell, StyledTableHeaderIcon } from './styled';
 
+interface Localization {
+  ascendingOrder: string;
+  descendingOrder: string;
+}
+
+const defaultLocalization: Localization = {
+  ascendingOrder: 'Ascending order',
+  descendingOrder: 'Descending order',
+};
+
 export interface HeaderCellProps<T>
   extends TableHTMLAttributes<HTMLTableCellElement>,
     TableColumnDisplayProps {
   actionsRef: RefObject<HTMLDivElement>;
-  ascendingOrderLabel?: string;
   children?: React.ReactNode;
   column: TableColumn<T>;
-  descendingOrderLabel?: string;
   id: string;
   hide?: boolean;
   isSorted?: boolean;
+  localization?: Localization;
   sortDirection?: 'ASC' | 'DESC';
   stickyHeader?: boolean;
   onSortClick?(column: TableColumn<T>): void;
@@ -42,14 +51,13 @@ export interface DragIconCellProps {
 
 const InternalHeaderCell = <T extends TableItem>({
   actionsRef,
-  ascendingOrderLabel = 'Ascending order',
   children,
   column,
-  descendingOrderLabel = 'Desceding order',
   display,
   hide = false,
   id,
   isSorted,
+  localization = defaultLocalization,
   onSortClick,
   sortDirection,
   stickyHeader,
@@ -64,9 +72,13 @@ const InternalHeaderCell = <T extends TableItem>({
     }
 
     return sortDirection === 'ASC' ? (
-      <ArrowUpwardIcon data-testid="asc-icon" size="medium" title={ascendingOrderLabel} />
+      <ArrowUpwardIcon data-testid="asc-icon" size="medium" title={localization.ascendingOrder} />
     ) : (
-      <ArrowDownwardIcon data-testid="desc-icon" size="medium" title={descendingOrderLabel} />
+      <ArrowDownwardIcon
+        data-testid="desc-icon"
+        size="medium"
+        title={localization.descendingOrder}
+      />
     );
   };
 

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -27,6 +27,7 @@ const InternalTable = <T extends TableItem>(
     itemName,
     items,
     keyField = 'id',
+    localization,
     onRowDrop,
     pagination,
     selectable,
@@ -149,7 +150,9 @@ const InternalTable = <T extends TableItem>(
           return (
             <HeaderCell
               actionsRef={actionsRef}
+              ascendingOrderLabel={localization?.ascendingOrder}
               column={{ ...column, width: widthColumn }}
+              descendingOrderLabel={localization?.descendingOrder}
               display={display}
               hide={hideHeader}
               id={`header-cell-${index}`}

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -150,14 +150,13 @@ const InternalTable = <T extends TableItem>(
           return (
             <HeaderCell
               actionsRef={actionsRef}
-              ascendingOrderLabel={localization?.ascendingOrder}
               column={{ ...column, width: widthColumn }}
-              descendingOrderLabel={localization?.descendingOrder}
               display={display}
               hide={hideHeader}
               id={`header-cell-${index}`}
               isSorted={isSorted}
               key={index}
+              localization={localization}
               onSortClick={onSortClick}
               sortDirection={sortDirection}
               stickyHeader={stickyHeader}

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -14,6 +14,16 @@ import { Row } from './Row';
 import { StyledTable, StyledTableFigure } from './styled';
 import { TableColumn, TableItem, TableProps } from './types';
 
+interface Localization {
+  ascendingOrder: string;
+  descendingOrder: string;
+}
+
+const defaultLocalization: Localization = {
+  ascendingOrder: 'Ascending order',
+  descendingOrder: 'Descending order',
+};
+
 const InternalTable = <T extends TableItem>(
   props: TableProps<T>,
 ): React.ReactElement<TableProps<T>> => {
@@ -27,7 +37,7 @@ const InternalTable = <T extends TableItem>(
     itemName,
     items,
     keyField = 'id',
-    localization,
+    localization = defaultLocalization,
     onRowDrop,
     pagination,
     selectable,

--- a/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
@@ -14,8 +14,7 @@ export const TablePagination: React.FC<TablePaginationProps> = memo(
     onPageChange,
     totalItems,
     label,
-    previousLabel,
-    nextLabel,
+    localization,
     getRangeLabel,
   }) => {
     return (
@@ -26,10 +25,9 @@ export const TablePagination: React.FC<TablePaginationProps> = memo(
           itemsPerPage={itemsPerPage}
           itemsPerPageOptions={itemsPerPageOptions}
           label={label}
-          nextLabel={nextLabel}
+          localization={localization}
           onItemsPerPageChange={onItemsPerPageChange}
           onPageChange={onPageChange}
-          previousLabel={previousLabel}
           totalItems={totalItems}
         />
       </StyledPaginationContainer>

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -266,7 +266,6 @@ test('renders a pagination component with custom button labels', async () => {
         getRangeLabel,
         label: '[Custom] Pagination',
         localization: {
-          of: 'of',
           previousPage: '[Custom] Previous page',
           nextPage: '[Custom] Next page',
         },

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -265,8 +265,11 @@ test('renders a pagination component with custom button labels', async () => {
         onPageChange,
         getRangeLabel,
         label: '[Custom] Pagination',
-        previousLabel: '[Custom] Previous page',
-        nextLabel: '[Custom] Next page',
+        localization: {
+          of: 'of',
+          previousPage: '[Custom] Previous page',
+          nextPage: '[Custom] Next page',
+        },
       }}
     />,
   );
@@ -614,4 +617,70 @@ describe('draggable', () => {
 
     expect(onRowDrop).toHaveBeenCalledWith(0, 1);
   });
+});
+
+test('renders localized ascending label', async () => {
+  const onSort = jest.fn();
+  const items = [
+    { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+    { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+    { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+    { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+    { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+  ];
+  const columns = [
+    { header: 'Sku', hash: 'sku', render: ({ sku }: any) => sku, isSortable: true },
+    { header: 'Name', hash: 'name', render: ({ name }: any) => name },
+    { header: 'Stock', hash: 'stock', render: ({ stock }: any) => stock },
+  ];
+
+  render(
+    <Table
+      columns={columns}
+      items={items}
+      localization={{ ascendingOrder: 'Orden ascendiente', descendingOrder: 'Orden descendiente' }}
+      sortable={{
+        columnHash: 'sku',
+        direction: 'ASC',
+        onSort,
+      }}
+    />,
+  );
+
+  const ascSortIcon = screen.getByTitle('Orden ascendiente');
+
+  expect(ascSortIcon).toBeInTheDocument();
+});
+
+test('renders localized descending label', async () => {
+  const onSort = jest.fn();
+  const items = [
+    { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+    { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+    { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+    { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+    { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+  ];
+  const columns = [
+    { header: 'Sku', hash: 'sku', render: ({ sku }: any) => sku, isSortable: true },
+    { header: 'Name', hash: 'name', render: ({ name }: any) => name },
+    { header: 'Stock', hash: 'stock', render: ({ stock }: any) => stock },
+  ];
+
+  render(
+    <Table
+      columns={columns}
+      items={items}
+      localization={{ ascendingOrder: 'Orden ascendiente', descendingOrder: 'Orden descendiente' }}
+      sortable={{
+        columnHash: 'sku',
+        direction: 'DESC',
+        onSort,
+      }}
+    />,
+  );
+
+  const descSortIcon = await screen.queryByTitle('Orden descendiente');
+
+  expect(descSortIcon).toBeInTheDocument();
 });

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -40,6 +40,11 @@ export interface TableColumn<T> extends TableColumnDisplayProps {
 
 export type TablePaginationProps = Omit<PaginationProps, keyof MarginProps>;
 
+interface Localization {
+  ascendingOrder: string;
+  descendingOrder: string;
+}
+
 export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElement> {
   actions?: React.ReactNode;
   columns: Array<TableColumn<T>>;
@@ -48,6 +53,7 @@ export interface TableProps<T> extends React.TableHTMLAttributes<HTMLTableElemen
   itemName?: string;
   items: T[];
   keyField?: string;
+  localization?: Localization;
   onRowDrop?(from: number, to: number): void;
   pagination?: TablePaginationProps;
   selectable?: TableSelectable<T>;

--- a/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
@@ -18,8 +18,10 @@ export interface HeaderCellProps<T>
   extends TableHTMLAttributes<HTMLTableCellElement>,
     TableColumnDisplayProps {
   actionsRef: RefObject<HTMLDivElement>;
+  ascendingOrderLabel?: string;
   children?: React.ReactNode;
   column: TableColumn<T>;
+  descendingOrderLabel?: string;
   id: string;
   hide?: boolean;
   isSorted?: boolean;
@@ -40,8 +42,10 @@ export interface DragIconCellProps {
 
 const InternalHeaderCell = <T extends TableItem>({
   actionsRef,
+  ascendingOrderLabel = 'Ascending order',
   children,
   column,
+  descendingOrderLabel = 'Desceding order',
   display,
   hide = false,
   id,
@@ -60,9 +64,9 @@ const InternalHeaderCell = <T extends TableItem>({
     }
 
     return sortDirection === 'ASC' ? (
-      <ArrowUpwardIcon data-testid="asc-icon" size="medium" title="Ascending order" />
+      <ArrowUpwardIcon data-testid="asc-icon" size="medium" title={ascendingOrderLabel} />
     ) : (
-      <ArrowDownwardIcon data-testid="desc-icon" size="medium" title="Descending order" />
+      <ArrowDownwardIcon data-testid="desc-icon" size="medium" title={descendingOrderLabel} />
     );
   };
 

--- a/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
@@ -19,11 +19,6 @@ interface Localization {
   descendingOrder: string;
 }
 
-const defaultLocalization: Localization = {
-  ascendingOrder: 'Ascending order',
-  descendingOrder: 'Descending order',
-};
-
 export interface HeaderCellProps<T>
   extends TableHTMLAttributes<HTMLTableCellElement>,
     TableColumnDisplayProps {
@@ -33,7 +28,7 @@ export interface HeaderCellProps<T>
   id: string;
   hide?: boolean;
   isSorted?: boolean;
-  localization?: Localization;
+  localization: Localization;
   sortDirection?: 'ASC' | 'DESC';
   stickyHeader?: boolean;
   onSortClick?(column: TableColumn<T>): void;
@@ -57,7 +52,7 @@ const InternalHeaderCell = <T extends TableItem>({
   hide = false,
   id,
   isSorted,
-  localization = defaultLocalization,
+  localization,
   onSortClick,
   sortDirection,
   stickyHeader,

--- a/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
@@ -14,17 +14,26 @@ import { TableColumn, TableItem } from '../types';
 
 import { StyledFlex, StyledTableHeaderCell, StyledTableHeaderIcon } from './styled';
 
+interface Localization {
+  ascendingOrder: string;
+  descendingOrder: string;
+}
+
+const defaultLocalization: Localization = {
+  ascendingOrder: 'Ascending order',
+  descendingOrder: 'Descending order',
+};
+
 export interface HeaderCellProps<T>
   extends TableHTMLAttributes<HTMLTableCellElement>,
     TableColumnDisplayProps {
   actionsRef: RefObject<HTMLDivElement>;
-  ascendingOrderLabel?: string;
   children?: React.ReactNode;
   column: TableColumn<T>;
-  descendingOrderLabel?: string;
   id: string;
   hide?: boolean;
   isSorted?: boolean;
+  localization?: Localization;
   sortDirection?: 'ASC' | 'DESC';
   stickyHeader?: boolean;
   onSortClick?(column: TableColumn<T>): void;
@@ -42,14 +51,13 @@ export interface DragIconCellProps {
 
 const InternalHeaderCell = <T extends TableItem>({
   actionsRef,
-  ascendingOrderLabel = 'Ascending order',
   children,
   column,
-  descendingOrderLabel = 'Desceding order',
   display,
   hide = false,
   id,
   isSorted,
+  localization = defaultLocalization,
   onSortClick,
   sortDirection,
   stickyHeader,
@@ -64,9 +72,13 @@ const InternalHeaderCell = <T extends TableItem>({
     }
 
     return sortDirection === 'ASC' ? (
-      <ArrowUpwardIcon data-testid="asc-icon" size="medium" title={ascendingOrderLabel} />
+      <ArrowUpwardIcon data-testid="asc-icon" size="medium" title={localization.ascendingOrder} />
     ) : (
-      <ArrowDownwardIcon data-testid="desc-icon" size="medium" title={descendingOrderLabel} />
+      <ArrowDownwardIcon
+        data-testid="desc-icon"
+        size="medium"
+        title={localization.descendingOrder}
+      />
     );
   };
 

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -157,14 +157,13 @@ const InternalTableNext = <T extends TableItem>(
           return (
             <HeaderCell
               actionsRef={actionsRef}
-              ascendingOrderLabel={localization?.ascendingOrder}
               column={{ ...column, width: widthColumn }}
-              descendingOrderLabel={localization?.descendingOrder}
               display={display}
               hide={hideHeader}
               id={`header-cell-${index}`}
               isSorted={isSorted}
               key={index}
+              localization={localization}
               onSortClick={onSortClick}
               sortDirection={sortDirection}
               stickyHeader={stickyHeader}

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -33,6 +33,7 @@ const InternalTableNext = <T extends TableItem>(
     itemName,
     items,
     keyField = 'id',
+    localization,
     pagination,
     selectable,
     sortable,
@@ -156,7 +157,9 @@ const InternalTableNext = <T extends TableItem>(
           return (
             <HeaderCell
               actionsRef={actionsRef}
+              ascendingOrderLabel={localization?.ascendingOrder}
               column={{ ...column, width: widthColumn }}
+              descendingOrderLabel={localization?.descendingOrder}
               display={display}
               hide={hideHeader}
               id={`header-cell-${index}`}

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -19,6 +19,16 @@ import { RowContainer } from './RowContainer';
 import { StyledTable, StyledTableFigure } from './styled';
 import { TableColumn, TableItem, TableProps } from './types';
 
+interface Localization {
+  ascendingOrder: string;
+  descendingOrder: string;
+}
+
+const defaultLocalization: Localization = {
+  ascendingOrder: 'Ascending order',
+  descendingOrder: 'Descending order',
+};
+
 const InternalTableNext = <T extends TableItem>(
   props: TableProps<T>,
 ): React.ReactElement<TableProps<T>> => {
@@ -33,7 +43,7 @@ const InternalTableNext = <T extends TableItem>(
     itemName,
     items,
     keyField = 'id',
-    localization,
+    localization = defaultLocalization,
     pagination,
     selectable,
     sortable,

--- a/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
@@ -14,8 +14,7 @@ export const TablePagination: React.FC<TablePaginationProps> = memo(
     onPageChange,
     totalItems,
     label,
-    previousLabel,
-    nextLabel,
+    localization,
     getRangeLabel,
   }) => {
     return (
@@ -26,10 +25,9 @@ export const TablePagination: React.FC<TablePaginationProps> = memo(
           itemsPerPage={itemsPerPage}
           itemsPerPageOptions={itemsPerPageOptions}
           label={label}
-          nextLabel={nextLabel}
+          localization={localization}
           onItemsPerPageChange={onItemsPerPageChange}
           onPageChange={onPageChange}
-          previousLabel={previousLabel}
           totalItems={totalItems}
         />
       </StyledPaginationContainer>

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -290,8 +290,11 @@ describe('pagination', () => {
           onItemsPerPageChange,
           onPageChange,
           label: '[Custom] Pagination',
-          previousLabel: '[Custom] Previous page',
-          nextLabel: '[Custom] Next page',
+          localization: {
+            of: 'of',
+            previousPage: '[Custom] Previous page',
+            nextPage: '[Custom] Next page',
+          },
           getRangeLabel,
         }}
       />,
@@ -1711,4 +1714,70 @@ describe('expandable', () => {
 
     expect(cellWithHelperRow).not.toBeInTheDocument();
   });
+});
+
+test('renders localized ascending label', async () => {
+  const onSort = jest.fn();
+  const items = [
+    { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+    { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+    { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+    { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+    { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+  ];
+  const columns = [
+    { header: 'Sku', hash: 'sku', render: ({ sku }: any) => sku, isSortable: true },
+    { header: 'Name', hash: 'name', render: ({ name }: any) => name },
+    { header: 'Stock', hash: 'stock', render: ({ stock }: any) => stock },
+  ];
+
+  render(
+    <TableNext
+      columns={columns}
+      items={items}
+      localization={{ ascendingOrder: 'Orden ascendiente', descendingOrder: 'Orden descendiente' }}
+      sortable={{
+        columnHash: 'sku',
+        direction: 'ASC',
+        onSort,
+      }}
+    />,
+  );
+
+  const ascSortIcon = screen.getByTitle('Orden ascendiente');
+
+  expect(ascSortIcon).toBeInTheDocument();
+});
+
+test('renders localized descending label', async () => {
+  const onSort = jest.fn();
+  const items = [
+    { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+    { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+    { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+    { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+    { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+  ];
+  const columns = [
+    { header: 'Sku', hash: 'sku', render: ({ sku }: any) => sku, isSortable: true },
+    { header: 'Name', hash: 'name', render: ({ name }: any) => name },
+    { header: 'Stock', hash: 'stock', render: ({ stock }: any) => stock },
+  ];
+
+  render(
+    <TableNext
+      columns={columns}
+      items={items}
+      localization={{ ascendingOrder: 'Orden ascendiente', descendingOrder: 'Orden descendiente' }}
+      sortable={{
+        columnHash: 'sku',
+        direction: 'DESC',
+        onSort,
+      }}
+    />,
+  );
+
+  const descSortIcon = await screen.queryByTitle('Orden descendiente');
+
+  expect(descSortIcon).toBeInTheDocument();
 });

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -291,7 +291,6 @@ describe('pagination', () => {
           onPageChange,
           label: '[Custom] Pagination',
           localization: {
-            of: 'of',
             previousPage: '[Custom] Previous page',
             nextPage: '[Custom] Next page',
           },

--- a/packages/big-design/src/components/TableNext/types.ts
+++ b/packages/big-design/src/components/TableNext/types.ts
@@ -56,6 +56,11 @@ export interface TableColumn<T> extends TableColumnDisplayProps {
 
 export type TablePaginationProps = Omit<PaginationProps, keyof MarginProps>;
 
+interface Localization {
+  ascendingOrder: string;
+  descendingOrder: string;
+}
+
 export interface TableProps<T> extends TableHTMLAttributes<HTMLTableElement> {
   actions?: React.ReactNode;
   columns: Array<TableColumn<T>>;
@@ -65,6 +70,7 @@ export interface TableProps<T> extends TableHTMLAttributes<HTMLTableElement> {
   itemName?: string;
   items: T[];
   keyField?: string;
+  localization?: Localization;
   onRowDrop?(from: number, to: number): void;
   pagination?: TablePaginationProps;
   selectable?: TableSelectable;

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -58,7 +58,7 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
         <FormControlLabel
           htmlFor={id}
           id={labelId}
-          optionalLabel={localization?.optional}
+          localization={localization}
           renderOptional={!props.required}
         >
           {label}
@@ -77,7 +77,7 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
     }
 
     warning('label must be either a string or a FormControlLabel component.');
-  }, [id, label, labelId, localization?.optional, props.required]);
+  }, [id, label, labelId, localization, props.required]);
 
   const renderedDescription = useMemo(() => {
     if (!description) {

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -11,6 +11,7 @@ import React, {
 import { typedMemo, warning } from '../../utils';
 import { FormControlDescription, FormControlLabel } from '../Form';
 import { useInputErrors } from '../Form/useInputErrors';
+import { InputLocalization } from '../Input/Input';
 
 import { StyledTextarea, StyledTextareaWrapper } from './styled';
 
@@ -19,6 +20,7 @@ export interface Props {
   error?: React.ReactNode | React.ReactNode[];
   label?: React.ReactChild;
   labelId?: string;
+  localization?: InputLocalization;
   rows?: 1 | 2 | 3 | 4 | 5 | 6 | 7;
   resize?: boolean;
 }
@@ -35,6 +37,7 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
   forwardedRef,
   label,
   labelId,
+  localization = { optional: 'optional' },
   rows = 3,
   resize = true,
   ...props
@@ -52,7 +55,12 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
 
     if (typeof label === 'string') {
       return (
-        <FormControlLabel htmlFor={id} id={labelId} renderOptional={!props.required}>
+        <FormControlLabel
+          htmlFor={id}
+          id={labelId}
+          optionalLabel={localization.optional}
+          renderOptional={!props.required}
+        >
           {label}
         </FormControlLabel>
       );
@@ -69,7 +77,7 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
     }
 
     warning('label must be either a string or a FormControlLabel component.');
-  }, [id, label, labelId, props.required]);
+  }, [id, label, labelId, localization.optional, props.required]);
 
   const renderedDescription = useMemo(() => {
     if (!description) {

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -37,7 +37,7 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
   forwardedRef,
   label,
   labelId,
-  localization = { optional: 'optional' },
+  localization,
   rows = 3,
   resize = true,
   ...props
@@ -58,7 +58,7 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
         <FormControlLabel
           htmlFor={id}
           id={labelId}
-          optionalLabel={localization.optional}
+          optionalLabel={localization?.optional}
           renderOptional={!props.required}
         >
           {label}
@@ -77,7 +77,7 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
     }
 
     warning('label must be either a string or a FormControlLabel component.');
-  }, [id, label, labelId, localization.optional, props.required]);
+  }, [id, label, labelId, localization?.optional, props.required]);
 
   const renderedDescription = useMemo(() => {
     if (!description) {

--- a/packages/big-design/src/components/Textarea/spec.tsx
+++ b/packages/big-design/src/components/Textarea/spec.tsx
@@ -276,6 +276,16 @@ test('renders all together', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
+test('renders localized labels', () => {
+  const { container } = render(
+    <Textarea label="Test label" localization={{ optional: 'opcional' }} />,
+  );
+
+  const label = container.querySelector('label');
+
+  expect(label).toHaveStyleRule('content', "' (opcional)'", { modifier: '::after' });
+});
+
 describe('error shows when an array of strings', () => {
   test('empty array', () => {
     const { container } = render(

--- a/packages/big-design/src/components/Timepicker/Timepicker.tsx
+++ b/packages/big-design/src/components/Timepicker/Timepicker.tsx
@@ -1,12 +1,14 @@
 import React, { forwardRef, memo, Ref, useMemo } from 'react';
 
 import { createLocalizationProvider, getTimeIntervals } from '../../utils';
+import { InputLocalization } from '../Input/Input';
 import { Select } from '../Select';
 
 interface Props {
   error?: React.ReactNode;
   label?: React.ReactChild;
   locale?: string;
+  localization?: InputLocalization;
   onTimeChange(date: string): void;
 }
 
@@ -21,12 +23,13 @@ const RawTimePicker: React.FC<TimepickerProps & PrivateProps> = ({
   forwardedRef,
   label,
   locale = 'en-US',
+  localization,
   onTimeChange,
   value,
   ...props
 }) => {
-  const localization = createLocalizationProvider(locale);
-  const options = useMemo(() => getTimeIntervals(localization), [localization]);
+  const localizationProvider = createLocalizationProvider(locale);
+  const options = useMemo(() => getTimeIntervals(localizationProvider), [localizationProvider]);
 
   return (
     <Select
@@ -34,6 +37,7 @@ const RawTimePicker: React.FC<TimepickerProps & PrivateProps> = ({
       error={error}
       inputRef={forwardedRef}
       label={label}
+      localization={localization}
       onOptionChange={onTimeChange}
       options={options}
       placeholder="hh : mm"

--- a/packages/big-design/src/components/Timepicker/spec.tsx
+++ b/packages/big-design/src/components/Timepicker/spec.tsx
@@ -254,3 +254,18 @@ test('appends (optional) text to label if input is not required', async () => {
 
   expect(label).toHaveStyleRule('content', "' (optional)'", { modifier: '::after' });
 });
+
+test('renders localized labels', async () => {
+  const { findByText } = render(
+    <Timepicker
+      data-testid="timepicker"
+      label="Test Label"
+      localization={{ optional: 'opcional' }}
+      onTimeChange={jest.fn()}
+    />,
+  );
+
+  const label = await findByText('Test Label');
+
+  expect(label).toHaveStyleRule('content', "' (opcional)'", { modifier: '::after' });
+});

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -23,6 +23,7 @@ import { Header, StyledBox, Table } from './styled';
 import {
   InternalWorksheetColumn,
   WorksheetItem,
+  WorksheetLocalization,
   WorksheetModalColumn,
   WorksheetProps,
 } from './types';
@@ -195,12 +196,20 @@ const InternalWorksheet = typedMemo(
 
 export const WorksheetContext = createContext<StoreApi<BaseState<any>> | null>(null);
 
-export const Worksheet = typedMemo(<T extends WorksheetItem>(props: WorksheetProps<T>) => {
-  const store = useMemo(() => createWorksheetStore<T>(), []);
+export const WorksheetLocalizationContext = createContext<WorksheetLocalization | undefined>(
+  undefined,
+);
 
-  return (
-    <WorksheetContext.Provider value={store}>
-      <InternalWorksheet {...props} />
-    </WorksheetContext.Provider>
-  );
-});
+export const Worksheet = typedMemo(
+  <T extends WorksheetItem>({ localization, ...props }: WorksheetProps<T>) => {
+    const store = useMemo(() => createWorksheetStore<T>(), []);
+
+    return (
+      <WorksheetContext.Provider value={store}>
+        <WorksheetLocalizationContext.Provider value={localization}>
+          <InternalWorksheet {...props} />
+        </WorksheetLocalizationContext.Provider>
+      </WorksheetContext.Provider>
+    );
+  },
+);

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -196,12 +196,19 @@ const InternalWorksheet = typedMemo(
 
 export const WorksheetContext = createContext<StoreApi<BaseState<any>> | null>(null);
 
-export const WorksheetLocalizationContext = createContext<WorksheetLocalization | undefined>(
-  undefined,
-);
+export const WorksheetLocalizationContext = createContext<WorksheetLocalization>({
+  toggleRowExpanded: 'toggle row expanded',
+});
+
+const defaultLocalization = {
+  toggleRowExpanded: 'toggle row expanded',
+};
 
 export const Worksheet = typedMemo(
-  <T extends WorksheetItem>({ localization, ...props }: WorksheetProps<T>) => {
+  <T extends WorksheetItem>({
+    localization = defaultLocalization,
+    ...props
+  }: WorksheetProps<T>) => {
     const store = useMemo(() => createWorksheetStore<T>(), []);
 
     return (

--- a/packages/big-design/src/components/Worksheet/editors/ToggleEditor/ToggleEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ToggleEditor/ToggleEditor.tsx
@@ -1,7 +1,8 @@
 import { ChevronRightIcon, ExpandMoreIcon } from '@bigcommerce/big-design-icons';
-import React, { memo, useEffect } from 'react';
+import React, { memo, useContext, useEffect } from 'react';
 
 import { useExpandable, useWorksheetStore } from '../../hooks';
+import { WorksheetLocalizationContext } from '../../Worksheet';
 
 import { StyledExpandButton } from './styled';
 
@@ -13,6 +14,7 @@ interface ToggleEditorProps {
 const InternalToggleEditor = ({ rowId, toggle }: ToggleEditorProps) => {
   const { onToggle, isExpandable, hasExpanded } = useExpandable(rowId);
   const { store, useStore } = useWorksheetStore();
+  const localization = useContext(WorksheetLocalizationContext);
 
   const setEditingCell = useStore(store, (state) => state.setEditingCell);
 
@@ -35,7 +37,7 @@ const InternalToggleEditor = ({ rowId, toggle }: ToggleEditorProps) => {
         onClick={() => {
           onToggle(true);
         }}
-        title="toggle row expanded"
+        title={localization?.toggleRowExpanded || 'toggle row expanded'}
         variant="subtle"
       />
     );
@@ -47,7 +49,7 @@ const InternalToggleEditor = ({ rowId, toggle }: ToggleEditorProps) => {
       onClick={() => {
         onToggle(false);
       }}
-      title="toggle row expanded"
+      title={localization?.toggleRowExpanded || 'toggle row expanded'}
       variant="subtle"
     />
   );

--- a/packages/big-design/src/components/Worksheet/editors/ToggleEditor/ToggleEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ToggleEditor/ToggleEditor.tsx
@@ -37,7 +37,7 @@ const InternalToggleEditor = ({ rowId, toggle }: ToggleEditorProps) => {
         onClick={() => {
           onToggle(true);
         }}
-        title={localization?.toggleRowExpanded || 'toggle row expanded'}
+        title={localization.toggleRowExpanded}
         variant="subtle"
       />
     );
@@ -49,7 +49,7 @@ const InternalToggleEditor = ({ rowId, toggle }: ToggleEditorProps) => {
       onClick={() => {
         onToggle(false);
       }}
-      title={localization?.toggleRowExpanded || 'toggle row expanded'}
+      title={localization.toggleRowExpanded}
       variant="subtle"
     />
   );

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -1465,3 +1465,17 @@ describe('Header tooltip', () => {
     expect(result).toBeInTheDocument();
   });
 });
+
+test('renders localized labels', () => {
+  render(
+    <Worksheet
+      columns={disabledColumns}
+      expandableRows={{ 2: [3], 5: [6, 7] }}
+      items={items}
+      localization={{ toggleRowExpanded: 'cambiar expansion de fila' }}
+      onChange={handleChange}
+    />,
+  );
+
+  expect(screen.queryAllByTitle('cambiar expansion de fila')).toHaveLength(2);
+});

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -9,12 +9,17 @@ export interface ExpandableRows {
 
 export type DisabledRows = Array<string | number>;
 
+export interface WorksheetLocalization {
+  toggleRowExpanded: string;
+}
+
 export interface WorksheetProps<Item extends WorksheetItem> {
   columns: Array<WorksheetColumn<Item>>;
   items: Item[];
   expandableRows?: ExpandableRows;
   defaultExpandedRows?: Array<string | number>;
   disabledRows?: DisabledRows;
+  localization?: WorksheetLocalization;
   minWidth?: number;
   onChange(items: Item[]): void;
   onErrors?(items: Array<WorksheetError<Item>>): void;

--- a/packages/docs/PropTables/ButtonGroupPropTable.tsx
+++ b/packages/docs/PropTables/ButtonGroupPropTable.tsx
@@ -14,6 +14,11 @@ const buttonGroupProps: Prop[] = [
     ),
     required: true,
   },
+  {
+    name: 'localization',
+    types: '{ more: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 export const ButtonGroupPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/CounterPropTable.tsx
+++ b/packages/docs/PropTables/CounterPropTable.tsx
@@ -85,6 +85,11 @@ const counterProps: Prop[] = [
       'Function to be called that changes counter value. Receives the new count from the component.',
     required: true,
   },
+  {
+    name: 'localization',
+    types: '{ decreaseCount: string, increaseCount: string, optional: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 export const CounterPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/CounterPropTable.tsx
+++ b/packages/docs/PropTables/CounterPropTable.tsx
@@ -88,7 +88,7 @@ const counterProps: Prop[] = [
   {
     name: 'localization',
     types: '{ decreaseCount: string, increaseCount: string, optional: string }',
-    description: 'Overrides the label with localized text.',
+    description: 'Overrides the labels with localized text.',
   },
 ];
 

--- a/packages/docs/PropTables/DatepickerPropsTable.tsx
+++ b/packages/docs/PropTables/DatepickerPropsTable.tsx
@@ -52,6 +52,11 @@ const datepickerProps: Prop[] = [
       </>
     ),
   },
+  {
+    name: 'localization',
+    types: '{ optional: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 export const DatepickerPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/FormPropTable.tsx
+++ b/packages/docs/PropTables/FormPropTable.tsx
@@ -34,8 +34,26 @@ export const FormFieldsetPropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable propList={formFieldsetProps} title="Fieldset" {...props} />
 );
 
+const formLabelProps: Prop[] = [
+  {
+    name: 'renderOptional',
+    types: 'boolean',
+    description: 'Shows optional label.',
+  },
+  {
+    name: 'localization',
+    types: '{ optional: string }',
+    description: 'Overrides the label with localized text.',
+  },
+];
+
 export const FormLabelPropTable: React.FC<PropTableWrapper> = (props) => (
-  <PropTable nativeElement={['label', 'all']} propList={[]} title="FormControlLabel" {...props} />
+  <PropTable
+    nativeElement={['label', 'all']}
+    propList={formLabelProps}
+    title="FormControlLabel"
+    {...props}
+  />
 );
 
 export const FormDescriptionPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/InlineMessagePropTable.tsx
+++ b/packages/docs/PropTables/InlineMessagePropTable.tsx
@@ -17,6 +17,11 @@ const inlineMessageProps: Prop[] = [
     ),
   },
   ...sharedMessagingProps,
+  {
+    name: 'localization',
+    types: '{ close: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 export const InlineMessagePropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/InputPropTable.tsx
+++ b/packages/docs/PropTables/InputPropTable.tsx
@@ -57,6 +57,11 @@ const inputProps: Prop[] = [
       </>
     ),
   },
+  {
+    name: 'localization',
+    types: '{ optional: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 export const InputPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/MessagePropTable.tsx
+++ b/packages/docs/PropTables/MessagePropTable.tsx
@@ -17,6 +17,11 @@ const messageProps: Prop[] = [
     ),
   },
   ...sharedMessagingProps,
+  {
+    name: 'localization',
+    types: '{ close: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 export const MessagePropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/MultiSelectPropTable.tsx
+++ b/packages/docs/PropTables/MultiSelectPropTable.tsx
@@ -144,6 +144,11 @@ const selectProps: Prop[] = [
     types: '[any]',
     description: <>Modifies the current selected value of the field.</>,
   },
+  {
+    name: 'localization',
+    types: '{ optional: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 export const MultiSelectPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/PaginationPropTable.tsx
+++ b/packages/docs/PropTables/PaginationPropTable.tsx
@@ -54,7 +54,7 @@ const paginationProps: Prop[] = [
   },
   {
     name: 'localization',
-    types: '{of: string, previousPage: string, nextPage: string}',
+    types: '{ of: string, previousPage: string, nextPage: string }',
     required: false,
     description: 'Overrides the labels with localized text.',
   },

--- a/packages/docs/PropTables/PaginationPropTable.tsx
+++ b/packages/docs/PropTables/PaginationPropTable.tsx
@@ -47,24 +47,16 @@ const paginationProps: Prop[] = [
     description: 'Overrides the aria label of the pagination wrapper navigation element.',
   },
   {
-    name: 'previousLabel',
-    types: 'string',
-    required: false,
-    defaultValue: 'Previous page',
-    description: 'Overrides the title and aria label of the previous page navigation arrow.',
-  },
-  {
-    name: 'nextLabel',
-    types: 'string',
-    required: false,
-    defaultValue: 'Next page',
-    description: 'Overrides the title and aria label of the next page navigation arrow.',
-  },
-  {
     name: 'getRangeLabel',
     types: '(start: number, end: number, totalItems: number) => string',
     required: false,
     description: 'A callback to format the label of the per-page range dropdown.',
+  },
+  {
+    name: 'localization',
+    types: '{of: string, previousPage: string, nextPage: string}',
+    required: false,
+    description: 'Overrides the labels with localized text.',
   },
 ];
 

--- a/packages/docs/PropTables/SearchPropTable.tsx
+++ b/packages/docs/PropTables/SearchPropTable.tsx
@@ -21,6 +21,11 @@ const searchProps: Prop[] = [
     description: 'Native onSubmit attribute for a HTML form element.',
     required: true,
   },
+  {
+    name: 'localization',
+    types: '{ search: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 export const SearchPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/SelectPropTable.tsx
+++ b/packages/docs/PropTables/SelectPropTable.tsx
@@ -153,6 +153,11 @@ const selectProps: Prop[] = [
     types: 'any ',
     description: <>Modifies the current selected value of the field.</>,
   },
+  {
+    name: 'localization',
+    types: '{ optional: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 const selectOptionProps: Prop[] = [

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -113,9 +113,15 @@ const statefulTableProps: Prop[] = [
     ),
   },
   {
+    name: 'getRangeLabel',
+    types: '(start: number, end: number, totalItems: number) => string',
+    required: false,
+    description: 'A callback to format the label of the per-page range dropdown.',
+  },
+  {
     name: 'localization',
     types:
-      '{ of: string, nextPage: string, previousPage: string } | { search: string } | ({ of: string, nextPage: string, previousPage: string } & { search: string })',
+      '{ nextPage: string, previousPage: string } | { search: string } | ({ nextPage: string, previousPage: string } & { search: string })',
     description: 'Overrides the labels with localized text.',
   },
 ];

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -112,6 +112,12 @@ const statefulTableProps: Prop[] = [
       </>
     ),
   },
+  {
+    name: 'localization',
+    types:
+      '{ of: string, nextPage: string, previousPage: string } | { search: string } | ({ of: string, nextPage: string, previousPage: string } & { search: string })',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 const tableColumnsProps: Prop[] = [

--- a/packages/docs/PropTables/StatefulTablePropTable.tsx
+++ b/packages/docs/PropTables/StatefulTablePropTable.tsx
@@ -116,7 +116,7 @@ const statefulTableProps: Prop[] = [
     name: 'localization',
     types:
       '{ of: string, nextPage: string, previousPage: string } | { search: string } | ({ of: string, nextPage: string, previousPage: string } & { search: string })',
-    description: 'Overrides the label with localized text.',
+    description: 'Overrides the labels with localized text.',
   },
 ];
 

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -107,7 +107,7 @@ const tableProps: Prop[] = [
   {
     name: 'localization',
     types: '{ ascendingOrder: string, descendingOrder: string }',
-    description: 'Overrides the label with localized text.',
+    description: 'Overrides the labels with localized text.',
   },
 ];
 

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -104,6 +104,11 @@ const tableProps: Prop[] = [
     types: 'React.ReactElement',
     description: 'Component to render when there are no items.',
   },
+  {
+    name: 'localization',
+    types: '{ ascendingOrder: string, descendingOrder: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 const tableColumnsProps: Prop[] = [

--- a/packages/docs/PropTables/TextareaPropTable.tsx
+++ b/packages/docs/PropTables/TextareaPropTable.tsx
@@ -48,6 +48,11 @@ const textareaProps: Prop[] = [
     defaultValue: 'true',
     description: 'Determines if the textarea is resizable vertically.',
   },
+  {
+    name: 'localization',
+    types: '{ optional: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 export const TextareaPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/TimepickerPropTable.tsx
+++ b/packages/docs/PropTables/TimepickerPropTable.tsx
@@ -36,6 +36,11 @@ const timepickerProps: Prop[] = [
     types: 'string',
     description: 'The time that should be used as the input value.',
   },
+  {
+    name: 'localization',
+    types: '{ optional: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 export const TimepickerPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/PropTables/WorksheetPropTable.tsx
+++ b/packages/docs/PropTables/WorksheetPropTable.tsx
@@ -99,6 +99,11 @@ const worksheetProps: Prop[] = [
     types: 'number',
     description: 'Sets a min-width.',
   },
+  {
+    name: 'localization',
+    types: '{ toggleRowExpanded: string }',
+    description: 'Overrides the label with localized text.',
+  },
 ];
 
 const worksheetTextColumnProps: Prop[] = [


### PR DESCRIPTION
Breaking changes

## What?
Localize components per feedback from #1194 

## How
Created a `localization` object prop that has all values that can be localized within the component. This is a breaking change because I changed the pagination props.

## Screen with example of new `localization` prop
![screencapture-localhost-3000-table-2023-05-10-13_59_58](https://github.com/bigcommerce/big-design/assets/196129/d46c5e07-38e2-416a-a52b-82eb5cdb2b67)


## Testing/Proof
Locally + unit tests.
