### PR TITLE
feat(component): allow Alerts to be labelled by their header

### DIFF
--- a/packages/big-design/src/components/Alert/Alert.tsx
+++ b/packages/big-design/src/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import { CloseIcon } from '@bigcommerce/big-design-icons';
-import React, { memo, useMemo } from 'react';
+import React, { memo, useId, useMemo } from 'react';
 
 import { excludePaddingProps } from '../../mixins';
 import { getMessagingIcon, SharedMessagingProps } from '../../utils';
@@ -14,6 +14,7 @@ export interface AlertProps extends Omit<SharedMessagingProps, 'actions'> {
 }
 
 export const Alert: React.FC<AlertProps> = memo(({ className, style, header, ...props }) => {
+  const headerId = useId();
   const filteredProps = excludePaddingProps(props);
   const icon = useMemo(() => props.type && getMessagingIcon(props.type), [props.type]);
 
@@ -28,10 +29,13 @@ export const Alert: React.FC<AlertProps> = memo(({ className, style, header, ...
     [props.messages],
   );
 
-  const renderedHeader = useMemo(() => header && <StyledHeader>{header}</StyledHeader>, [header]);
+  const renderedHeader = useMemo(
+    () => header && <StyledHeader id={headerId}>{header}</StyledHeader>,
+    [header, headerId],
+  );
 
   return (
-    <StyledAlert {...filteredProps} role="alert">
+    <StyledAlert {...filteredProps} aria-labelledby={header && headerId} role="alert">
       <GridItem gridArea="icon">{icon}</GridItem>
       <GridItem gridArea="messages">
         {renderedHeader}

--- a/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
@@ -771,6 +771,7 @@ exports[`renders header 1`] = `
 }
 
 <div
+  aria-labelledby=":rd:"
   class="c0 c1 c2"
   role="alert"
   type="success"
@@ -803,6 +804,7 @@ exports[`renders header 1`] = `
   >
     <h4
       class="c6 c7"
+      id=":rd:"
     >
       Header
     </h4>

--- a/packages/big-design/src/components/Alert/spec.tsx
+++ b/packages/big-design/src/components/Alert/spec.tsx
@@ -88,6 +88,12 @@ test('renders header', () => {
   expect(heading).toBeDefined();
 });
 
+test('uses the header as an accessibility label for the alert', () => {
+  render(<Alert header="Some reason for the alert" messages={[{ text: 'Success' }]} />);
+
+  expect(screen.getByRole('alert', { name: 'Some reason for the alert' })).toBeInTheDocument();
+});
+
 test('renders close button', () => {
   render(<Alert messages={[{ text: 'Success' }]} onClose={() => null} />);
 


### PR DESCRIPTION
## What?

Adds an `aria-labelledby` to the `Alert` component, which is associated to the optional `header`.

## Why?

1. To provide screen readers with an accessible 'name' for the alert
2. Also useful in tests, proving that the correct alert was selected

## Screenshots/Screen Recordings

### Before (notice no 'name' in the accessibility panel)

<img width="820" alt="Screenshot 2024-04-08 at 11 14 51 am" src="https://github.com/bigcommerce/big-design/assets/56807262/2446f1e0-fb76-4040-9655-863ebf223981">

### After (notice new 'name' in the accessibility panel)

<img width="820" alt="Screenshot 2024-04-08 at 11 14 26 am" src="https://github.com/bigcommerce/big-design/assets/56807262/b062cd38-52e8-4fb3-a620-b559eb80b5df">

## Testing/Proof

New test: https://github.com/bigcommerce/big-design/pull/1388/files#diff-c8881538168695ea6e7ca5ba1d22e808a91da2fe5552072b18ede0869ebee815R91-R96
