### PR TITLE
chore(deps): bump downshift

### DIFF
--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -38,7 +38,7 @@
     "@popperjs/core": "^2.11.6",
     "@types/react-datepicker": "^4.4.2",
     "date-fns": "2.30.0",
-    "downshift": "7.4.1",
+    "downshift": "7.6.0",
     "focus-trap": "^7.0.0",
     "polished": "^4.0.0",
     "react-beautiful-dnd": "^13.1.1",

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -342,7 +342,6 @@ exports[`render pagination component 1`] = `
           class="c9"
           id=":r0:-menu"
           role="menu"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -761,7 +760,6 @@ exports[`render pagination component with invalid page info 1`] = `
           class="c9"
           id=":r4:-menu"
           role="menu"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -1180,7 +1178,6 @@ exports[`render pagination component with invalid range info 1`] = `
           class="c9"
           id=":r8:-menu"
           role="menu"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -1600,7 +1597,6 @@ exports[`render pagination component with no items 1`] = `
           class="c9"
           id=":rc:-menu"
           role="menu"
-          tabindex="-1"
         />
       </div>
     </div>

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -360,7 +360,6 @@ exports[`dropdown is not visible if items fit 1`] = `
           class="c10"
           id=":r2:-menu"
           role="menu"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -728,7 +727,6 @@ exports[`it renders the given tabs 1`] = `
           class="c10"
           id=":r0:-menu"
           role="menu"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -1128,7 +1126,6 @@ exports[`only the pills that fit are visible 1`] = `
           class="c10"
           id=":r8:-menu"
           role="menu"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -1527,7 +1524,6 @@ exports[`only the pills that fit are visible 2 1`] = `
           class="c10"
           id=":ra:-menu"
           role="menu"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -1925,7 +1921,6 @@ exports[`renders all the filters if they fit 1`] = `
           class="c10"
           id=":r6:-menu"
           role="menu"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -2310,7 +2305,6 @@ exports[`renders dropdown if items do not fit 1`] = `
           class="c10"
           id=":r4:-menu"
           role="menu"
-          tabindex="-1"
         />
       </div>
     </div>

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -392,7 +392,6 @@ exports[`renders a pagination component 1`] = `
               class="c12"
               id=":r13:-menu"
               role="menu"
-              tabindex="-1"
             />
           </div>
         </div>

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -392,7 +392,6 @@ exports[`pagination renders a pagination component 1`] = `
               class="c12"
               id=":r13:-menu"
               role="menu"
-              tabindex="-1"
             />
           </div>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4815,10 +4815,10 @@ dotenv@~10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
-downshift@7.4.1:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-7.4.1.tgz#50114d4479e9bd5751a9fc3af72fb12b6178147f"
-  integrity sha512-HbzzY55YB/kbtnBQVds9fVPp9JBw913HAgGFlh4q5qNlzuwFJLyM7h0mkbBRAv3TmVaSPDdprM+sTMoQeIx04w==
+downshift@7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-7.6.0.tgz#de04fb2962bd6c4ea94589c797c91f34aa9816f3"
+  integrity sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==
   dependencies:
     "@babel/runtime" "^7.14.8"
     compute-scroll-into-view "^2.0.4"


### PR DESCRIPTION
## What?

Upgrade `downshift` to `7.6.0`

## Why?

Snyk says we should but doesn't seem to update lockfiles: https://github.com/bigcommerce/big-design/pull/1247

## Testing/Proof

CircleCI.
