### PR TITLE
chore: change publish branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to BigDesign
 
-Before contributing please read the [Code of Conduct](https://github.com/bigcommerce/big-design/blob/master/CODE_OF_CONDUCT.md) as we expect all participants to adhere to it.
+Before contributing please read the [Code of Conduct](https://github.com/bigcommerce/big-design/blob/main/CODE_OF_CONDUCT.md) as we expect all participants to adhere to it.
 
 ## Issues / Bugs
 
@@ -24,14 +24,14 @@ If your change just fixes a bug, you can submit a pull request but ensure there 
 
 A good first place to start is our list of [good first issues](https://github.com/bigcommerce/big-design/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 
-Once you are ready to start working on an issue, follow steps in **[Opening a Pull Request](#opening-a-pull-request)** and **[Development Workflow](https://github.com/bigcommerce/big-design/blob/master/README.md#development)**.
+Once you are ready to start working on an issue, follow steps in **[Opening a Pull Request](#opening-a-pull-request)** and **[Development Workflow](https://github.com/bigcommerce/big-design/blob/main/README.md#development)**.
 
 ## Opening a Pull Request
 
 The core team will be monitoring for new pull requests. We will review your pull request and either merge it, request changes to it, or close it with an explanation, within a timely manner.
 
 **Before submitting a pull request,** please make sure the following is done:
-1. Fork the repository and ensure you branch from `master`.
+1. Fork the repository and ensure you branch from `main`.
 2. Install dependencies using `yarn install`.
 3. Tests should be added/updating to reflect changes.
 4. Ensure the test suite passes (`yarn test`).
@@ -41,4 +41,4 @@ The core team will be monitoring for new pull requests. We will review your pull
 
 ## License
 
-By contributing to BigDesign, you agree that your contributions will be licensed under our [license](https://github.com/bigcommerce/big-design/blob/master/LICENSE.md).
+By contributing to BigDesign, you agree that your contributions will be licensed under our [license](https://github.com/bigcommerce/big-design/blob/main/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -55,28 +55,28 @@ import { Button, GlobalStyles } from '@bigcommerce/big-design';
 
 This is a monorepo that uses [Lerna](https://lerna.js.org/) and [Yarn Workspaces](https://yarnpkg.com/lang/en/docs/workspaces/).
 
-Workspaces are inside the [packages](https://github.com/bigcommerce/big-design/blob/master/packages) directory.
+Workspaces are inside the [packages](https://github.com/bigcommerce/big-design/blob/main/packages) directory.
 
-- [big-design](https://github.com/bigcommerce/big-design/blob/master/packages/big-design): React component library.
-- [big-design-theme](https://github.com/bigcommerce/big-design/blob/master/packages/big-design-theme): Default Theme.
-- [big-design-icons](https://github.com/bigcommerce/big-design/blob/master/packages/big-design-icons): Icons library.
-- [docs](https://github.com/bigcommerce/big-design/blob/master/packages/docs): Documentation live here.
-- [configs](https://github.com/bigcommerce/big-design/blob/master/packages/configs): (internal) Shared configs between packages.
+- [big-design](https://github.com/bigcommerce/big-design/blob/main/packages/big-design): React component library.
+- [big-design-theme](https://github.com/bigcommerce/big-design/blob/main/packages/big-design-theme): Default Theme.
+- [big-design-icons](https://github.com/bigcommerce/big-design/blob/main/packages/big-design-icons): Icons library.
+- [docs](https://github.com/bigcommerce/big-design/blob/main/packages/docs): Documentation live here.
+- [configs](https://github.com/bigcommerce/big-design/blob/main/packages/configs): (internal) Shared configs between packages.
 
 ### Changelogs
 
 As this is a monorepo, each package has it's own Changelog. Links for each can be found below
 
-- [big-design](https://github.com/bigcommerce/big-design/blob/master/packages/big-design/CHANGELOG.md)
-- [big-design-theme](https://github.com/bigcommerce/big-design/blob/master/packages/big-design-theme/CHANGELOG.md)
-- [big-design-icons](https://github.com/bigcommerce/big-design/blob/master/packages/big-design-icons/CHANGELOG.md)
-- [configs](https://github.com/bigcommerce/big-design/tree/master/packages/configs)
-- [docs](https://github.com/bigcommerce/big-design/blob/master/packages/docs/CHANGELOG.md)
+- [big-design](https://github.com/bigcommerce/big-design/blob/main/packages/big-design/CHANGELOG.md)
+- [big-design-theme](https://github.com/bigcommerce/big-design/blob/main/packages/big-design-theme/CHANGELOG.md)
+- [big-design-icons](https://github.com/bigcommerce/big-design/blob/main/packages/big-design-icons/CHANGELOG.md)
+- [configs](https://github.com/bigcommerce/big-design/tree/main/packages/configs)
+- [docs](https://github.com/bigcommerce/big-design/blob/main/packages/docs/CHANGELOG.md)
 
 ### Contributing
 
-To contribute, please read our [Contributing](https://github.com/bigcommerce/big-design/blob/master/CONTRIBUTING.md) guidelines
-and [Code of Conduct](https://github.com/bigcommerce/big-design/blob/master/CODE_OF_CONDUCT.md) first.
+To contribute, please read our [Contributing](https://github.com/bigcommerce/big-design/blob/main/CONTRIBUTING.md) guidelines
+and [Code of Conduct](https://github.com/bigcommerce/big-design/blob/main/CODE_OF_CONDUCT.md) first.
 
 ### Development
 
@@ -122,7 +122,7 @@ GH_TOKEN=<token> yarn lerna publish <patch/minor/major> --conventional-graduate 
 
 #### `from-package`
 
-`from-package` allows you to release what's on `upstream/master` if the publish script failed. By default the `lerna publish` command will push commits and tags before running through the build. This is a just-in-case command.
+`from-package` allows you to release what's on `upstream/main` if the publish script failed. By default the `lerna publish` command will push commits and tags before running through the build. This is a just-in-case command.
 
 ```
 GH_TOKEN=<token> yarn lerna publish from-package --git-remote upstream

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
   "useWorkspaces": true,
   "command": {
     "version": {
-      "allowBranch": "master",
+      "allowBranch": "main",
       "conventionalCommits": true,
       "message": "chore(release): publish"
     }

--- a/packages/big-design-theme/README.md
+++ b/packages/big-design-theme/README.md
@@ -8,7 +8,7 @@ You can find documentation and examples on our [docs page](https://developer.big
 
 ## Note
 
-[BigDesign](https://github.com/bigcommerce/big-design/blob/master/packages/big-design) components use this theme by default.
+[BigDesign](https://github.com/bigcommerce/big-design/blob/main/packages/big-design) components use this theme by default.
 This package is only meant to be used directly when more advanced features are needed such as:
 
 - When you app uses an html font size different than `16px`.


### PR DESCRIPTION
## What?

Changes the publish branch from `master` to `main`.

## Why?

Slight miss from changing the default branch name 2 weeks ago.
