### PR TITLE
chore(component): improving worksheet performance

### DIFF
--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -12,6 +12,7 @@ import {
   WorksheetSelectableColumn,
   WorksheetTextColumn,
 } from '../types';
+import { getCellIdx } from '../utils';
 
 import { AutoFillHandler, CellNote, StyledCell } from './styled';
 
@@ -46,6 +47,7 @@ const InternalCell = <T extends WorksheetItem>({
     () => ({ columnIndex, disabled, hash, rowIndex, type, value }),
     [columnIndex, disabled, hash, rowIndex, type, value],
   );
+  const cellIdx = useMemo(() => getCellIdx(cell), [cell]);
 
   const { handleBlur, handleChange, handleDoubleClick, handleKeyDown, isEditing } =
     useEditableCell<T>(cell);
@@ -88,49 +90,27 @@ const InternalCell = <T extends WorksheetItem>({
     store,
     useMemo(
       () => (state) => {
-        const idx = state.selectedCells.findIndex(
-          (selectedCell) =>
-            selectedCell.columnIndex === cell.columnIndex &&
-            selectedCell.rowIndex === cell.rowIndex,
-        );
+        const idx = Object.keys(state.selectedCellsMap).indexOf(cellIdx);
 
         return {
           selectedCells: state.selectedCells,
           isLastSelected: state.selectedCells.length - 1 === idx,
           isFirstSelected: idx === 0,
-          isSelected: state.selectedCells.some(
-            (selectedCell) =>
-              selectedCell.columnIndex === cell.columnIndex &&
-              selectedCell.rowIndex === cell.rowIndex,
-          ),
+          isSelected: idx !== -1,
         };
       },
-      [cell],
+      [cellIdx],
     ),
   );
 
   const isEdited = useStore(
     store,
-    useMemo(
-      () => (state) =>
-        state.editedCells.some(
-          (editedCell) =>
-            editedCell.columnIndex === cell.columnIndex && editedCell.rowIndex === cell.rowIndex,
-        ),
-      [cell],
-    ),
+    useMemo(() => (state) => !!state.editedCellsMap[cellIdx], [cellIdx]),
   );
 
   const invalidCell = useStore(
     store,
-    useMemo(
-      () => (state) =>
-        state.invalidCells.find(
-          (invalidCell) =>
-            invalidCell.columnIndex === cell.columnIndex && invalidCell.rowIndex === cell.rowIndex,
-        ),
-      [cell.columnIndex, cell.rowIndex],
-    ),
+    useMemo(() => (state) => state.invalidCellsMap[cellIdx], [cellIdx]),
   );
 
   const isValid = useMemo(

--- a/packages/big-design/src/components/Worksheet/Row/Row.tsx
+++ b/packages/big-design/src/components/Worksheet/Row/Row.tsx
@@ -12,8 +12,6 @@ import {
   WorksheetTextColumn,
 } from '../types';
 
-import { StyledTableRow } from './styled';
-
 interface RowProps<Item> {
   columns: Array<InternalWorksheetColumn<Item>>;
   rowIndex: number;
@@ -75,8 +73,12 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
     [expandableRows, row.id],
   );
 
+  if (isChild && !isExpanded) {
+    return null;
+  }
+
   return (
-    <StyledTableRow isExpanded={!isChild || isExpanded}>
+    <tr>
       <RowStatus rowIndex={rowIndex} />
       {columns.map((column, columnIndex) => (
         <Cell
@@ -97,7 +99,7 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
           value={row[column.hash] ?? ''}
         />
       ))}
-    </StyledTableRow>
+    </tr>
   );
 };
 

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -74,9 +74,7 @@ exports[`renders worksheet 1`] = `
       </tr>
     </thead>
     <tbody>
-      <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 LrOOj"
-      >
+      <tr>
         <td
           class="styled__Status-sc-1aacki0-0 jJFKzo"
         />
@@ -224,9 +222,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
       </tr>
-      <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 LrOOj"
-      >
+      <tr>
         <td
           class="styled__Status-sc-1aacki0-0 jJFKzo"
         />
@@ -374,9 +370,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
       </tr>
-      <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 LrOOj"
-      >
+      <tr>
         <td
           class="styled__Status-sc-1aacki0-0 jJFKzo"
         />
@@ -521,9 +515,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
       </tr>
-      <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 LrOOj"
-      >
+      <tr>
         <td
           class="styled__Status-sc-1aacki0-0 jJFKzo"
         />
@@ -671,9 +663,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
       </tr>
-      <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 LrOOj"
-      >
+      <tr>
         <td
           class="styled__Status-sc-1aacki0-0 eWXKBa"
         />
@@ -811,9 +801,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
       </tr>
-      <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 LrOOj"
-      >
+      <tr>
         <td
           class="styled__Status-sc-1aacki0-0 jJFKzo"
         />
@@ -961,9 +949,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
       </tr>
-      <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 LrOOj"
-      >
+      <tr>
         <td
           class="styled__Status-sc-1aacki0-0 eWXKBa"
         />
@@ -1110,9 +1096,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
       </tr>
-      <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 LrOOj"
-      >
+      <tr>
         <td
           class="styled__Status-sc-1aacki0-0 jJFKzo"
         />
@@ -1260,9 +1244,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
       </tr>
-      <tr
-        class="styled__StyledTableRow-sc-1bzgr3l-0 LrOOj"
-      >
+      <tr>
         <td
           class="styled__Status-sc-1aacki0-0 jJFKzo"
         />

--- a/packages/big-design/src/components/Worksheet/utils.ts
+++ b/packages/big-design/src/components/Worksheet/utils.ts
@@ -78,3 +78,15 @@ export const getHiddenRows = (
       defaultExpandedRows.map(String).includes(key) ? accum : [...accum, ...value],
     [],
   );
+
+export const getCellIdx = <T extends WorksheetItem>({ columnIndex, rowIndex }: Cell<T>) =>
+  `${rowIndex}_${columnIndex}`;
+
+export const getCellsMap = <T extends WorksheetItem>(cells: Array<Cell<T>>) =>
+  cells.reduce(
+    (acc, cell) => ({
+      ...acc,
+      [getCellIdx(cell)]: cell,
+    }),
+    {},
+  );


### PR DESCRIPTION
## What?
- Add conditional rendering for the `Rows` instead of `display: none` to improve initial rendering performance;
- Improve `Cell` performance by adding `Maps` for the `selectedCells, invalidCells and editedCells` entities to remove cycles in the `zustand` selectors.

## Why?
When the `Worksheet` component contains `50 rows` + every row has `40 children` browsers completely crush.

## Screenshots/Screen Recordings
**Before:**
Browser stuck.

**Now:**

https://github.com/bigcommerce/big-design/assets/9980803/8f9e2019-2e8f-4d1b-88da-20c3a3569319



## Testing/Proof
Existing tests + locally.
