### PR TITLE
feat: specify packageManager for corepack usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,6 @@
     "lerna": "^8.1.2",
     "lint-staged": "^15.2.2",
     "typescript": "^5.3.3"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
## What?

Specifying a `packageManager` field in `package.json` makes it easier for contributors with corepack enabled to ensure they are running the correct package manager + version required for the project. 

From the Corepack documentation ([nodejs.org](https://nodejs.org/api/corepack.html)):

> The Corepack proxies will find the closest [package.json](https://nodejs.org/api/packages.html#nodejs-packagejson-field-definitions) file in your current directory hierarchy to extract its ["packageManager"](https://nodejs.org/api/packages.html#packagemanager) property.
>
> If the value corresponds to a [supported package manager](https://nodejs.org/api/corepack.html#supported-package-managers), Corepack will make sure that all calls to the relevant binaries are run against the requested version, downloading it on demand if needed, and aborting if it cannot be successfully retrieved.

## Why?

Easier than installing and managing multiple `yarn` binaries on one machine. Makes it easier to enforce correct package manager usage. 

## Screenshots/Screen Recordings

N/A

## Testing/Proof

N/A