### PR TITLE
fix(component): update disabled input text color

### DIFF
--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -115,6 +115,7 @@ exports[`simple form render 1`] = `
 
 .c8[disabled] {
   background-color: #ECEEF5;
+  color: #5E637A;
 }
 
 .c7 {

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -86,6 +86,7 @@ exports[`renders all together 1`] = `
 
 .c7[disabled] {
   background-color: #ECEEF5;
+  color: #5E637A;
 }
 
 .c4 {

--- a/packages/big-design/src/components/Input/styled.tsx
+++ b/packages/big-design/src/components/Input/styled.tsx
@@ -112,6 +112,7 @@ export const StyledInput = styled.input<InputProps>`
 
   &[disabled] {
     background-color: ${({ theme }) => theme.colors.secondary20};
+    color: ${({ theme }) => theme.colors.secondary60};
   }
 `;
 


### PR DESCRIPTION
## What?

Change text color in disabled input to `Secondary60` / `#5E637A`

## Why?

According to figma color should be `Secondary60`
https://www.figma.com/file/duwtpbP2tnLLQQmAkwtrNC/BigDesign-Lib?type=design&node-id=573-1945&mode=design&t=yDNokNBDsjl1Yukc-4

## Screenshots/Screen Recordings

<img width="456" alt="image" src="https://github.com/bigcommerce/big-design/assets/7959201/e0939ecc-5b17-4058-becc-17aa6daa9fd0">


## Testing/Proof

Manually tested on latest google chrome.
