### PR TITLE
feat: export types without reassignment

### DIFF
--- a/packages/big-design-icons/src/flags/index.ts
+++ b/packages/big-design-icons/src/flags/index.ts
@@ -1,1 +1,2 @@
-export * from './components/';
+export * from './components';
+export { type FlagIconProps } from './base';

--- a/packages/big-design-icons/src/index.ts
+++ b/packages/big-design-icons/src/index.ts
@@ -1,5 +1,2 @@
-import { IconProps as _IconProps } from './base';
-
 export * from './components';
-export { createStyledIcon } from './base';
-export type IconProps = _IconProps;
+export { createStyledIcon, type IconProps } from './base';

--- a/packages/big-design/src/components/AccordionPanel/Accordion/index.ts
+++ b/packages/big-design/src/components/AccordionPanel/Accordion/index.ts
@@ -1,4 +1,1 @@
-import { AccordionProps as _AccordionProps } from './Accordion';
-
-export { Accordion } from './Accordion';
-export type AccordionProps = _AccordionProps;
+export { Accordion, type AccordionProps } from './Accordion';

--- a/packages/big-design/src/components/AccordionPanel/index.ts
+++ b/packages/big-design/src/components/AccordionPanel/index.ts
@@ -1,5 +1,2 @@
-import { AccordionPanelProps as _AccordionPanelProps } from './AccordionPanel';
-
-export { AccordionPanel } from './AccordionPanel';
+export { AccordionPanel, type AccordionPanelProps } from './AccordionPanel';
 export { useAccordionPanel } from './useAccordionPanel';
-export type AccordionPanelProps = _AccordionPanelProps;

--- a/packages/big-design/src/components/Alert/index.ts
+++ b/packages/big-design/src/components/Alert/index.ts
@@ -1,4 +1,1 @@
-import { AlertProps as _AlertProps } from './Alert';
-
-export { Alert } from './Alert';
-export type AlertProps = _AlertProps;
+export { Alert, type AlertProps } from './Alert';

--- a/packages/big-design/src/components/Badge/index.ts
+++ b/packages/big-design/src/components/Badge/index.ts
@@ -1,4 +1,1 @@
-import { BadgeProps as _BadgeProps } from './Badge';
-
-export { Badge } from './Badge';
-export type BadgeProps = _BadgeProps;
+export { Badge, type BadgeProps } from './Badge';

--- a/packages/big-design/src/components/Box/index.ts
+++ b/packages/big-design/src/components/Box/index.ts
@@ -1,4 +1,1 @@
-import { BoxProps as _BoxProps } from './Box';
-
-export { Box } from './Box';
-export type BoxProps = _BoxProps;
+export { Box, type BoxProps } from './Box';

--- a/packages/big-design/src/components/Button/index.ts
+++ b/packages/big-design/src/components/Button/index.ts
@@ -1,4 +1,1 @@
-import { ButtonProps as _ButtonProps } from './Button';
-
-export { Button } from './Button';
-export type ButtonProps = _ButtonProps;
+export { Button, type ButtonProps } from './Button';

--- a/packages/big-design/src/components/ButtonGroup/index.ts
+++ b/packages/big-design/src/components/ButtonGroup/index.ts
@@ -1,1 +1,1 @@
-export * from './ButtonGroup';
+export { ButtonGroup, type ButtonGroupAction, type ButtonGroupProps } from './ButtonGroup';

--- a/packages/big-design/src/components/Checkbox/Label/index.ts
+++ b/packages/big-design/src/components/Checkbox/Label/index.ts
@@ -1,1 +1,1 @@
-export * from './Label';
+export { CheckboxLabel } from './Label';

--- a/packages/big-design/src/components/Checkbox/index.ts
+++ b/packages/big-design/src/components/Checkbox/index.ts
@@ -1,5 +1,2 @@
-import { CheckboxProps as _CheckboxProps } from './Checkbox';
-
-export { Checkbox } from './Checkbox';
-export * from './Label';
-export type CheckboxProps = _CheckboxProps;
+export { Checkbox, type CheckboxProps } from './Checkbox';
+export { CheckboxLabel } from './Label';

--- a/packages/big-design/src/components/Chip/index.ts
+++ b/packages/big-design/src/components/Chip/index.ts
@@ -1,4 +1,1 @@
-import { ChipProps as _ChipProps } from './Chip';
-
-export { Chip } from './Chip';
-export type ChipProps = _ChipProps;
+export { Chip, type ChipProps } from './Chip';

--- a/packages/big-design/src/components/Collapse/index.ts
+++ b/packages/big-design/src/components/Collapse/index.ts
@@ -1,4 +1,1 @@
-import { CollapseProps as _CollapseProps } from './Collapse';
-
-export { Collapse } from './Collapse';
-export type CollapseProps = _CollapseProps;
+export { Collapse, type CollapseProps } from './Collapse';

--- a/packages/big-design/src/components/Counter/index.ts
+++ b/packages/big-design/src/components/Counter/index.ts
@@ -1,4 +1,1 @@
-import { CounterProps as _CounterProps } from './Counter';
-
-export { Counter } from './Counter';
-export type CounterProps = _CounterProps;
+export { Counter, type CounterProps } from './Counter';

--- a/packages/big-design/src/components/Datepicker/index.ts
+++ b/packages/big-design/src/components/Datepicker/index.ts
@@ -1,4 +1,1 @@
-import { DatepickerProps as _DatepickerProps } from './Datepicker';
-
-export { Datepicker } from './Datepicker';
-export type DatepickerProps = _DatepickerProps;
+export { Datepicker, type DatepickerProps } from './Datepicker';

--- a/packages/big-design/src/components/Dropdown/index.ts
+++ b/packages/big-design/src/components/Dropdown/index.ts
@@ -1,12 +1,8 @@
-import {
-  DropdownItem as _DropdownItem,
-  DropdownItemGroup as _DropdownItemGroup,
-  DropdownLinkItem as _DropdownLinkItem,
-  DropdownProps as _DropdownProps,
-} from './types';
-
 export { Dropdown } from './Dropdown';
-export type DropdownItem = _DropdownItem;
-export type DropdownItemGroup = _DropdownItemGroup;
-export type DropdownLinkItem = _DropdownLinkItem;
-export type DropdownProps = _DropdownProps;
+
+export {
+  type DropdownItem,
+  type DropdownItemGroup,
+  type DropdownLinkItem,
+  type DropdownProps,
+} from './types';

--- a/packages/big-design/src/components/Fieldset/index.ts
+++ b/packages/big-design/src/components/Fieldset/index.ts
@@ -1,6 +1,3 @@
-import { FieldsetProps as _FieldsetProps } from './Fieldset';
-
 export { FieldsetDescription } from './Description';
-export { Fieldset } from './Fieldset';
+export { Fieldset, type FieldsetProps } from './Fieldset';
 export { FieldsetLegend } from './Legend';
-export type FieldsetProps = _FieldsetProps;

--- a/packages/big-design/src/components/FileUploader/DropZone.tsx
+++ b/packages/big-design/src/components/FileUploader/DropZone.tsx
@@ -17,20 +17,16 @@ import { Box } from '../Box';
 import { Flex } from '../Flex';
 import { Small, Text } from '../Typography';
 
-import { defaultLocalization } from './FileUploader';
 import { ButtonStyled, DropzoneStyled } from './styled';
+import { Localization } from './types';
 import { validateFileFormat } from './utils';
-
-export interface DropZoneLocalization {
-  upload: string;
-}
 
 export interface Props extends ComponentPropsWithoutRef<'input'> {
   description?: string;
   viewType?: 'row' | 'block';
   icon?: React.ReactNode;
   label?: string;
-  localization?: DropZoneLocalization;
+  localization: Localization;
   onFilesChange(files: FileList | null): void;
 }
 
@@ -41,7 +37,7 @@ export const DropZone = ({
   icon = <DraftIcon />,
   id,
   label,
-  localization = defaultLocalization,
+  localization,
   multiple,
   viewType = 'row',
   onFilesChange,

--- a/packages/big-design/src/components/FileUploader/FileUploader.tsx
+++ b/packages/big-design/src/components/FileUploader/FileUploader.tsx
@@ -12,25 +12,19 @@ import React, {
 } from 'react';
 
 import { warning } from '../../utils';
-import { DropdownItem } from '../Dropdown/types';
+import { DropdownItem } from '../Dropdown';
 import { FormControlDescription, FormControlLabel } from '../Form';
 import { useInputErrors } from '../Form/useInputErrors';
 import { InlineMessage } from '../InlineMessage';
 
-import { DropZoneLocalization } from './DropZone';
+import { defaultLocalization } from './constants';
 import { File } from './File';
 import { DropZoneWrapper, StyledFileUploaderWrapper, StyledList } from './styled';
+import type { Localization, ValidatorConfig } from './types';
 import { getImagesPreview, validateFiles } from './utils';
 
 export interface FileAction extends Omit<DropdownItem, 'onItemClick'> {
   onItemClick: (name: File, idx: number) => void;
-}
-
-export interface FileUploaderLocalization extends DropZoneLocalization {
-  optional: string;
-  showLess: string;
-  showMore: string;
-  canNotUploadTheseFiles: string;
 }
 
 interface DropzoneConfig {
@@ -40,26 +34,12 @@ interface DropzoneConfig {
   label?: string;
 }
 
-export interface FileValidationError {
+interface FileValidationError {
   file: File;
   fileIdx: number;
   message?: string;
   type: string | string[];
 }
-
-export interface ValidatorConfig {
-  message?: string;
-  type: string;
-  validator: (file: File) => boolean;
-}
-
-export const defaultLocalization: FileUploaderLocalization = {
-  optional: 'optional',
-  upload: 'Upload',
-  showLess: 'Show less',
-  showMore: 'Show more',
-  canNotUploadTheseFiles: `Can't upload these files`,
-};
 
 interface Props {
   actions?: FileAction[];
@@ -69,7 +49,7 @@ interface Props {
   files: File[];
   label?: React.ReactNode;
   labelId?: string;
-  localization?: FileUploaderLocalization;
+  localization?: Localization;
   previewHidden?: boolean;
   validators?: ValidatorConfig[];
   onFilesChange(files: File[]): void;

--- a/packages/big-design/src/components/FileUploader/constants.ts
+++ b/packages/big-design/src/components/FileUploader/constants.ts
@@ -1,0 +1,9 @@
+import { Localization } from './types';
+
+export const defaultLocalization: Localization = {
+  optional: 'optional',
+  upload: 'Upload',
+  showLess: 'Show less',
+  showMore: 'Show more',
+  canNotUploadTheseFiles: `Can't upload these files`,
+};

--- a/packages/big-design/src/components/FileUploader/index.ts
+++ b/packages/big-design/src/components/FileUploader/index.ts
@@ -1,1 +1,2 @@
-export * from './FileUploader';
+export { FileUploader, type FileUploaderProps, type FileAction } from './FileUploader';
+export { type ValidatorConfig } from './types';

--- a/packages/big-design/src/components/FileUploader/spec.tsx
+++ b/packages/big-design/src/components/FileUploader/spec.tsx
@@ -8,9 +8,11 @@ import { render, screen } from '@test/utils';
 import { warning } from '../../utils';
 import { FormControlLabel, FormGroup } from '../Form';
 
+import { defaultLocalization } from './constants';
 import { DropZone } from './DropZone';
 import { File as FileComponent } from './File';
-import { FileUploader, ValidatorConfig } from './FileUploader';
+import { FileUploader } from './FileUploader';
+import { type ValidatorConfig } from './types';
 
 import 'jest-styled-components';
 
@@ -431,6 +433,7 @@ describe('DropZone', () => {
       <DropZone
         description="File types: JPG, GIF, PNG. Recommended size: 250x100px."
         label="Upload your images"
+        localization={defaultLocalization}
         onFilesChange={jest.fn()}
       />,
     );
@@ -443,6 +446,7 @@ describe('DropZone', () => {
       <DropZone
         description="File types: JPG, GIF, PNG. Recommended size: 250x100px."
         label="Upload your images"
+        localization={defaultLocalization}
         onFilesChange={jest.fn()}
       />,
     );
@@ -455,6 +459,7 @@ describe('DropZone', () => {
       <DropZone
         description="File types: JPG, GIF, PNG. Recommended size: 250x100px."
         label="Upload your images"
+        localization={defaultLocalization}
         onFilesChange={jest.fn()}
       />,
     );
@@ -472,6 +477,7 @@ describe('DropZone', () => {
       <DropZone
         description="File types: JPG, GIF, PNG. Recommended size: 250x100px."
         label="Upload your images"
+        localization={defaultLocalization}
         onFilesChange={onFilesChangeMock}
       />,
     );
@@ -488,7 +494,7 @@ describe('DropZone', () => {
       <DropZone
         description="File types: JPG, GIF, PNG. Recommended size: 250x100px."
         label="Upload your images"
-        localization={{ upload: 'some button text' }}
+        localization={{ ...defaultLocalization, upload: 'some button text' }}
         onFilesChange={jest.fn()}
       />,
     );

--- a/packages/big-design/src/components/FileUploader/types.ts
+++ b/packages/big-design/src/components/FileUploader/types.ts
@@ -1,0 +1,13 @@
+export interface Localization {
+  upload: string;
+  optional: string;
+  showLess: string;
+  showMore: string;
+  canNotUploadTheseFiles: string;
+}
+
+export interface ValidatorConfig {
+  message?: string;
+  type: string;
+  validator: (file: File) => boolean;
+}

--- a/packages/big-design/src/components/FileUploader/utils/validateFile.ts
+++ b/packages/big-design/src/components/FileUploader/utils/validateFile.ts
@@ -1,4 +1,4 @@
-import { ValidatorConfig } from '../FileUploader';
+import { ValidatorConfig } from '../types';
 
 export const validateFileFormat = (file: File | DataTransferItem, fileFormats = '') => {
   const allowedFormats = fileFormats.split(',').map((format) => format.trim());

--- a/packages/big-design/src/components/Flex/Item/index.ts
+++ b/packages/big-design/src/components/Flex/Item/index.ts
@@ -1,4 +1,1 @@
-import { FlexItemProps as _FlexItemProps } from './Item';
-
-export { FlexItem } from './Item';
-export type FlexItemProps = _FlexItemProps;
+export { FlexItem, type FlexItemProps } from './Item';

--- a/packages/big-design/src/components/Flex/index.ts
+++ b/packages/big-design/src/components/Flex/index.ts
@@ -1,5 +1,2 @@
-import { FlexProps as _FlexProps } from './Flex';
-
-export { Flex } from './Flex';
-export * from './Item';
-export type FlexProps = _FlexProps;
+export { Flex, type FlexProps } from './Flex';
+export { FlexItem, type FlexItemProps } from './Item';

--- a/packages/big-design/src/components/Form/Description/index.ts
+++ b/packages/big-design/src/components/Form/Description/index.ts
@@ -1,4 +1,5 @@
-import { FormControlDescriptionLinkProps as _FormControlDescriptionLinkProps } from './Description';
-
-export { FormControlDescription } from './Description';
-export type FormControlDescriptionLinkProps = _FormControlDescriptionLinkProps;
+export {
+  FormControlDescription,
+  type FormControlDescriptionProps,
+  type FormControlDescriptionLinkProps,
+} from './Description';

--- a/packages/big-design/src/components/Form/Group/Group.tsx
+++ b/packages/big-design/src/components/Form/Group/Group.tsx
@@ -17,7 +17,7 @@ import { useFormContext } from '../useFormContext';
 
 import { StyledError, StyledGroup, StyledInlineGroup } from './styled';
 
-export interface GroupProps extends ComponentPropsWithoutRef<'div'> {
+export interface FormGroupProps extends ComponentPropsWithoutRef<'div'> {
   children?: React.ReactNode;
   errors?: React.ReactNode | React.ReactNode[];
 }
@@ -33,7 +33,7 @@ interface Context {
 
 export const FormGroupContext = createContext<Context>({});
 
-export const FormGroup: React.FC<GroupProps> = (props) => {
+export const FormGroup: React.FC<FormGroupProps> = (props) => {
   const { fullWidth } = useFormContext();
   const [inputErrors, setInputErrors] = useState<Errors>({});
 
@@ -78,7 +78,7 @@ export const FormGroup: React.FC<GroupProps> = (props) => {
 };
 
 const generateErrors = (
-  errors: GroupProps['errors'],
+  errors: FormGroupProps['errors'],
   fromGroup = false,
   key?: number,
 ): React.ReactNode => {

--- a/packages/big-design/src/components/Form/Group/index.ts
+++ b/packages/big-design/src/components/Form/Group/index.ts
@@ -1,1 +1,1 @@
-export * from './Group';
+export { FormGroup, FormGroupContext, type FormGroupProps } from './Group';

--- a/packages/big-design/src/components/Form/Label/Label.tsx
+++ b/packages/big-design/src/components/Form/Label/Label.tsx
@@ -10,12 +10,12 @@ const defaultLocalization: LabelLocalization = {
   optional: 'optional',
 };
 
-export interface LabelProps extends ComponentPropsWithoutRef<'label'> {
+export interface FormControlLabelProps extends ComponentPropsWithoutRef<'label'> {
   renderOptional?: boolean;
   localization?: LabelLocalization;
 }
 
-export const FormControlLabel: React.FC<LabelProps> = ({
+export const FormControlLabel: React.FC<FormControlLabelProps> = ({
   className,
   localization = defaultLocalization,
   style,

--- a/packages/big-design/src/components/Form/Label/index.ts
+++ b/packages/big-design/src/components/Form/Label/index.ts
@@ -1,1 +1,1 @@
-export { FormControlLabel } from './Label';
+export { FormControlLabel, type FormControlLabelProps } from './Label';

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -4,18 +4,18 @@ import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
 import { StyleableH4 } from '../../Typography/private';
 import { HeadingProps } from '../../Typography/types';
 
-import { LabelLocalization, LabelProps } from './Label';
+import { type FormControlLabelProps, type LabelLocalization } from './Label';
 
-interface StyledLabelArgument extends Omit<LabelProps, 'localization'> {
+interface StyledLabelArgument extends Omit<FormControlLabelProps, 'localization'> {
   theme: DefaultTheme;
   localization: LabelLocalization;
 }
 
 export const StyledLabel = styled<
-  StyledComponent<'label' | 'h4', DefaultTheme, Partial<HeadingProps>> & LabelProps
+  StyledComponent<'label' | 'h4', DefaultTheme, Partial<HeadingProps>> & FormControlLabelProps
 >(StyleableH4).attrs({
   as: 'label',
-})<LabelProps>`
+})<FormControlLabelProps>`
   cursor: pointer;
   display: inline-block;
   margin-bottom: ${({ theme }: StyledLabelArgument) => theme.spacing.xxSmall};

--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -38,16 +38,6 @@ exports[`simple form render 1`] = `
   margin: 0;
 }
 
-.c4 {
-  display: grid;
-  grid-gap: 0.5rem 1rem;
-  margin-bottom: 1rem;
-}
-
-.c4:last-child {
-  margin-bottom: 0;
-}
-
 .c6 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
@@ -145,6 +135,16 @@ exports[`simple form render 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+}
+
+.c4 {
+  display: grid;
+  grid-gap: 0.5rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.c4:last-child {
+  margin-bottom: 0;
 }
 
 .c5 {

--- a/packages/big-design/src/components/Form/index.ts
+++ b/packages/big-design/src/components/Form/index.ts
@@ -1,10 +1,5 @@
-import { FormControlDescriptionLinkProps as _FormControlDescriptionLinkProps } from './Description';
-import { FormProps as _FormProps } from './Form';
-
-export { Form } from './Form';
-export { FormControlDescription } from './Description';
+export { Form, type FormProps } from './Form';
+export { FormControlDescription, type FormControlDescriptionLinkProps } from './Description';
 export { FormControlError } from './Error';
-export { FormGroup } from './Group';
-export { FormControlLabel } from './Label';
-export type FormProps = _FormProps;
-export type FormControlDescriptionLinkProps = _FormControlDescriptionLinkProps;
+export { FormGroup, type FormGroupProps } from './Group';
+export { FormControlLabel, type FormControlLabelProps } from './Label';

--- a/packages/big-design/src/components/Grid/Item/index.ts
+++ b/packages/big-design/src/components/Grid/Item/index.ts
@@ -1,4 +1,1 @@
-import { GridItemProps as _GridItemProps } from './Item';
-
-export { GridItem } from './Item';
-export type GridItemProps = _GridItemProps;
+export { GridItem, type GridItemProps } from './Item';

--- a/packages/big-design/src/components/Grid/index.ts
+++ b/packages/big-design/src/components/Grid/index.ts
@@ -1,5 +1,2 @@
-import { GridProps as _GridProps } from './Grid';
-
-export { Grid } from './Grid';
-export * from './Item';
-export type GridProps = _GridProps;
+export { Grid, type GridProps } from './Grid';
+export { GridItem, type GridItemProps } from './Item';

--- a/packages/big-design/src/components/InlineMessage/index.ts
+++ b/packages/big-design/src/components/InlineMessage/index.ts
@@ -1,4 +1,1 @@
-import { InlineMessageProps as _InlineMessageProps } from './InlineMessage';
-
-export { InlineMessage } from './InlineMessage';
-export type InlineMessageProps = _InlineMessageProps;
+export { InlineMessage, type InlineMessageProps } from './InlineMessage';

--- a/packages/big-design/src/components/Input/index.ts
+++ b/packages/big-design/src/components/Input/index.ts
@@ -1,4 +1,1 @@
-import { InputProps as _InputProps } from './Input';
-
-export { Input } from './Input';
-export type InputProps = _InputProps;
+export { Input, type InputProps } from './Input';

--- a/packages/big-design/src/components/Input/private.ts
+++ b/packages/big-design/src/components/Input/private.ts
@@ -1,4 +1,1 @@
-import { StyledInputWrapperProps as _StyledInputWrapperProps } from './styled';
-
-export { StyledInput, StyledInputWrapper } from './styled';
-export type StyledInputWrapperProps = _StyledInputWrapperProps;
+export { StyledInput, StyledInputWrapper, type StyledInputWrapperProps } from './styled';

--- a/packages/big-design/src/components/Link/index.ts
+++ b/packages/big-design/src/components/Link/index.ts
@@ -1,4 +1,1 @@
-import { LinkProps as _LinkProps } from './Link';
-
-export { Link } from './Link';
-export type LinkProps = _LinkProps;
+export { Link, type LinkProps } from './Link';

--- a/packages/big-design/src/components/List/Item/index.ts
+++ b/packages/big-design/src/components/List/Item/index.ts
@@ -1,4 +1,1 @@
-import { ListItemProps as _ListItemProps } from './Item';
-
-export { ListItem } from './Item';
-export type ListItemProps<T> = _ListItemProps<T>;
+export { ListItem, type ListItemProps } from './Item';

--- a/packages/big-design/src/components/List/index.ts
+++ b/packages/big-design/src/components/List/index.ts
@@ -1,1 +1,1 @@
-export { List } from './List';
+export { List, type ListProps } from './List';

--- a/packages/big-design/src/components/Message/index.ts
+++ b/packages/big-design/src/components/Message/index.ts
@@ -1,4 +1,1 @@
-import { MessageProps as _MessageProps } from './Message';
-
-export { Message } from './Message';
-export type MessageProps = _MessageProps;
+export { Message, type MessageProps } from './Message';

--- a/packages/big-design/src/components/Modal/index.ts
+++ b/packages/big-design/src/components/Modal/index.ts
@@ -1,5 +1,1 @@
-import { ModalAction as _ModalAction, ModalProps as _ModalProps } from './Modal';
-
-export { Modal } from './Modal';
-export type ModalProps = _ModalProps;
-export type ModalAction = _ModalAction;
+export { Modal, type ModalProps, type ModalAction } from './Modal';

--- a/packages/big-design/src/components/MultiSelect/index.ts
+++ b/packages/big-design/src/components/MultiSelect/index.ts
@@ -1,5 +1,2 @@
-import { MultiSelectProps as _MultiSelectProps } from './types';
-
 export { MultiSelect } from './MultiSelect';
-
-export type MultiSelectProps<T> = _MultiSelectProps<T>;
+export { type MultiSelectProps } from './types';

--- a/packages/big-design/src/components/Pagination/index.ts
+++ b/packages/big-design/src/components/Pagination/index.ts
@@ -1,4 +1,1 @@
-import { PaginationProps as _PaginationProps } from './Pagination';
-
-export { Pagination } from './Pagination';
-export type PaginationProps = _PaginationProps;
+export { Pagination, type PaginationProps } from './Pagination';

--- a/packages/big-design/src/components/Panel/index.ts
+++ b/packages/big-design/src/components/Panel/index.ts
@@ -1,4 +1,1 @@
-import { PanelProps as _PanelProps } from './Panel';
-
-export { Panel } from './Panel';
-export type PanelProps = _PanelProps;
+export { Panel, type PanelProps } from './Panel';

--- a/packages/big-design/src/components/PillTabs/index.ts
+++ b/packages/big-design/src/components/PillTabs/index.ts
@@ -1,1 +1,1 @@
-export * from './PillTabs';
+export { PillTabs, type PillTabItem, type PillTabsProps } from './PillTabs';

--- a/packages/big-design/src/components/Popover/index.ts
+++ b/packages/big-design/src/components/Popover/index.ts
@@ -1,4 +1,1 @@
-import { PopoverProps as _PopoverProps } from './Popover';
-
-export { Popover } from './Popover';
-export type PopoverProps = _PopoverProps;
+export { Popover, type PopoverProps } from './Popover';

--- a/packages/big-design/src/components/ProgressBar/index.ts
+++ b/packages/big-design/src/components/ProgressBar/index.ts
@@ -1,4 +1,1 @@
-import { ProgressBarProps as _ProgressBarProps } from './ProgressBar';
-
-export { ProgressBar } from './ProgressBar';
-export type ProgressBarProps = _ProgressBarProps;
+export { ProgressBar, type ProgressBarProps } from './ProgressBar';

--- a/packages/big-design/src/components/ProgressCircle/index.ts
+++ b/packages/big-design/src/components/ProgressCircle/index.ts
@@ -1,4 +1,1 @@
-import { ProgressCircleProps as _ProgressCircleProps } from './ProgressCircle';
-
-export { ProgressCircle } from './ProgressCircle';
-export type ProgressCircleProps = _ProgressCircleProps;
+export { ProgressCircle, type ProgressCircleProps } from './ProgressCircle';

--- a/packages/big-design/src/components/Radio/Label/index.ts
+++ b/packages/big-design/src/components/Radio/Label/index.ts
@@ -1,1 +1,1 @@
-export * from './Label';
+export { RadioLabel } from './Label';

--- a/packages/big-design/src/components/Radio/index.ts
+++ b/packages/big-design/src/components/Radio/index.ts
@@ -1,5 +1,2 @@
-import { RadioProps as _RadioProps } from './Radio';
-
-export { Radio } from './Radio';
-export * from './Label';
-export type RadioProps = _RadioProps;
+export { Radio, type RadioProps } from './Radio';
+export { RadioLabel } from './Label';

--- a/packages/big-design/src/components/Search/index.ts
+++ b/packages/big-design/src/components/Search/index.ts
@@ -1,4 +1,2 @@
-import { SearchProps as _SearchProps } from './types';
-
 export { Search } from './Search';
-export type SearchProps = _SearchProps;
+export { type SearchProps } from './types';

--- a/packages/big-design/src/components/Select/index.ts
+++ b/packages/big-design/src/components/Select/index.ts
@@ -1,13 +1,7 @@
-import {
-  SelectAction as _SelectAction,
-  SelectOption as _SelectOption,
-  SelectOptionGroup as _SelectOptionGroup,
-  SelectProps as _SelectProps,
-} from './types';
-
 export { Select } from './Select';
-
-export type SelectAction = _SelectAction;
-export type SelectOptionGroup<T> = _SelectOptionGroup<T>;
-export type SelectOption<T> = _SelectOption<T>;
-export type SelectProps<T> = _SelectProps<T>;
+export {
+  type SelectAction,
+  type SelectOption,
+  type SelectOptionGroup,
+  type SelectProps,
+} from './types';

--- a/packages/big-design/src/components/StatefulTable/index.ts
+++ b/packages/big-design/src/components/StatefulTable/index.ts
@@ -1,9 +1,1 @@
-import {
-  StatefulTableColumn as _StatefulTableColumn,
-  StatefulTableProps as _StatefulTableProps,
-} from './StatefulTable';
-
-export { StatefulTable } from './StatefulTable';
-
-export type StatefulTableProps<T> = _StatefulTableProps<T>;
-export type StatefulTableColumn<T> = _StatefulTableColumn<T>;
+export { StatefulTable, type StatefulTableProps, type StatefulTableColumn } from './StatefulTable';

--- a/packages/big-design/src/components/StatefulTree/index.ts
+++ b/packages/big-design/src/components/StatefulTree/index.ts
@@ -1,8 +1,2 @@
-import { TreeNodeProps as _TreeNodeProps } from '../Tree';
-
-import { StatefulTreeProps as _StatefulTreeProps } from './StatefulTree';
-
-export { StatefulTree } from './StatefulTree';
-
-export type StatefulTreeProps<T> = _StatefulTreeProps<T>;
-export type TreeNodeProps<T> = _TreeNodeProps<T>;
+export { StatefulTree, type StatefulTreeProps } from './StatefulTree';
+export { type TreeNodeProps } from '../Tree';

--- a/packages/big-design/src/components/Stepper/index.ts
+++ b/packages/big-design/src/components/Stepper/index.ts
@@ -1,4 +1,1 @@
-export { Stepper } from './Stepper';
-import { StepperProps as _StepperProps } from './Stepper';
-
-export type StepperProps = _StepperProps;
+export { Stepper, type StepperProps } from './Stepper';

--- a/packages/big-design/src/components/Switch/index.ts
+++ b/packages/big-design/src/components/Switch/index.ts
@@ -1,4 +1,1 @@
-export { Switch } from './Switch';
-import { SwitchProps as _SwitchProps } from './Switch';
-
-export type SwitchProps = _SwitchProps;
+export { Switch, type SwitchProps } from './Switch';

--- a/packages/big-design/src/components/Table/Actions/index.ts
+++ b/packages/big-design/src/components/Table/Actions/index.ts
@@ -1,5 +1,1 @@
-import { ActionsProps as _ActionsProps } from './Actions';
-
-export { Actions } from './Actions';
-
-export type ActionsProps<T> = _ActionsProps<T>;
+export { Actions, type ActionsProps } from './Actions';

--- a/packages/big-design/src/components/Table/Body/index.ts
+++ b/packages/big-design/src/components/Table/Body/index.ts
@@ -1,5 +1,1 @@
-import { BodyProps as _BodyProps } from './Body';
-
-export { Body } from './Body';
-
-export type BodyProps = _BodyProps;
+export { Body, type BodyProps } from './Body';

--- a/packages/big-design/src/components/Table/DataCell/index.ts
+++ b/packages/big-design/src/components/Table/DataCell/index.ts
@@ -1,5 +1,1 @@
-import { DataCellProps as _DataCellProps } from './DataCell';
-
-export { DataCell } from './DataCell';
-
-export type DataCellProps = _DataCellProps;
+export { DataCell, type DataCellProps } from './DataCell';

--- a/packages/big-design/src/components/Table/Head/index.ts
+++ b/packages/big-design/src/components/Table/Head/index.ts
@@ -1,5 +1,1 @@
-import { HeadProps as _HeadProps } from './Head';
-
-export { Head } from './Head';
-
-export type HeadProps = _HeadProps;
+export { Head, type HeadProps } from './Head';

--- a/packages/big-design/src/components/Table/HeaderCell/index.ts
+++ b/packages/big-design/src/components/Table/HeaderCell/index.ts
@@ -1,5 +1,1 @@
-import { HeaderCellProps as _HeaderCellProps } from './HeaderCell';
-
-export { HeaderCell } from './HeaderCell';
-
-export type HeaderCellProps<T> = _HeaderCellProps<T>;
+export { HeaderCell, type HeaderCellProps } from './HeaderCell';

--- a/packages/big-design/src/components/Table/Row/index.ts
+++ b/packages/big-design/src/components/Table/Row/index.ts
@@ -1,5 +1,1 @@
-import { RowProps as _RowProps } from './Row';
-
-export { Row } from './Row';
-
-export type RowProps<T> = _RowProps<T>;
+export { Row, type RowProps } from './Row';

--- a/packages/big-design/src/components/Table/helpers/display/index.ts
+++ b/packages/big-design/src/components/Table/helpers/display/index.ts
@@ -1,5 +1,2 @@
-import { TableColumnDisplayProps as _TableColumnDisplayProps } from './types';
-
+export { type TableColumnDisplayProps } from './types';
 export { withTableColumnDisplay } from './display';
-
-export type TableColumnDisplayProps = _TableColumnDisplayProps;

--- a/packages/big-design/src/components/Table/index.ts
+++ b/packages/big-design/src/components/Table/index.ts
@@ -1,2 +1,10 @@
 export { Table, TableFigure } from './Table';
-export * from './types';
+export type {
+  TableColumn,
+  TableItem,
+  TablePaginationProps,
+  TableProps,
+  TableSelectable,
+  TableSortDirection,
+  TableSortable,
+} from './types';

--- a/packages/big-design/src/components/TableNext/Actions/index.ts
+++ b/packages/big-design/src/components/TableNext/Actions/index.ts
@@ -1,5 +1,1 @@
-import { ActionsProps as _ActionsProps } from './Actions';
-
-export { Actions } from './Actions';
-
-export type ActionsProps<T> = _ActionsProps<T>;
+export { Actions, type ActionsProps } from './Actions';

--- a/packages/big-design/src/components/TableNext/Body/index.ts
+++ b/packages/big-design/src/components/TableNext/Body/index.ts
@@ -1,5 +1,1 @@
-import { BodyProps as _BodyProps } from './Body';
-
-export { Body } from './Body';
-
-export type BodyProps = _BodyProps;
+export { Body, type BodyProps } from './Body';

--- a/packages/big-design/src/components/TableNext/DataCell/index.ts
+++ b/packages/big-design/src/components/TableNext/DataCell/index.ts
@@ -1,5 +1,1 @@
-import { DataCellProps as _DataCellProps } from './DataCell';
-
-export { DataCell } from './DataCell';
-
-export type DataCellProps = _DataCellProps;
+export { DataCell, type DataCellProps } from './DataCell';

--- a/packages/big-design/src/components/TableNext/Head/index.ts
+++ b/packages/big-design/src/components/TableNext/Head/index.ts
@@ -1,5 +1,1 @@
-import { HeadProps as _HeadProps } from './Head';
-
-export { Head } from './Head';
-
-export type HeadProps = _HeadProps;
+export { Head, type HeadProps } from './Head';

--- a/packages/big-design/src/components/TableNext/HeaderCell/index.ts
+++ b/packages/big-design/src/components/TableNext/HeaderCell/index.ts
@@ -1,5 +1,1 @@
-import { HeaderCellProps as _HeaderCellProps } from './HeaderCell';
-
-export { HeaderCell } from './HeaderCell';
-
-export type HeaderCellProps<T> = _HeaderCellProps<T>;
+export { HeaderCell, type HeaderCellProps } from './HeaderCell';

--- a/packages/big-design/src/components/TableNext/Row/index.ts
+++ b/packages/big-design/src/components/TableNext/Row/index.ts
@@ -1,5 +1,1 @@
-import { RowProps as _RowProps } from './Row';
-
-export { Row } from './Row';
-
-export type RowProps<T> = _RowProps<T>;
+export { Row, type RowProps } from './Row';

--- a/packages/big-design/src/components/TableNext/helpers/display/index.ts
+++ b/packages/big-design/src/components/TableNext/helpers/display/index.ts
@@ -1,5 +1,2 @@
-import { TableColumnDisplayProps as _TableColumnDisplayProps } from './types';
-
+export { type TableColumnDisplayProps } from './types';
 export { withTableColumnDisplay } from './display';
-
-export type TableColumnDisplayProps = _TableColumnDisplayProps;

--- a/packages/big-design/src/components/Tabs/index.ts
+++ b/packages/big-design/src/components/Tabs/index.ts
@@ -1,6 +1,1 @@
-import { TabItem as _TabItem, TabsProps as _TabsProps } from './Tabs';
-
-export { Tabs } from './Tabs';
-
-export type TabItem = _TabItem;
-export type TabsProps = _TabsProps;
+export { Tabs, type TabItem, type TabsProps } from './Tabs';

--- a/packages/big-design/src/components/Textarea/index.ts
+++ b/packages/big-design/src/components/Textarea/index.ts
@@ -1,5 +1,1 @@
-import { TextareaProps as _TextareaProps } from './Textarea';
-
-export { Textarea } from './Textarea';
-
-export type TextareaProps = _TextareaProps;
+export { Textarea, type TextareaProps } from './Textarea';

--- a/packages/big-design/src/components/Timepicker/index.ts
+++ b/packages/big-design/src/components/Timepicker/index.ts
@@ -1,4 +1,1 @@
-import { TimepickerProps as _TimepickerProps } from '../Timepicker/Timepicker';
-
-export { Timepicker } from './Timepicker';
-export type TimepickerProps = _TimepickerProps;
+export { Timepicker, type TimepickerProps } from './Timepicker';

--- a/packages/big-design/src/components/Toggle/index.ts
+++ b/packages/big-design/src/components/Toggle/index.ts
@@ -1,1 +1,1 @@
-export * from './Toggle';
+export { Toggle, type ToggleProps } from './Toggle';

--- a/packages/big-design/src/components/Tooltip/index.ts
+++ b/packages/big-design/src/components/Tooltip/index.ts
@@ -1,5 +1,1 @@
-import { TooltipProps as _TooltipProps } from './Tooltip';
-
-export { Tooltip } from './Tooltip';
-
-export type TooltipProps = _TooltipProps;
+export { Tooltip, type TooltipProps } from './Tooltip';

--- a/packages/big-design/src/components/Tree/index.ts
+++ b/packages/big-design/src/components/Tree/index.ts
@@ -1,21 +1,13 @@
-import {
-  NodeMap as _NodeMap,
-  TreeExpandable as _TreeExandable,
-  TreeFocusable as _TreeFocusable,
-  TreeNodeId as _TreeNodeId,
-  TreeNodeProps as _TreeNodeProps,
-  TreeProps as _TreeProps,
-  TreeSelectable as _TreeSelectable,
-  TreeSelectableType as _TreeSelectableType,
+export { Tree } from './Tree';
+export {
+  type NodeMap,
+  type TreeExpandable,
+  type TreeFocusable,
+  type TreeNodeId,
+  type TreeNodeProps,
+  type TreeProps,
+  type TreeSelectable,
+  type TreeSelectableType,
 } from './types';
 
 export * from './hooks';
-export { Tree } from './Tree';
-export type NodeMap = _NodeMap;
-export type TreeExpandable = _TreeExandable;
-export type TreeFocusable = _TreeFocusable;
-export type TreeNodeId = _TreeNodeId;
-export type TreeProps<T> = _TreeProps<T>;
-export type TreeNodeProps<T> = _TreeNodeProps<T>;
-export type TreeSelectable<T> = _TreeSelectable<T>;
-export type TreeSelectableType = _TreeSelectableType;

--- a/packages/big-design/src/components/Typography/index.ts
+++ b/packages/big-design/src/components/Typography/index.ts
@@ -1,11 +1,2 @@
-import {
-  HeadingProps as _HeadingProps,
-  HRProps as _HRProps,
-  TextProps as _TextProps,
-} from './types';
-
 export { Text, Small, HR, H0, H1, H2, H3, H4 } from './Typography';
-
-export type TextProps = _TextProps;
-export type HeadingProps = _HeadingProps;
-export type HRProps = _HRProps;
+export { type TextProps, type HeadingProps, type HRProps } from './types';

--- a/packages/big-design/src/components/Worksheet/index.ts
+++ b/packages/big-design/src/components/Worksheet/index.ts
@@ -1,3 +1,18 @@
 export { Worksheet } from './Worksheet';
-
-export * from './types';
+export type {
+  Cell,
+  DisabledRows,
+  ExpandableRows,
+  NotationConfig,
+  WorksheetCheckboxColumn,
+  WorksheetColumn,
+  WorksheetError,
+  WorksheetItem,
+  WorksheetLocalization,
+  WorksheetModalColumn,
+  WorksheetNumberColumn,
+  WorksheetProps,
+  WorksheetSelectableColumn,
+  WorksheetTextColumn,
+  WorksheetToggleColumn,
+} from './types';

--- a/packages/big-design/src/helpers/display/index.ts
+++ b/packages/big-design/src/helpers/display/index.ts
@@ -1,5 +1,2 @@
-import { DisplayProps as _DisplayProps } from './types';
-
+export { type DisplayProps } from './types';
 export { withDisplay } from './display';
-
-export type DisplayProps = _DisplayProps;

--- a/packages/big-design/src/helpers/margins/index.ts
+++ b/packages/big-design/src/helpers/margins/index.ts
@@ -1,5 +1,1 @@
-import { MarginProps as _MarginProps } from './margins';
-
-export { excludeMarginProps, withMargins } from './margins';
-
-export type MarginProps = _MarginProps;
+export { excludeMarginProps, withMargins, type MarginProps } from './margins';

--- a/packages/big-design/src/helpers/paddings/index.ts
+++ b/packages/big-design/src/helpers/paddings/index.ts
@@ -1,5 +1,1 @@
-import { PaddingProps as _PaddingProps } from './paddings';
-
-export { excludePaddingProps, withPaddings } from './paddings';
-
-export type PaddingProps = _PaddingProps;
+export { excludePaddingProps, withPaddings, type PaddingProps } from './paddings';


### PR DESCRIPTION
## What?

Exports the types without reassignment to new type definitions.

## Why?

Previously, we were reassigning the types due to tree-shaking issues. However, this is no longer with later versions of typescript, so this reassignment is not longer needed.

## Screenshots/Screen Recordings

![Screenshot 2024-04-10 at 15 33 20](https://github.com/bigcommerce/big-design/assets/10539418/54c5cb4a-b3a4-4ee9-93ec-5a35bd4e4b88)
