### PR TITLE
fix: declaration tsconfig for theme publishing

### DIFF
--- a/packages/big-design-theme/package.json
+++ b/packages/big-design-theme/package.json
@@ -14,7 +14,7 @@
     "build": "yarn run build:cjs && yarn run build:es && yarn run build:dt",
     "build:cjs": "NODE_ENV=production BABEL_ENV=cjs babel --extensions \".ts,.tsx\" ./src --out-dir ./dist/cjs",
     "build:es": "NODE_ENV=production BABEL_ENV=es babel --extensions \".ts,.tsx\" ./src --out-dir ./dist/es",
-    "build:dt": "tsc --emitDeclarationOnly",
+    "build:dt": "tsc -p tsconfig.declarations.json --emitDeclarationOnly",
     "prepublishOnly": "rimraf dist && yarn run typeCheck && yarn run test && yarn run build",
     "prepack": "big-design-prepack",
     "postpack": "big-design-postpack",

--- a/packages/big-design-theme/tsconfig.declarations.json
+++ b/packages/big-design-theme/tsconfig.declarations.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.spec.ts",
+    "setupTests.ts"
+  ]
+}


### PR DESCRIPTION
## What?

As part of #1187 we added `setupTests.ts` to the `include` in `tsconfig.json`. This caused the generated types to not be flat. You can see below in the screenshots that adding the `setupTests.ts` caused the types to be located in a `src/` folder instead.

## Why?

We noticed this issue on the latest published version. This should fix the type declarations being exported on the correct path.

## Screenshots/Screen Recordings

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://github.com/bigcommerce/big-design/assets/10539418/a9502f99-073c-4601-bda3-8916484e801c" />
	<td><img src="https://github.com/bigcommerce/big-design/assets/10539418/5e65f700-affa-473d-8b28-96d2dc33b008)" />
</table>