### PR TITLE
chore(ci): install package managers in ~/bin folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
       - run:
           name: Install pnpm package manager
           command: |
-            corepack enable
+            corepack enable --install-directory ~/bin
             corepack prepare pnpm@latest-8 --activate
             pnpm config set store-dir .pnpm-store
       - run:


### PR DESCRIPTION
## What?

Installs any corepack installed package managers in a folder with permissions.

## Why?

Running into a `Internal Error: EACCES: permission denied, unlink '/usr/local/bin/pnpm'` when activating pnpm.
https://app.circleci.com/pipelines/github/bigcommerce/big-design/6077/workflows/469edca2-53d5-41ec-a6d0-75e629711561/jobs/28248

## Screenshots/Screen Recordings

N/A

## Testing/Proof

See CI.
