### PR TITLE
feat: react server component support

### DIFF
--- a/packages/big-design-icons/scripts/svgr-flags.config.js
+++ b/packages/big-design-icons/scripts/svgr-flags.config.js
@@ -15,6 +15,9 @@ module.exports = {
     // **********************************
     // Auto-generated file, do NOT modify
     // **********************************
+    'use client';
+    BREAK
+
     import React, { forwardRef, memo, useId } from 'react';
     BREAK
 

--- a/packages/big-design-icons/scripts/svgr.config.js
+++ b/packages/big-design-icons/scripts/svgr.config.js
@@ -16,6 +16,9 @@ module.exports = {
     // **********************************
     // Auto-generated file, do NOT modify
     // **********************************
+    'use client';
+    BREAK
+
     import React, { forwardRef, memo, useId } from 'react';
     BREAK
 

--- a/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/AddIcon.tsx
+++ b/packages/big-design-icons/src/components/AddIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ArrowBackIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowBackIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/AssignmentIcon.tsx
+++ b/packages/big-design-icons/src/components/AssignmentIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
+++ b/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/BrushIcon.tsx
+++ b/packages/big-design-icons/src/components/BrushIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/CheckCircleIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckCircleIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/CheckIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ChevronRightIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronRightIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/CloseIcon.tsx
+++ b/packages/big-design-icons/src/components/CloseIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/CloudUploadIcon.tsx
+++ b/packages/big-design-icons/src/components/CloudUploadIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/CodeIcon.tsx
+++ b/packages/big-design-icons/src/components/CodeIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ContentCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/ContentCopyIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/DeleteIcon.tsx
+++ b/packages/big-design-icons/src/components/DeleteIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
+++ b/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/EditIcon.tsx
+++ b/packages/big-design-icons/src/components/EditIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ErrorIcon.tsx
+++ b/packages/big-design-icons/src/components/ErrorIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ExpandLessIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandLessIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/FileCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/FileCopyIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/FilterListIcon.tsx
+++ b/packages/big-design-icons/src/components/FilterListIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/FolderIcon.tsx
+++ b/packages/big-design-icons/src/components/FolderIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/GetAppIcon.tsx
+++ b/packages/big-design-icons/src/components/GetAppIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/HomeIcon.tsx
+++ b/packages/big-design-icons/src/components/HomeIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/InfoIcon.tsx
+++ b/packages/big-design-icons/src/components/InfoIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/InsertDriveFileIcon.tsx
+++ b/packages/big-design-icons/src/components/InsertDriveFileIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/InvertColorsIcon.tsx
+++ b/packages/big-design-icons/src/components/InvertColorsIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/KeyboardDoubleArrowLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/KeyboardDoubleArrowLeftIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/LanguageIcon.tsx
+++ b/packages/big-design-icons/src/components/LanguageIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/MenuIcon.tsx
+++ b/packages/big-design-icons/src/components/MenuIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/MoreHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/MoreHorizIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/NotificationsIcon.tsx
+++ b/packages/big-design-icons/src/components/NotificationsIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/OpenInNewIcon.tsx
+++ b/packages/big-design-icons/src/components/OpenInNewIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/PublicIcon.tsx
+++ b/packages/big-design-icons/src/components/PublicIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/ReceiptIcon.tsx
+++ b/packages/big-design-icons/src/components/ReceiptIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/RedoIcon.tsx
+++ b/packages/big-design-icons/src/components/RedoIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/RemoveIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/RestoreIcon.tsx
+++ b/packages/big-design-icons/src/components/RestoreIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/SearchIcon.tsx
+++ b/packages/big-design-icons/src/components/SearchIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/SettingsIcon.tsx
+++ b/packages/big-design-icons/src/components/SettingsIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/StarBorderIcon.tsx
+++ b/packages/big-design-icons/src/components/StarBorderIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/StarHalfIcon.tsx
+++ b/packages/big-design-icons/src/components/StarHalfIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/StarIcon.tsx
+++ b/packages/big-design-icons/src/components/StarIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/StoreIcon.tsx
+++ b/packages/big-design-icons/src/components/StoreIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/SwapHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/SwapHorizIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/UndoIcon.tsx
+++ b/packages/big-design-icons/src/components/UndoIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/VisibilityIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/components/WarningIcon.tsx
+++ b/packages/big-design-icons/src/components/WarningIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { createStyledIcon, IconProps, PrivateIconProps } from '../base';

--- a/packages/big-design-icons/src/flags/components/ACFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ACFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ADFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ADFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AFFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AIFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ALFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ALFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AOFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AQFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ARFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ARFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ASFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ASFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ATFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ATFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AUFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AWFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AXFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/AZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AZFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BBFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BDFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BFFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BHFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BIFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BJFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BLFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BOFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BQFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BSFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BTFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BVFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BWFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BYFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/BZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BZFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CCFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CDFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CEFTAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CEFTAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CFFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CHFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CIFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CKFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CLFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/COFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/COFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CPFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CUFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CVFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CWFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CXFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CYFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/CZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CZFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/DEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/DGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/DJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DJFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/DKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DKFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/DMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/DOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DOFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/DZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DZFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/EAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ECFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ECFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/EEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/EGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/EHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EHFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ERFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ERFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ESCTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESCTFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ESFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ESGAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESGAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ETFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ETFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/EUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EUFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/FIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FIFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/FJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FJFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/FKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FKFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/FMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/FOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FOFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/FRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GBENGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBENGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GBNIRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBNIRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GBSCTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBSCTFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GBWLSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBWLSFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GDFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GFFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GHFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GIFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GLFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GPFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GQFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GSFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GTFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GUFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GWFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/GYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GYFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/HKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HKFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/HMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/HNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/HRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/HTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HTFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/HUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HUFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ICFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ICFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/IDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IDFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/IEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ILFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ILFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/IMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/INFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/INFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/IOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IOFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/IQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IQFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/IRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ISFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ISFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ITFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ITFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/JEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/JMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/JOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JOFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/JPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JPFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KHFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KIFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KPFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KWFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KYFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/KZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KZFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LBFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LCFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LIFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LKFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LSFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LTFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LUFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LVFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/LYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LYFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MCFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MDFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MFFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MHFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MKFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MLFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MOFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MPFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MQFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MSFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MTFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MUFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MVFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MWFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MXFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MYFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/MZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MZFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NCFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NFFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NIFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NLFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NOFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NPFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NUFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/NZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NZFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/OMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/OMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PFFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PHFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PKFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PLFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PSFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PTFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PWFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/PYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PYFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/QAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/QAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/REFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/REFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ROFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ROFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/RSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RSFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/RUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RUFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/RWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RWFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SBFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SCFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SDFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SHFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SIFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SJFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SKFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SLFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SOFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SSFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/STFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/STFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SVFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SXFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SYFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/SZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SZFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TCFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TDFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TFFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/THFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/THFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TJFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TKFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TLFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TOFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TRFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TTFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TVFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TWFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/TZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TZFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/UAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/UGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/UMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/UNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/USFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/USFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/UYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UYFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/UZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UZFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/VAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/VCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VCFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/VEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/VGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VGFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/VIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VIFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/VNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VNFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/VUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VUFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/WFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/WFFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/WSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/WSFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/XKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/XKFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/XXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/XXFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/YEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/YEFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/YTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/YTFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ZAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZAFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ZMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZMFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design-icons/src/flags/components/ZWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZWFlagIcon.tsx
@@ -1,6 +1,9 @@
 // **********************************
 // Auto-generated file, do NOT modify
 // **********************************
+
+'use client';
+
 import React, { forwardRef, memo, useId } from 'react';
 
 import { PrivateIconProps } from '../../base';

--- a/packages/big-design/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/big-design/src/components/AccordionPanel/AccordionPanel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { Panel } from '../Panel';

--- a/packages/big-design/src/components/AccordionPanel/useAccordionPanel.ts
+++ b/packages/big-design/src/components/AccordionPanel/useAccordionPanel.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 
 import { AccordionProps } from './Accordion';

--- a/packages/big-design/src/components/Alert/Alert.tsx
+++ b/packages/big-design/src/components/Alert/Alert.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CloseIcon } from '@bigcommerce/big-design-icons';
 import React, { memo, useMemo } from 'react';
 

--- a/packages/big-design/src/components/Badge/Badge.tsx
+++ b/packages/big-design/src/components/Badge/Badge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { HTMLAttributes, memo } from 'react';
 
 import { MarginProps } from '../../mixins';

--- a/packages/big-design/src/components/Box/Box.tsx
+++ b/packages/big-design/src/components/Box/Box.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Border, BorderRadius, Colors, Shadow, ZIndex } from '@bigcommerce/big-design-theme';
 import React, { forwardRef, HTMLAttributes, memo } from 'react';
 

--- a/packages/big-design/src/components/Button/Button.tsx
+++ b/packages/big-design/src/components/Button/Button.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { ButtonHTMLAttributes, forwardRef, memo, Ref } from 'react';
 
 import { MarginProps } from '../../mixins';

--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { MoreHorizIcon } from '@bigcommerce/big-design-icons';
 import React, {
   createRef,

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CheckIcon, RemoveIcon } from '@bigcommerce/big-design-icons';
 import React, {
   cloneElement,

--- a/packages/big-design/src/components/Checkbox/Label/Label.tsx
+++ b/packages/big-design/src/components/Checkbox/Label/Label.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { StyledLabel, StyledLabelProps } from './styled';

--- a/packages/big-design/src/components/Chip/Chip.tsx
+++ b/packages/big-design/src/components/Chip/Chip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CloseIcon } from '@bigcommerce/big-design-icons';
 import React, { memo } from 'react';
 

--- a/packages/big-design/src/components/Collapse/Collapse.tsx
+++ b/packages/big-design/src/components/Collapse/Collapse.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ExpandMoreIcon } from '@bigcommerce/big-design-icons';
 import React, { useId, useState } from 'react';
 

--- a/packages/big-design/src/components/Counter/Counter.tsx
+++ b/packages/big-design/src/components/Counter/Counter.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { AddCircleOutlineIcon, RemoveCircleOutlineIcon } from '@bigcommerce/big-design-icons';
 import React, {
   cloneElement,

--- a/packages/big-design/src/components/Datepicker/Datepicker.tsx
+++ b/packages/big-design/src/components/Datepicker/Datepicker.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef, memo, Ref, useEffect, useState } from 'react';
 import { default as ReactDatePicker, registerLocale } from 'react-datepicker';
 

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useSelect, UseSelectProps, UseSelectState } from 'downshift';
 import React, {
   cloneElement,

--- a/packages/big-design/src/components/Fieldset/Description/Description.tsx
+++ b/packages/big-design/src/components/Fieldset/Description/Description.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { Small, TextProps } from '../../Typography';

--- a/packages/big-design/src/components/Fieldset/Fieldset.tsx
+++ b/packages/big-design/src/components/Fieldset/Fieldset.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FieldsetHTMLAttributes, isValidElement, memo, useMemo } from 'react';
 
 import { warning } from '../../utils';

--- a/packages/big-design/src/components/Fieldset/Legend/Legend.tsx
+++ b/packages/big-design/src/components/Fieldset/Legend/Legend.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { HeadingProps } from '../../Typography';

--- a/packages/big-design/src/components/Flex/Flex.tsx
+++ b/packages/big-design/src/components/Flex/Flex.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef } from 'react';
 
 import { BoxProps } from '../Box';

--- a/packages/big-design/src/components/Flex/Item/Item.tsx
+++ b/packages/big-design/src/components/Flex/Item/Item.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef } from 'react';
 
 import { BoxProps } from '../../Box';

--- a/packages/big-design/src/components/Form/Group/Group.tsx
+++ b/packages/big-design/src/components/Form/Group/Group.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ErrorIcon } from '@bigcommerce/big-design-icons';
 import React, {
   Children,

--- a/packages/big-design/src/components/Form/useFormContext.ts
+++ b/packages/big-design/src/components/Form/useFormContext.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { createContext, useContext } from 'react';
 
 interface FormContextProps {

--- a/packages/big-design/src/components/Form/useInputErrors.ts
+++ b/packages/big-design/src/components/Form/useInputErrors.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { isValidElement, useContext, useEffect, useMemo } from 'react';
 
 import { warning } from '../../utils';

--- a/packages/big-design/src/components/GlobalStyles/GlobalStyles.tsx
+++ b/packages/big-design/src/components/GlobalStyles/GlobalStyles.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { normalize } from 'polished';
 import { createGlobalStyle } from 'styled-components';

--- a/packages/big-design/src/components/Grid/Grid.tsx
+++ b/packages/big-design/src/components/Grid/Grid.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef } from 'react';
 
 import { BoxProps } from '../Box';

--- a/packages/big-design/src/components/Grid/Item/Item.tsx
+++ b/packages/big-design/src/components/Grid/Item/Item.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 import { BoxProps } from '../../Box';

--- a/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
+++ b/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CloseIcon } from '@bigcommerce/big-design-icons';
 import React, { memo, useMemo } from 'react';
 

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   cloneElement,
   forwardRef,

--- a/packages/big-design/src/components/Link/Link.tsx
+++ b/packages/big-design/src/components/Link/Link.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { OpenInNewIcon } from '@bigcommerce/big-design-icons';
 import React, { AnchorHTMLAttributes, forwardRef, memo, Ref } from 'react';
 

--- a/packages/big-design/src/components/List/GroupHeader/ListGroupHeader.tsx
+++ b/packages/big-design/src/components/List/GroupHeader/ListGroupHeader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { StyledGroupHeader } from './styled';

--- a/packages/big-design/src/components/List/GroupSeparator/ListGroupSeparator.tsx
+++ b/packages/big-design/src/components/List/GroupSeparator/ListGroupSeparator.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { HR } from '../../Typography';

--- a/packages/big-design/src/components/List/Item/Content.tsx
+++ b/packages/big-design/src/components/List/Item/Content.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { IconProps } from '@bigcommerce/big-design-icons';
 import React, { cloneElement, isValidElement, memo, useCallback, useMemo } from 'react';
 

--- a/packages/big-design/src/components/List/Item/Item.tsx
+++ b/packages/big-design/src/components/List/Item/Item.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CheckIcon } from '@bigcommerce/big-design-icons';
 import { UseSelectPropGetters } from 'downshift';
 import React, { forwardRef, LiHTMLAttributes, memo, Ref } from 'react';

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { State } from '@popperjs/core';
 import { UseSelectPropGetters } from 'downshift';
 import React, {

--- a/packages/big-design/src/components/Message/Message.tsx
+++ b/packages/big-design/src/components/Message/Message.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CloseIcon } from '@bigcommerce/big-design-icons';
 import React, { memo, useMemo } from 'react';
 

--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CloseIcon } from '@bigcommerce/big-design-icons';
 import { createFocusTrap, FocusTrap } from 'focus-trap';
 import React, { useEffect, useId, useMemo, useRef, useState } from 'react';

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCombobox, UseComboboxState, UseComboboxStateChangeOptions } from 'downshift';
 import React, {
   cloneElement,

--- a/packages/big-design/src/components/Pagination/Pagination.tsx
+++ b/packages/big-design/src/components/Pagination/Pagination.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   ArrowDropDownIcon,
   ChevronLeftIcon,

--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef, HTMLAttributes, isValidElement, memo, Ref } from 'react';
 
 import { MarginProps } from '../../mixins';

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CheckIcon, MoreHorizIcon } from '@bigcommerce/big-design-icons';
 import React, { createRef, useCallback, useEffect, useMemo, useState } from 'react';
 

--- a/packages/big-design/src/components/Popover/Popover.tsx
+++ b/packages/big-design/src/components/Popover/Popover.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Modifier, Obj, Placement } from '@popperjs/core';
 import { OffsetModifier } from '@popperjs/core/lib/modifiers/offset';
 import React, { useEffect, useId, useMemo, useRef, useState } from 'react';

--- a/packages/big-design/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/big-design/src/components/ProgressBar/ProgressBar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 import { StyledProgressBar, StyledProgressBarFiller } from './styled';

--- a/packages/big-design/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/big-design/src/components/ProgressCircle/ProgressCircle.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CheckCircleIcon, ErrorIcon } from '@bigcommerce/big-design-icons';
 import React, { useMemo } from 'react';
 

--- a/packages/big-design/src/components/Radio/Label/Label.tsx
+++ b/packages/big-design/src/components/Radio/Label/Label.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { StyledLabel, StyledLabelProps } from './styled';

--- a/packages/big-design/src/components/Radio/Radio.tsx
+++ b/packages/big-design/src/components/Radio/Radio.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   cloneElement,
   forwardRef,

--- a/packages/big-design/src/components/Search/Search.tsx
+++ b/packages/big-design/src/components/Search/Search.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { SearchIcon } from '@bigcommerce/big-design-icons';
 import React, { FormEvent } from 'react';
 

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCombobox, UseComboboxState, UseComboboxStateChangeOptions } from 'downshift';
 import React, {
   cloneElement,

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 
 import { useDidUpdate } from '../../hooks';

--- a/packages/big-design/src/components/StatefulTree/StatefulTree.tsx
+++ b/packages/big-design/src/components/StatefulTree/StatefulTree.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 import { typedMemo } from '../../utils';

--- a/packages/big-design/src/components/StatefulTree/hooks/useExpandable.ts
+++ b/packages/big-design/src/components/StatefulTree/hooks/useExpandable.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 
 import { TreeExpandable } from '../../Tree';

--- a/packages/big-design/src/components/StatefulTree/hooks/useFocusable.ts
+++ b/packages/big-design/src/components/StatefulTree/hooks/useFocusable.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 
 import { TreeFocusable, TreeNodeId, TreeNodeProps, TreeSelectableType } from '../../Tree';

--- a/packages/big-design/src/components/StatefulTree/hooks/useSelectable.ts
+++ b/packages/big-design/src/components/StatefulTree/hooks/useSelectable.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 
 import { depthFirstSearch } from '../../../utils';

--- a/packages/big-design/src/components/StatefulTree/hooks/useVisibleNodes.ts
+++ b/packages/big-design/src/components/StatefulTree/hooks/useVisibleNodes.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 
 import { NodeMap, TreeNodeId } from '../../Tree';

--- a/packages/big-design/src/components/Stepper/Step/Step.tsx
+++ b/packages/big-design/src/components/Stepper/Step/Step.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CheckIcon } from '@bigcommerce/big-design-icons';
 import React, { memo } from 'react';
 

--- a/packages/big-design/src/components/Stepper/Stepper.tsx
+++ b/packages/big-design/src/components/Stepper/Stepper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { HTMLAttributes, memo } from 'react';
 
 import { Flex } from '../Flex';

--- a/packages/big-design/src/components/Switch/Switch.tsx
+++ b/packages/big-design/src/components/Switch/Switch.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef, memo, Ref, useId } from 'react';
 
 import { Flex } from '../Flex';

--- a/packages/big-design/src/components/Table/Actions/Actions.tsx
+++ b/packages/big-design/src/components/Table/Actions/Actions.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { RefObject } from 'react';
 
 import { typedMemo } from '../../../utils';

--- a/packages/big-design/src/components/Table/Body/Body.tsx
+++ b/packages/big-design/src/components/Table/Body/Body.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef, memo, TableHTMLAttributes } from 'react';
 
 import { StyledTableBody } from './styled';

--- a/packages/big-design/src/components/Table/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/Table/DataCell/DataCell.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo, TableHTMLAttributes } from 'react';
 
 import { TableColumnDisplayProps } from '../mixins';

--- a/packages/big-design/src/components/Table/Head/Head.tsx
+++ b/packages/big-design/src/components/Table/Head/Head.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { StyledTableHead } from './styled';

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   ArrowDownwardIcon,
   ArrowUpwardIcon,

--- a/packages/big-design/src/components/Table/Row/Row.tsx
+++ b/packages/big-design/src/components/Table/Row/Row.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { DragIndicatorIcon } from '@bigcommerce/big-design-icons';
 import React, { forwardRef, TableHTMLAttributes } from 'react';
 

--- a/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 import { Checkbox } from '../../Checkbox';

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo, useCallback, useEffect, useId, useRef, useState } from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 

--- a/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { Pagination } from '../../Pagination';

--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Dispatch, RefObject, SetStateAction } from 'react';
 
 import { typedMemo } from '../../../utils';

--- a/packages/big-design/src/components/TableNext/Body/Body.tsx
+++ b/packages/big-design/src/components/TableNext/Body/Body.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef, memo, TableHTMLAttributes } from 'react';
 
 import { StyledTableBody } from './styled';

--- a/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo, TdHTMLAttributes } from 'react';
 
 import { PaddingProps } from '../../../mixins';

--- a/packages/big-design/src/components/TableNext/Head/Head.tsx
+++ b/packages/big-design/src/components/TableNext/Head/Head.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { StyledTableHead } from './styled';

--- a/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   ArrowDownwardIcon,
   ArrowUpwardIcon,

--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ChevronRightIcon, DragIndicatorIcon, ExpandMoreIcon } from '@bigcommerce/big-design-icons';
 import React, { forwardRef, ReactNode, TableHTMLAttributes } from 'react';
 

--- a/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
+++ b/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef } from 'react';
 
 import { typedMemo } from '../../../utils';

--- a/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Dispatch, SetStateAction } from 'react';
 
 import { Checkbox } from '../../Checkbox';

--- a/packages/big-design/src/components/TableNext/SelectAll/useSelectAllState.ts
+++ b/packages/big-design/src/components/TableNext/SelectAll/useSelectAllState.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { areAllInPageSelected, areSomeInPageSelected, getSelectAllState } from './helpers';
 import { SelectAllProps } from './SelectAll';
 

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo, useCallback, useId, useRef, useState } from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 

--- a/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import { Pagination } from '../../Pagination';

--- a/packages/big-design/src/components/TableNext/hooks/useExpandable/useExpandable.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useExpandable/useExpandable.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 
 import { useEventCallback } from '../../../../hooks';

--- a/packages/big-design/src/components/TableNext/hooks/useSelectable/useSelectable.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useSelectable/useSelectable.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 
 import { useEventCallback } from '../../../../hooks';

--- a/packages/big-design/src/components/Tabs/Tabs.tsx
+++ b/packages/big-design/src/components/Tabs/Tabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { HTMLAttributes, memo } from 'react';
 
 import { warning } from '../../utils';

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   cloneElement,
   forwardRef,

--- a/packages/big-design/src/components/Timepicker/Timepicker.tsx
+++ b/packages/big-design/src/components/Timepicker/Timepicker.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef, memo, Ref, useMemo } from 'react';
 
 import { createLocalizationProvider, getTimeIntervals } from '../../utils';

--- a/packages/big-design/src/components/Tooltip/Tooltip.tsx
+++ b/packages/big-design/src/components/Tooltip/Tooltip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Placement } from '@popperjs/core';
 import React, { cloneElement, HTMLAttributes, memo, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/packages/big-design/src/components/Tree/Tree.tsx
+++ b/packages/big-design/src/components/Tree/Tree.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { createContext, useMemo, useRef } from 'react';
 
 import { StyledUl } from './styled';

--- a/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CheckIcon, ChevronRightIcon, FolderIcon } from '@bigcommerce/big-design-icons';
 import React, { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 

--- a/packages/big-design/src/components/Tree/hooks/useNodeMap.ts
+++ b/packages/big-design/src/components/Tree/hooks/useNodeMap.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo } from 'react';
 
 import { NodeMap, TreeNodeId, TreeNodeProps } from '../types';

--- a/packages/big-design/src/components/Tree/hooks/useSelectedChildrenCount.ts
+++ b/packages/big-design/src/components/Tree/hooks/useSelectedChildrenCount.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo } from 'react';
 
 import { depthFirstSearch } from '../../../utils';

--- a/packages/big-design/src/components/Tree/hooks/useTreeKeyEvents.ts
+++ b/packages/big-design/src/components/Tree/hooks/useTreeKeyEvents.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   NodeMap,
   TreeExpandable,

--- a/packages/big-design/src/components/Typography/Typography.tsx
+++ b/packages/big-design/src/components/Typography/Typography.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { memo } from 'react';
 
 import {

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { BaselineHelpIcon } from '@bigcommerce/big-design-icons';
 import React, {
   createContext,

--- a/packages/big-design/src/managers/alerts/AlertsManager.tsx
+++ b/packages/big-design/src/managers/alerts/AlertsManager.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState } from 'react';
 
 import { Alert, AlertProps } from '../../components';

--- a/packages/big-design/src/mixins/display/display.tsx
+++ b/packages/big-design/src/mixins/display/display.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Breakpoints, breakpointsOrder, ThemeInterface } from '@bigcommerce/big-design-theme';
 import { css, FlattenSimpleInterpolation } from 'styled-components';
 

--- a/packages/big-design/src/mixins/margins/margins.tsx
+++ b/packages/big-design/src/mixins/margins/margins.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Spacing } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 

--- a/packages/big-design/src/mixins/paddings/paddings.tsx
+++ b/packages/big-design/src/mixins/paddings/paddings.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Spacing } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 

--- a/packages/docs/app/layout.tsx
+++ b/packages/docs/app/layout.tsx
@@ -1,0 +1,23 @@
+import { GlobalStyles } from '@bigcommerce/big-design';
+import React from 'react';
+
+import StyledComponentsRegistry from './registry';
+
+export default function RootLayout({
+  // Layouts must accept a children prop.
+  // This will be populated with nested layouts or pages
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <StyledComponentsRegistry>
+          <GlobalStyles />
+          {children}
+        </StyledComponentsRegistry>
+      </body>
+    </html>
+  );
+}

--- a/packages/docs/app/registry.tsx
+++ b/packages/docs/app/registry.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useServerInsertedHTML } from 'next/navigation';
+import React, { useState } from 'react';
+import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
+
+export default function StyledComponentsRegistry({ children }: { children: React.ReactNode }) {
+  // Only create stylesheet once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement();
+
+    return <>{styles}</>;
+  });
+
+  if (typeof window !== 'undefined') {
+    return <>{children}</>;
+  }
+
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>{children}</StyleSheetManager>
+  );
+}

--- a/packages/docs/app/test/client-component.tsx
+++ b/packages/docs/app/test/client-component.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { AccordionPanel, useAccordionPanel } from '@bigcommerce/big-design';
+import React from 'react';
+
+export default function ClientComponent() {
+  const { panels } = useAccordionPanel([]);
+
+  return <AccordionPanel header="Test" panels={panels} />;
+}

--- a/packages/docs/app/test/page.tsx
+++ b/packages/docs/app/test/page.tsx
@@ -1,0 +1,15 @@
+import { AccordionPanel, Alert, Badge, Box } from '@bigcommerce/big-design';
+import React from 'react';
+
+// import ClientComponent from './client-component';
+
+export default function Page() {
+  return (
+    <>
+      <AccordionPanel header="Test" panels={[]} />
+      <Alert messages={[{ text: 'Test' }]} />
+      <Badge label="Test" />
+      <Box backgroundColor="brand" padding="large" />
+    </>
+  );
+}

--- a/packages/docs/next-env.d.ts
+++ b/packages/docs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -13,6 +13,10 @@ const URL_PREFIX = '/big-design';
 const examplesVersion = pkg.devDependencies['@bigcommerce/examples'].replace('^', '');
 
 module.exports = withTM({
+  experimental: {
+    appDir: true,
+  },
+  output: 'export',
   basePath: isProduction ? URL_PREFIX : '',
   env: {
     CODE_SANDBOX_URL: `https://codesandbox.io/s/github/bigcommerce/big-design/tree/%40bigcommerce/examples%40${examplesVersion}/packages/examples`,
@@ -35,14 +39,14 @@ module.exports = withTM({
       },
     };
   },
-  exportPathMap: (defaultPathMap) => {
-    if (isDev) {
-      return defaultPathMap;
-    }
+  // exportPathMap: (defaultPathMap) => {
+  //   if (isDev) {
+  //     return defaultPathMap;
+  //   }
 
-    // Ensures the dev page doesn't get built to production
-    const { '/dev': dev, ...rest } = defaultPathMap;
+  //   // Ensures the dev page doesn't get built to production
+  //   const { '/dev': dev, ...rest } = defaultPathMap;
 
-    return rest;
-  },
+  //   return rest;
+  // },
 });

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/docs"
   },
   "scripts": {
-    "build": "next build && next export",
+    "build": "next build",
     "deploy": "yarn run build && touch out/.nojekyll && push-dir --dir=out --branch=gh-pages --verbose",
     "start": "next",
     "typeCheck": "tsc --noEmit"
@@ -45,7 +45,7 @@
     "@types/styled-components": "^5.1.26",
     "babel-plugin-styled-components": "^2.0.7",
     "jsx-to-string-loader": "^1.2.0",
-    "next": "^12.0.8",
+    "next": "^13.3.0",
     "push-dir": "^0.4.1",
     "typescript": "^4.4.3",
     "typescript-styled-plugin": "^0.18.2"

--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -10,14 +10,16 @@
     "jsx": "preserve",
     "noUnusedLocals": false,
     "noImplicitAny": false,
-    "incremental": true
+    "incremental": true,
+    "strictNullChecks": true
   },
   "include": [
     "next-env.d.ts",
     "styled.d.ts",
     "global.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,75 +1900,55 @@
     write-pkg "4.0.0"
     yargs "16.2.0"
 
-"@next/env@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.3.4.tgz#c787837d36fcad75d72ff8df6b57482027d64a47"
-  integrity sha512-H/69Lc5Q02dq3o+dxxy5O/oNxFsZpdL6WREtOOtOM1B/weonIwDXkekr1KV5DPVPr12IHFPrMrcJQ6bgPMfn7A==
+"@next/env@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.3.0.tgz#cc2e49f03060a4684ce7ec7fd617a21bc5b9edba"
+  integrity sha512-AjppRV4uG3No7L1plinoTQETH+j2F10TEnrMfzbTUYwze5sBUPveeeBAPZPm8OkJZ1epq9OyYKhZrvbD6/9HCQ==
 
-"@next/swc-android-arm-eabi@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.4.tgz#fd1c2dafe92066c6120761c6a39d19e666dc5dd0"
-  integrity sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==
+"@next/swc-darwin-arm64@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.0.tgz#38f18e0639cd4c7edc6a38d4b83fe00f38eea4f2"
+  integrity sha512-DmIQCNq6JtccLPPBzf0dgh2vzMWt5wjxbP71pCi5EWpWYE3MsP6FcRXi4MlAmFNDQOfcFXR2r7kBeG1LpZUh1w==
 
-"@next/swc-android-arm64@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.3.4.tgz#11a146dae7b8bca007239b21c616e83f77b19ed4"
-  integrity sha512-5jf0dTBjL+rabWjGj3eghpLUxCukRhBcEJgwLedewEA/LJk2HyqCvGIwj5rH+iwmq1llCWbOky2dO3pVljrapg==
+"@next/swc-darwin-x64@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.3.0.tgz#b670ed1fd1d231aa21279173ec52e3ad56dc6aeb"
+  integrity sha512-oQoqFa88OGgwnYlnAGHVct618FRI/749se0N3S8t9Bzdv5CRbscnO0RcX901+YnNK4Q6yeiizfgO3b7kogtsZg==
 
-"@next/swc-darwin-arm64@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.4.tgz#14ac8357010c95e67327f47082af9c9d75d5be79"
-  integrity sha512-DqsSTd3FRjQUR6ao0E1e2OlOcrF5br+uegcEGPVonKYJpcr0MJrtYmPxd4v5T6UCJZ+XzydF7eQo5wdGvSZAyA==
+"@next/swc-linux-arm64-gnu@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.3.0.tgz#b114935f6b4c94c123f6cac55a4823d483209ba5"
+  integrity sha512-Wzz2p/WqAJUqTVoLo6H18WMeAXo3i+9DkPDae4oQG8LMloJ3if4NEZTnOnTUlro6cq+S/W4pTGa97nWTrOjbGw==
 
-"@next/swc-darwin-x64@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.4.tgz#e7dc63cd2ac26d15fb84d4d2997207fb9ba7da0f"
-  integrity sha512-PPF7tbWD4k0dJ2EcUSnOsaOJ5rhT3rlEt/3LhZUGiYNL8KvoqczFrETlUx0cUYaXe11dRA3F80Hpt727QIwByQ==
+"@next/swc-linux-arm64-musl@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.3.0.tgz#67a57309f8761c7d00d629d6785d56ed0567a0d2"
+  integrity sha512-xPVrIQOQo9WXJYgmoTlMnAD/HlR/1e1ZIWGbwIzEirXBVBqMARUulBEIKdC19zuvoJ477qZJgBDCKtKEykCpyQ==
 
-"@next/swc-freebsd-x64@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz#fe7ceec58746fdf03f1fcb37ec1331c28e76af93"
-  integrity sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==
+"@next/swc-linux-x64-gnu@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.3.0.tgz#11bd2bea7c00b40be111c0dd16e71171f3792086"
+  integrity sha512-jOFlpGuPD7W2tuXVJP4wt9a3cpNxWAPcloq5EfMJRiXsBBOjLVFZA7boXYxEBzSVgUiVVr1V9T0HFM7pULJ1qA==
 
-"@next/swc-linux-arm-gnueabihf@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.4.tgz#d7016934d02bfc8bd69818ffb0ae364b77b17af7"
-  integrity sha512-3zqD3pO+z5CZyxtKDTnOJ2XgFFRUBciOox6EWkoZvJfc9zcidNAQxuwonUeNts6Xbm8Wtm5YGIRC0x+12YH7kw==
+"@next/swc-linux-x64-musl@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.3.0.tgz#d57e99f85890799b78719c3ea32a4624de8d701b"
+  integrity sha512-2OwKlzaBgmuet9XYHc3KwsEilzb04F540rlRXkAcjMHL7eCxB7uZIGtsVvKOnQLvC/elrUegwSw1+5f7WmfyOw==
 
-"@next/swc-linux-arm64-gnu@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.4.tgz#43a7bc409b03487bff5beb99479cacdc7bd29af5"
-  integrity sha512-kiX0vgJGMZVv+oo1QuObaYulXNvdH/IINmvdZnVzMO/jic/B8EEIGlZ8Bgvw8LCjH3zNVPO3mGrdMvnEEPEhKA==
+"@next/swc-win32-arm64-msvc@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.3.0.tgz#0c209aa35d1c88b01e78259a89cd68f4139b5093"
+  integrity sha512-OeHiA6YEvndxT46g+rzFK/MQTfftKxJmzslERMu9LDdC6Kez0bdrgEYed5eXFK2Z1viKZJCGRlhd06rBusyztA==
 
-"@next/swc-linux-arm64-musl@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.4.tgz#4d1db6de6dc982b974cd1c52937111e3e4a34bd3"
-  integrity sha512-EETZPa1juczrKLWk5okoW2hv7D7WvonU+Cf2CgsSoxgsYbUCZ1voOpL4JZTOb6IbKMDo6ja+SbY0vzXZBUMvkQ==
+"@next/swc-win32-ia32-msvc@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.3.0.tgz#52ae74da1dd6d840c3743923367d27ed013803dd"
+  integrity sha512-4aB7K9mcVK1lYEzpOpqWrXHEZympU3oK65fnNcY1Qc4HLJFLJj8AViuqQd4jjjPNuV4sl8jAwTz3gN5VNGWB7w==
 
-"@next/swc-linux-x64-gnu@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.4.tgz#c3b414d77bab08b35f7dd8943d5586f0adb15e38"
-  integrity sha512-4csPbRbfZbuWOk3ATyWcvVFdD9/Rsdq5YHKvRuEni68OCLkfy4f+4I9OBpyK1SKJ00Cih16NJbHE+k+ljPPpag==
-
-"@next/swc-linux-x64-musl@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.4.tgz#187a883ec09eb2442a5ebf126826e19037313c61"
-  integrity sha512-YeBmI+63Ro75SUiL/QXEVXQ19T++58aI/IINOyhpsRL1LKdyfK/35iilraZEFz9bLQrwy1LYAR5lK200A9Gjbg==
-
-"@next/swc-win32-arm64-msvc@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.4.tgz#89befa84e453ed2ef9a888f375eba565a0fde80b"
-  integrity sha512-Sd0qFUJv8Tj0PukAYbCCDbmXcMkbIuhnTeHm9m4ZGjCf6kt7E/RMs55Pd3R5ePjOkN7dJEuxYBehawTR/aPDSQ==
-
-"@next/swc-win32-ia32-msvc@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.4.tgz#cb50c08f0e40ead63642a7f269f0c8254261f17c"
-  integrity sha512-rt/vv/vg/ZGGkrkKcuJ0LyliRdbskQU+91bje+PgoYmxTZf/tYs6IfbmgudBJk6gH3QnjHWbkphDdRQrseRefQ==
-
-"@next/swc-win32-x64-msvc@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.4.tgz#d28ea15a72cdcf96201c60a43e9630cd7fda168f"
-  integrity sha512-DQ20JEfTBZAgF8QCjYfJhv2/279M6onxFjdG/+5B0Cyj00/EdBxiWb2eGGFgQhrBbNv/lsvzFbbi0Ptf8Vw/bg==
+"@next/swc-win32-x64-msvc@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.3.0.tgz#db7b55fee834dc8c2c484c696469e65bae2ee770"
+  integrity sha512-Reer6rkLLcoOvB0dd66+Y7WrWVFH7sEEkF/4bJCIfsSKnTStTYaHtwIJAwbqnt9I392Tqvku0KkoqZOryWV9LQ==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
@@ -2546,10 +2526,10 @@
     deepmerge "^4.2.2"
     svgo "^1.2.2"
 
-"@swc/helpers@0.4.11":
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.11.tgz#db23a376761b3d31c26502122f349a21b592c8de"
-  integrity sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==
+"@swc/helpers@0.4.14":
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.14.tgz#1352ac6d95e3617ccb7c1498ff019654f1e12a74"
+  integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
   dependencies:
     tslib "^2.4.0"
 
@@ -3628,6 +3608,13 @@ builtins@^5.0.0:
   dependencies:
     semver "^7.0.0"
 
+busboy@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 byte-size@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-7.0.0.tgz#36528cd1ca87d39bd9abd51f5715dc93b6ceb032"
@@ -3860,6 +3847,11 @@ cli-width@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.0.0.tgz#a5622f6a3b0a9e3e711a25f099bf2399f608caf6"
   integrity sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==
+
+client-only@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
 clipboard-copy@^4.0.1:
   version "4.0.1"
@@ -7817,31 +7809,27 @@ next-transpile-modules@^10.0.0:
   dependencies:
     enhanced-resolve "^5.10.0"
 
-next@^12.0.8:
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/next/-/next-12.3.4.tgz#f2780a6ebbf367e071ce67e24bd8a6e05de2fcb1"
-  integrity sha512-VcyMJUtLZBGzLKo3oMxrEF0stxh8HwuW976pAzlHhI3t8qJ4SROjCrSh1T24bhrbjw55wfZXAbXPGwPt5FLRfQ==
+next@^13.3.0:
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/next/-/next-13.3.0.tgz#40632d303d74fc8521faa0a5bf4a033a392749b1"
+  integrity sha512-OVTw8MpIPa12+DCUkPqRGPS3thlJPcwae2ZL4xti3iBff27goH024xy4q2lhlsdoYiKOi8Kz6uJoLW/GXwgfOA==
   dependencies:
-    "@next/env" "12.3.4"
-    "@swc/helpers" "0.4.11"
+    "@next/env" "13.3.0"
+    "@swc/helpers" "0.4.14"
+    busboy "1.6.0"
     caniuse-lite "^1.0.30001406"
     postcss "8.4.14"
-    styled-jsx "5.0.7"
-    use-sync-external-store "1.2.0"
+    styled-jsx "5.1.1"
   optionalDependencies:
-    "@next/swc-android-arm-eabi" "12.3.4"
-    "@next/swc-android-arm64" "12.3.4"
-    "@next/swc-darwin-arm64" "12.3.4"
-    "@next/swc-darwin-x64" "12.3.4"
-    "@next/swc-freebsd-x64" "12.3.4"
-    "@next/swc-linux-arm-gnueabihf" "12.3.4"
-    "@next/swc-linux-arm64-gnu" "12.3.4"
-    "@next/swc-linux-arm64-musl" "12.3.4"
-    "@next/swc-linux-x64-gnu" "12.3.4"
-    "@next/swc-linux-x64-musl" "12.3.4"
-    "@next/swc-win32-arm64-msvc" "12.3.4"
-    "@next/swc-win32-ia32-msvc" "12.3.4"
-    "@next/swc-win32-x64-msvc" "12.3.4"
+    "@next/swc-darwin-arm64" "13.3.0"
+    "@next/swc-darwin-x64" "13.3.0"
+    "@next/swc-linux-arm64-gnu" "13.3.0"
+    "@next/swc-linux-arm64-musl" "13.3.0"
+    "@next/swc-linux-x64-gnu" "13.3.0"
+    "@next/swc-linux-x64-musl" "13.3.0"
+    "@next/swc-win32-arm64-msvc" "13.3.0"
+    "@next/swc-win32-ia32-msvc" "13.3.0"
+    "@next/swc-win32-x64-msvc" "13.3.0"
 
 node-addon-api@^3.2.1:
   version "3.2.1"
@@ -9719,6 +9707,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 string-argv@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
@@ -9894,10 +9887,12 @@ styled-components@^5.3.5:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
-styled-jsx@5.0.7:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.7.tgz#be44afc53771b983769ac654d355ca8d019dff48"
-  integrity sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==
+styled-jsx@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.1.1.tgz#839a1c3aaacc4e735fed0781b8619ea5d0009d1f"
+  integrity sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==
+  dependencies:
+    client-only "0.0.1"
 
 sucrase@^3.21.0:
   version "3.28.0"


### PR DESCRIPTION
---

⚠️ This PR will not just work (hence draft PR), getting some React hydration issues after adding `use client` throughout the codebase, plus there's some other React warnings with `defaultProps` and others.

---

## What?

Adding support for React Server Components (RSC).

## Why?

Currently, `styled-components` uses the context API + a lot of our components are stateful in a way so the best solution for now was to add `use client` for all the components/exported hooks.

## Screenshots/Screen Recordings

TBD...

## Testing/Proof

TBD...