### PR TITLE
fix(component): fix unselecting via chips list for multi-select

### DIFF
--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -145,7 +145,9 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
       return null;
     }
 
-    return chips.map((chip) => <Chip {...chip} key={chip.label} marginBottom="none" />);
+    return chips.map((chip, idx) => (
+      <Chip {...chip} key={`${chip.label}-${idx}`} marginBottom="none" />
+    ));
   }, [chips]);
 
   return (


### PR DESCRIPTION
## What?
Fix unselecting via chips list for multi-select.

## Why?
The issue appears because of `key` collision, since the `key` for a `Chip` consisted only from `label` which is non unic.

## Screenshots/Screen Recordings


### `isOpen` prop for the List component was hardcoded for demo
<img width="664" alt="Screenshot 2024-01-08 at 18 40 22" src="https://github.com/bigcommerce/big-design/assets/84462142/804daaac-33df-4666-aa2a-5f1a44e782c2">


BEFORE

https://github.com/bigcommerce/big-design/assets/84462142/765e5693-41a2-4e5f-ba6c-385f8233ca0a

AFTER


https://github.com/bigcommerce/big-design/assets/84462142/f3631e0d-f0ad-41dc-b558-609f28f4e14f


## Testing/Proof

Locally.
