### PR TITLE
docs: add ux writing guide mdx to support dev docs portal

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,19 @@ module.exports = {
   },
   overrides: [
     {
+      files: ['packages/docs/design-docs/**/*.mdx'],
+      extends: ['plugin:mdx/recommended', 'plugin:react/recommended'],
+      settings: {
+        react: {
+          version: 'detect',
+        },
+      },
+      rules: {
+        // These ignored files are resolved when they are consumed by the BigCommerce developer-center repo.
+        'import/no-unresolved': ['error', { ignore: ['^@components/.+'] }],
+      },
+    },
+    {
       files: ['**/*.ts', '**/*.tsx', '**/*.js'],
       rules: {
         '@typescript-eslint/naming-convention': 'off',

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "ci:typeCheck": "lerna run typeCheck --stream",
     "ci:test": "lerna run test --stream -- --maxWorkers=2 --coverage",
     "diff": "lerna diff",
-    "lint": "eslint . --ext .ts,.tsx,.js",
+    "lint": "eslint . --ext .ts,.tsx,.js,.mdx",
     "start": "yarn workspace @bigcommerce/docs run start",
     "test": "lerna run test --stream",
     "prepare": "husky install"
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": [
+    "*.{js,ts,tsx,mdx}": [
       "eslint --fix"
     ]
   },
@@ -28,6 +28,7 @@
     "@commitlint/config-conventional": "^17.4.2",
     "@types/babel__standalone": "^7.1.4",
     "eslint": "^8.33.0",
+    "eslint-plugin-mdx": "^2.2.0",
     "husky": "^8.0.3",
     "lerna": "^6.4.1",
     "lint-staged": "^14.0.1",

--- a/packages/docs/design-docs/ux-writing/glossary.mdx
+++ b/packages/docs/design-docs/ux-writing/glossary.mdx
@@ -1,0 +1,756 @@
+import { Dos, IconDo  } from "@components/big-design/DosAndDonts";
+
+# Glossary
+
+We know the discourse of ecommerce changes over time. If we find a word choice in our vocabulary doesn’t make sense anymore, we'll change it.
+
+### 1, 2, 3
+
+<dl class="ml-4">
+<dt class="font-bold mt-4">
+2-step verification
+</dt>
+<dd>
+Use “2-step verification.” Don’t use “2 step verification” or “two-step verification.”
+</dd>
+
+<dt class="font-bold mt-4">
+3D Secure
+</dt>
+<dd>
+3D Secure is a fraud protection layer available to users as long as they’re using a participating payment gateway. Treat 3D Secure as a proper noun and capitalize accordingly.
+</dd>
+
+</dl>
+
+### A
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+able to
+</dt>
+<dd>
+Avoid using sentences using “You will be able to….” Instead, just say “You can….” It’s shorter and easier to scan.
+</dd>
+
+<dt class="font-bold mt-4">
+add
+</dt>
+<dd>
+Use “add” when referring to the act of putting a thing with another group of things. Compare this with “connect,” which refers to the act of joining two things together.
+
+For example, users can add products to their catalog. They can also connect their BigCommerce site with a marketplace, like Amazon or Facebook.
+</dd>
+<dt class="font-bold mt-4">
+App Marketplace
+</dt>
+<dd>
+App Marketplace is a proper noun. Capitalize both words.
+</dd>
+
+</dl>
+
+### B
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+back
+</dt>
+<dd>
+“Back” means, “I want to return to the previous step in this workflow without quitting the current process.” Don’t use “back” in place of “cancel.”
+</dd>
+
+<dt class="font-bold mt-4">
+BigCommerce
+</dt>
+<dd>
+Use BigCommerce. Don’t use Bigcommerce or Big Commerce. And never abbreviate as BC.
+</dd>
+
+<dt class="font-bold mt-4">
+Buy Now, Pay Later (BNPL)
+</dt>
+<dd>
+Treat “Buy Now, Pay Later” as a branded, proper noun and use title case.
+</dd>
+
+<dt class="font-bold mt-4">
+buy online, pick up in-store (BOPIS)
+</dt>
+<dd>
+“Pick up” is a verb and should be two words, no hyphen. “In-store” is an adjective describing the type of pick up. In the UK, “buy online, pick up in-store” is called “click and collect.”
+
+At BigCommerce, the default language for UX writing is American English. Accordingly, always use “buy online, pick up in-store.”
+
+Don’t abbreviate as BOPIS.
+</dd>
+
+</dl>
+
+### C
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+cancel
+</dt>
+<dd>
+“Cancel” means, “I don’t want to do this anymore.” Any in-progress changes should be discarded as a result of clicking the button.
+
+Don’t use “stop,” “pause,” “terminate” or “nevermind” and don’t use “cancel” in place of “back.”
+</dd>
+
+<dt class="font-bold mt-4">
+catalog
+</dt>
+<dd>
+A catalog is a collection of virtual representations of a merchant’s saleable products for a channel, stored within the BigCommerce platform. A catalog contains products. Products can be both physical and digital. For the latter, think music downloads, digital images, treatments, services, etc. A collection of products, sorted by the user for merchandising purposes, is called a category.
+</dd>
+
+<dt class="font-bold mt-4">
+category
+</dt>
+<dd>
+A collection of products, sorted by the user for merchandising purposes.
+</dd>
+
+<dt class="font-bold mt-4">
+channel
+</dt>
+<dd>
+A place where a BigCommerce user can market and sell goods. Channels include storefronts, marketplaces, advertising and social media.
+</dd>
+
+<dt class="font-bold mt-4">
+Channel Manager
+</dt>
+<dd>
+Channel Manager is a proper noun. Capitalize both words.
+</dd>
+
+<dt class="font-bold mt-4">
+check out, checkout
+</dt>
+<dd>
+Use check out (verb) when referring to the act of paying for items and creating an order.
+
+Use checkout (noun) when talking about the place shoppers go to pay for items and create an order.
+
+Use checkout (adjective) when describing the type of page or process.
+
+Never use check-out.
+</dd>
+
+<Dos>
+<div class="hidden">
+Do
+</div>
+ - Ready to check out?
+ - When you’re done shopping, proceed to the checkout.
+ - Navigate to the checkout page.
+</Dos>
+
+<dt class="font-bold mt-4">
+click
+</dt>
+<dd>
+Since we don’t know if a user is on a desktop or mobile device, avoid using “click” when instructing the user on how to complete an action within the UI. Whenever possible, write around the issue with generic verbs like “choose,” “select” or “pick.”
+
+Avoid using “hit."
+</dd>
+
+<dt class="font-bold mt-4">
+clickthrough, click-through
+</dt>
+<dd>
+Use “clickthrough” (noun) when referring to an instance or multiple instances of clickthrough. Use “click through” (verb) when referring to the act of following a link or button to another site or location.
+
+Don’t use “click-through.”
+</dd>
+
+<dt class="font-bold mt-4">
+close
+</dt>
+<dd>
+Use “close” instead of “exit” for modals and pop-ups.
+</dd>
+
+<dt class="font-bold mt-4">
+connect
+</dt>
+<dd>
+Use “connect” when referring to the act of joining two things together. Compare this to “add,” which refers to the act of putting a thing with another group of things.
+
+For example, users can add products to their catalog. They can also connect their BigCommerce site with a marketplace, like Amazon or Facebook.
+
+When writing about an integration between BigCommerce and another third party technology, you’ll probably be using “connect.”
+</dd>
+
+<dt class="font-bold mt-4">
+continue
+</dt>
+<dd>
+“Continue” means “I want to go forward a step in this workflow,” like an onboarding, for example.
+
+Do not use “next.”
+</dd>
+
+<dt class="font-bold mt-4">
+control panel
+</dt>
+<dd>
+Control panel is not a proper noun. No need to capitalize. Of course, always capitalize the first letter of the first word if it appears at the start of a sentence. Keep in mind, there are very few instances when you’ll need to refer to the control panel by name. Most of the time you’ll just say “store.”
+</dd>
+
+<dt class="font-bold mt-4">
+create
+</dt>
+<dd>
+Use “create,” as opposed to “save,” as the CTA when creating a product, customer, setting, object, item etc. for the first time. When making changes to something that already exists, use “save” as the CTA.
+</dd>
+
+<dt class="font-bold mt-4">
+customer
+</dt>
+<dd>
+Use “customer” when referring to our users’ end-user: the customer. You can use “customer” and “shopper” interchangeably. Just keep in mind, depending on the context, there can be a subtle difference between a shopper and a customer. A shopper is a visitor to a merchant’s storefront who hasn’t necessarily purchased anything.
+
+To avoid confusion, try not to use “customer” to refer to BigCommerce clients. Use “merchant,” “retailer” or “brand” instead.
+</dd>
+
+</dl>
+
+### D
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+delete
+</dt>
+<dd>
+Use “delete” for destructive behaviors. Don’t use “remove” or “dismiss.”
+</dd>
+
+<dt class="font-bold mt-4">
+deploy
+</dt>
+<dd>
+Use “deploy” when talking about a one-way connection between applications. If one application sends data to another, one time or on an occasional basis, it’s deploying.
+</dd>
+
+<dt class="font-bold mt-4">
+details
+</dt>
+<dd>
+On its own, as a clickable, UI item, use “details.” Don’t use “information” or “info.”
+</dd>
+
+<dt class="font-bold mt-4">
+Dev Center
+</dt>
+<dd>
+A resource center for developers looking to make their own solutions using the BigCommerce platform. Dev Center is a proper noun, so capitalize both words.
+</dd>
+
+<dt class="font-bold mt-4">
+disable
+</dt>
+<dd>
+Use “disable” when referring to the act of turning something off. Don’t use “turn off” or “deactivate.”
+</dd>
+
+</dl>
+
+### E
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+ecommerce
+</dt>
+<dd>
+Use “ecommerce” (or "Ecommerce" if at the start of a sentence). Never use “e-commerce” or “eCommerce.”
+</dd>
+
+<dt class="font-bold mt-4">
+edit
+</dt>
+<dd>
+Use “edit” when referring to the act of changing previously entered information. Don’t use “change,” “modify,” “update” or “manage.”
+</dd>
+
+<dt class="font-bold mt-4">
+email
+</dt>
+<dd>
+Do not use “e-mail.” For form field labeling use “Email” instead of “Email address.”
+</dd>
+
+<dt class="font-bold mt-4">
+enable
+</dt>
+<dd>
+Use “enable” when referring to the act of turning something on. Don’t use “activate,” “deactivate,” “turn on” or “turn off.”
+</dd>
+
+</dl>
+
+### F
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+finish
+</dt>
+<dd>
+Use “finish” as the final CTA in a multi-step workflow, like an onboarding flow, for example.
+</dd>
+
+</dl>
+
+### G
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+got it
+</dt>
+<dd>
+“Got it” means “I understand.” Clicking “got it” is merely an acknowledgment on the part of the user. No change or action should take place as a result of clicking the button.
+</dd>
+
+</dl>
+
+### H
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+headless
+</dt>
+<dd>
+A technology stack that uses a third party solution to create and maintain the shopper-facing front-end of a user’s store, while using BigCommerce for the administrative back-end.
+</dd>
+
+<dt class="font-bold mt-4">
+homepage
+</dt>
+<dd>
+Use “homepage,” one word, not “home page.”
+</dd>
+
+</dl>
+
+### I
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+in stock
+</dt>
+<dd>
+No hyphen.
+</dd>
+
+<dt class="font-bold mt-4">
+in-store
+</dt>
+<dd>
+Use “in-store” when describing where something exists or takes place; e.g., “pick up in-store” or “in-store special.” Don’t use “in store.”
+</dd>
+
+<dt class="font-bold mt-4">
+internet
+</dt>
+<dd>
+Do not capitalize unless at the start of a sentence.
+</dd>
+
+</dl>
+
+### J
+
+<dl class="ml-4">
+
+</dl>
+
+### K
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+Knowledge Base
+</dt>
+<dd>
+Treat “Knowledge Base” as a proper noun and capitalize both words. Don’t abbreviate as “KB.”
+</dd>
+
+</dl>
+
+### L
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+Learn more
+</dt>
+<dd>
+Use “Learn more” when linking from the control panel to an article in the Knowledge Base.
+</dd>
+
+<dt class="font-bold mt-4">
+log in, login
+</dt>
+<dd>
+Use “log in” as a verb describing the act of entering one’s username and password to access an account.
+
+Use “login” as a noun referring to the credentials used to log in.
+
+Never use “log-in,” “sign in” or “sign-in.”
+</dd>
+
+</dl>
+
+### M
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+Multi-Storefront
+</dt>
+<dd>
+Multi-Storefront should be capitalized when talking about the specific BigCommerce solution. If speaking about the technology in general, then use lowercase "multi-storefront."
+</dd>
+
+<dt class="font-bold mt-4">
+multi-channel
+</dt>
+<dd>
+As in “multi-channel marketing” or “multi-channel fulfillment,” should be two words, hyphenated.
+</dd>
+
+</dl>
+
+### N
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+need
+</dt>
+<dd>
+Use “need” instead of “must” when referring to something merchants or shoppers “need” to do.
+</dd>
+
+</dl>
+
+### O
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+OK
+</dt>
+<dd>
+“OK” means “Yes, I want to do this.” Never use “okay” or “Ok.”
+</dd>
+
+<dt class="font-bold mt-4">
+omnichannel
+</dt>
+<dd>
+As in “omnichannel marketing,” should be one word. Don’t abbreviate as “omni.”
+</dd>
+
+<dt class="font-bold mt-4">
+onboarding
+</dt>
+<dd>
+Primarily refers to the new user workflows and helpful tips shown to merchants on the homepage of the Control Panel. Can also refer to the steps taken to connect a channel in Channel Manager.
+</dd>
+
+<dt class="font-bold mt-4">
+Optimized One-Page Checkout
+</dt>
+<dd>
+Treat as a branded, proper noun and capitalize accordingly.
+</dd>
+
+<dt class="font-bold mt-4">
+optional vs. required
+</dt>
+<dd>
+Label optional fields. Don’t label required fields. More often than not, a given settings page will have more required fields than optional fields. As such, it makes more sense to denote any optional fields as those are the ones deviating from the merchant’s expectations. Not to mention, it’s less cluttered looking than labeling all the required fields.
+
+Also keep in mind, if a given setting has a default option, it’s not an optional setting and shouldn’t be labeled as such.
+</dd>
+
+</dl>
+
+### P
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+page
+</dt>
+<dd>
+Avoid using “webpage” and “web page.” Use “page” instead.
+</dd>
+
+<dt class="font-bold mt-4">
+Page Builder
+</dt>
+<dd>
+Used to create and edit pages on a BigCommerce site. Treat Page Builder as a proper noun and capitalize accordingly.
+</dd>
+
+<dt class="font-bold mt-4">
+phone
+</dt>
+<dd>
+Use “Phone” instead of “Phone number” when labelling form fields.
+</dd>
+
+<dt class="font-bold mt-4">
+pick up, pickup
+</dt>
+<dd>
+“Pick up” is always a verb, as in “buy online, pick up in-store” or “in-store pick up” or “ready for pick up.”
+
+“Pickup” can be an adjective or a noun. For example, “pickup methods.” In this example “pickup” is acting as an adjective modifying a noun. What kind of methods are these? They are pickup methods.
+
+“Pickup” as a noun refers specifically to a type of vehicle. For example, Philip drives a pickup truck.
+
+Never use “pick-up.”
+</dd>
+
+<dt class="font-bold mt-4">
+please
+</dt>
+<dd>
+Use “please” only when asking the user to go out of their way to do something. For example, “Please update your credit card info.” Otherwise, it’s okay to just ask the user to perform basic, everyday actions.
+</dd>
+
+<dt class="font-bold mt-4">
+pre-order
+</dt>
+<dd>
+Don’t use “preorder” or “pre order.”
+</dd>
+
+<dt class="font-bold mt-4">
+product
+</dt>
+<dd>
+A virtual representation of something a merchant sells on their BigCommerce store. A catalog contains products. Products can be both physical and digital. For the latter, think music downloads, digital images, treatments, services, etc. A collection of products, sorted by the user for merchandising purposes, is called a category.
+</dd>
+
+<dt class="font-bold mt-4">
+Product Filtering
+</dt>
+<dd>
+Product Filtering is a proper noun when referring to the specific BigCommerce tool. If you’re talking about the general concept, don’t capitalize.
+</dd>
+
+</dl>
+
+### Q, R, S
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+save
+</dt>
+<dd>
+Use “save” when applying changes or saving edits to a product, customer, setting, object, item etc that already exists.
+</dd>
+
+<dt class="font-bold mt-4">
+Script Manager
+</dt>
+<dd>
+Treat as a proper noun.
+</dd>
+
+<dt class="font-bold mt-4">
+select
+</dt>
+<dd>
+Use “select” when referring to the act of selecting something in the UI, like a menu item. Avoid using “choose.”
+</dd>
+
+<dt class="font-bold mt-4">
+setup, set up
+</dt>
+<dd>
+Use “setup” (noun) when referring to an arrangement of things, usually settings. Use “set up” (verb) when referring to the act of creating a setup.
+</dd>
+
+<dt class="font-bold mt-4">
+shopper
+</dt>
+<dd>
+Use “shopper” when referring to our users’ end-user: the shopper. You can use “customer” and “shopper” interchangeably. Just keep in mind, depending on the context, there can be a subtle difference between a shopper and a customer. A shopper is a visitor to a merchant’s storefront who hasn’t necessarily purchased anything.
+</dd>
+
+<dt class="font-bold mt-4">
+Stencil
+</dt>
+<dd>
+BigCommerce’s theme engine. Stencil is a proper noun so capitalize accordingly. When referring to themes created using Stencil, use “Stencil theme.” Don’t use “Stencil Theme” or “Stencil-based theme.”
+</dd>
+
+<dt class="font-bold mt-4">
+store
+</dt>
+<dd>
+An online business built on the BigCommerce platform. Use “store” when referring to the administrative portion of a BigCommerce site and “storefront” when referring to the shopper-facing portion.
+</dd>
+
+<dt class="font-bold mt-4">
+storefront
+</dt>
+<dd>
+The shopper-facing part of a user’s online store. A store may have more than one storefront for different regions and customer segments (by way of Multi-Storefront).
+</dd>
+
+Don’t use “store-front” or “store front.”
+
+<dt class="font-bold mt-4">
+Style Editor
+</dt>
+<dd>
+The Style Editor was phased out with the introduction of Page Builder. Only use “Style Editor” when talking about legacy themes.
+</dd>
+
+<dt class="font-bold mt-4">
+subtotal
+</dt>
+<dd>
+Use “subtotal,” one word. Don’t use “sub-total.”
+</dd>
+
+<dt class="font-bold mt-4">
+Support PIN
+</dt>
+<dd>
+Don’t use “support PIN,” “support pin,” “Support Pin” or any combination thereof. Also, PIN is an acronym for personal identification number so definitely don’t use “Support PIN number” as that would be redundant. Treat Support PIN as a proper noun and capitalize accordingly.
+</dd>
+
+<dt class="font-bold mt-4">
+sync
+</dt>
+<dd>
+Use “sync” when talking about a two-way connection between applications. If two applications share data back and forth, they are syncing.
+</dd>
+
+</dl>
+
+### T
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+tap
+</dt>
+<dd>
+Use “tap” when writing instructions specifically for the mobile app. Otherwise, write around the issue with generic verbs like “choose,” “select” or “pick” instead.
+</dd>
+
+<dt class="font-bold mt-4">
+theme editor
+</dt>
+<dd>
+The theme editor was phased out with the introduction of Page Builder. Only use “theme editor” when talking about legacy themes.
+</dd>
+
+<dt class="font-bold mt-4">
+third party
+</dt>
+<dd>
+An external partner. Don’t use “third-party.”
+</dd>
+
+<dt class="font-bold mt-4">
+two-factor authentication
+</dt>
+<dd>
+If abbreviating use “2FA.”
+</dd>
+
+</dl>
+
+### U
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+username
+</dt>
+<dd>
+One word, not “user name.”
+</dd>
+
+</dl>
+
+### V
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+variations
+</dt>
+<dd>
+Different versions of the same design theme; e.g., different color schemes. To avoid confusion with product variants, don’t use “variants” or “versions” when talking about design themes.
+</dd>
+<dt class="font-bold mt-4">
+variants
+</dt>
+<dd>
+Different product options; e.g., color and size.
+</dd>
+
+<dt class="font-bold mt-4">
+view
+</dt>
+<dd>
+Use “view” when referring to the act of examining the contents of a UI item. Don’t use “read,” “open,” “preview,” “see” or “expand.”
+</dd>
+
+<dt class="font-bold mt-4">
+website
+</dt>
+<dd>
+One word, no space.
+</dd>
+
+<dt class="font-bold mt-4">
+wishlist
+</dt>
+<dd>
+Do not use wish list.
+</dd>
+
+</dl>
+
+### X, Y, Z
+
+<dl class="ml-4">
+
+<dt class="font-bold mt-4">
+ZIP code
+</dt>
+<dd>
+ZIP is an acronym so capitalize accordingly.
+</dd>
+
+<dt class="font-bold mt-4">
+Zoom2u
+</dt>
+<dd>
+Zoom2u is an on-demand, same-day express courier‎ in Australia. Treat Zoom2u as a proper noun and capitalize accordingly.
+</dd>
+</dl>

--- a/packages/docs/design-docs/ux-writing/glossary.mdx
+++ b/packages/docs/design-docs/ux-writing/glossary.mdx
@@ -1,4 +1,4 @@
-import { Dos, IconDo  } from "@components/big-design/DosAndDonts";
+import { Dos } from '@components/big-design/DosAndDonts';
 
 # Glossary
 
@@ -6,43 +6,42 @@ We know the discourse of ecommerce changes over time. If we find a word choice i
 
 ### 1, 2, 3
 
-<dl class="ml-4">
-<dt class="font-bold mt-4">
+<dl className="ml-4">
+<dt className="font-bold mt-4">
 2-step verification
 </dt>
 <dd>
 Use “2-step verification.” Don’t use “2 step verification” or “two-step verification.”
 </dd>
 
-<dt class="font-bold mt-4">
-3D Secure
-</dt>
+<dt className="font-bold mt-4">3D Secure</dt>
 <dd>
-3D Secure is a fraud protection layer available to users as long as they’re using a participating payment gateway. Treat 3D Secure as a proper noun and capitalize accordingly.
+  3D Secure is a fraud protection layer available to users as long as they’re using a participating
+  payment gateway. Treat 3D Secure as a proper noun and capitalize accordingly.
 </dd>
 
 </dl>
 
 ### A
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-able to
-</dt>
+<dt className="font-bold mt-4">able to</dt>
 <dd>
-Avoid using sentences using “You will be able to….” Instead, just say “You can….” It’s shorter and easier to scan.
+  Avoid using sentences using “You will be able to….” Instead, just say “You can….” It’s shorter and
+  easier to scan.
 </dd>
 
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 add
 </dt>
 <dd>
 Use “add” when referring to the act of putting a thing with another group of things. Compare this with “connect,” which refers to the act of joining two things together.
 
 For example, users can add products to their catalog. They can also connect their BigCommerce site with a marketplace, like Amazon or Facebook.
+
 </dd>
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 App Marketplace
 </dt>
 <dd>
@@ -53,30 +52,21 @@ App Marketplace is a proper noun. Capitalize both words.
 
 ### B
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-back
-</dt>
+<dt className="font-bold mt-4">back</dt>
 <dd>
-“Back” means, “I want to return to the previous step in this workflow without quitting the current process.” Don’t use “back” in place of “cancel.”
+  “Back” means, “I want to return to the previous step in this workflow without quitting the current
+  process.” Don’t use “back” in place of “cancel.”
 </dd>
 
-<dt class="font-bold mt-4">
-BigCommerce
-</dt>
-<dd>
-Use BigCommerce. Don’t use Bigcommerce or Big Commerce. And never abbreviate as BC.
-</dd>
+<dt className="font-bold mt-4">BigCommerce</dt>
+<dd>Use BigCommerce. Don’t use Bigcommerce or Big Commerce. And never abbreviate as BC.</dd>
 
-<dt class="font-bold mt-4">
-Buy Now, Pay Later (BNPL)
-</dt>
-<dd>
-Treat “Buy Now, Pay Later” as a branded, proper noun and use title case.
-</dd>
+<dt className="font-bold mt-4">Buy Now, Pay Later (BNPL)</dt>
+<dd>Treat “Buy Now, Pay Later” as a branded, proper noun and use title case.</dd>
 
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 buy online, pick up in-store (BOPIS)
 </dt>
 <dd>
@@ -85,52 +75,47 @@ buy online, pick up in-store (BOPIS)
 At BigCommerce, the default language for UX writing is American English. Accordingly, always use “buy online, pick up in-store.”
 
 Don’t abbreviate as BOPIS.
+
 </dd>
 
 </dl>
 
 ### C
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 cancel
 </dt>
 <dd>
 “Cancel” means, “I don’t want to do this anymore.” Any in-progress changes should be discarded as a result of clicking the button.
 
 Don’t use “stop,” “pause,” “terminate” or “nevermind” and don’t use “cancel” in place of “back.”
+
 </dd>
 
-<dt class="font-bold mt-4">
-catalog
-</dt>
+<dt className="font-bold mt-4">catalog</dt>
 <dd>
-A catalog is a collection of virtual representations of a merchant’s saleable products for a channel, stored within the BigCommerce platform. A catalog contains products. Products can be both physical and digital. For the latter, think music downloads, digital images, treatments, services, etc. A collection of products, sorted by the user for merchandising purposes, is called a category.
+  A catalog is a collection of virtual representations of a merchant’s saleable products for a
+  channel, stored within the BigCommerce platform. A catalog contains products. Products can be both
+  physical and digital. For the latter, think music downloads, digital images, treatments, services,
+  etc. A collection of products, sorted by the user for merchandising purposes, is called a
+  category.
 </dd>
 
-<dt class="font-bold mt-4">
-category
-</dt>
+<dt className="font-bold mt-4">category</dt>
+<dd>A collection of products, sorted by the user for merchandising purposes.</dd>
+
+<dt className="font-bold mt-4">channel</dt>
 <dd>
-A collection of products, sorted by the user for merchandising purposes.
+  A place where a BigCommerce user can market and sell goods. Channels include storefronts,
+  marketplaces, advertising and social media.
 </dd>
 
-<dt class="font-bold mt-4">
-channel
-</dt>
-<dd>
-A place where a BigCommerce user can market and sell goods. Channels include storefronts, marketplaces, advertising and social media.
-</dd>
+<dt className="font-bold mt-4">Channel Manager</dt>
+<dd>Channel Manager is a proper noun. Capitalize both words.</dd>
 
-<dt class="font-bold mt-4">
-Channel Manager
-</dt>
-<dd>
-Channel Manager is a proper noun. Capitalize both words.
-</dd>
-
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 check out, checkout
 </dt>
 <dd>
@@ -141,43 +126,38 @@ Use checkout (noun) when talking about the place shoppers go to pay for items an
 Use checkout (adjective) when describing the type of page or process.
 
 Never use check-out.
+
 </dd>
 
 <Dos>
-<div class="hidden">
-Do
-</div>
- - Ready to check out?
- - When you’re done shopping, proceed to the checkout.
- - Navigate to the checkout page.
+  <div className="hidden">Do</div>- Ready to check out? - When you’re done shopping, proceed to the
+  checkout. - Navigate to the checkout page.
 </Dos>
 
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 click
 </dt>
 <dd>
 Since we don’t know if a user is on a desktop or mobile device, avoid using “click” when instructing the user on how to complete an action within the UI. Whenever possible, write around the issue with generic verbs like “choose,” “select” or “pick.”
 
 Avoid using “hit."
+
 </dd>
 
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 clickthrough, click-through
 </dt>
 <dd>
 Use “clickthrough” (noun) when referring to an instance or multiple instances of clickthrough. Use “click through” (verb) when referring to the act of following a link or button to another site or location.
 
 Don’t use “click-through.”
+
 </dd>
 
-<dt class="font-bold mt-4">
-close
-</dt>
-<dd>
-Use “close” instead of “exit” for modals and pop-ups.
-</dd>
+<dt className="font-bold mt-4">close</dt>
+<dd>Use “close” instead of “exit” for modals and pop-ups.</dd>
 
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 connect
 </dt>
 <dd>
@@ -186,221 +166,184 @@ Use “connect” when referring to the act of joining two things together. Comp
 For example, users can add products to their catalog. They can also connect their BigCommerce site with a marketplace, like Amazon or Facebook.
 
 When writing about an integration between BigCommerce and another third party technology, you’ll probably be using “connect.”
+
 </dd>
 
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 continue
 </dt>
 <dd>
 “Continue” means “I want to go forward a step in this workflow,” like an onboarding, for example.
 
 Do not use “next.”
+
 </dd>
 
-<dt class="font-bold mt-4">
-control panel
-</dt>
+<dt className="font-bold mt-4">control panel</dt>
 <dd>
-Control panel is not a proper noun. No need to capitalize. Of course, always capitalize the first letter of the first word if it appears at the start of a sentence. Keep in mind, there are very few instances when you’ll need to refer to the control panel by name. Most of the time you’ll just say “store.”
+  Control panel is not a proper noun. No need to capitalize. Of course, always capitalize the first
+  letter of the first word if it appears at the start of a sentence. Keep in mind, there are very
+  few instances when you’ll need to refer to the control panel by name. Most of the time you’ll just
+  say “store.”
 </dd>
 
-<dt class="font-bold mt-4">
-create
-</dt>
+<dt className="font-bold mt-4">create</dt>
 <dd>
-Use “create,” as opposed to “save,” as the CTA when creating a product, customer, setting, object, item etc. for the first time. When making changes to something that already exists, use “save” as the CTA.
+  Use “create,” as opposed to “save,” as the CTA when creating a product, customer, setting, object,
+  item etc. for the first time. When making changes to something that already exists, use “save” as
+  the CTA.
 </dd>
 
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 customer
 </dt>
 <dd>
 Use “customer” when referring to our users’ end-user: the customer. You can use “customer” and “shopper” interchangeably. Just keep in mind, depending on the context, there can be a subtle difference between a shopper and a customer. A shopper is a visitor to a merchant’s storefront who hasn’t necessarily purchased anything.
 
 To avoid confusion, try not to use “customer” to refer to BigCommerce clients. Use “merchant,” “retailer” or “brand” instead.
+
 </dd>
 
 </dl>
 
 ### D
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-delete
-</dt>
+<dt className="font-bold mt-4">delete</dt>
+<dd>Use “delete” for destructive behaviors. Don’t use “remove” or “dismiss.”</dd>
+
+<dt className="font-bold mt-4">deploy</dt>
 <dd>
-Use “delete” for destructive behaviors. Don’t use “remove” or “dismiss.”
+  Use “deploy” when talking about a one-way connection between applications. If one application
+  sends data to another, one time or on an occasional basis, it’s deploying.
 </dd>
 
-<dt class="font-bold mt-4">
-deploy
-</dt>
+<dt className="font-bold mt-4">details</dt>
+<dd>On its own, as a clickable, UI item, use “details.” Don’t use “information” or “info.”</dd>
+
+<dt className="font-bold mt-4">Dev Center</dt>
 <dd>
-Use “deploy” when talking about a one-way connection between applications. If one application sends data to another, one time or on an occasional basis, it’s deploying.
+  A resource center for developers looking to make their own solutions using the BigCommerce
+  platform. Dev Center is a proper noun, so capitalize both words.
 </dd>
 
-<dt class="font-bold mt-4">
-details
-</dt>
+<dt className="font-bold mt-4">disable</dt>
 <dd>
-On its own, as a clickable, UI item, use “details.” Don’t use “information” or “info.”
-</dd>
-
-<dt class="font-bold mt-4">
-Dev Center
-</dt>
-<dd>
-A resource center for developers looking to make their own solutions using the BigCommerce platform. Dev Center is a proper noun, so capitalize both words.
-</dd>
-
-<dt class="font-bold mt-4">
-disable
-</dt>
-<dd>
-Use “disable” when referring to the act of turning something off. Don’t use “turn off” or “deactivate.”
+  Use “disable” when referring to the act of turning something off. Don’t use “turn off” or
+  “deactivate.”
 </dd>
 
 </dl>
 
 ### E
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-ecommerce
-</dt>
+<dt className="font-bold mt-4">ecommerce</dt>
 <dd>
-Use “ecommerce” (or "Ecommerce" if at the start of a sentence). Never use “e-commerce” or “eCommerce.”
+  Use “ecommerce” (or "Ecommerce" if at the start of a sentence). Never use “e-commerce” or
+  “eCommerce.”
 </dd>
 
-<dt class="font-bold mt-4">
-edit
-</dt>
+<dt className="font-bold mt-4">edit</dt>
 <dd>
-Use “edit” when referring to the act of changing previously entered information. Don’t use “change,” “modify,” “update” or “manage.”
+  Use “edit” when referring to the act of changing previously entered information. Don’t use
+  “change,” “modify,” “update” or “manage.”
 </dd>
 
-<dt class="font-bold mt-4">
-email
-</dt>
-<dd>
-Do not use “e-mail.” For form field labeling use “Email” instead of “Email address.”
-</dd>
+<dt className="font-bold mt-4">email</dt>
+<dd>Do not use “e-mail.” For form field labeling use “Email” instead of “Email address.”</dd>
 
-<dt class="font-bold mt-4">
-enable
-</dt>
+<dt className="font-bold mt-4">enable</dt>
 <dd>
-Use “enable” when referring to the act of turning something on. Don’t use “activate,” “deactivate,” “turn on” or “turn off.”
+  Use “enable” when referring to the act of turning something on. Don’t use “activate,”
+  “deactivate,” “turn on” or “turn off.”
 </dd>
 
 </dl>
 
 ### F
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-finish
-</dt>
+<dt className="font-bold mt-4">finish</dt>
 <dd>
-Use “finish” as the final CTA in a multi-step workflow, like an onboarding flow, for example.
+  Use “finish” as the final CTA in a multi-step workflow, like an onboarding flow, for example.
 </dd>
 
 </dl>
 
 ### G
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-got it
-</dt>
+<dt className="font-bold mt-4">got it</dt>
 <dd>
-“Got it” means “I understand.” Clicking “got it” is merely an acknowledgment on the part of the user. No change or action should take place as a result of clicking the button.
+  “Got it” means “I understand.” Clicking “got it” is merely an acknowledgment on the part of the
+  user. No change or action should take place as a result of clicking the button.
 </dd>
 
 </dl>
 
 ### H
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-headless
-</dt>
+<dt className="font-bold mt-4">headless</dt>
 <dd>
-A technology stack that uses a third party solution to create and maintain the shopper-facing front-end of a user’s store, while using BigCommerce for the administrative back-end.
+  A technology stack that uses a third party solution to create and maintain the shopper-facing
+  front-end of a user’s store, while using BigCommerce for the administrative back-end.
 </dd>
 
-<dt class="font-bold mt-4">
-homepage
-</dt>
-<dd>
-Use “homepage,” one word, not “home page.”
-</dd>
+<dt className="font-bold mt-4">homepage</dt>
+<dd>Use “homepage,” one word, not “home page.”</dd>
 
 </dl>
 
 ### I
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-in stock
-</dt>
+<dt className="font-bold mt-4">in stock</dt>
+<dd>No hyphen.</dd>
+
+<dt className="font-bold mt-4">in-store</dt>
 <dd>
-No hyphen.
+  Use “in-store” when describing where something exists or takes place; e.g., “pick up in-store” or
+  “in-store special.” Don’t use “in store.”
 </dd>
 
-<dt class="font-bold mt-4">
-in-store
-</dt>
-<dd>
-Use “in-store” when describing where something exists or takes place; e.g., “pick up in-store” or “in-store special.” Don’t use “in store.”
-</dd>
-
-<dt class="font-bold mt-4">
-internet
-</dt>
-<dd>
-Do not capitalize unless at the start of a sentence.
-</dd>
+<dt className="font-bold mt-4">internet</dt>
+<dd>Do not capitalize unless at the start of a sentence.</dd>
 
 </dl>
 
 ### J
 
-<dl class="ml-4">
+<dl className="ml-4">
 
 </dl>
 
 ### K
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-Knowledge Base
-</dt>
+<dt className="font-bold mt-4">Knowledge Base</dt>
 <dd>
-Treat “Knowledge Base” as a proper noun and capitalize both words. Don’t abbreviate as “KB.”
+  Treat “Knowledge Base” as a proper noun and capitalize both words. Don’t abbreviate as “KB.”
 </dd>
 
 </dl>
 
 ### L
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-Learn more
-</dt>
-<dd>
-Use “Learn more” when linking from the control panel to an article in the Knowledge Base.
-</dd>
+<dt className="font-bold mt-4">Learn more</dt>
+<dd>Use “Learn more” when linking from the control panel to an article in the Knowledge Base.</dd>
 
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 log in, login
 </dt>
 <dd>
@@ -409,112 +352,87 @@ Use “log in” as a verb describing the act of entering one’s username and p
 Use “login” as a noun referring to the credentials used to log in.
 
 Never use “log-in,” “sign in” or “sign-in.”
+
 </dd>
 
 </dl>
 
 ### M
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-Multi-Storefront
-</dt>
+<dt className="font-bold mt-4">Multi-Storefront</dt>
 <dd>
-Multi-Storefront should be capitalized when talking about the specific BigCommerce solution. If speaking about the technology in general, then use lowercase "multi-storefront."
+  Multi-Storefront should be capitalized when talking about the specific BigCommerce solution. If
+  speaking about the technology in general, then use lowercase "multi-storefront."
 </dd>
 
-<dt class="font-bold mt-4">
-multi-channel
-</dt>
+<dt className="font-bold mt-4">multi-channel</dt>
 <dd>
-As in “multi-channel marketing” or “multi-channel fulfillment,” should be two words, hyphenated.
+  As in “multi-channel marketing” or “multi-channel fulfillment,” should be two words, hyphenated.
 </dd>
 
 </dl>
 
 ### N
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-need
-</dt>
+<dt className="font-bold mt-4">need</dt>
 <dd>
-Use “need” instead of “must” when referring to something merchants or shoppers “need” to do.
+  Use “need” instead of “must” when referring to something merchants or shoppers “need” to do.
 </dd>
 
 </dl>
 
 ### O
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-OK
-</dt>
+<dt className="font-bold mt-4">OK</dt>
+<dd>“OK” means “Yes, I want to do this.” Never use “okay” or “Ok.”</dd>
+
+<dt className="font-bold mt-4">omnichannel</dt>
+<dd>As in “omnichannel marketing,” should be one word. Don’t abbreviate as “omni.”</dd>
+
+<dt className="font-bold mt-4">onboarding</dt>
 <dd>
-“OK” means “Yes, I want to do this.” Never use “okay” or “Ok.”
+  Primarily refers to the new user workflows and helpful tips shown to merchants on the homepage of
+  the Control Panel. Can also refer to the steps taken to connect a channel in Channel Manager.
 </dd>
 
-<dt class="font-bold mt-4">
-omnichannel
-</dt>
-<dd>
-As in “omnichannel marketing,” should be one word. Don’t abbreviate as “omni.”
-</dd>
+<dt className="font-bold mt-4">Optimized One-Page Checkout</dt>
+<dd>Treat as a branded, proper noun and capitalize accordingly.</dd>
 
-<dt class="font-bold mt-4">
-onboarding
-</dt>
-<dd>
-Primarily refers to the new user workflows and helpful tips shown to merchants on the homepage of the Control Panel. Can also refer to the steps taken to connect a channel in Channel Manager.
-</dd>
-
-<dt class="font-bold mt-4">
-Optimized One-Page Checkout
-</dt>
-<dd>
-Treat as a branded, proper noun and capitalize accordingly.
-</dd>
-
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 optional vs. required
 </dt>
 <dd>
 Label optional fields. Don’t label required fields. More often than not, a given settings page will have more required fields than optional fields. As such, it makes more sense to denote any optional fields as those are the ones deviating from the merchant’s expectations. Not to mention, it’s less cluttered looking than labeling all the required fields.
 
 Also keep in mind, if a given setting has a default option, it’s not an optional setting and shouldn’t be labeled as such.
+
 </dd>
 
 </dl>
 
 ### P
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-page
-</dt>
+<dt className="font-bold mt-4">page</dt>
+<dd>Avoid using “webpage” and “web page.” Use “page” instead.</dd>
+
+<dt className="font-bold mt-4">Page Builder</dt>
 <dd>
-Avoid using “webpage” and “web page.” Use “page” instead.
+  Used to create and edit pages on a BigCommerce site. Treat Page Builder as a proper noun and
+  capitalize accordingly.
 </dd>
 
-<dt class="font-bold mt-4">
-Page Builder
-</dt>
-<dd>
-Used to create and edit pages on a BigCommerce site. Treat Page Builder as a proper noun and capitalize accordingly.
-</dd>
+<dt className="font-bold mt-4">phone</dt>
+<dd>Use “Phone” instead of “Phone number” when labelling form fields.</dd>
 
-<dt class="font-bold mt-4">
-phone
-</dt>
-<dd>
-Use “Phone” instead of “Phone number” when labelling form fields.
-</dd>
-
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 pick up, pickup
 </dt>
 <dd>
@@ -525,229 +443,181 @@ pick up, pickup
 “Pickup” as a noun refers specifically to a type of vehicle. For example, Philip drives a pickup truck.
 
 Never use “pick-up.”
+
 </dd>
 
-<dt class="font-bold mt-4">
-please
-</dt>
+<dt className="font-bold mt-4">please</dt>
 <dd>
-Use “please” only when asking the user to go out of their way to do something. For example, “Please update your credit card info.” Otherwise, it’s okay to just ask the user to perform basic, everyday actions.
+  Use “please” only when asking the user to go out of their way to do something. For example,
+  “Please update your credit card info.” Otherwise, it’s okay to just ask the user to perform basic,
+  everyday actions.
 </dd>
 
-<dt class="font-bold mt-4">
-pre-order
-</dt>
+<dt className="font-bold mt-4">pre-order</dt>
+<dd>Don’t use “preorder” or “pre order.”</dd>
+
+<dt className="font-bold mt-4">product</dt>
 <dd>
-Don’t use “preorder” or “pre order.”
+  A virtual representation of something a merchant sells on their BigCommerce store. A catalog
+  contains products. Products can be both physical and digital. For the latter, think music
+  downloads, digital images, treatments, services, etc. A collection of products, sorted by the user
+  for merchandising purposes, is called a category.
 </dd>
 
-<dt class="font-bold mt-4">
-product
-</dt>
+<dt className="font-bold mt-4">Product Filtering</dt>
 <dd>
-A virtual representation of something a merchant sells on their BigCommerce store. A catalog contains products. Products can be both physical and digital. For the latter, think music downloads, digital images, treatments, services, etc. A collection of products, sorted by the user for merchandising purposes, is called a category.
-</dd>
-
-<dt class="font-bold mt-4">
-Product Filtering
-</dt>
-<dd>
-Product Filtering is a proper noun when referring to the specific BigCommerce tool. If you’re talking about the general concept, don’t capitalize.
+  Product Filtering is a proper noun when referring to the specific BigCommerce tool. If you’re
+  talking about the general concept, don’t capitalize.
 </dd>
 
 </dl>
 
 ### Q, R, S
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-save
-</dt>
+<dt className="font-bold mt-4">save</dt>
 <dd>
-Use “save” when applying changes or saving edits to a product, customer, setting, object, item etc that already exists.
+  Use “save” when applying changes or saving edits to a product, customer, setting, object, item etc
+  that already exists.
 </dd>
 
-<dt class="font-bold mt-4">
-Script Manager
-</dt>
+<dt className="font-bold mt-4">Script Manager</dt>
+<dd>Treat as a proper noun.</dd>
+
+<dt className="font-bold mt-4">select</dt>
 <dd>
-Treat as a proper noun.
+  Use “select” when referring to the act of selecting something in the UI, like a menu item. Avoid
+  using “choose.”
 </dd>
 
-<dt class="font-bold mt-4">
-select
-</dt>
+<dt className="font-bold mt-4">setup, set up</dt>
 <dd>
-Use “select” when referring to the act of selecting something in the UI, like a menu item. Avoid using “choose.”
+  Use “setup” (noun) when referring to an arrangement of things, usually settings. Use “set up”
+  (verb) when referring to the act of creating a setup.
 </dd>
 
-<dt class="font-bold mt-4">
-setup, set up
-</dt>
+<dt className="font-bold mt-4">shopper</dt>
 <dd>
-Use “setup” (noun) when referring to an arrangement of things, usually settings. Use “set up” (verb) when referring to the act of creating a setup.
+  Use “shopper” when referring to our users’ end-user: the shopper. You can use “customer” and
+  “shopper” interchangeably. Just keep in mind, depending on the context, there can be a subtle
+  difference between a shopper and a customer. A shopper is a visitor to a merchant’s storefront who
+  hasn’t necessarily purchased anything.
 </dd>
 
-<dt class="font-bold mt-4">
-shopper
-</dt>
+<dt className="font-bold mt-4">Stencil</dt>
 <dd>
-Use “shopper” when referring to our users’ end-user: the shopper. You can use “customer” and “shopper” interchangeably. Just keep in mind, depending on the context, there can be a subtle difference between a shopper and a customer. A shopper is a visitor to a merchant’s storefront who hasn’t necessarily purchased anything.
+  BigCommerce’s theme engine. Stencil is a proper noun so capitalize accordingly. When referring to
+  themes created using Stencil, use “Stencil theme.” Don’t use “Stencil Theme” or “Stencil-based
+  theme.”
 </dd>
 
-<dt class="font-bold mt-4">
-Stencil
-</dt>
+<dt className="font-bold mt-4">store</dt>
 <dd>
-BigCommerce’s theme engine. Stencil is a proper noun so capitalize accordingly. When referring to themes created using Stencil, use “Stencil theme.” Don’t use “Stencil Theme” or “Stencil-based theme.”
+  An online business built on the BigCommerce platform. Use “store” when referring to the
+  administrative portion of a BigCommerce site and “storefront” when referring to the shopper-facing
+  portion.
 </dd>
 
-<dt class="font-bold mt-4">
-store
-</dt>
+<dt className="font-bold mt-4">storefront</dt>
 <dd>
-An online business built on the BigCommerce platform. Use “store” when referring to the administrative portion of a BigCommerce site and “storefront” when referring to the shopper-facing portion.
-</dd>
-
-<dt class="font-bold mt-4">
-storefront
-</dt>
-<dd>
-The shopper-facing part of a user’s online store. A store may have more than one storefront for different regions and customer segments (by way of Multi-Storefront).
+  The shopper-facing part of a user’s online store. A store may have more than one storefront for
+  different regions and customer segments (by way of Multi-Storefront).
 </dd>
 
 Don’t use “store-front” or “store front.”
 
-<dt class="font-bold mt-4">
-Style Editor
-</dt>
+<dt className="font-bold mt-4">Style Editor</dt>
 <dd>
-The Style Editor was phased out with the introduction of Page Builder. Only use “Style Editor” when talking about legacy themes.
+  The Style Editor was phased out with the introduction of Page Builder. Only use “Style Editor”
+  when talking about legacy themes.
 </dd>
 
-<dt class="font-bold mt-4">
-subtotal
-</dt>
+<dt className="font-bold mt-4">subtotal</dt>
+<dd>Use “subtotal,” one word. Don’t use “sub-total.”</dd>
+
+<dt className="font-bold mt-4">Support PIN</dt>
 <dd>
-Use “subtotal,” one word. Don’t use “sub-total.”
+  Don’t use “support PIN,” “support pin,” “Support Pin” or any combination thereof. Also, PIN is an
+  acronym for personal identification number so definitely don’t use “Support PIN number” as that
+  would be redundant. Treat Support PIN as a proper noun and capitalize accordingly.
 </dd>
 
-<dt class="font-bold mt-4">
-Support PIN
-</dt>
+<dt className="font-bold mt-4">sync</dt>
 <dd>
-Don’t use “support PIN,” “support pin,” “Support Pin” or any combination thereof. Also, PIN is an acronym for personal identification number so definitely don’t use “Support PIN number” as that would be redundant. Treat Support PIN as a proper noun and capitalize accordingly.
-</dd>
-
-<dt class="font-bold mt-4">
-sync
-</dt>
-<dd>
-Use “sync” when talking about a two-way connection between applications. If two applications share data back and forth, they are syncing.
+  Use “sync” when talking about a two-way connection between applications. If two applications share
+  data back and forth, they are syncing.
 </dd>
 
 </dl>
 
 ### T
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-tap
-</dt>
+<dt className="font-bold mt-4">tap</dt>
 <dd>
-Use “tap” when writing instructions specifically for the mobile app. Otherwise, write around the issue with generic verbs like “choose,” “select” or “pick” instead.
+  Use “tap” when writing instructions specifically for the mobile app. Otherwise, write around the
+  issue with generic verbs like “choose,” “select” or “pick” instead.
 </dd>
 
-<dt class="font-bold mt-4">
-theme editor
-</dt>
+<dt className="font-bold mt-4">theme editor</dt>
 <dd>
-The theme editor was phased out with the introduction of Page Builder. Only use “theme editor” when talking about legacy themes.
+  The theme editor was phased out with the introduction of Page Builder. Only use “theme editor”
+  when talking about legacy themes.
 </dd>
 
-<dt class="font-bold mt-4">
-third party
-</dt>
-<dd>
-An external partner. Don’t use “third-party.”
-</dd>
+<dt className="font-bold mt-4">third party</dt>
+<dd>An external partner. Don’t use “third-party.”</dd>
 
-<dt class="font-bold mt-4">
-two-factor authentication
-</dt>
-<dd>
-If abbreviating use “2FA.”
-</dd>
+<dt className="font-bold mt-4">two-factor authentication</dt>
+<dd>If abbreviating use “2FA.”</dd>
 
 </dl>
 
 ### U
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-username
-</dt>
-<dd>
-One word, not “user name.”
-</dd>
+<dt className="font-bold mt-4">username</dt>
+<dd>One word, not “user name.”</dd>
 
 </dl>
 
 ### V
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-variations
-</dt>
+<dt className="font-bold mt-4">variations</dt>
 <dd>
-Different versions of the same design theme; e.g., different color schemes. To avoid confusion with product variants, don’t use “variants” or “versions” when talking about design themes.
+  Different versions of the same design theme; e.g., different color schemes. To avoid confusion
+  with product variants, don’t use “variants” or “versions” when talking about design themes.
 </dd>
-<dt class="font-bold mt-4">
-variants
-</dt>
-<dd>
-Different product options; e.g., color and size.
-</dd>
+<dt className="font-bold mt-4">variants</dt>
+<dd>Different product options; e.g., color and size.</dd>
 
-<dt class="font-bold mt-4">
-view
-</dt>
+<dt className="font-bold mt-4">view</dt>
 <dd>
-Use “view” when referring to the act of examining the contents of a UI item. Don’t use “read,” “open,” “preview,” “see” or “expand.”
+  Use “view” when referring to the act of examining the contents of a UI item. Don’t use “read,”
+  “open,” “preview,” “see” or “expand.”
 </dd>
 
-<dt class="font-bold mt-4">
-website
-</dt>
-<dd>
-One word, no space.
-</dd>
+<dt className="font-bold mt-4">website</dt>
+<dd>One word, no space.</dd>
 
-<dt class="font-bold mt-4">
-wishlist
-</dt>
-<dd>
-Do not use wish list.
-</dd>
+<dt className="font-bold mt-4">wishlist</dt>
+<dd>Do not use wish list.</dd>
 
 </dl>
 
 ### X, Y, Z
 
-<dl class="ml-4">
+<dl className="ml-4">
 
-<dt class="font-bold mt-4">
-ZIP code
-</dt>
-<dd>
-ZIP is an acronym so capitalize accordingly.
-</dd>
+<dt className="font-bold mt-4">ZIP code</dt>
+<dd>ZIP is an acronym so capitalize accordingly.</dd>
 
-<dt class="font-bold mt-4">
+<dt className="font-bold mt-4">
 Zoom2u
 </dt>
 <dd>

--- a/packages/docs/design-docs/ux-writing/grammar.mdx
+++ b/packages/docs/design-docs/ux-writing/grammar.mdx
@@ -1,6 +1,6 @@
-import Icon from "@components/icons/Icon";
-import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
-import { ComparisonTable } from "@components/big-design/ComparisonTable";
+import { ComparisonTable } from '@components/big-design/ComparisonTable';
+import { Donts, Dos, DosAndDonts } from '@components/big-design/DosAndDonts';
+import Icon from '@components/icons/Icon';
 
 # Grammar
 
@@ -9,52 +9,45 @@ import { ComparisonTable } from "@components/big-design/ComparisonTable";
 Contractions are handy for adjusting your tone. Using them makes your writing sound more casual. Not using them makes your writing sound more formal. That said, if you wouldn’t use the contraction in everyday speech, avoid using it in your writing. And while BigCommerce is a Texas company, let’s avoid “y’all,” y’all.
 
 <DosAndDonts>
-<Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-Aren’t, can’t, couldn’t, could’ve, didn’t, don’t, doesn’t, hasn’t, haven’t, isn’t, let’s, shouldn’t, should’ve, that’s, there’s, they’re, we’ll, weren’t, we’ve, wasn’t, won’t, wouldn’t, you’ll, you’re
-</div>
-</Dos>
-<Donts hideHeader={true}>
-<div class="hidden">
-**Don't**
-</div>
-<div>
-Ain’t, e’er, mightn’t, mustn’t, o’clock, shan’t, ‘twas, y’all
-</div>
-</Donts>
+  <Dos hideHeader={true}>
+    <div className="hidden">**Do**</div>
+    <div>
+      Aren’t, can’t, couldn’t, could’ve, didn’t, don’t, doesn’t, hasn’t, haven’t, isn’t, let’s,
+      shouldn’t, should’ve, that’s, there’s, they’re, we’ll, weren’t, we’ve, wasn’t, won’t,
+      wouldn’t, you’ll, you’re
+    </div>
+  </Dos>
+  <Donts hideHeader={true}>
+    <div className="hidden">**Don't**</div>
+    <div>Ain’t, e’er, mightn’t, mustn’t, o’clock, shan’t, ‘twas, y’all</div>
+  </Donts>
 </DosAndDonts>
 
 ## Numbers
 
 Always use numerals (1, 2, 3, etc.) instead of writing out numbers (one, two, three, etc.). This is a big departure from traditional writing style. Keep in mind, you're writing for the web and the old rules were made with print in mind.
 
-From [Nielsen Norman Group <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.nngroup.com/articles/web-writing-show-numbers-as-numerals/ "https://www.nngroup.com/articles/web-writing-show-numbers-as-numerals/") (NN/g):
+From [Nielsen Norman Group <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.nngroup.com/articles/web-writing-show-numbers-as-numerals/ 'https://www.nngroup.com/articles/web-writing-show-numbers-as-numerals/') (NN/g):
 
 > **When writing for the Web:**
-> 
+>
 > - Write numbers with digits, not letters (23, not twenty-three).
-> 
+>
 > - Use numerals even when the number is the first word in a sentence or bullet point.
-> 
+>
 > - Use numerals for big numbers up to one billion:
+>
 >   - 2,000,000 is better than two million.
-> 
+>
 >   - Two trillion is better than 2,000,000,000,000 because most people can't interpret that many zeros.
-> 
+>
 >   - As a compromise, you can often use numerals for the significant digits and write out the magnitude as a word. For example, write 24 billion (not twenty-four billion or 24,000,000,000).
 
 NN/g still recommends writing out numbers that don’t represent specific data. In the example below, it’s better to write out “thousands” than “1000s.”
 
 <Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-Thousands of online stores are created using BigCommerce every year.
-</div>
+  <div className="hidden">**Do**</div>
+  <div>Thousands of online stores are created using BigCommerce every year.</div>
 </Dos>
 
 ## Active vs. passive voice
@@ -62,57 +55,40 @@ Thousands of online stores are created using BigCommerce every year.
 Try to use the active voice. It’s simpler and more direct than the passive voice. Not sure what the difference is between active and passive? Here are some examples:
 
 <ComparisonTable>
-| Active | Passive |
-| --- | --- |
-| Choose a payment method | Choose the preferred payment method |
-| We recommend… | It is recommended… |
-| Turn on the setting | The setting should be turned on |
+  | Active | Passive | | --- | --- | | Choose a payment method | Choose the preferred payment method
+  | | We recommend… | It is recommended… | | Turn on the setting | The setting should be turned on |
 </ComparisonTable>
 
 As you can see, with the passive voice it’s not clear who the subject is and who’s doing the acting. It’s indirect, confusing and wordy. Granted, writing in the active voice can sometimes feel too direct, even a little bossy. Users, however, appreciate it when you give them the info they need without a lot of fluff.
 
 Of course, there are exceptions to the rule. Here’s when it might be okay to use the passive voice:
 
- -   To avoid referencing BigCommerce or your app by name when doing so would be distracting
-    
- -   To make it clear that BigCommerce or your app didn’t personally take an action or make a decision; rather, the software took the action
-    
- -   If the object or the action are more important than the subject doing the action
+- To avoid referencing BigCommerce or your app by name when doing so would be distracting
+
+- To make it clear that BigCommerce or your app didn’t personally take an action or make a decision; rather, the software took the action
+
+- If the object or the action are more important than the subject doing the action
 
 <DosAndDonts>
-<Dos hideHeader={true}>
-BigCommerce will create and email your invoices monthly to
-</Dos>
-<Donts hideHeader={true}>
-BigCommerce creates and emails your invoices monthly to philip@nomail.com.
-</Donts>
+  <Dos hideHeader={true}>BigCommerce will create and email your invoices monthly to</Dos>
+  <Donts hideHeader={true}>
+    BigCommerce creates and emails your invoices monthly to philip@nomail.com.
+  </Donts>
 </DosAndDonts>
-
 
 ## Pluralities
 
 A plurality occurs when the copy changes depending on the number of items you’re writing about. Whenever possible, write unique copy for the singular and plural forms, displaying the appropriate version as needed. If the possibility of a plural exists, but technological limitations prevent you from using variable copy, then default to the plural form.
 
-
 <DosAndDonts>
-<Dos>
-<div class="hidden">
-**Do**
-</div>
-<div>
- - You have a new message.
- - You have 10 new messages.
-</div>
-</Dos>
-<Donts>
-<div class="hidden">
-**Don't**
-</div>
-<div>
- - You have a new message or messages.
- - You have a new message(s)
-</div>
-</Donts>
+  <Dos>
+    <div className="hidden">**Do**</div>
+    <div>- You have a new message. - You have 10 new messages.</div>
+  </Dos>
+  <Donts>
+    <div className="hidden">**Don't**</div>
+    <div>- You have a new message or messages. - You have a new message(s)</div>
+  </Donts>
 </DosAndDonts>
 
 ## Present vs. past tense
@@ -124,27 +100,14 @@ For confirmation, success and error messages it’s okay to use the past partici
 Past participles usually end with “-ed,” “-d,” “-t,” “-en” or “-n.”
 
 <DosAndDonts>
-<Dos>
-<div class="hidden">
-**Do**
-</div>
-<div>
- - Settings saved
- - App installed
- - Payment failed
- - Message sent
-</div>
-</Dos>
-<Donts>
-<div class="hidden">
-**Don't**
-</div>
-<div>
- - Settings have been saved
- - App was installed
- - Payment has failed
- - Message was sent
-</div>
-</Donts>
+  <Dos>
+    <div className="hidden">**Do**</div>
+    <div>- Settings saved - App installed - Payment failed - Message sent</div>
+  </Dos>
+  <Donts>
+    <div className="hidden">**Don't**</div>
+    <div>
+      - Settings have been saved - App was installed - Payment has failed - Message was sent
+    </div>
+  </Donts>
 </DosAndDonts>
-

--- a/packages/docs/design-docs/ux-writing/grammar.mdx
+++ b/packages/docs/design-docs/ux-writing/grammar.mdx
@@ -1,0 +1,150 @@
+import Icon from "@components/icons/Icon";
+import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
+import { ComparisonTable } from "@components/big-design/ComparisonTable";
+
+# Grammar
+
+## Contractions
+
+Contractions are handy for adjusting your tone. Using them makes your writing sound more casual. Not using them makes your writing sound more formal. That said, if you wouldn’t use the contraction in everyday speech, avoid using it in your writing. And while BigCommerce is a Texas company, let’s avoid “y’all,” y’all.
+
+<DosAndDonts>
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+Aren’t, can’t, couldn’t, could’ve, didn’t, don’t, doesn’t, hasn’t, haven’t, isn’t, let’s, shouldn’t, should’ve, that’s, there’s, they’re, we’ll, weren’t, we’ve, wasn’t, won’t, wouldn’t, you’ll, you’re
+</div>
+</Dos>
+<Donts hideHeader={true}>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+Ain’t, e’er, mightn’t, mustn’t, o’clock, shan’t, ‘twas, y’all
+</div>
+</Donts>
+</DosAndDonts>
+
+## Numbers
+
+Always use numerals (1, 2, 3, etc.) instead of writing out numbers (one, two, three, etc.). This is a big departure from traditional writing style. Keep in mind, you're writing for the web and the old rules were made with print in mind.
+
+From [Nielsen Norman Group <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.nngroup.com/articles/web-writing-show-numbers-as-numerals/ "https://www.nngroup.com/articles/web-writing-show-numbers-as-numerals/") (NN/g):
+
+> **When writing for the Web:**
+> 
+> - Write numbers with digits, not letters (23, not twenty-three).
+> 
+> - Use numerals even when the number is the first word in a sentence or bullet point.
+> 
+> - Use numerals for big numbers up to one billion:
+>   - 2,000,000 is better than two million.
+> 
+>   - Two trillion is better than 2,000,000,000,000 because most people can't interpret that many zeros.
+> 
+>   - As a compromise, you can often use numerals for the significant digits and write out the magnitude as a word. For example, write 24 billion (not twenty-four billion or 24,000,000,000).
+
+NN/g still recommends writing out numbers that don’t represent specific data. In the example below, it’s better to write out “thousands” than “1000s.”
+
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+Thousands of online stores are created using BigCommerce every year.
+</div>
+</Dos>
+
+## Active vs. passive voice
+
+Try to use the active voice. It’s simpler and more direct than the passive voice. Not sure what the difference is between active and passive? Here are some examples:
+
+<ComparisonTable>
+| Active | Passive |
+| --- | --- |
+| Choose a payment method | Choose the preferred payment method |
+| We recommend… | It is recommended… |
+| Turn on the setting | The setting should be turned on |
+</ComparisonTable>
+
+As you can see, with the passive voice it’s not clear who the subject is and who’s doing the acting. It’s indirect, confusing and wordy. Granted, writing in the active voice can sometimes feel too direct, even a little bossy. Users, however, appreciate it when you give them the info they need without a lot of fluff.
+
+Of course, there are exceptions to the rule. Here’s when it might be okay to use the passive voice:
+
+ -   To avoid referencing BigCommerce or your app by name when doing so would be distracting
+    
+ -   To make it clear that BigCommerce or your app didn’t personally take an action or make a decision; rather, the software took the action
+    
+ -   If the object or the action are more important than the subject doing the action
+
+<DosAndDonts>
+<Dos hideHeader={true}>
+BigCommerce will create and email your invoices monthly to
+</Dos>
+<Donts hideHeader={true}>
+BigCommerce creates and emails your invoices monthly to philip@nomail.com.
+</Donts>
+</DosAndDonts>
+
+
+## Pluralities
+
+A plurality occurs when the copy changes depending on the number of items you’re writing about. Whenever possible, write unique copy for the singular and plural forms, displaying the appropriate version as needed. If the possibility of a plural exists, but technological limitations prevent you from using variable copy, then default to the plural form.
+
+
+<DosAndDonts>
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+<div>
+ - You have a new message.
+ - You have 10 new messages.
+</div>
+</Dos>
+<Donts>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+ - You have a new message or messages.
+ - You have a new message(s)
+</div>
+</Donts>
+</DosAndDonts>
+
+## Present vs. past tense
+
+Write using the present tense. It’s immediate, direct and concise.
+
+For confirmation, success and error messages it’s okay to use the past participle to express an action that was completed at some point in the past.
+
+Past participles usually end with “-ed,” “-d,” “-t,” “-en” or “-n.”
+
+<DosAndDonts>
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+<div>
+ - Settings saved
+ - App installed
+ - Payment failed
+ - Message sent
+</div>
+</Dos>
+<Donts>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+ - Settings have been saved
+ - App was installed
+ - Payment has failed
+ - Message was sent
+</div>
+</Donts>
+</DosAndDonts>
+

--- a/packages/docs/design-docs/ux-writing/index.mdx
+++ b/packages/docs/design-docs/ux-writing/index.mdx
@@ -1,0 +1,36 @@
+import LandingCard from "@components/Card/LandingCard";
+import CardGrid from "@components/Card/CardGrid";
+import Icon from "@components/icons/Icon";
+
+# UX writing guide
+
+<CardGrid>
+  <LandingCard
+    className="bg-white"
+    variant="secondary"
+    title="Learn the basics"
+    description="Get to know the basic principles on how we communicate with our users."
+    href="the-basics"
+    icon={<Icon name="widgets" />}
+  />
+  <LandingCard
+    className="bg-white"
+    variant="secondary"
+    title="Jump to glossary"
+    description="Learn how to use specific words within the BigCommerce ecosystem."
+    href="glossary"
+    icon={<Icon name="world" />}
+  />
+</CardGrid>
+
+The purpose of the **BigCommerce UX writing guide** is to present a consistent, coherent and competent voice to BigCommerce merchants and their shoppers as it relates to in-product, customer-facing communication, aka microcopy.
+
+Writers, researchers, designers and developers, both internal and external, who have a hand in designing BigCommerce products can refer to this guide anytime there’s a question about the writing.
+
+- Not sure if you need a period at the end of a heading?
+
+- Is there a difference between “log in” and “login?” 
+
+- Can the words “back” and “cancel” be used interchangeably?
+
+The answers to these questions, and many more, can be found in the pages of this guide.

--- a/packages/docs/design-docs/ux-writing/index.mdx
+++ b/packages/docs/design-docs/ux-writing/index.mdx
@@ -1,6 +1,6 @@
-import LandingCard from "@components/Card/LandingCard";
-import CardGrid from "@components/Card/CardGrid";
-import Icon from "@components/icons/Icon";
+import CardGrid from '@components/Card/CardGrid';
+import LandingCard from '@components/Card/LandingCard';
+import Icon from '@components/icons/Icon';
 
 # UX writing guide
 
@@ -29,7 +29,7 @@ Writers, researchers, designers and developers, both internal and external, who 
 
 - Not sure if you need a period at the end of a heading?
 
-- Is there a difference between “log in” and “login?” 
+- Is there a difference between “log in” and “login?”
 
 - Can the words “back” and “cancel” be used interchangeably?
 

--- a/packages/docs/design-docs/ux-writing/interactions.mdx
+++ b/packages/docs/design-docs/ux-writing/interactions.mdx
@@ -1,5 +1,5 @@
-import Icon from "@components/icons/Icon";
-import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
+import { Donts, Dos, DosAndDonts } from '@components/big-design/DosAndDonts';
+import Icon from '@components/icons/Icon';
 
 # Interactions
 
@@ -9,11 +9,9 @@ An interaction is where the user’s intention becomes an action. It could be so
 
 When writing titles, heading and subheadings:
 
--   Never use periods or other ending punctuation
-    
--   Try to be brief
-    
--   Titles should be titles, not sentences
+- Never use periods or other ending punctuation
+- Try to be brief
+- Titles should be titles, not sentences
 
 ## Navigation
 
@@ -26,22 +24,14 @@ Do not use ending punctuation on menu titles or items within a menu.
 Avoid linking entire sentences. Instead, link only the most relevant portion of the sentence. Use ending punctuation, as normal, but do not include ending punctuation in the link.
 
 <DosAndDonts>
-<Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-View all integrations in the [app manager](javascript:;).
-</div>
-</Dos>
-<Donts hideHeader={true}>
-<div class="hidden">
-**Don't**
-</div>
-<div>
-[View all integrations in the app manager](javascript:;)
-</div>
-</Donts>
+  <Dos hideHeader={true}>
+    <div className="hidden">**Do**</div>
+    <div>View all integrations in the [app manager](javascript:;).</div>
+  </Dos>
+  <Donts hideHeader={true}>
+    <div className="hidden">**Don't**</div>
+    <div>[View all integrations in the app manager](javascript:;)</div>
+  </Donts>
 </DosAndDonts>
 
 ### Links outside of a sentence
@@ -50,38 +40,44 @@ Links outside of a sentence should follow the &#123;verb&#125; + &#123;noun&#125
 
 <DosAndDonts>
 <Dos hideHeader={true}>
-<div class="hidden">
+<div className="hidden">
 **Do**
 </div>
 <div>
 [Forgot password?](https://www.bigcommerce.com/ "https://www.bigcommerce.com/")
 
-[Learn more](https://www.bigcommerce.com/ "https://www.bigcommerce.com/")
+[Learn more](https://www.bigcommerce.com/ 'https://www.bigcommerce.com/')
+
 </div>
 </Dos>
 <Donts hideHeader={true}>
-<div class="hidden">
+<div className="hidden">
 **Don't**
 </div>
 <div>
 [Learn more.](https://www.bigcommerce.com/ "https://www.bigcommerce.com/")
 
-[Edit settings!](https://www.bigcommerce.com/ "https://www.bigcommerce.com/")
+[Edit settings!](https://www.bigcommerce.com/ 'https://www.bigcommerce.com/')
+
 </div>
 </Donts>
 </DosAndDonts>
 
 ### External links
 
-Links that go to other websites must follow best practices such as opening in a new tab or window and including the external llink icon (<Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />) at the end.
+Links that go to other websites must follow best practices such as opening in a new tab or window and including the external link icon (<Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />) at the end.
 
 <Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-For more stories like this one, check out the [BigCommerce Blog <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.bigcommerce.com/blog/ "https://www.bigcommerce.com/blog/").
-</div>
+  <div className="hidden">**Do**</div>
+  <div>
+    {/* // eslint-disable-next-line no-unused-expressions forces the space to be before the icon */}
+    For more stories like this one, check out the [BigCommerce Blog <Icon
+      name="external"
+      className="inline w-4 h-auto"
+      includesWrapper={false}
+    />
+    ](https://www.bigcommerce.com/blog/ "https://www.bigcommerce.com/blog/").
+  </div>
 </Dos>
 
 ## Actionable items
@@ -90,21 +86,13 @@ For more stories like this one, check out the [BigCommerce Blog <Icon name="exte
 
 Users should know exactly what will happen when they click. Button language should be unambiguous, direct and action-oriented and 3 words at most.
 
- -   Follow the &#123;verb&#125; + &#123;noun&#125; formula
-    
- -   Use sentence case and never include ending punctuation
-    
+- Follow the &#123;verb&#125; + &#123;noun&#125; formula
+
+- Use sentence case and never include ending punctuation
+
 <Dos>
-<div class="hidden">
-**Do**
-</div>
- - Learn more
- - Start trial
- - Save settings
- - Customize dashboard
- - View more
- - Add new
- - Create channel
+  <div className="hidden">**Do**</div>- Learn more - Start trial - Save settings - Customize
+  dashboard - View more - Add new - Create channel
 </Dos>
 
 ## Information patterns
@@ -113,8 +101,7 @@ Users should know exactly what will happen when they click. Button language shou
 
 Help text and tooltips provide additional guidance to users when completing an action.
 
--   Link to relevant Knowledge Base articles whenever one exists
-
+- Link to relevant Knowledge Base articles whenever one exists
 
 ### Placeholder text
 
@@ -127,12 +114,11 @@ If you’ve got a lot to say, present the info outside the field as help text.
 Copy for empty states should tell the user why the field is empty and tell them how to start adding items.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
-<div className="flex items-center justify-center">
-![No products found empty state](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-empty_states_1.png)
-</div>
+  <div className="hidden">**Do**</div>
+  <div className="flex items-center justify-center">
+    ![No products found empty
+    state](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-empty_states_1.png)
+  </div>
 </Dos>
 
 ### Deprecation
@@ -140,22 +126,20 @@ Copy for empty states should tell the user why the field is empty and tell them 
 When deprecating an older feature it’s important to set the right tone. Calling the new version of the feature “advanced” makes it sounds harder to use. Calling the feature “new,” while true, also implies the feature is unproven. Instead, if a user has a choice between an older, deprecated version and a new version, just call the new version by its name — without any fancy adjectives.
 
 <DosAndDonts>
-<Dos>
-<div class="hidden">
-**Do**
-</div>
-<div>
-![The right way to deprecate a product or feature](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-deprecation_do.png)
-</div>
-</Dos>
-<Donts>
-<div class="hidden">
-**Don't**
-</div>
-<div>
-![The wrong way to deprecate a product or feature](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-deprecation_dont.png)
-</div>
-</Donts>
+  <Dos>
+    <div className="hidden">**Do**</div>
+    <div>
+      ![The right way to deprecate a product or
+      feature](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-deprecation_do.png)
+    </div>
+  </Dos>
+  <Donts>
+    <div className="hidden">**Don't**</div>
+    <div>
+      ![The wrong way to deprecate a product or
+      feature](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-deprecation_dont.png)
+    </div>
+  </Donts>
 </DosAndDonts>
 
 ## Common flows
@@ -165,15 +149,6 @@ When deprecating an older feature it’s important to set the right tone. Callin
 When writing about the checkout process, follow established patterns. Ecommerce has been around long enough that users have strong expectations about what the process should look like.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
- - Add to cart
- - Check out
- - Check out securely
- - Go to checkout
- - View cart
- - Edit cart
- - Confirm payment
- - Place order
+  <div className="hidden">**Do**</div>- Add to cart - Check out - Check out securely - Go to
+  checkout - View cart - Edit cart - Confirm payment - Place order
 </Dos>

--- a/packages/docs/design-docs/ux-writing/interactions.mdx
+++ b/packages/docs/design-docs/ux-writing/interactions.mdx
@@ -1,0 +1,179 @@
+import Icon from "@components/icons/Icon";
+import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
+
+# Interactions
+
+An interaction is where the user’s intention becomes an action. It could be something as simple as a button or as complex as an entire checkout process. Whatever the case may be, the writing should be focused on what’s best for the user.
+
+## Titles, headings and subheadings
+
+When writing titles, heading and subheadings:
+
+-   Never use periods or other ending punctuation
+    
+-   Try to be brief
+    
+-   Titles should be titles, not sentences
+
+## Navigation
+
+### Menus
+
+Do not use ending punctuation on menu titles or items within a menu.
+
+### Links in a sentence
+
+Avoid linking entire sentences. Instead, link only the most relevant portion of the sentence. Use ending punctuation, as normal, but do not include ending punctuation in the link.
+
+<DosAndDonts>
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+View all integrations in the [app manager](javascript:;).
+</div>
+</Dos>
+<Donts hideHeader={true}>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+[View all integrations in the app manager](javascript:;)
+</div>
+</Donts>
+</DosAndDonts>
+
+### Links outside of a sentence
+
+Links outside of a sentence should follow the &#123;verb&#125; + &#123;noun&#125; format. Do not use periods or exclamation points. Question marks are fine within the context of a forgotten password link. Otherwise, avoid using them.
+
+<DosAndDonts>
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+[Forgot password?](https://www.bigcommerce.com/ "https://www.bigcommerce.com/")
+
+[Learn more](https://www.bigcommerce.com/ "https://www.bigcommerce.com/")
+</div>
+</Dos>
+<Donts hideHeader={true}>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+[Learn more.](https://www.bigcommerce.com/ "https://www.bigcommerce.com/")
+
+[Edit settings!](https://www.bigcommerce.com/ "https://www.bigcommerce.com/")
+</div>
+</Donts>
+</DosAndDonts>
+
+### External links
+
+Links that go to other websites must follow best practices such as opening in a new tab or window and including the external llink icon (<Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />) at the end.
+
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+For more stories like this one, check out the [BigCommerce Blog <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.bigcommerce.com/blog/ "https://www.bigcommerce.com/blog/").
+</div>
+</Dos>
+
+## Actionable items
+
+### Buttons
+
+Users should know exactly what will happen when they click. Button language should be unambiguous, direct and action-oriented and 3 words at most.
+
+ -   Follow the &#123;verb&#125; + &#123;noun&#125; formula
+    
+ -   Use sentence case and never include ending punctuation
+    
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+ - Learn more
+ - Start trial
+ - Save settings
+ - Customize dashboard
+ - View more
+ - Add new
+ - Create channel
+</Dos>
+
+## Information patterns
+
+### Help text and tooltips
+
+Help text and tooltips provide additional guidance to users when completing an action.
+
+-   Link to relevant Knowledge Base articles whenever one exists
+
+
+### Placeholder text
+
+Placeholder text inside a form field should be short and have no periods. If it needs a period it’s too long. Keep in mind, placeholder text disappears when the user starts writing and if it’s too long to remember the user will need to delete what they’ve written to see the placeholder again.
+
+If you’ve got a lot to say, present the info outside the field as help text.
+
+### Empty states
+
+Copy for empty states should tell the user why the field is empty and tell them how to start adding items.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+<div className="flex items-center justify-center">
+![No products found empty state](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-empty_states_1.png)
+</div>
+</Dos>
+
+### Deprecation
+
+When deprecating an older feature it’s important to set the right tone. Calling the new version of the feature “advanced” makes it sounds harder to use. Calling the feature “new,” while true, also implies the feature is unproven. Instead, if a user has a choice between an older, deprecated version and a new version, just call the new version by its name — without any fancy adjectives.
+
+<DosAndDonts>
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+<div>
+![The right way to deprecate a product or feature](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-deprecation_do.png)
+</div>
+</Dos>
+<Donts>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+![The wrong way to deprecate a product or feature](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-deprecation_dont.png)
+</div>
+</Donts>
+</DosAndDonts>
+
+## Common flows
+
+### Checkout
+
+When writing about the checkout process, follow established patterns. Ecommerce has been around long enough that users have strong expectations about what the process should look like.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+ - Add to cart
+ - Check out
+ - Check out securely
+ - Go to checkout
+ - View cart
+ - Edit cart
+ - Confirm payment
+ - Place order
+</Dos>

--- a/packages/docs/design-docs/ux-writing/localization.mdx
+++ b/packages/docs/design-docs/ux-writing/localization.mdx
@@ -1,6 +1,6 @@
-import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
-import { ComparisonTable } from "@components/big-design/ComparisonTable";
-import Icon from "@components/icons/Icon";
+import { ComparisonTable } from '@components/big-design/ComparisonTable';
+import { Donts, Dos, DosAndDonts } from '@components/big-design/DosAndDonts';
+import Icon from '@components/icons/Icon';
 
 # Localization
 
@@ -21,24 +21,31 @@ What would happen if the copy were longer after localization? Take German, for e
 Instead link only the most relevant, actionable portion of the sentence. When linking a larger sentence the arrangement of the words may change after localization, causing problems with the UI.
 
 <DosAndDonts>
-<Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-For more stories like this one, check out the [BigCommerce Blog <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.bigcommerce.com/blog/ "https://www.bigcommerce.com/blog/").
-</div>
-</Dos>
-<Donts hideHeader={true}>
-<div class="hidden">
-**Don't**
-</div>
-<div>
-[For more stories, visit the BigCommerce Blog <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />.](https://www.bigcommerce.com/blog/ "https://www.bigcommerce.com/blog/")
-</div>
-</Donts>
+  <Dos hideHeader={true}>
+    <div className="hidden">**Do**</div>
+    <div>
+      {/* // eslint-disable-next-line no-unused-expressions forces the space before the icon */}
+      For more stories like this one, check out the [BigCommerce Blog <Icon
+        name="external"
+        className="inline w-4 h-auto"
+        includesWrapper={false}
+      />
+      ](https://www.bigcommerce.com/blog/ "https://www.bigcommerce.com/blog/").
+    </div>
+  </Dos>
+  <Donts hideHeader={true}>
+    <div className="hidden">**Don't**</div>
+    <div>
+      {/* // eslint-disable-next-line no-unused-expressions forces the space before the icon */}
+      [For more stories, visit the BigCommerce Blog <Icon
+        name="external"
+        className="inline w-4 h-auto"
+        includesWrapper={false}
+      />
+      .](https://www.bigcommerce.com/blog/ "https://www.bigcommerce.com/blog/")
+    </div>
+  </Donts>
 </DosAndDonts>
-
 
 **Watch out for special characters**
 
@@ -49,16 +56,7 @@ Symbols like “#” and “&” don’t carry the same meaning in every languag
 Here are some British English words and phrases, common to ecommerce, and American English equivalents you should use instead.
 
 <ComparisonTable>
-| American |  British |
-|---|---|
-| Buy online, pick up in-store | Click and collect |
-| Canceled | Cancelled |
-| Center | Centre |
-| Color | Colour |
-| Fulfill | Fulfil |
-| Gray | Grey |
-| Organize | Organise |
-| Meter | Metre |
-| Ship, mail | Post |
+  | American | British | |---|---| | Buy online, pick up in-store | Click and collect | | Canceled |
+  Cancelled | | Center | Centre | | Color | Colour | | Fulfill | Fulfil | | Gray | Grey | | Organize
+  | Organise | | Meter | Metre | | Ship, mail | Post |
 </ComparisonTable>
-

--- a/packages/docs/design-docs/ux-writing/localization.mdx
+++ b/packages/docs/design-docs/ux-writing/localization.mdx
@@ -1,0 +1,64 @@
+import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
+import { ComparisonTable } from "@components/big-design/ComparisonTable";
+import Icon from "@components/icons/Icon";
+
+# Localization
+
+At BigCommerce, we use American English as the default language for UX writing. That doesn’t mean, that we shouldn't consider our global audience when designing.
+
+Regardless of the user, the country, or the region, take care to avoid words and phrases that may cause confusion or break the UI during localization.
+
+**Watch out for idiomatic expressions, metaphors, cliches and slang**
+
+Global audiences won’t understand what you're talking about. And in many cases the history and true meaning behind these words and phrases are offensive to certain groups.
+
+**Test copy for length**
+
+What would happen if the copy were longer after localization? Take German, for example, which features long, compound words, would the design break? As a good rule of thumb, try to limit copy to 2/3rds of available space, allowing 1/3rd for copy to grow longer during localization.
+
+**Avoid linking full sentences**
+
+Instead link only the most relevant, actionable portion of the sentence. When linking a larger sentence the arrangement of the words may change after localization, causing problems with the UI.
+
+<DosAndDonts>
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+For more stories like this one, check out the [BigCommerce Blog <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.bigcommerce.com/blog/ "https://www.bigcommerce.com/blog/").
+</div>
+</Dos>
+<Donts hideHeader={true}>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+[For more stories, visit the BigCommerce Blog <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />.](https://www.bigcommerce.com/blog/ "https://www.bigcommerce.com/blog/")
+</div>
+</Donts>
+</DosAndDonts>
+
+
+**Watch out for special characters**
+
+Symbols like “#” and “&” don’t carry the same meaning in every language as they do in English — if they have any meaning at all.
+
+**American vs. British English**
+
+Here are some British English words and phrases, common to ecommerce, and American English equivalents you should use instead.
+
+<ComparisonTable>
+| American |  British |
+|---|---|
+| Buy online, pick up in-store | Click and collect |
+| Canceled | Cancelled |
+| Center | Centre |
+| Color | Colour |
+| Fulfill | Fulfil |
+| Gray | Grey |
+| Organize | Organise |
+| Meter | Metre |
+| Ship, mail | Post |
+</ComparisonTable>
+

--- a/packages/docs/design-docs/ux-writing/mechanics.mdx
+++ b/packages/docs/design-docs/ux-writing/mechanics.mdx
@@ -1,6 +1,5 @@
-import Icon from "@components/icons/Icon";
-import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
-import { ComparisonTable } from "@components/big-design/ComparisonTable";
+import { Donts, Dos, DosAndDonts } from '@components/big-design/DosAndDonts';
+import Icon from '@components/icons/Icon';
 
 # Mechanics
 
@@ -9,14 +8,10 @@ import { ComparisonTable } from "@components/big-design/ComparisonTable";
 Use sentence case.
 
 - Sentence case applies everywhere. This includes buttons, menus, headings, subheadings and titles.
-  
-- Capitalize [proper nouns <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.grammarly.com/blog/proper-nouns/ "https://www.grammarly.com/blog/proper-nouns/")
-    
--   Capitalize the first word of every sentence
-    
--   Lowercase everything else
-    
--   When referring to items within the UI, capitalize exactly as the item appears in the UI. For example: "Click 'My profile' to change your password."
+- Capitalize [proper nouns <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.grammarly.com/blog/proper-nouns/ 'https://www.grammarly.com/blog/proper-nouns/')
+- Capitalize the first word of every sentence
+- Lowercase everything else
+- When referring to items within the UI, capitalize exactly as the item appears in the UI. For example: "Click 'My profile' to change your password."
 
 ## Punctuation and formatting
 
@@ -25,23 +20,18 @@ Use sentence case.
 For uncommon abbreviations/acronyms, write out the full phrase, followed by the abbreviation/acronym in parentheses in corresponding help text or a tooltip.
 
 <Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-A stock keeping unit (SKU) is a unique code that helps you keep track of an item or service in your inventory.
-</div>
+  <div className="hidden">**Do**</div>
+  <div>
+    A stock keeping unit (SKU) is a unique code that helps you keep track of an item or service in
+    your inventory.
+  </div>
 </Dos>
 
 There’s no need to spell out commonly understood abbreviations and acronyms.
 
 <Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-Enter your PIN.
-</div>
+  <div className="hidden">**Do**</div>
+  <div>Enter your PIN.</div>
 </Dos>
 
 ### Ampersands (&)
@@ -53,73 +43,51 @@ The ampersand (&) isn’t used in all languages and doesn’t localize well. Try
 Don’t use the serial comma, aka the Oxford comma, aka the comma before “and” in a list of 3 or more items.
 
 <DosAndDonts>
-<Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-Planes, trains and automobiles.
-</div>
-</Dos>
-<Donts hideHeader={true}>
-<div class="hidden">
-**Don't**
-</div>
-<div>
-Planes, trains, and automobiles.
-</div>
-</Donts>
+  <Dos hideHeader={true}>
+    <div className="hidden">**Do**</div>
+    <div>Planes, trains and automobiles.</div>
+  </Dos>
+  <Donts hideHeader={true}>
+    <div className="hidden">**Don't**</div>
+    <div>Planes, trains, and automobiles.</div>
+  </Donts>
 </DosAndDonts>
 
 It’s okay to use a serial comma if leaving the comma out causes ambiguity in the sentence’s meaning.
 
 <DosAndDonts>
-<Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-This writing guide is dedicated to my parents, Olivia Rodrigo, and Harry Styles.
-</div>
-</Dos>
-<Donts hideHeader={true}>
-<div class="hidden">
-**Don't**
-</div>
-<div>
-This writing guide is dedicated to my parents, Olivia Rodrigo and Harry Styles.
-</div>
-</Donts>
+  <Dos hideHeader={true}>
+    <div className="hidden">**Do**</div>
+    <div>This writing guide is dedicated to my parents, Olivia Rodrigo, and Harry Styles.</div>
+  </Dos>
+  <Donts hideHeader={true}>
+    <div className="hidden">**Don't**</div>
+    <div>This writing guide is dedicated to my parents, Olivia Rodrigo and Harry Styles.</div>
+  </Donts>
 </DosAndDonts>
 
 Use a comma before “but” if the “but” connects two independent clauses. In the example below, you can see each part of the sentence is an independent clause because each clause could stand on its own as two separate sentences.
 
-<Dos hideHeader={true}>I would like to buy tickets to the Olivia Rodrigo concert, but the show is sold-out.</Dos>
+<Dos hideHeader={true}>
+  I would like to buy tickets to the Olivia Rodrigo concert, but the show is sold-out.
+</Dos>
 
 Generally, you should not use a comma before “because” if it's a subordinating conjunction. Its job is to join subordinate clauses to independent clauses.
 
 <Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-I had to return my new shoes because they were too small.
-</div>
+  <div className="hidden">**Do**</div>
+  <div>I had to return my new shoes because they were too small.</div>
 </Dos>
 
 ### Currencies
 
-When referring to currencies, always use the 3-letter [ISO 4217 currency abbreviation <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://en.wikipedia.org/wiki/ISO_4217 "https://en.wikipedia.org/wiki/ISO_4217"). Don’t write out the full currency name. In many cases, the full name is less recognizable than the abbreviation.
+When referring to currencies, always use the 3-letter [ISO 4217 currency abbreviation <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://en.wikipedia.org/wiki/ISO_4217 'https://en.wikipedia.org/wiki/ISO_4217'). Don’t write out the full currency name. In many cases, the full name is less recognizable than the abbreviation.
 
 When the currency abbreviation follows a monetary amount, put the abbreviation in parentheses.
 
 <Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-$100 (USD)
-</div>
+  <div className="hidden">**Do**</div>
+  <div>$100 (USD)</div>
 </Dos>
 
 ### Date, time and phone numbers
@@ -132,12 +100,7 @@ Use the 3-letter month abbreviations: Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Se
 Use day-of-the-week abbreviations: Mon, Tue, Wed, Thu, Fri, Sat and Sun. Do not use a period after the day when abbreviating.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
- - Jan 5, 2022
- - 1/02/22
- - Mon, Jan 5, 2022
+  <div className="hidden">**Do**</div>- Jan 5, 2022 - 1/02/22 - Mon, Jan 5, 2022
 </Dos>
 
 **Time**
@@ -147,24 +110,14 @@ Don’t use periods in “AM” and “PM”
 Be sure to check the region’s time zone and if it’s daylight savings time or not. For example, CDT is Central Daylight Time and CST is Central Standard Time.
 
 <DosAndDonts>
-<Dos>
-<div class="hidden">
-**Do**
-</div>
-<div>
- - 2:00 AM CST
- - 3:30 PM CDT
-</div>
-</Dos>
-<Donts>
-<div class="hidden">
-**Don't**
-</div>
-<div>
- - 2:00am CST
- - 3:30 P.M. CDT
-</div>
-</Donts>
+  <Dos>
+    <div className="hidden">**Do**</div>
+    <div>- 2:00 AM CST - 3:30 PM CDT</div>
+  </Dos>
+  <Donts>
+    <div className="hidden">**Don't**</div>
+    <div>- 2:00am CST - 3:30 P.M. CDT</div>
+  </Donts>
 </DosAndDonts>
 
 **Phone numbers**
@@ -172,23 +125,14 @@ Be sure to check the region’s time zone and if it’s daylight savings time or
 Use hyphens to break up phone numbers. Don’t use parentheses or periods.
 
 <DosAndDonts>
-<Dos>
-<div class="hidden">
-**Do**
-</div>
-<div>
- - 1-888-555-5555
-</div>
-</Dos>
-<Donts>
-<div class="hidden">
-**Don't**
-</div>
-<div>
- - 1 (888) 555-5555
- - 1.888.555.5555
-</div>
-</Donts>
+  <Dos>
+    <div className="hidden">**Do**</div>
+    <div>- 1-888-555-5555</div>
+  </Dos>
+  <Donts>
+    <div className="hidden">**Don't**</div>
+    <div>- 1 (888) 555-5555 - 1.888.555.5555</div>
+  </Donts>
 </DosAndDonts>
 
 ### Exclamation point
@@ -200,22 +144,14 @@ Save the exclamation point for something that’s actually exciting. Settings sa
 There’s no need to write out file extensions in full. Always use the abbreviation, lowercase, no period.
 
 <DosAndDonts>
-<Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-Uploads must be jpeg, png or gif.
-</div>
-</Dos>
-<Donts hideHeader={true}>
-<div class="hidden">
-**Don't**
-</div>
-<div>
-Uploads must be JPEG, .png or Gif.
-</div>
-</Donts>
+  <Dos hideHeader={true}>
+    <div className="hidden">**Do**</div>
+    <div>Uploads must be jpeg, png or gif.</div>
+  </Dos>
+  <Donts hideHeader={true}>
+    <div className="hidden">**Don't**</div>
+    <div>Uploads must be JPEG, .png or Gif.</div>
+  </Donts>
 </DosAndDonts>
 
 ### Hyphens and dashes
@@ -231,12 +167,9 @@ En dashes are used to indicate a range between two numbers. Don’t put spaces a
 If the number range is preceded by the words “from,” or “between,” then use the word “to” instead of an en dash.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
- - There are 500–1000 employees at BigCommerce.
- - There are somewhere between 500 to 1000 employees at BigCommerce.
- - Philip will be in the office May 3 – May 5.
+  <div className="hidden">**Do**</div>- There are 500–1000 employees at BigCommerce. - There are
+  somewhere between 500 to 1000 employees at BigCommerce. - Philip will be in the office May 3 – May
+  5.
 </Dos>
 
 **This is an em dash (—)**
@@ -244,11 +177,8 @@ If the number range is preceded by the words “from,” or “between,” then 
 Em dashes are used to indicate an abrupt pause or change in the middle of a sentence. Em dashes can also be used to call out or add emphasis to an important part of a sentence. Em dashes should always have a space before and after.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
- - Wait, that’s not a hyphen — it’s an em dash.
- - I went shopping — on a site powered by BigCommerce — and bought a new pair of jeans.
+  <div className="hidden">**Do**</div>- Wait, that’s not a hyphen — it’s an em dash. - I went
+  shopping — on a site powered by BigCommerce — and bought a new pair of jeans.
 </Dos>
 
 ### Percentages
@@ -262,7 +192,7 @@ Do not use periods, or any ending punctuation of any kind, on titles, labels, he
 Let’s look at an example:
 
 <div className="flex items-center justify-center">
-![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.grammar_and_mechanics-periods.png)
+  ![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.grammar_and_mechanics-periods.png)
 </div>
 
 In the card above, the text above the divider qualifies as a header — it’s giving a name to the tile that it appears on — and doesn’t need a period.
@@ -275,23 +205,18 @@ As for the button, interactive items should never have ending punctuation of any
 
 Use quotation marks when referring, in the UI, to another item within the UI. This could be a page or area within a page. It could also be an item the user can interact with, for example, buttons, menus and links (anything clickable). This typically happens when writing help text or tooltips.
 
--   The quoted item should be written exactly as it appears in the UI
-    
--   Ending punctuation always goes inside of the quotes
-    
--   Don’t use bolding
+- The quoted item should be written exactly as it appears in the UI
+- Ending punctuation always goes inside of the quotes
+- Don’t use bolding
 
 Let’s look at an example:
 
 <div className="flex items-center justify-center">
-![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.grammar_and_mechanics-periods.png)
+  ![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.grammar_and_mechanics-periods.png)
 </div>
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
- - Under “List your products on Google,” click “Get started.”
+  <div className="hidden">**Do**</div>- Under “List your products on Google,” click “Get started.”
 </Dos>
 
 ### Slashes
@@ -299,20 +224,14 @@ Let’s look at an example:
 You can use forward slashes “/” to indicate the word “or” between two words. When doing so, don’t use spaces before or after the slash. Don’t use backlashes “\”.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
- - if/when
- - and/or
+  <div className="hidden">**Do**</div>- if/when - and/or
 </Dos>
 
 On the other hand, when using a forward slash to signify “or” between two multi-word phrases, use spaces before and after the slash — it helps with readability.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
- - Download the app from the Apple App Store / Google Play Store.
+  <div className="hidden">**Do**</div>- Download the app from the Apple App Store / Google Play
+  Store.
 </Dos>
 
 ### Units of measurement
@@ -322,17 +241,11 @@ Add a space between numbers and units of measurement. Use all lowercase and alwa
 Don’t add a period. Don’t pluralize measurements (“lbs” is in common use and okay to use).
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
- - 75 lbs, 14 in, 7 cm
+  <div className="hidden">**Do**</div>- 75 lbs, 14 in, 7 cm
 </Dos>
 
 When abbreviating units of data, always capitalize MB (megabyte) and GB (gigabyte). Don’t use Mb and Gb as these represent different units of measurement typically used when measuring Internet speeds.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
- - 10 MB, 10 GB
+  <div className="hidden">**Do**</div>- 10 MB, 10 GB
 </Dos>

--- a/packages/docs/design-docs/ux-writing/mechanics.mdx
+++ b/packages/docs/design-docs/ux-writing/mechanics.mdx
@@ -1,0 +1,338 @@
+import Icon from "@components/icons/Icon";
+import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
+import { ComparisonTable } from "@components/big-design/ComparisonTable";
+
+# Mechanics
+
+## Capitalization
+
+Use sentence case.
+
+- Sentence case applies everywhere. This includes buttons, menus, headings, subheadings and titles.
+  
+- Capitalize [proper nouns <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.grammarly.com/blog/proper-nouns/ "https://www.grammarly.com/blog/proper-nouns/")
+    
+-   Capitalize the first word of every sentence
+    
+-   Lowercase everything else
+    
+-   When referring to items within the UI, capitalize exactly as the item appears in the UI. For example: "Click 'My profile' to change your password."
+
+## Punctuation and formatting
+
+### Abbreviations and acronyms
+
+For uncommon abbreviations/acronyms, write out the full phrase, followed by the abbreviation/acronym in parentheses in corresponding help text or a tooltip.
+
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+A stock keeping unit (SKU) is a unique code that helps you keep track of an item or service in your inventory.
+</div>
+</Dos>
+
+There’s no need to spell out commonly understood abbreviations and acronyms.
+
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+Enter your PIN.
+</div>
+</Dos>
+
+### Ampersands (&)
+
+The ampersand (&) isn’t used in all languages and doesn’t localize well. Try and avoid using them unless it’s part of a company or brand name (for example, M&M's) or you’re trying to save on character count within the UI.
+
+### Commas
+
+Don’t use the serial comma, aka the Oxford comma, aka the comma before “and” in a list of 3 or more items.
+
+<DosAndDonts>
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+Planes, trains and automobiles.
+</div>
+</Dos>
+<Donts hideHeader={true}>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+Planes, trains, and automobiles.
+</div>
+</Donts>
+</DosAndDonts>
+
+It’s okay to use a serial comma if leaving the comma out causes ambiguity in the sentence’s meaning.
+
+<DosAndDonts>
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+This writing guide is dedicated to my parents, Olivia Rodrigo, and Harry Styles.
+</div>
+</Dos>
+<Donts hideHeader={true}>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+This writing guide is dedicated to my parents, Olivia Rodrigo and Harry Styles.
+</div>
+</Donts>
+</DosAndDonts>
+
+Use a comma before “but” if the “but” connects two independent clauses. In the example below, you can see each part of the sentence is an independent clause because each clause could stand on its own as two separate sentences.
+
+<Dos hideHeader={true}>I would like to buy tickets to the Olivia Rodrigo concert, but the show is sold-out.</Dos>
+
+Generally, you should not use a comma before “because” if it's a subordinating conjunction. Its job is to join subordinate clauses to independent clauses.
+
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+I had to return my new shoes because they were too small.
+</div>
+</Dos>
+
+### Currencies
+
+When referring to currencies, always use the 3-letter [ISO 4217 currency abbreviation <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://en.wikipedia.org/wiki/ISO_4217 "https://en.wikipedia.org/wiki/ISO_4217"). Don’t write out the full currency name. In many cases, the full name is less recognizable than the abbreviation.
+
+When the currency abbreviation follows a monetary amount, put the abbreviation in parentheses.
+
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+$100 (USD)
+</div>
+</Dos>
+
+### Date, time and phone numbers
+
+American English is the default language of UX writing at BigCommerce. As such, follow the American style of date, time and phone number notation.
+
+**Date**
+Use the 3-letter month abbreviations: Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct and Nov. Do not use a period after the month name when abbreviating.
+
+Use day-of-the-week abbreviations: Mon, Tue, Wed, Thu, Fri, Sat and Sun. Do not use a period after the day when abbreviating.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+ - Jan 5, 2022
+ - 1/02/22
+ - Mon, Jan 5, 2022
+</Dos>
+
+**Time**
+
+Don’t use periods in “AM” and “PM”
+
+Be sure to check the region’s time zone and if it’s daylight savings time or not. For example, CDT is Central Daylight Time and CST is Central Standard Time.
+
+<DosAndDonts>
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+<div>
+ - 2:00 AM CST
+ - 3:30 PM CDT
+</div>
+</Dos>
+<Donts>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+ - 2:00am CST
+ - 3:30 P.M. CDT
+</div>
+</Donts>
+</DosAndDonts>
+
+**Phone numbers**
+
+Use hyphens to break up phone numbers. Don’t use parentheses or periods.
+
+<DosAndDonts>
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+<div>
+ - 1-888-555-5555
+</div>
+</Dos>
+<Donts>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+ - 1 (888) 555-5555
+ - 1.888.555.5555
+</div>
+</Donts>
+</DosAndDonts>
+
+### Exclamation point
+
+Save the exclamation point for something that’s actually exciting. Settings saved! Product added! Not too exciting. Doesn’t need an exclamation point.
+
+### File extensions
+
+There’s no need to write out file extensions in full. Always use the abbreviation, lowercase, no period.
+
+<DosAndDonts>
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+Uploads must be jpeg, png or gif.
+</div>
+</Dos>
+<Donts hideHeader={true}>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+Uploads must be JPEG, .png or Gif.
+</div>
+</Donts>
+</DosAndDonts>
+
+### Hyphens and dashes
+
+**This is a hyphen (-)**
+
+Hyphens are used to join compound words. Hyphens never have spaces around them.
+
+**This is an en dash (–)**
+
+En dashes are used to indicate a range between two numbers. Don’t put spaces around an en dash, unless you’re talking about dates featuring words. For example, May 3 – May 5.
+
+If the number range is preceded by the words “from,” or “between,” then use the word “to” instead of an en dash.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+ - There are 500–1000 employees at BigCommerce.
+ - There are somewhere between 500 to 1000 employees at BigCommerce.
+ - Philip will be in the office May 3 – May 5.
+</Dos>
+
+**This is an em dash (—)**
+
+Em dashes are used to indicate an abrupt pause or change in the middle of a sentence. Em dashes can also be used to call out or add emphasis to an important part of a sentence. Em dashes should always have a space before and after.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+ - Wait, that’s not a hyphen — it’s an em dash.
+ - I went shopping — on a site powered by BigCommerce — and bought a new pair of jeans.
+</Dos>
+
+### Percentages
+
+Use the “%” symbol instead of writing out the word.
+
+### Periods
+
+Do not use periods, or any ending punctuation of any kind, on titles, labels, headings, subheadings, numbered/bulleted lists or anything that a user can interact with (anything clickable). The latter category includes CTAs, buttons, menus and links outside of sentences.
+
+Let’s look at an example:
+
+<div className="flex items-center justify-center">
+![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.grammar_and_mechanics-periods.png)
+</div>
+
+In the card above, the text above the divider qualifies as a header — it’s giving a name to the tile that it appears on — and doesn’t need a period.
+
+The line of text below the divider needs a period because it’s just body text. It’s not giving a name to anything, it’s visually separated from the header and just too long to be a subheading.
+
+As for the button, interactive items should never have ending punctuation of any kind.
+
+### Quotation marks
+
+Use quotation marks when referring, in the UI, to another item within the UI. This could be a page or area within a page. It could also be an item the user can interact with, for example, buttons, menus and links (anything clickable). This typically happens when writing help text or tooltips.
+
+-   The quoted item should be written exactly as it appears in the UI
+    
+-   Ending punctuation always goes inside of the quotes
+    
+-   Don’t use bolding
+
+Let’s look at an example:
+
+<div className="flex items-center justify-center">
+![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.grammar_and_mechanics-periods.png)
+</div>
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+ - Under “List your products on Google,” click “Get started.”
+</Dos>
+
+### Slashes
+
+You can use forward slashes “/” to indicate the word “or” between two words. When doing so, don’t use spaces before or after the slash. Don’t use backlashes “\”.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+ - if/when
+ - and/or
+</Dos>
+
+On the other hand, when using a forward slash to signify “or” between two multi-word phrases, use spaces before and after the slash — it helps with readability.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+ - Download the app from the Apple App Store / Google Play Store.
+</Dos>
+
+### Units of measurement
+
+Add a space between numbers and units of measurement. Use all lowercase and always abbreviate.
+
+Don’t add a period. Don’t pluralize measurements (“lbs” is in common use and okay to use).
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+ - 75 lbs, 14 in, 7 cm
+</Dos>
+
+When abbreviating units of data, always capitalize MB (megabyte) and GB (gigabyte). Don’t use Mb and Gb as these represent different units of measurement typically used when measuring Internet speeds.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+ - 10 MB, 10 GB
+</Dos>

--- a/packages/docs/design-docs/ux-writing/status-messages.mdx
+++ b/packages/docs/design-docs/ux-writing/status-messages.mdx
@@ -1,4 +1,4 @@
-import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
+import { Donts, Dos } from '@components/big-design/DosAndDonts';
 
 # Status messages
 
@@ -15,12 +15,11 @@ Messages should be short and to the point. Focus on what happened and what the u
 Don’t start status messages with “It seems like…” or “It looks like….” It sounds like we don’t know what went wrong. There’s no room for ambiguity — especially when we’re trying to confirm a potentially destructive action.
 
 <Donts>
-<div class="hidden">
-**Don't**
-</div>
-<div className="flex items-center justify-center">
-![Don't write vague error messages](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-status-messages_vague_language.png)
-</div>
+  <div className="hidden">**Don't**</div>
+  <div className="flex items-center justify-center">
+    ![Don't write vague error
+    messages](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-status-messages_vague_language.png)
+  </div>
 </Donts>
 
 ### Use positive language
@@ -40,12 +39,11 @@ Only use “please” when asking the user to go out of their way to do somethin
 Words and phrases like “Whoops” or “Oh no!” could be taken as inconsiderate, even insulting.
 
 <Donts>
-<div class="hidden">
-**Don't**
-</div>
-<div className="flex items-center justify-center">
-![Avoid humor in error messages](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-status-messages-avoid_humor.png)
-</div>
+  <div className="hidden">**Don't**</div>
+  <div className="flex items-center justify-center">
+    ![Avoid humor in error
+    messages](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-status-messages-avoid_humor.png)
+  </div>
 </Donts>
 
 ### Follow the &#123;verb&#125; + &#123;noun&#125; formula.
@@ -53,12 +51,11 @@ Words and phrases like “Whoops” or “Oh no!” could be taken as inconsider
 Use supporting copy to provide additional context as needed.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
-<div className="flex items-center justify-center">
-![Confirmation example](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-confirmations-supporting_copy.png)
-</div>
+  <div className="hidden">**Do**</div>
+  <div className="flex items-center justify-center">
+    ![Confirmation
+    example](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-confirmations-supporting_copy.png)
+  </div>
 </Dos>
 
 ### Don’t ask vague questions
@@ -66,29 +63,27 @@ Use supporting copy to provide additional context as needed.
 “Are you sure?” About what? It’s not clear to the user what we’re trying to confirm.
 
 <Donts>
-<div class="hidden">
-**Don't**
-</div>
-<div className="flex items-center justify-center">
-![Don't ask vague questions](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-confirmations-vague_questions.png)
-</div>
+  <div className="hidden">**Don't**</div>
+  <div className="flex items-center justify-center">
+    ![Don't ask vague
+    questions](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-confirmations-vague_questions.png)
+  </div>
 </Donts>
 
 ### Always use “Cancel”
 
-For modal alerts, always use “cancel” when giving the user the option to back out. Never use “stop,” “pause,” “terminate,” “never mind” or “back” 
+For modal alerts, always use “cancel” when giving the user the option to back out. Never use “stop,” “pause,” “terminate,” “never mind” or “back”
 
 ### Write descriptive buttons
 
 When a user clicks a button, whether it’s to confirm an action or cancel one, it should be clear what will happen when they click.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
-<div className="flex items-center justify-center">
-![Don't use vague CTAs](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-confirmations-supporting_copy.png)
-</div>
+  <div className="hidden">**Do**</div>
+  <div className="flex items-center justify-center">
+    ![Don't use vague
+    CTAs](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-confirmations-supporting_copy.png)
+  </div>
 </Dos>
 
 ### Include applicable links
@@ -96,10 +91,9 @@ When a user clicks a button, whether it’s to confirm an action or cancel one, 
 Whenever possible, save the user some trouble and provide a link to the place where the user can fix the error. It’s okay to include “Learn more” links to Knowledge Base articles.
 
 <Dos>
-<div class="hidden">
-**Do**
-</div>
-<div className="flex items-center justify-center">
-![Banner error, with header](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-status-messages_banners.png)
-</div>
+  <div className="hidden">**Do**</div>
+  <div className="flex items-center justify-center">
+    ![Banner error, with
+    header](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-status-messages_banners.png)
+  </div>
 </Dos>

--- a/packages/docs/design-docs/ux-writing/status-messages.mdx
+++ b/packages/docs/design-docs/ux-writing/status-messages.mdx
@@ -1,0 +1,105 @@
+import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
+
+# Status messages
+
+Status messages help the user to understand what is happening in the application. Their common instances are success, warning and error messages.
+
+## Basic guidelines
+
+### Keep it simple
+
+Messages should be short and to the point. Focus on what happened and what the user needs to do to move forward. When applicable, include a link to the place where the user can act upon what's being announced.
+
+### Avoid vague language
+
+Don’t start status messages with “It seems like…” or “It looks like….” It sounds like we don’t know what went wrong. There’s no room for ambiguity — especially when we’re trying to confirm a potentially destructive action.
+
+<Donts>
+<div class="hidden">
+**Don't**
+</div>
+<div className="flex items-center justify-center">
+![Don't write vague error messages](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-status-messages_vague_language.png)
+</div>
+</Donts>
+
+### Use positive language
+
+Don’t use scary or dramatic words like “bad,” “forbidden,” “fatal,” “failed,” “unresolved,” “invalid” etc.
+
+### Don’t mention error codes
+
+Error codes mean nothing to the average user.
+
+### Avoid using “please”
+
+Only use “please” when asking the user to go out of their way to do something they might find inconvenient.
+
+### Avoid humor
+
+Words and phrases like “Whoops” or “Oh no!” could be taken as inconsiderate, even insulting.
+
+<Donts>
+<div class="hidden">
+**Don't**
+</div>
+<div className="flex items-center justify-center">
+![Avoid humor in error messages](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-status-messages-avoid_humor.png)
+</div>
+</Donts>
+
+### Follow the &#123;verb&#125; + &#123;noun&#125; formula.
+
+Use supporting copy to provide additional context as needed.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+<div className="flex items-center justify-center">
+![Confirmation example](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-confirmations-supporting_copy.png)
+</div>
+</Dos>
+
+### Don’t ask vague questions
+
+“Are you sure?” About what? It’s not clear to the user what we’re trying to confirm.
+
+<Donts>
+<div class="hidden">
+**Don't**
+</div>
+<div className="flex items-center justify-center">
+![Don't ask vague questions](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-confirmations-vague_questions.png)
+</div>
+</Donts>
+
+### Always use “Cancel”
+
+For modal alerts, always use “cancel” when giving the user the option to back out. Never use “stop,” “pause,” “terminate,” “never mind” or “back” 
+
+### Write descriptive buttons
+
+When a user clicks a button, whether it’s to confirm an action or cancel one, it should be clear what will happen when they click.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+<div className="flex items-center justify-center">
+![Don't use vague CTAs](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-confirmations-supporting_copy.png)
+</div>
+</Dos>
+
+### Include applicable links
+
+Whenever possible, save the user some trouble and provide a link to the place where the user can fix the error. It’s okay to include “Learn more” links to Knowledge Base articles.
+
+<Dos>
+<div class="hidden">
+**Do**
+</div>
+<div className="flex items-center justify-center">
+![Banner error, with header](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.interactions-status-messages_banners.png)
+</div>
+</Dos>

--- a/packages/docs/design-docs/ux-writing/the-basics.mdx
+++ b/packages/docs/design-docs/ux-writing/the-basics.mdx
@@ -1,6 +1,6 @@
-import Icon from "@components/icons/Icon";
-import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
-import { ComparisonTable } from "@components/big-design/ComparisonTable";
+import { ComparisonTable } from '@components/big-design/ComparisonTable';
+import { Donts, Dos, DosAndDonts } from '@components/big-design/DosAndDonts';
+import Icon from '@components/icons/Icon';
 
 # The basics
 
@@ -9,17 +9,17 @@ import { ComparisonTable } from "@components/big-design/ComparisonTable";
 For general guidelines on voice and tone, here’s a passage from the BigCommerce _Global Writing Style Guide:_
 
 > Just like a person, a brand has a distinct personality and voice. This voice is unique, recognizable, and consistent, helping bring BigCommerce to life across all channels and touchpoints.
-> 
+>
 > BigCommerce is:
-> 
+>
 > **Professional**, not boring
-> 
+>
 > **Direct**, not wordy
-> 
+>
 > **Relatable**, not sales-y
-> 
+>
 > **Knowledgeable**, and proud to be ecommerce experts
-> 
+>
 > **Often inspirational**, sometimes clever
 
 ## Show empathy
@@ -31,44 +31,36 @@ Showing empathy towards the user is one of the fundamental precepts of product d
 We want to tell users what they _can_ do, as opposed to what they _can’t_ do. Why? Because using BigCommerce should be a positive experience. When words like “can’t” and “don’t” appear in your writing, they should serve as red flags that you’re using negative language.
 
 <DosAndDonts>
-<Dos hideHeader={true}>
-<div class="hidden">
-**Do**
-</div>
-<div>
-To turn on this setting, connect your PayPal account first.
-</div>
-</Dos>
-<Donts hideHeader={true}>
-<div class="hidden">
-**Don't**
-</div>
-<div>
-You can’t turn on this setting until you connect your PayPal account.
-</div>
-</Donts>
+  <Dos hideHeader={true}>
+    <div className="hidden">**Do**</div>
+    <div>To turn on this setting, connect your PayPal account first.</div>
+  </Dos>
+  <Donts hideHeader={true}>
+    <div className="hidden">**Don't**</div>
+    <div>You can’t turn on this setting until you connect your PayPal account.</div>
+  </Donts>
 </DosAndDonts>
 
 You should also watch out for deceptive design (sometimes called dark UX). Deceptive design refers to any friction or tricks present in the UI, put there to try and get users to do something they probably don’t want to do. If you’ve ever had a hard time canceling or unsubscribing from an online account — that’s deceptive design. If you’ve ever been made to feel bad about your decisions — that’s deceptive design. Don’t do it.
 
-
-
 <DosAndDonts>
-<Dos>
-![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.the_basics-be_positive-do.png "title")
-</Dos>
-<Donts>
-![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.the_basics-be_positive-dont.png "title")
-</Donts>
+  <Dos>
+    ![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.the_basics-be_positive-do.png
+    "title")
+  </Dos>
+  <Donts>
+    ![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.the_basics-be_positive-dont.png
+    "title")
+  </Donts>
 </DosAndDonts>
 
 ## Don’t get meta
 
-Have you ever watched a movie where the characters talked about being in a movie? That’s what it means to be [meta <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.merriam-webster.com/dictionary/meta "https://www.merriam-webster.com/dictionary/meta"). The _Scream_ and _Deadpool_ movies are great examples. The characters seem to know they’re in a movie and help the audience by explaining what’s happening.
+Have you ever watched a movie where the characters talked about being in a movie? That’s what it means to be [meta <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.merriam-webster.com/dictionary/meta 'https://www.merriam-webster.com/dictionary/meta'). The _Scream_ and _Deadpool_ movies are great examples. The characters seem to know they’re in a movie and help the audience by explaining what’s happening.
 
 A good design, like a bad movie, should be predictable. If we need to get meta and explain where something is or how to use it within the UI itself, then we should take a second look at the UI.
 
-Granted, there may be instances where you must provide guidance to the user as to what they should do next or where they need to go to find something. In a cases like these, try to be concrete and specific. 
+Granted, there may be instances where you must provide guidance to the user as to what they should do next or where they need to go to find something. In a cases like these, try to be concrete and specific.
 
 Avoid vague directions like “below/above” and “left/right.” If you need to direct the user to a specific page, link to the page or section of the page.
 
@@ -82,7 +74,7 @@ The goal of this section of the UX writing guide is to give you a quick gloss on
 
 ### What is inclusive language?
 
-[Inclusive language <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.collinsdictionary.com/dictionary/english/inclusive-language "https://www.collinsdictionary.com/dictionary/english/inclusive-language") is defined as:
+[Inclusive language <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.collinsdictionary.com/dictionary/english/inclusive-language 'https://www.collinsdictionary.com/dictionary/english/inclusive-language') is defined as:
 
 > Language that avoids the use of certain expressions or words that might be considered to exclude particular groups of people, esp gender-specific words, such as ‘man,’ ‘mankind,’ and masculine pronouns, the use of which might be considered to exclude women.
 
@@ -115,24 +107,26 @@ Promotes negative beliefs about aging and older adults.
 Check the chart below for non-inclusive words and phrases commonly encountered in UX writing and suggested replacements.
 
 <ComparisonTable>
-| Inclusive |  Non-inclusive |
-|---|---|
-| Artificial, synthetic, fabricated, manufactured   | Man-made |
-| Businessperson                                    | Businessman |
-| Staffed, managed, staffing, workforce             | Manned, manpower |
-| Baffling, confusing, unbelievable, silly          | Crazy, insane |
-| Denylist, blocklist                               | Blacklist |
-| Allowlist                                         | Whitelist |
-| Slows                                             | Cripples |
-| Placeholder                                       | Dummy |
-| You all                                           | Guys |
-| They, them, their                                 | He, him, she, her |
-| Primary, secondary                                | Master, slave |
-| Confidence check                                  | Sanity check |
-| Gap, weak point                                   | Blind spot |
-| Legacy, exempt                                    | Grandfathered in |
-| Meeting, gathering                                | Pow wow |
-| Easy, simple                                      | Cakewalk |
+
+| Inclusive                                       | Non-inclusive     |
+| ----------------------------------------------- | ----------------- |
+| Artificial, synthetic, fabricated, manufactured | Man-made          |
+| Businessperson                                  | Businessman       |
+| Staffed, managed, staffing, workforce           | Manned, manpower  |
+| Baffling, confusing, unbelievable, silly        | Crazy, insane     |
+| Denylist, blocklist                             | Blacklist         |
+| Allowlist                                       | Whitelist         |
+| Slows                                           | Cripples          |
+| Placeholder                                     | Dummy             |
+| You all                                         | Guys              |
+| They, them, their                               | He, him, she, her |
+| Primary, secondary                              | Master, slave     |
+| Confidence check                                | Sanity check      |
+| Gap, weak point                                 | Blind spot        |
+| Legacy, exempt                                  | Grandfathered in  |
+| Meeting, gathering                              | Pow wow           |
+| Easy, simple                                    | Cakewalk          |
+
 </ComparisonTable>
 
 ### Rules for inclusive writing
@@ -152,5 +146,3 @@ Only mention gender, sexual orientation, religion, race, age or physical abiliti
 **When all else fails, write around the pronouns**
 
 In many cases you can reword your sentences and avoid using pronouns in the first place.
-
-

--- a/packages/docs/design-docs/ux-writing/the-basics.mdx
+++ b/packages/docs/design-docs/ux-writing/the-basics.mdx
@@ -1,0 +1,156 @@
+import Icon from "@components/icons/Icon";
+import { DosAndDonts, Dos, Donts, IconDo, IconDont } from "@components/big-design/DosAndDonts";
+import { ComparisonTable } from "@components/big-design/ComparisonTable";
+
+# The basics
+
+## Voice and tone
+
+For general guidelines on voice and tone, here’s a passage from the BigCommerce _Global Writing Style Guide:_
+
+> Just like a person, a brand has a distinct personality and voice. This voice is unique, recognizable, and consistent, helping bring BigCommerce to life across all channels and touchpoints.
+> 
+> BigCommerce is:
+> 
+> **Professional**, not boring
+> 
+> **Direct**, not wordy
+> 
+> **Relatable**, not sales-y
+> 
+> **Knowledgeable**, and proud to be ecommerce experts
+> 
+> **Often inspirational**, sometimes clever
+
+## Show empathy
+
+Showing empathy towards the user is one of the fundamental precepts of product design. We all know it’s important and that we’re supposed to do it. Unfortunately, when you’re the one designing the product, and you know everything about how it works, it’s easy to get nearsighted and forget about the user. When this happens, try stepping back and imagine yourself as the user. Would the writing make sense to you?
+
+## Be positive
+
+We want to tell users what they _can_ do, as opposed to what they _can’t_ do. Why? Because using BigCommerce should be a positive experience. When words like “can’t” and “don’t” appear in your writing, they should serve as red flags that you’re using negative language.
+
+<DosAndDonts>
+<Dos hideHeader={true}>
+<div class="hidden">
+**Do**
+</div>
+<div>
+To turn on this setting, connect your PayPal account first.
+</div>
+</Dos>
+<Donts hideHeader={true}>
+<div class="hidden">
+**Don't**
+</div>
+<div>
+You can’t turn on this setting until you connect your PayPal account.
+</div>
+</Donts>
+</DosAndDonts>
+
+You should also watch out for deceptive design (sometimes called dark UX). Deceptive design refers to any friction or tricks present in the UI, put there to try and get users to do something they probably don’t want to do. If you’ve ever had a hard time canceling or unsubscribing from an online account — that’s deceptive design. If you’ve ever been made to feel bad about your decisions — that’s deceptive design. Don’t do it.
+
+
+
+<DosAndDonts>
+<Dos>
+![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.the_basics-be_positive-do.png "title")
+</Dos>
+<Donts>
+![](https://storage.googleapis.com/bigcommerce-production-dev-center/images/big-design/big-design.ux-writing-guide.the_basics-be_positive-dont.png "title")
+</Donts>
+</DosAndDonts>
+
+## Don’t get meta
+
+Have you ever watched a movie where the characters talked about being in a movie? That’s what it means to be [meta <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.merriam-webster.com/dictionary/meta "https://www.merriam-webster.com/dictionary/meta"). The _Scream_ and _Deadpool_ movies are great examples. The characters seem to know they’re in a movie and help the audience by explaining what’s happening.
+
+A good design, like a bad movie, should be predictable. If we need to get meta and explain where something is or how to use it within the UI itself, then we should take a second look at the UI.
+
+Granted, there may be instances where you must provide guidance to the user as to what they should do next or where they need to go to find something. In a cases like these, try to be concrete and specific. 
+
+Avoid vague directions like “below/above” and “left/right.” If you need to direct the user to a specific page, link to the page or section of the page.
+
+## Be inclusive
+
+Merchants who use BigCommerce come from a wide range of different social and ethnic backgrounds, sexual orientations and physical abilities.
+
+The language we use inside our products should take into account the diversity of our users. To that end, communicate in such a way that is inclusive, being careful to avoid culturally ingrained biases that, actively or passively, exclude certain groups.
+
+The goal of this section of the UX writing guide is to give you a quick gloss on how to remove non-inclusive terms and phrases from the discourse of ecommerce.
+
+### What is inclusive language?
+
+[Inclusive language <Icon name="external" className="inline w-4 h-auto" includesWrapper={false} />](https://www.collinsdictionary.com/dictionary/english/inclusive-language "https://www.collinsdictionary.com/dictionary/english/inclusive-language") is defined as:
+
+> Language that avoids the use of certain expressions or words that might be considered to exclude particular groups of people, esp gender-specific words, such as ‘man,’ ‘mankind,’ and masculine pronouns, the use of which might be considered to exclude women.
+
+### What does non-inclusive language look like?
+
+Non-inclusive language goes beyond gender. It’s impossible to list out every example of non-inclusive language, but here are some examples that exclude certain groups of people:
+
+**“Hey guys”**
+
+Implies that men are the preferred gender.
+
+**“Psycho” or “crazy”**
+
+Downplays people’s real experiences with mental disorders.
+
+**“Trim the fat”**
+
+Suggests those of a certain body type are less valued than other groups.
+
+**“Lame”**
+
+Denigrates people with disabilities.
+
+**“Senior moment”**
+
+Promotes negative beliefs about aging and older adults.
+
+### Words to avoid, words to use instead
+
+Check the chart below for non-inclusive words and phrases commonly encountered in UX writing and suggested replacements.
+
+<ComparisonTable>
+| Inclusive |  Non-inclusive |
+|---|---|
+| Artificial, synthetic, fabricated, manufactured   | Man-made |
+| Businessperson                                    | Businessman |
+| Staffed, managed, staffing, workforce             | Manned, manpower |
+| Baffling, confusing, unbelievable, silly          | Crazy, insane |
+| Denylist, blocklist                               | Blacklist |
+| Allowlist                                         | Whitelist |
+| Slows                                             | Cripples |
+| Placeholder                                       | Dummy |
+| You all                                           | Guys |
+| They, them, their                                 | He, him, she, her |
+| Primary, secondary                                | Master, slave |
+| Confidence check                                  | Sanity check |
+| Gap, weak point                                   | Blind spot |
+| Legacy, exempt                                    | Grandfathered in |
+| Meeting, gathering                                | Pow wow |
+| Easy, simple                                      | Cakewalk |
+</ComparisonTable>
+
+### Rules for inclusive writing
+
+**Avoid gendered language**
+
+Use the third person singular “they/them/their,” unless you know the subject’s preferred pronouns. Failing that, use the second person “you.” Doing the latter makes your writing more personal and engaging.
+
+**Avoid directional language**
+
+Directions like left, right, above and below won’t be much help to someone using a screen reader. Instead, provide specific, concrete directions, referring to areas of the page by name.
+
+**Focus on the person, not their characteristics**
+
+Only mention gender, sexual orientation, religion, race, age or physical abilities when it’s actually relevant to the topic at hand.
+
+**When all else fails, write around the pronouns**
+
+In many cases you can reword your sentences and avoid using pronouns in the first place.
+
+

--- a/packages/docs/design-docs/ux-writing/writing-for-mobile.mdx
+++ b/packages/docs/design-docs/ux-writing/writing-for-mobile.mdx
@@ -2,8 +2,8 @@
 
 When writing for the mobile app:
 
- - Use “tap” instead of “click” when instructing the user to interact with the UI
- - Use "enter" instead of "type" when instructing users to complete form fields
+- Use “tap” instead of “click” when instructing the user to interact with the UI
+- Use "enter" instead of "type" when instructing users to complete form fields
 - Keep titles, headings and subheadings short. As a good rule of thumb, try to limit copy to 2/3rds of available space, allowing 1/3rd for copy to grow longer during localization.
 - Button copy should be no longer than 3 words
 - Consider the device — not all mobile devices are the same size

--- a/packages/docs/design-docs/ux-writing/writing-for-mobile.mdx
+++ b/packages/docs/design-docs/ux-writing/writing-for-mobile.mdx
@@ -1,0 +1,9 @@
+# Writing for mobile
+
+When writing for the mobile app:
+
+ - Use “tap” instead of “click” when instructing the user to interact with the UI
+ - Use "enter" instead of "type" when instructing users to complete form fields
+- Keep titles, headings and subheadings short. As a good rule of thumb, try to limit copy to 2/3rds of available space, allowing 1/3rd for copy to grow longer during localization.
+- Button copy should be no longer than 3 words
+- Consider the device — not all mobile devices are the same size

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,14 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
+"@babel/code-frame@^7.16.0":
+  version "7.23.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
+  integrity sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==
+  dependencies:
+    "@babel/highlight" "^7.23.4"
+    chalk "^2.4.2"
+
 "@babel/code-frame@^7.22.13":
   version "7.22.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
@@ -473,6 +481,15 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.22.5"
     chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz#edaadf4d8232e1a961432db785091207ead0621b"
+  integrity sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.20"
+    chalk "^2.4.2"
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7":
@@ -2288,6 +2305,20 @@
     treeverse "^3.0.0"
     walk-up-path "^1.0.0"
 
+"@npmcli/config@^6.0.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/config/-/config-6.4.0.tgz#3b1ddfa0c452fd09beac2cf05ca49b76c7a36bc8"
+  integrity sha512-/fQjIbuNVIT/PbXvw178Tm97bxV0E0nVUFKHivMKtSI2pcs8xKdaWkHJxf9dTI0G/y5hp/KuCvgcUu5HwAtI1w==
+  dependencies:
+    "@npmcli/map-workspaces" "^3.0.2"
+    ci-info "^3.8.0"
+    ini "^4.1.0"
+    nopt "^7.0.0"
+    proc-log "^3.0.0"
+    read-package-json-fast "^3.0.2"
+    semver "^7.3.5"
+    walk-up-path "^3.0.1"
+
 "@npmcli/fs@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-2.1.0.tgz#f2a21c28386e299d1a9fae8051d35ad180e33109"
@@ -2639,6 +2670,18 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
+"@pkgr/utils@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.4.2.tgz#9e638bbe9a6a6f165580dc943f138fd3309a2cbc"
+  integrity sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==
+  dependencies:
+    cross-spawn "^7.0.3"
+    fast-glob "^3.3.0"
+    is-glob "^4.0.3"
+    open "^9.1.0"
+    picocolors "^1.0.0"
+    tslib "^2.6.0"
+
 "@popperjs/core@^2.11.6", "@popperjs/core@^2.9.2":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
@@ -2878,6 +2921,13 @@
     "@tufjs/canonical-json" "1.0.0"
     minimatch "^9.0.0"
 
+"@types/acorn@^4.0.0":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.6.tgz#d61ca5480300ac41a7d973dd5b84d0a591154a22"
+  integrity sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==
+  dependencies:
+    "@types/estree" "*"
+
 "@types/aria-query@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"
@@ -2923,6 +2973,32 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/concat-stream@^2.0.0":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/concat-stream/-/concat-stream-2.0.3.tgz#1f5c2ad26525716c181191f7ed53408f78eb758e"
+  integrity sha512-3qe4oQAPNwVNwK4C9c8u+VJqv9kez+2MR4qJpoPFfXtgxxif1QbFusvXzK0/Wra2VX07smostI2VMmJNSpZjuQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/debug@^4.0.0":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
+  integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
+  dependencies:
+    "@types/ms" "*"
+
+"@types/estree-jsx@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/estree-jsx/-/estree-jsx-1.0.3.tgz#f8aa833ec986d82b8271a294a92ed1565bf2c66a"
+  integrity sha512-pvQ+TKeRHeiUGRhvYwRrQ/ISnohKkSJR14fT2yqyZ4e9K5vqc7hrtY2Y1Dw0ZwAzQ6DQsxsaCUuSIIi8v0Cq6w==
+  dependencies:
+    "@types/estree" "*"
+
+"@types/estree@*", "@types/estree@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
+  integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
+
 "@types/glob@^8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.0.0.tgz#321607e9cbaec54f687a0792b2d1d370739455d2"
@@ -2943,6 +3019,13 @@
   resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.12.tgz#095122edca896689bdfcdd73b057e23064d23572"
   integrity sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==
 
+"@types/hast@^2.0.0":
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.8.tgz#4ac5caf38b262b7bd5ca3202dda71f0271635660"
+  integrity sha512-aMIqAlFd2wTIDZuvLbhUT+TGvMxrNC8ECUIVtH6xxy0sQLs3iu6NO8Kp/VT5je7i5ufnebXzdV1dNDMnvaH6IQ==
+  dependencies:
+    "@types/unist" "^2"
+
 "@types/hoist-non-react-statics@*", "@types/hoist-non-react-statics@^3.3.0":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -2950,6 +3033,11 @@
   dependencies:
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
+
+"@types/is-empty@^1.0.0":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/is-empty/-/is-empty-1.2.3.tgz#a2d55ea8a5ec57bf61e411ba2a9e5132fe4f0899"
+  integrity sha512-4J1l5d79hoIvsrKh5VUKVRA1aIdsOb10Hu5j3J2VfP/msDnfTdGPmNp2E1Wg+vs97Bktzo+MZePFFXSGoykYJw==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
@@ -2997,6 +3085,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/mdast@^3.0.0":
+  version "3.0.15"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.15.tgz#49c524a263f30ffa28b71ae282f813ed000ab9f5"
+  integrity sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==
+  dependencies:
+    "@types/unist" "^2"
+
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
@@ -3007,10 +3102,22 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
+"@types/ms@*":
+  version "0.7.34"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
+  integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
+
 "@types/node@*", "@types/node@^18.11.18":
   version "18.13.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.13.0.tgz#0400d1e6ce87e9d3032c19eb6c58205b0d3f7850"
   integrity sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==
+
+"@types/node@^18.0.0":
+  version "18.19.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.2.tgz#865107157bda220eef9fa8c2173152d6559a41ae"
+  integrity sha512-6wzfBdbWpe8QykUkXBjtmO3zITA0A3FIjoy+in0Y2K4KrCiRhNYJIdwAPDffZ3G6GnaKaSLSEa9ZuORLfEoiwg==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -3111,6 +3218,11 @@
     "@types/react" "*"
     csstype "^3.0.2"
 
+"@types/supports-color@^8.0.0":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@types/supports-color/-/supports-color-8.1.3.tgz#b769cdce1d1bb1a3fa794e35b62c62acdf93c139"
+  integrity sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==
+
 "@types/testing-library__jest-dom@^5.9.1":
   version "5.14.2"
   resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz#564fb2b2dc827147e937a75b639a05d17ce18b44"
@@ -3122,6 +3234,11 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
+
+"@types/unist@^2", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.10.tgz#04ffa7f406ab628f7f7e97ca23e290cd8ab15efc"
+  integrity sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -3419,7 +3536,7 @@ acorn-globals@^7.0.0:
     acorn "^8.1.0"
     acorn-walk "^8.0.2"
 
-acorn-jsx@^5.3.2:
+acorn-jsx@^5.0.0, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -3428,6 +3545,11 @@ acorn-walk@^8.0.2, acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.0.0, acorn@^8.10.0:
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
+  integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
 
 acorn@^8.1.0, acorn@^8.4.1, acorn@^8.8.1:
   version "8.8.2"
@@ -3842,6 +3964,11 @@ babel-preset-jest@^29.5.0:
     babel-plugin-jest-hoist "^29.5.0"
     babel-preset-current-node-syntax "^1.0.0"
 
+bail@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -3856,6 +3983,11 @@ before-after-hook@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
+
+big-integer@^1.6.44:
+  version "1.6.52"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
+  integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
 
 bin-links@^4.0.1:
   version "4.0.1"
@@ -3885,6 +4017,13 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+bplist-parser@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.2.0.tgz#43a9d183e5bf9d545200ceac3e712f79ebbe8d0e"
+  integrity sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==
+  dependencies:
+    big-integer "^1.6.44"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3957,6 +4096,13 @@ builtins@^5.0.0:
   integrity sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==
   dependencies:
     semver "^7.0.0"
+
+bundle-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-3.0.0.tgz#ba59bcc9ac785fb67ccdbf104a2bf60c099f0e1a"
+  integrity sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==
+  dependencies:
+    run-applescript "^5.0.0"
 
 byte-size@7.0.0:
   version "7.0.0"
@@ -4053,6 +4199,11 @@ caniuse-lite@^1.0.30001503:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001513.tgz#382fe5fbfb0f7abbaf8c55ca3ac71a0307a752e9"
   integrity sha512-pnjGJo7SOOjAGytZZ203Em95MRM8Cr6jhCXNF/FAXTpCTRTECnqQWLpiTRqrFtdYcth8hf4WECUpkezuYsMVww==
 
+ccount@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
+  integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
 chalk@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
@@ -4096,6 +4247,41 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
+character-entities-html4@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
+  integrity sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
+
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities-legacy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
+  integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
+character-entities@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
+
+character-reference-invalid@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz#85c66b041e43b47210faf401278abf808ac45cb9"
+  integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -4135,6 +4321,11 @@ ci-info@^3.6.1:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
+
+ci-info@^3.8.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 cjs-module-lexer@^1.0.0:
   version "1.2.2"
@@ -4672,7 +4863,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@4, debug@4.3.4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -4711,6 +4902,13 @@ decimal.js@^10.4.2:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
+decode-named-character-reference@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz#daabac9690874c394c81e4162a0304b35d824f0e"
+  integrity sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==
+  dependencies:
+    character-entities "^2.0.0"
+
 dedent@0.7.0, dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -4731,6 +4929,24 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.0.tgz#65491893ec47756d44719ae520e0e2609233b59b"
   integrity sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==
 
+default-browser-id@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-3.0.0.tgz#bee7bbbef1f4e75d31f98f4d3f1556a14cea790c"
+  integrity sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==
+  dependencies:
+    bplist-parser "^0.2.0"
+    untildify "^4.0.0"
+
+default-browser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-4.0.0.tgz#53c9894f8810bf86696de117a6ce9085a3cbc7da"
+  integrity sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==
+  dependencies:
+    bundle-name "^3.0.0"
+    default-browser-id "^3.0.0"
+    execa "^7.1.1"
+    titleize "^3.0.0"
+
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
@@ -4742,6 +4958,11 @@ define-lazy-prop@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
+define-lazy-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
+  integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
 define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.1.4"
@@ -4793,6 +5014,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+dequal@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
@@ -4812,6 +5038,11 @@ diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+diff@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -5001,7 +5232,7 @@ err-code@^2.0.2:
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
   integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
-error-ex@^1.3.1:
+error-ex@^1.3.1, error-ex@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
@@ -5193,6 +5424,26 @@ eslint-import-resolver-typescript@^3.5.2:
     is-glob "^4.0.3"
     synckit "^0.8.4"
 
+eslint-mdx@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-mdx/-/eslint-mdx-2.2.0.tgz#4e54710f3dc9778fdcac1fabeffacb8f65ad5cbc"
+  integrity sha512-AriN6lCW6KhWQ9GEiXapR1DokKHefOUqKvCmHxnE9puCWYhWiycU2SNKH8jmrasDBreZ+RtJDLi+RcUNLJatjg==
+  dependencies:
+    acorn "^8.10.0"
+    acorn-jsx "^5.3.2"
+    espree "^9.6.1"
+    estree-util-visit "^1.2.1"
+    remark-mdx "^2.3.0"
+    remark-parse "^10.0.2"
+    remark-stringify "^10.0.3"
+    synckit "^0.8.5"
+    tslib "^2.6.1"
+    unified "^10.1.2"
+    unified-engine "^10.1.0"
+    unist-util-visit "^4.1.2"
+    uvu "^0.5.6"
+    vfile "^5.3.7"
+
 eslint-module-utils@^2.7.3:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz#ad7e3a10552fdd0642e1e55292781bd6e34876ee"
@@ -5269,6 +5520,27 @@ eslint-plugin-jsx-a11y@^6.5.1:
     jsx-ast-utils "^3.2.1"
     language-tags "^1.0.5"
     minimatch "^3.0.4"
+
+eslint-plugin-markdown@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-markdown/-/eslint-plugin-markdown-3.0.1.tgz#fc6765bdb5f82a75e2438d7fac619602f2abc38c"
+  integrity sha512-8rqoc148DWdGdmYF6WSQFT3uQ6PO7zXYgeBpHAOAakX/zpq+NvFYbDA/H7PYzHajwtmaOzAwfxyl++x0g1/N9A==
+  dependencies:
+    mdast-util-from-markdown "^0.8.5"
+
+eslint-plugin-mdx@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mdx/-/eslint-plugin-mdx-2.2.0.tgz#eb1877fcaa2eaa02d3719d5f926d12a3f7f12ff7"
+  integrity sha512-OseoMXUIr8iy3E0me+wJLVAxuB0kxHP1plxuYAJDynzorzOj2OKv8Fhr+rIOJ32zfl3bnEWsqFnUiCnyznr1JQ==
+  dependencies:
+    eslint-mdx "^2.2.0"
+    eslint-plugin-markdown "^3.0.1"
+    remark-mdx "^2.3.0"
+    remark-parse "^10.0.2"
+    remark-stringify "^10.0.3"
+    tslib "^2.6.1"
+    unified "^10.1.2"
+    vfile "^5.3.7"
 
 eslint-plugin-prettier@^4.0.0:
   version "4.0.0"
@@ -5424,6 +5696,19 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-util-is-identifier-name@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/estree-util-is-identifier-name/-/estree-util-is-identifier-name-2.1.0.tgz#fb70a432dcb19045e77b05c8e732f1364b4b49b2"
+  integrity sha512-bEN9VHRyXAUOjkKVQVvArFym08BTWB0aJPppZZr0UNyAqWsLaVfAqP7hbaTJjzHifmB5ebnR8Wm7r7yGN/HonQ==
+
+estree-util-visit@^1.0.0, estree-util-visit@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/estree-util-visit/-/estree-util-visit-1.2.1.tgz#8bc2bc09f25b00827294703835aabee1cc9ec69d"
+  integrity sha512-xbgqcrkIVbIG+lI/gzbvd9SGTJL4zqJKBFttUl5pP27KhAjtMKbX/mQXJ7qgyXpMgVy/zvpm0xoQQaGL8OloOw==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/unist" "^2.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -5464,7 +5749,7 @@ execa@5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-execa@7.2.0:
+execa@7.2.0, execa@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-7.2.0.tgz#657e75ba984f42a70f38928cedc87d6f2d4fe4e9"
   integrity sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==
@@ -5510,6 +5795,11 @@ expect@^29.0.0, expect@^29.5.0:
     jest-message-util "^29.5.0"
     jest-util "^29.5.0"
 
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -5551,6 +5841,17 @@ fast-glob@^3.2.11, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -5567,6 +5868,13 @@ fastq@^1.6.0:
   integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
   dependencies:
     reusify "^1.0.4"
+
+fault@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-2.0.1.tgz#d47ca9f37ca26e4bd38374a7c500b5a384755b6c"
+  integrity sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==
+  dependencies:
+    format "^0.2.0"
 
 fb-watchman@^2.0.0:
   version "2.0.2"
@@ -5689,6 +5997,11 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
 
 formik@^2.0.6:
   version "2.4.3"
@@ -6013,7 +6326,7 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.1:
+glob@^8.0.0, glob@^8.0.1:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -6312,6 +6625,11 @@ ignore-walk@^6.0.0:
   dependencies:
     minimatch "^7.4.2"
 
+ignore@^5.0.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
+  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+
 ignore@^5.0.4, ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
@@ -6332,6 +6650,11 @@ import-local@^3.0.2:
   dependencies:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
+
+import-meta-resolve@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz#75237301e72d1f0fbd74dbc6cca9324b164c2cc9"
+  integrity sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -6365,6 +6688,11 @@ ini@^1.3.2, ini@^1.3.4:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+ini@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-4.1.1.tgz#d95b3d843b1e906e56d6747d5447904ff50ce7a1"
+  integrity sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==
 
 init-package-json@3.0.2, init-package-json@^3.0.2:
   version "3.0.2"
@@ -6455,6 +6783,32 @@ ip@^1.1.5:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphabetical@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz#01072053ea7c1036df3c7d19a6daaec7f19e789b"
+  integrity sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
+is-alphanumerical@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz#7c03fbe96e3e931113e57f964b0a368cc2dfd875"
+  integrity sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==
+  dependencies:
+    is-alphabetical "^2.0.0"
+    is-decimal "^2.0.0"
+
 is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
@@ -6491,6 +6845,11 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-buffer@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
+
 is-callable@^1.1.3, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
@@ -6522,10 +6881,30 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
+
+is-decimal@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
+  integrity sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==
+
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
+is-docker@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
+  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
+
+is-empty@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-empty/-/is-empty-1.2.0.tgz#de9bb5b278738a05a0b09a57e1fb4d4a341a9f6b"
+  integrity sha512-F2FnH/otLNJv0J6wc73A5Xo7oHLNnqplYqZhUu01tD54DIPvxIRSTSLkrUB/M0nHO4vo1O9PDfN4KoTxCzLh/w==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -6553,6 +6932,23 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
+
+is-hexadecimal@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz#86b5bf668fca307498d319dfc03289d781a90027"
+  integrity sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==
+
+is-inside-container@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
+  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
+  dependencies:
+    is-docker "^3.0.0"
 
 is-interactive@^1.0.0:
   version "1.0.0"
@@ -6600,6 +6996,11 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
+is-plain-obj@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
 is-plain-object@^2.0.4:
   version "2.0.4"
@@ -7408,6 +7809,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+kleur@^4.0.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
+  integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
+
 language-subtag-registry@~0.3.2:
   version "0.3.21"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz#04ac218bea46f04cb039084602c6da9e788dd45a"
@@ -7557,6 +7963,11 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+lines-and-columns@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-2.0.4.tgz#d00318855905d2660d8c0822e3f5a4715855fc42"
+  integrity sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==
+
 lines-and-columns@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-2.0.3.tgz#b2f0badedb556b747020ab8ea7f0373e22efac1b"
@@ -7609,6 +8020,14 @@ load-json-file@^4.0.0:
     parse-json "^4.0.0"
     pify "^3.0.0"
     strip-bom "^3.0.0"
+
+load-plugin@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/load-plugin/-/load-plugin-5.1.0.tgz#15600f5191c742b16e058cfc908c227c13db0104"
+  integrity sha512-Lg1CZa1CFj2CbNaxijTL6PCbzd4qGTlZov+iH2p5Xwy/ApcZJh+i6jMN2cYePouTfjJfrNu3nXFdEw8LvbjPFQ==
+  dependencies:
+    "@npmcli/config" "^6.0.0"
+    import-meta-resolve "^2.0.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -7730,6 +8149,11 @@ log-update@^5.0.1:
     slice-ansi "^5.0.0"
     strip-ansi "^7.0.1"
     wrap-ansi "^8.0.1"
+
+longest-streak@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
+  integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -7873,6 +8297,120 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.1.0.tgz#b91221b542734b9f14256c0132c897c5d7256fd5"
   integrity sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
 
+mdast-util-from-markdown@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
+  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
+mdast-util-from-markdown@^1.0.0, mdast-util-from-markdown@^1.1.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz#9421a5a247f10d31d2faed2a30df5ec89ceafcf0"
+  integrity sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    mdast-util-to-string "^3.1.0"
+    micromark "^3.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-decode-string "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    unist-util-stringify-position "^3.0.0"
+    uvu "^0.5.0"
+
+mdast-util-mdx-expression@^1.0.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdx-expression/-/mdast-util-mdx-expression-1.3.2.tgz#d027789e67524d541d6de543f36d51ae2586f220"
+  integrity sha512-xIPmR5ReJDu/DHH1OoIT1HkuybIfRGYRywC+gJtI7qHjCJp/M9jrmBEJW22O8lskDWm562BX2W8TiAwRTb0rKA==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    mdast-util-from-markdown "^1.0.0"
+    mdast-util-to-markdown "^1.0.0"
+
+mdast-util-mdx-jsx@^2.0.0:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-2.1.4.tgz#7c1f07f10751a78963cfabee38017cbc8b7786d1"
+  integrity sha512-DtMn9CmVhVzZx3f+optVDF8yFgQVt7FghCRNdlIaS3X5Bnym3hZwPbg/XW86vdpKjlc1PVj26SpnLGeJBXD3JA==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    ccount "^2.0.0"
+    mdast-util-from-markdown "^1.1.0"
+    mdast-util-to-markdown "^1.3.0"
+    parse-entities "^4.0.0"
+    stringify-entities "^4.0.0"
+    unist-util-remove-position "^4.0.0"
+    unist-util-stringify-position "^3.0.0"
+    vfile-message "^3.0.0"
+
+mdast-util-mdx@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdx/-/mdast-util-mdx-2.0.1.tgz#49b6e70819b99bb615d7223c088d295e53bb810f"
+  integrity sha512-38w5y+r8nyKlGvNjSEqWrhG0w5PmnRA+wnBvm+ulYCct7nsGYhFVb0lljS9bQav4psDAS1eGkP2LMVcZBi/aqw==
+  dependencies:
+    mdast-util-from-markdown "^1.0.0"
+    mdast-util-mdx-expression "^1.0.0"
+    mdast-util-mdx-jsx "^2.0.0"
+    mdast-util-mdxjs-esm "^1.0.0"
+    mdast-util-to-markdown "^1.0.0"
+
+mdast-util-mdxjs-esm@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-1.3.1.tgz#645d02cd607a227b49721d146fd81796b2e2d15b"
+  integrity sha512-SXqglS0HrEvSdUEfoXFtcg7DRl7S2cwOXc7jkuusG472Mmjag34DUDeOJUZtl+BVnyeO1frIgVpHlNRWc2gk/w==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    mdast-util-from-markdown "^1.0.0"
+    mdast-util-to-markdown "^1.0.0"
+
+mdast-util-phrasing@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz#c7c21d0d435d7fb90956038f02e8702781f95463"
+  integrity sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    unist-util-is "^5.0.0"
+
+mdast-util-to-markdown@^1.0.0, mdast-util-to-markdown@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz#c13343cb3fc98621911d33b5cd42e7d0731171c6"
+  integrity sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    longest-streak "^3.0.0"
+    mdast-util-phrasing "^3.0.0"
+    mdast-util-to-string "^3.0.0"
+    micromark-util-decode-string "^1.0.0"
+    unist-util-visit "^4.0.0"
+    zwitch "^2.0.0"
+
+mdast-util-to-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
+  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
+
+mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz#66f7bb6324756741c5f47a53557f0cbf16b6f789"
+  integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+
 mdn-data@2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
@@ -7914,6 +8452,302 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromark-core-commonmark@^1.0.0, micromark-core-commonmark@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz#1386628df59946b2d39fb2edfd10f3e8e0a75bb8"
+  integrity sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-factory-destination "^1.0.0"
+    micromark-factory-label "^1.0.0"
+    micromark-factory-space "^1.0.0"
+    micromark-factory-title "^1.0.0"
+    micromark-factory-whitespace "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-classify-character "^1.0.0"
+    micromark-util-html-tag-name "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
+
+micromark-extension-mdx-expression@^1.0.0:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.8.tgz#5bc1f5fd90388e8293b3ef4f7c6f06c24aff6314"
+  integrity sha512-zZpeQtc5wfWKdzDsHRBY003H2Smg+PUi2REhqgIhdzAa5xonhP03FcXxqFSerFiNUr5AWmHpaNPQTBVOS4lrXw==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    micromark-factory-mdx-expression "^1.0.0"
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-events-to-acorn "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-extension-mdx-jsx@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-1.0.5.tgz#e72d24b7754a30d20fb797ece11e2c4e2cae9e82"
+  integrity sha512-gPH+9ZdmDflbu19Xkb8+gheqEDqkSpdCEubQyxuz/Hn8DOXiXvrXeikOoBA71+e8Pfi0/UYmU3wW3H58kr7akA==
+  dependencies:
+    "@types/acorn" "^4.0.0"
+    "@types/estree" "^1.0.0"
+    estree-util-is-identifier-name "^2.0.0"
+    micromark-factory-mdx-expression "^1.0.0"
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+    vfile-message "^3.0.0"
+
+micromark-extension-mdx-md@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-md/-/micromark-extension-mdx-md-1.0.1.tgz#595d4b2f692b134080dca92c12272ab5b74c6d1a"
+  integrity sha512-7MSuj2S7xjOQXAjjkbjBsHkMtb+mDGVW6uI2dBL9snOBCbZmoNgDAeZ0nSn9j3T42UE/g2xVNMn18PJxZvkBEA==
+  dependencies:
+    micromark-util-types "^1.0.0"
+
+micromark-extension-mdxjs-esm@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-1.0.5.tgz#e4f8be9c14c324a80833d8d3a227419e2b25dec1"
+  integrity sha512-xNRBw4aoURcyz/S69B19WnZAkWJMxHMT5hE36GtDAyhoyn/8TuAeqjFJQlwk+MKQsUD7b3l7kFX+vlfVWgcX1w==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    micromark-core-commonmark "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-events-to-acorn "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    unist-util-position-from-estree "^1.1.0"
+    uvu "^0.5.0"
+    vfile-message "^3.0.0"
+
+micromark-extension-mdxjs@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs/-/micromark-extension-mdxjs-1.0.1.tgz#f78d4671678d16395efeda85170c520ee795ded8"
+  integrity sha512-7YA7hF6i5eKOfFUzZ+0z6avRG52GpWR8DL+kN47y3f2KhxbBZMhmxe7auOeaTBrW2DenbbZTf1ea9tA2hDpC2Q==
+  dependencies:
+    acorn "^8.0.0"
+    acorn-jsx "^5.0.0"
+    micromark-extension-mdx-expression "^1.0.0"
+    micromark-extension-mdx-jsx "^1.0.0"
+    micromark-extension-mdx-md "^1.0.0"
+    micromark-extension-mdxjs-esm "^1.0.0"
+    micromark-util-combine-extensions "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-destination@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz#eb815957d83e6d44479b3df640f010edad667b9f"
+  integrity sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-label@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz#cc95d5478269085cfa2a7282b3de26eb2e2dec68"
+  integrity sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-factory-mdx-expression@^1.0.0:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.9.tgz#57ba4571b69a867a1530f34741011c71c73a4976"
+  integrity sha512-jGIWzSmNfdnkJq05c7b0+Wv0Kfz3NJ3N4cBjnbO4zjXIlxJr+f8lk+5ZmwFvqdAbUy2q6B5rCY//g0QAAaXDWA==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-events-to-acorn "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    unist-util-position-from-estree "^1.0.0"
+    uvu "^0.5.0"
+    vfile-message "^3.0.0"
+
+micromark-factory-space@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz#c8f40b0640a0150751d3345ed885a080b0d15faf"
+  integrity sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-title@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz#dd0fe951d7a0ac71bdc5ee13e5d1465ad7f50ea1"
+  integrity sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-whitespace@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz#798fb7489f4c8abafa7ca77eed6b5745853c9705"
+  integrity sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-character@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-1.2.0.tgz#4fedaa3646db249bc58caeb000eb3549a8ca5dcc"
+  integrity sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-chunked@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz#37a24d33333c8c69a74ba12a14651fd9ea8a368b"
+  integrity sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-classify-character@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz#6a7f8c8838e8a120c8e3c4f2ae97a2bff9190e9d"
+  integrity sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-combine-extensions@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz#192e2b3d6567660a85f735e54d8ea6e3952dbe84"
+  integrity sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-decode-numeric-character-reference@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz#b1e6e17009b1f20bc652a521309c5f22c85eb1c6"
+  integrity sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-decode-string@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz#dc12b078cba7a3ff690d0203f95b5d5537f2809c"
+  integrity sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz#92e4f565fd4ccb19e0dcae1afab9a173bbeb19a5"
+  integrity sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==
+
+micromark-util-events-to-acorn@^1.0.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-1.2.3.tgz#a4ab157f57a380e646670e49ddee97a72b58b557"
+  integrity sha512-ij4X7Wuc4fED6UoLWkmo0xJQhsktfNh1J0m8g4PbIMPlx+ek/4YdW5mvbye8z/aZvAPUoxgXHrwVlXAPKMRp1w==
+  dependencies:
+    "@types/acorn" "^4.0.0"
+    "@types/estree" "^1.0.0"
+    "@types/unist" "^2.0.0"
+    estree-util-visit "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+    vfile-message "^3.0.0"
+
+micromark-util-html-tag-name@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz#48fd7a25826f29d2f71479d3b4e83e94829b3588"
+  integrity sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==
+
+micromark-util-normalize-identifier@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz#7a73f824eb9f10d442b4d7f120fecb9b38ebf8b7"
+  integrity sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-resolve-all@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz#4652a591ee8c8fa06714c9b54cd6c8e693671188"
+  integrity sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==
+  dependencies:
+    micromark-util-types "^1.0.0"
+
+micromark-util-sanitize-uri@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz#613f738e4400c6eedbc53590c67b197e30d7f90d"
+  integrity sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-subtokenize@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz#941c74f93a93eaf687b9054aeb94642b0e92edb1"
+  integrity sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-util-symbol@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz#813cd17837bdb912d069a12ebe3a44b6f7063142"
+  integrity sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==
+
+micromark-util-types@^1.0.0, micromark-util-types@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-1.1.0.tgz#e6676a8cae0bb86a2171c498167971886cb7e283"
+  integrity sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==
+
+micromark@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.2.0.tgz#1af9fef3f995ea1ea4ac9c7e2f19c48fd5c006e9"
+  integrity sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    micromark-core-commonmark "^1.0.1"
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-combine-extensions "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
+
+micromark@~2.11.0:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
+  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
 
 micromatch@4.0.5, micromatch@^4.0.4:
   version "4.0.5"
@@ -8126,6 +8960,11 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+mri@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
 ms@2.0.0:
   version "2.0.0"
@@ -8674,6 +9513,16 @@ open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
+open@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-9.1.0.tgz#684934359c90ad25742f5a26151970ff8c6c80b6"
+  integrity sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==
+  dependencies:
+    default-browser "^4.0.0"
+    define-lazy-prop "^3.0.0"
+    is-inside-container "^1.0.0"
+    is-wsl "^2.2.0"
+
 optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
@@ -8859,6 +9708,32 @@ parse-conflict-json@^3.0.0:
     just-diff "^6.0.0"
     just-diff-apply "^5.2.0"
 
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
+parse-entities@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-4.0.1.tgz#4e2a01111fb1c986549b944af39eeda258fc9e4e"
+  integrity sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    character-entities "^2.0.0"
+    character-entities-legacy "^3.0.0"
+    character-reference-invalid "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    is-alphanumerical "^2.0.0"
+    is-decimal "^2.0.0"
+    is-hexadecimal "^2.0.0"
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -8876,6 +9751,16 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse-json@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-6.0.2.tgz#6bf79c201351cc12d5d66eba48d5a097c13dc200"
+  integrity sha512-SA5aMiaIjXkAiBrW/yPgLgQAQg42f7K3ACO+2l/zOvtQBwX58DMUsFJXelW2fx3yMBmWOVkR6j1MGsdSbCA4UA==
+  dependencies:
+    "@babel/code-frame" "^7.16.0"
+    error-ex "^1.3.2"
+    json-parse-even-better-errors "^2.3.1"
+    lines-and-columns "^2.0.2"
 
 parse-path@^7.0.0:
   version "7.0.0"
@@ -9602,6 +10487,32 @@ regjsparser@^0.9.1:
   dependencies:
     jsesc "~0.5.0"
 
+remark-mdx@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-2.3.0.tgz#efe678025a8c2726681bde8bf111af4a93943db4"
+  integrity sha512-g53hMkpM0I98MU266IzDFMrTD980gNF3BJnkyFcmN+dD873mQeD5rdMO3Y2X+x8umQfbSE0PcoEDl7ledSA+2g==
+  dependencies:
+    mdast-util-mdx "^2.0.0"
+    micromark-extension-mdxjs "^1.0.0"
+
+remark-parse@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.2.tgz#ca241fde8751c2158933f031a4e3efbaeb8bc262"
+  integrity sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-from-markdown "^1.0.0"
+    unified "^10.0.0"
+
+remark-stringify@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-10.0.3.tgz#83b43f2445c4ffbb35b606f967d121b2b6d69717"
+  integrity sha512-koyOzCMYoUHudypbj4XpnAKFbkddRMYZHwghnxd7ue5210WzGw6kOBwauJTRUMq16jsovXx8dYNvSSWP89kZ3A==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-markdown "^1.0.0"
+    unified "^10.0.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -9722,6 +10633,13 @@ rollup@^3.21.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+run-applescript@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-5.0.0.tgz#e11e1c932e055d5c6b40d98374e0268d9b11899c"
+  integrity sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==
+  dependencies:
+    execa "^5.0.0"
+
 run-async@^2.4.0, run-async@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -9747,6 +10665,13 @@ rxjs@^7.5.5:
   integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
   dependencies:
     tslib "^2.1.0"
+
+sade@^1.7.3:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
+  integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
+  dependencies:
+    mri "^1.1.0"
 
 safe-array-concat@^1.0.0:
   version "1.0.0"
@@ -10155,6 +11080,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-entities@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-4.0.3.tgz#cfabd7039d22ad30f3cc435b0ca2c1574fc88ef8"
+  integrity sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==
+  dependencies:
+    character-entities-html4 "^2.0.0"
+    character-entities-legacy "^3.0.0"
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -10264,6 +11197,11 @@ supports-color@^8.0.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-color@^9.0.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.4.0.tgz#17bfcf686288f531db3dea3215510621ccb55954"
+  integrity sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==
+
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
@@ -10305,6 +11243,14 @@ synckit@^0.8.4:
   dependencies:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.4.0"
+
+synckit@^0.8.5:
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.6.tgz#b69b7fbce3917c2673cbdc0d87fb324db4a5b409"
+  integrity sha512-laHF2savN6sMeHCjLRkheIU4wo3Zg9Ln5YOjOo7sZ5dVQW8yF5pPE5SIw1dsPhq3TRp1jisKRCdPhfs/1WMqDA==
+  dependencies:
+    "@pkgr/utils" "^2.4.2"
+    tslib "^2.6.2"
 
 tabbable@^6.2.0:
   version "6.2.0"
@@ -10441,6 +11387,11 @@ tiny-warning@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
+titleize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53"
+  integrity sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -10471,6 +11422,14 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+to-vfile@^7.0.0:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-7.2.4.tgz#b97ecfcc15905ffe020bc975879053928b671378"
+  integrity sha512-2eQ+rJ2qGbyw3senPI0qjuM7aut8IYXK6AEoOWb+fJx/mQYzviTckm1wDjq91QYHAPBTYzmdJXxMFA6Mk14mdw==
+  dependencies:
+    is-buffer "^2.0.0"
+    vfile "^5.1.0"
 
 toposort@^2.0.2:
   version "2.0.2"
@@ -10508,6 +11467,11 @@ trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+
+trough@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
+  integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
 
 ts-api-utils@^1.0.1:
   version "1.0.1"
@@ -10566,6 +11530,11 @@ tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
   integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
+
+tslib@^2.6.0, tslib@^2.6.1, tslib@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -10710,6 +11679,11 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
@@ -10737,6 +11711,47 @@ unicode-property-aliases-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
   integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
+
+unified-engine@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/unified-engine/-/unified-engine-10.1.0.tgz#6899f00d1f53ee9af94f7abd0ec21242aae3f56c"
+  integrity sha512-5+JDIs4hqKfHnJcVCxTid1yBoI/++FfF/1PFdSMpaftZZZY+qg2JFruRbf7PaIwa9KgLotXQV3gSjtY0IdcFGQ==
+  dependencies:
+    "@types/concat-stream" "^2.0.0"
+    "@types/debug" "^4.0.0"
+    "@types/is-empty" "^1.0.0"
+    "@types/node" "^18.0.0"
+    "@types/unist" "^2.0.0"
+    concat-stream "^2.0.0"
+    debug "^4.0.0"
+    fault "^2.0.0"
+    glob "^8.0.0"
+    ignore "^5.0.0"
+    is-buffer "^2.0.0"
+    is-empty "^1.0.0"
+    is-plain-obj "^4.0.0"
+    load-plugin "^5.0.0"
+    parse-json "^6.0.0"
+    to-vfile "^7.0.0"
+    trough "^2.0.0"
+    unist-util-inspect "^7.0.0"
+    vfile-message "^3.0.0"
+    vfile-reporter "^7.0.0"
+    vfile-statistics "^2.0.0"
+    yaml "^2.0.0"
+
+unified@^10.0.0, unified@^10.1.2:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.2.tgz#b1d64e55dafe1f0b98bb6c719881103ecf6c86df"
+  integrity sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    bail "^2.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^5.0.0"
 
 unique-filename@^1.1.1:
   version "1.1.1"
@@ -10773,6 +11788,66 @@ unique-string@^2.0.0:
   dependencies:
     crypto-random-string "^2.0.0"
 
+unist-util-inspect@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-inspect/-/unist-util-inspect-7.0.2.tgz#858e4f02ee4053f7c6ada8bc81662901a0ee1893"
+  integrity sha512-Op0XnmHUl6C2zo/yJCwhXQSm/SmW22eDZdWP2qdf4WpGrgO1ZxFodq+5zFyeRGasFjJotAnLgfuD1jkcKqiH1Q==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-is@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.2.1.tgz#b74960e145c18dcb6226bc57933597f5486deae9"
+  integrity sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-position-from-estree@^1.0.0, unist-util-position-from-estree@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-position-from-estree/-/unist-util-position-from-estree-1.1.2.tgz#8ac2480027229de76512079e377afbcabcfcce22"
+  integrity sha512-poZa0eXpS+/XpoQwGwl79UUdea4ol2ZuCYguVaJS4qzIOMDzbqz8a3erUCOmubSZkaOuGamb3tX790iwOIROww==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-remove-position@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-4.0.2.tgz#a89be6ea72e23b1a402350832b02a91f6a9afe51"
+  integrity sha512-TkBb0HABNmxzAcfLf4qsIbFbaPDvMO6wa3b3j4VcEzFVaw1LBKwnW4/sRJ/atSLSzoIg41JWEdnE7N6DIhGDGQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-visit "^4.0.0"
+
+unist-util-stringify-position@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz#cce3bfa1cdf85ba7375d1d5b17bdc4cada9bd9da"
+  integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
+  dependencies:
+    "@types/unist" "^2.0.2"
+
+unist-util-stringify-position@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz#03ad3348210c2d930772d64b489580c13a7db39d"
+  integrity sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-visit-parents@^5.1.1:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz#b4520811b0ca34285633785045df7a8d6776cfeb"
+  integrity sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
+unist-util-visit@^4.0.0, unist-util-visit@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.2.tgz#125a42d1eb876283715a3cb5cceaa531828c72e2"
+  integrity sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.1.1"
+
 universal-user-agent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
@@ -10792,6 +11867,11 @@ unquote@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
   integrity sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==
+
+untildify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 upath@2.0.1, upath@^2.0.1:
   version "2.0.1"
@@ -10856,6 +11936,16 @@ uuid@8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uvu@^0.5.0, uvu@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.6.tgz#2754ca20bcb0bb59b64e9985e84d2e81058502df"
+  integrity sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==
+  dependencies:
+    dequal "^2.0.0"
+    diff "^5.0.0"
+    kleur "^4.0.3"
+    sade "^1.7.3"
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -10903,6 +11993,54 @@ validate-npm-package-name@^5.0.0:
   integrity sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==
   dependencies:
     builtins "^5.0.0"
+
+vfile-message@^3.0.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.1.4.tgz#15a50816ae7d7c2d1fa87090a7f9f96612b59dea"
+  integrity sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+
+vfile-reporter@^7.0.0:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-7.0.5.tgz#a0cbf3922c08ad428d6db1161ec64a53b5725785"
+  integrity sha512-NdWWXkv6gcd7AZMvDomlQbK3MqFWL1RlGzMn++/O2TI+68+nqxCPTvLugdOtfSzXmjh+xUyhp07HhlrbJjT+mw==
+  dependencies:
+    "@types/supports-color" "^8.0.0"
+    string-width "^5.0.0"
+    supports-color "^9.0.0"
+    unist-util-stringify-position "^3.0.0"
+    vfile "^5.0.0"
+    vfile-message "^3.0.0"
+    vfile-sort "^3.0.0"
+    vfile-statistics "^2.0.0"
+
+vfile-sort@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-sort/-/vfile-sort-3.0.1.tgz#4b06ec63e2946749b0bb514e736554cd75e441a2"
+  integrity sha512-1os1733XY6y0D5x0ugqSeaVJm9lYgj0j5qdcZQFyxlZOSy1jYarL77lLyb5gK4Wqr1d5OxmuyflSO3zKyFnTFw==
+  dependencies:
+    vfile "^5.0.0"
+    vfile-message "^3.0.0"
+
+vfile-statistics@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-statistics/-/vfile-statistics-2.0.1.tgz#2e1adae1cd3a45c1ed4f2a24bd103c3d71e4bce3"
+  integrity sha512-W6dkECZmP32EG/l+dp2jCLdYzmnDBIw6jwiLZSER81oR5AHRcVqL+k3Z+pfH1R73le6ayDkJRMk0sutj1bMVeg==
+  dependencies:
+    vfile "^5.0.0"
+    vfile-message "^3.0.0"
+
+vfile@^5.0.0, vfile@^5.1.0, vfile@^5.3.7:
+  version "5.3.7"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.3.7.tgz#de0677e6683e3380fafc46544cfe603118826ab7"
+  integrity sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+    vfile-message "^3.0.0"
 
 vite@^4.1.1:
   version "4.3.9"
@@ -10973,6 +12111,11 @@ walk-up-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-1.0.0.tgz#d4745e893dd5fd0dbb58dd0a4c6a33d9c9fec53e"
   integrity sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==
+
+walk-up-path@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-3.0.1.tgz#c8d78d5375b4966c717eb17ada73dbd41490e886"
+  integrity sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==
 
 walker@^1.0.8:
   version "1.0.8"
@@ -11209,6 +12352,11 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.0.0:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.4.tgz#53fc1d514be80aabf386dc6001eb29bf3b7523b2"
+  integrity sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==
+
 yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
@@ -11276,3 +12424,8 @@ zustand@^4.3.2:
   integrity sha512-rd4haDmlwMTVWVqwvgy00ny8rtti/klRoZjFbL/MAcDnmD5qSw/RZc+Vddstdv90M5Lv6RPgWvm1Hivyn0QgJw==
   dependencies:
     use-sync-external-store "1.2.0"
+
+zwitch@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
+  integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION
## What?

> [!NOTE]
> If using VSCode, make sure you add `mdx` into your VSCode `eslint.validate` settings.

These are the MDX files needed to showcase our Ux Writing Guide on the dev docs portal.

## Why?

Dev docs portal pulls information when building from diverse sources. The recommendation from the team is to keep all BigDesign information within the BigDesign repo.

UX Writing guide will be the first item to make it into public from the renewed BigDesign documentation.

## Screenshots/Screen Recordings

You can check all screenshots at the Figma asset created to provide feedback.

https://www.figma.com/file/XWxcx6FLg1tGevfxkqFLcA/UX-writing-guide---redlining?type=whiteboard&node-id=0%3A1&t=EnmZXmRSz39KzwpT-1

## Testing/Proof

No tests associated to these docs as this will be parsed by the dev docs repo.
