### PR TITLE
refactor(docs): update side-nav to use radix scrollbar

### DIFF
--- a/packages/docs/components/NextLink/NextLink.tsx
+++ b/packages/docs/components/NextLink/NextLink.tsx
@@ -2,16 +2,6 @@ import { Link } from '@bigcommerce/big-design';
 import { LinkProps, default as NLink } from 'next/link';
 import React from 'react';
 
-function getLinkAs(as = '') {
-  if (!as) {
-    return undefined;
-  }
-
-  const prefix = process.env.URL_PREFIX || '';
-
-  return prefix + as;
-}
-
 interface Props {
   children?: React.ReactNode;
   href: LinkProps['href'];
@@ -19,11 +9,11 @@ interface Props {
 }
 
 export const NextLink: React.FC<Props> = (props) => {
-  const { as, children, href } = props;
+  const { children, href } = props;
 
   return (
-    <NLink as={getLinkAs(as)} href={href} legacyBehavior={true} passHref={true}>
-      {typeof children === 'string' ? <Link>{children}</Link> : children}
+    <NLink href={href} legacyBehavior passHref>
+      <Link>{children}</Link>
     </NLink>
   );
 };

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -1,130 +1,124 @@
-import { Flex, FlexItem } from '@bigcommerce/big-design';
+import { Box, Flex } from '@bigcommerce/big-design';
 import React from 'react';
 
 import { GithubLogoIcon } from '../Icons';
-import { List } from '../List';
 
 import { SideNavGroup } from './SideNavGroup';
-import { SideNavLink, StyledLink } from './SideNavLink';
+import { SideNavLink } from './SideNavLink';
 import { SideNavLogo } from './SideNavLogo';
 import { SideNavMenu } from './SideNavMenu';
-import { StyledFlex } from './styled';
+import {
+  StyledGridItem,
+  StyledScrollAreaRoot,
+  StyledScrollAreaScrollbar,
+  StyledScrollAreaThumb,
+  StyledScrollAreaViewport,
+} from './styled';
 
 const CodeSandboxUrl = process.env.CODE_SANDBOX_URL ?? '';
 
 export const SideNav: React.FC = () => {
   return (
-    <StyledFlex
-      alignContent={{ mobile: 'center', tablet: 'stretch' }}
-      flexDirection={{ mobile: 'row', tablet: 'column' }}
-      justifyContent={{ mobile: 'space-between', tablet: 'flex-start' }}
-      padding="medium"
-      paddingBottom={{ mobile: 'medium', tablet: 'xxxLarge' }}
-      paddingLeft="xLarge"
-    >
-      <FlexItem>
-        <SideNavLogo />
-      </FlexItem>
+    <StyledGridItem forwardedAs="nav" gridArea="nav" paddingVertical={{ tablet: 'xxLarge' }}>
+      <StyledScrollAreaRoot>
+        <StyledScrollAreaViewport>
+          <Flex
+            backgroundColor="secondary10"
+            display={{ mobile: 'flex', tablet: 'block' }}
+            flexDirection={{ mobile: 'row' }}
+            justifyContent="space-between"
+            paddingHorizontal={{ mobile: 'medium', tablet: 'none' }}
+            paddingVertical={{ mobile: 'medium', tablet: 'none' }}
+            shadow="raised"
+            style={{ position: 'relative' }}
+          >
+            <SideNavLogo />
 
-      <SideNavMenu>
-        <SideNavGroup title="Introduction">
-          <SideNavLink href="/">Getting Started</SideNavLink>
+            <SideNavMenu>
+              <SideNavGroup title="Introduction">
+                <SideNavLink href="/">Getting Started</SideNavLink>
 
-          <Link title="CodeSandbox Example" url={CodeSandboxUrl} />
-        </SideNavGroup>
+                <SideNavLink href={CodeSandboxUrl} target="_blank">
+                  CodeSandbox Example
+                </SideNavLink>
+                <Box padding="xSmall" />
+                <SideNavLink href="https://github.com/bigcommerce/big-design" target="_blank">
+                  <Flex alignItems="center" flexDirection="row" flexGap=".5rem">
+                    <GithubLogoIcon title="Github" /> Github
+                  </Flex>
+                </SideNavLink>
+              </SideNavGroup>
 
-        <SideNavGroup title="Foundations">
-          <SideNavLink href="/colors">Colors</SideNavLink>
-          <SideNavLink href="/icons">Icons</SideNavLink>
-          <SideNavLink href="/spacing">Spacing</SideNavLink>
-          <SideNavLink href="/typography">Typography</SideNavLink>
-        </SideNavGroup>
+              <SideNavGroup title="Foundations">
+                <SideNavLink href="/colors">Colors</SideNavLink>
+                <SideNavLink href="/icons">Icons</SideNavLink>
+                <SideNavLink href="/spacing">Spacing</SideNavLink>
+                <SideNavLink href="/typography">Typography</SideNavLink>
+              </SideNavGroup>
 
-        <SideNavGroup title="Layout">
-          <SideNavLink href="/accordion-panel">Accordion Panel</SideNavLink>
-          <SideNavLink href="/collapse">Collapse</SideNavLink>
-          <SideNavLink href="/modal">Modal</SideNavLink>
-          <SideNavLink href="/pagination">Pagination</SideNavLink>
-          <SideNavLink href="/panel">Panel</SideNavLink>
-          <SideNavLink href="/statefulTable">StatefulTable</SideNavLink>
-          <SideNavLink href="/statefulTree">StatefulTree</SideNavLink>
-          <SideNavLink href="/table">Table</SideNavLink>
-          <SideNavLink href="/tabs">Tabs</SideNavLink>
-          <SideNavLink href="/worksheet">Worksheet</SideNavLink>
-        </SideNavGroup>
+              <SideNavGroup title="Layout">
+                <SideNavLink href="/accordion-panel">Accordion Panel</SideNavLink>
+                <SideNavLink href="/collapse">Collapse</SideNavLink>
+                <SideNavLink href="/modal">Modal</SideNavLink>
+                <SideNavLink href="/pagination">Pagination</SideNavLink>
+                <SideNavLink href="/panel">Panel</SideNavLink>
+                <SideNavLink href="/statefulTable">StatefulTable</SideNavLink>
+                <SideNavLink href="/statefulTree">StatefulTree</SideNavLink>
+                <SideNavLink href="/table">Table</SideNavLink>
+                <SideNavLink href="/tabs">Tabs</SideNavLink>
+                <SideNavLink href="/worksheet">Worksheet</SideNavLink>
+              </SideNavGroup>
 
-        <SideNavGroup title="Actions &amp; Inputs">
-          <SideNavLink href="/button">Button</SideNavLink>
-          <SideNavLink href="/button-group">ButtonGroup</SideNavLink>
-          <SideNavLink href="/checkbox">Checkbox</SideNavLink>
-          <SideNavLink href="/counter">Counter</SideNavLink>
-          <SideNavLink href="/datepicker">Datepicker</SideNavLink>
-          <SideNavLink href="/dropdown">Dropdown</SideNavLink>
-          <SideNavLink href="/file-uploader">FileUploader</SideNavLink>
-          <SideNavLink href="/form">Form</SideNavLink>
-          <SideNavLink href="/input">Input</SideNavLink>
-          <SideNavLink href="/link">Link</SideNavLink>
-          <SideNavLink href="/multi-select">MultiSelect</SideNavLink>
-          <SideNavLink href="/pill-tabs">PillTabs</SideNavLink>
-          <SideNavLink href="/radio">Radio</SideNavLink>
-          <SideNavLink href="/search">Search</SideNavLink>
-          <SideNavLink href="/select">Select</SideNavLink>
-          <SideNavLink href="/switch">Switch</SideNavLink>
-          <SideNavLink href="/toggle">Toggle</SideNavLink>
-          <SideNavLink href="/textarea">Textarea</SideNavLink>
-          <SideNavLink href="/timepicker">Timepicker</SideNavLink>
-        </SideNavGroup>
+              <SideNavGroup title="Actions &amp; Inputs">
+                <SideNavLink href="/button">Button</SideNavLink>
+                <SideNavLink href="/button-group">ButtonGroup</SideNavLink>
+                <SideNavLink href="/checkbox">Checkbox</SideNavLink>
+                <SideNavLink href="/counter">Counter</SideNavLink>
+                <SideNavLink href="/datepicker">Datepicker</SideNavLink>
+                <SideNavLink href="/dropdown">Dropdown</SideNavLink>
+                <SideNavLink href="/file-uploader">FileUploader</SideNavLink>
+                <SideNavLink href="/form">Form</SideNavLink>
+                <SideNavLink href="/input">Input</SideNavLink>
+                <SideNavLink href="/link">Link</SideNavLink>
+                <SideNavLink href="/multi-select">MultiSelect</SideNavLink>
+                <SideNavLink href="/pill-tabs">PillTabs</SideNavLink>
+                <SideNavLink href="/radio">Radio</SideNavLink>
+                <SideNavLink href="/search">Search</SideNavLink>
+                <SideNavLink href="/select">Select</SideNavLink>
+                <SideNavLink href="/switch">Switch</SideNavLink>
+                <SideNavLink href="/toggle">Toggle</SideNavLink>
+                <SideNavLink href="/textarea">Textarea</SideNavLink>
+                <SideNavLink href="/timepicker">Timepicker</SideNavLink>
+              </SideNavGroup>
 
-        <SideNavGroup title="Status &amp; Feedback">
-          <SideNavLink href="/alert">Alert</SideNavLink>
-          <SideNavLink href="/badge">Badge</SideNavLink>
-          <SideNavLink href="/inline-message">InlineMessage</SideNavLink>
-          <SideNavLink href="/message">Message</SideNavLink>
-          <SideNavLink href="/progress-bar">ProgressBar</SideNavLink>
-          <SideNavLink href="/progress-circle">ProgressCircle</SideNavLink>
-          <SideNavLink href="/stepper">Stepper</SideNavLink>
-          <SideNavLink href="/tooltip">Tooltip</SideNavLink>
-        </SideNavGroup>
+              <SideNavGroup title="Status &amp; Feedback">
+                <SideNavLink href="/alert">Alert</SideNavLink>
+                <SideNavLink href="/badge">Badge</SideNavLink>
+                <SideNavLink href="/inline-message">InlineMessage</SideNavLink>
+                <SideNavLink href="/message">Message</SideNavLink>
+                <SideNavLink href="/progress-bar">ProgressBar</SideNavLink>
+                <SideNavLink href="/progress-circle">ProgressCircle</SideNavLink>
+                <SideNavLink href="/stepper">Stepper</SideNavLink>
+                <SideNavLink href="/tooltip">Tooltip</SideNavLink>
+              </SideNavGroup>
 
-        <SideNavGroup title="Utilities">
-          <SideNavLink href="/box">Box</SideNavLink>
-          <SideNavLink href="/breakpoints">Breakpoints</SideNavLink>
-          <SideNavLink href="/display">Display</SideNavLink>
-          <SideNavLink href="/flex">Flex</SideNavLink>
-          <SideNavLink href="/grid">Grid</SideNavLink>
-          <SideNavLink href="/margin">Margin</SideNavLink>
-          <SideNavLink href="/padding">Padding</SideNavLink>
-          <SideNavLink href="/popover">Popover</SideNavLink>
-        </SideNavGroup>
-
-        <SideNavGroup title="Helpful Links">
-          <Link
-            icon={<GithubLogoIcon title="Github Logo" />}
-            title="Github"
-            url="https://github.com/bigcommerce/big-design"
-          />
-        </SideNavGroup>
-      </SideNavMenu>
-    </StyledFlex>
-  );
-};
-
-const Link: React.FC<{ url: string; icon?: React.ReactNode; title: string }> = ({
-  url,
-  icon,
-  title,
-}) => {
-  const getChildrenWithIcon = () => (
-    <Flex alignItems="center">
-      {icon} <FlexItem marginLeft="xSmall">{title}</FlexItem>
-    </Flex>
-  );
-
-  return (
-    <List.Item>
-      <StyledLink href={url} target="_blank">
-        {icon ? getChildrenWithIcon() : title}
-      </StyledLink>
-    </List.Item>
+              <SideNavGroup title="Utilities">
+                <SideNavLink href="/box">Box</SideNavLink>
+                <SideNavLink href="/breakpoints">Breakpoints</SideNavLink>
+                <SideNavLink href="/display">Display</SideNavLink>
+                <SideNavLink href="/flex">Flex</SideNavLink>
+                <SideNavLink href="/grid">Grid</SideNavLink>
+                <SideNavLink href="/margin">Margin</SideNavLink>
+                <SideNavLink href="/padding">Padding</SideNavLink>
+                <SideNavLink href="/popover">Popover</SideNavLink>
+              </SideNavGroup>
+            </SideNavMenu>
+          </Flex>
+        </StyledScrollAreaViewport>
+        <StyledScrollAreaScrollbar orientation="vertical">
+          <StyledScrollAreaThumb />
+        </StyledScrollAreaScrollbar>
+      </StyledScrollAreaRoot>
+    </StyledGridItem>
   );
 };

--- a/packages/docs/components/SideNav/SideNavLink/SideNavLink.tsx
+++ b/packages/docs/components/SideNav/SideNavLink/SideNavLink.tsx
@@ -1,16 +1,17 @@
 import { Link } from '@bigcommerce/big-design';
+import NextLink from 'next/link';
 import React from 'react';
 import styled from 'styled-components';
 
-import { List, NextLink } from '../../';
+import { List } from '../../';
 
 interface Props {
   children?: React.ReactNode;
   href: string;
-  as?: string;
+  target?: string;
 }
 
-export const StyledLink = styled(Link)`
+const StyledLink = styled(Link)`
   display: block;
   line-height: ${({ theme }) => theme.lineHeight.large};
 
@@ -20,9 +21,9 @@ export const StyledLink = styled(Link)`
   }
 `;
 
-export const SideNavLink: React.FC<Props> = ({ as, children, href }) => (
+export const SideNavLink: React.FC<Props> = ({ children, href, target }) => (
   <List.Item>
-    <NextLink as={as} href={href}>
+    <NextLink href={href} legacyBehavior passHref target={target}>
       <StyledLink href="">{children}</StyledLink>
     </NextLink>
   </List.Item>

--- a/packages/docs/components/SideNav/SideNavLogo/SideNavLogo.tsx
+++ b/packages/docs/components/SideNav/SideNavLogo/SideNavLogo.tsx
@@ -1,13 +1,16 @@
 import { Small } from '@bigcommerce/big-design';
+import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
+
+import Logo from '../../../public/logo-with-text.svg';
 
 import { StyledLogo } from './styled';
 
 export const SideNavLogo: React.FC = () => (
-  <Link href="/">
+  <Link href="/" style={{ textDecoration: 'none' }}>
     <StyledLogo>
-      <img alt="BigDesign Logo" src={`${process.env.URL_PREFIX}/logo-with-text.svg`} />
+      <Image alt="BigDesign Logo" priority quality={100} src={Logo} />
       <Small>v{process.env.BD_VERSION}</Small>
     </StyledLogo>
   </Link>

--- a/packages/docs/components/SideNav/SideNavLogo/styled.tsx
+++ b/packages/docs/components/SideNav/SideNavLogo/styled.tsx
@@ -9,6 +9,12 @@ export const StyledLogo = styled.div`
   }
 
   p {
+    display: none;
     text-align: right;
+    margin-right: ${({ theme }) => theme.spacing.medium};
+
+    ${({ theme }) => theme.breakpoints.tablet} {
+      display: block;
+    }
   }
 `;

--- a/packages/docs/components/SideNav/styled.tsx
+++ b/packages/docs/components/SideNav/styled.tsx
@@ -1,22 +1,37 @@
-import { Flex } from '@bigcommerce/big-design';
+import { GridItem } from '@bigcommerce/big-design';
+import * as ScrollArea from '@radix-ui/react-scroll-area';
 import styled from 'styled-components';
 
-export const StyledFlex = styled(Flex)`
-  ${({ theme }) => theme.shadow.raised}
-
-  background-color: ${({ theme }) => theme.colors.secondary10};
-  border-radius: 0;
-  position: fixed;
+export const StyledGridItem = styled(GridItem)`
+  position: sticky;
   top: 0;
+  height: 100vh;
   width: 100%;
-  z-index: ${({ theme }) => theme.zIndex.sticky};
+`;
 
-  ${({ theme }) => theme.breakpoints.tablet} {
-    bottom: 0;
-    box-shadow: none;
-    display: block;
-    height: 100vh;
-    overflow: auto;
-    position: sticky;
-  }
+export const StyledScrollAreaRoot = styled(ScrollArea.Root)`
+  overflow: hidden;
+  height: 100%;
+`;
+
+export const StyledScrollAreaViewport = styled(ScrollArea.Viewport)`
+  height: 100%;
+  width: 100%;
+`;
+
+export const StyledScrollAreaScrollbar = styled(ScrollArea.Scrollbar)`
+  display: flex;
+  user-select: none;
+  touch-action: none;
+  padding: ${({ theme }) => theme.helpers.remCalc(1)};
+  border-radius: ${({ theme }) => theme.borderRadius.normal};
+  transition: background-color 160ms ease-out;
+  width: ${({ theme }) => theme.helpers.remCalc(8)};
+  flex-direction: column;
+  background-color: ${({ theme }) => theme.helpers.createRGBA(theme.colors.secondary70, 0.1)};
+`;
+
+export const StyledScrollAreaThumb = styled(ScrollArea.Thumb)`
+  background-color: ${({ theme }) => theme.helpers.createRGBA(theme.colors.secondary70, 0.2)};
+  border-radius: ${({ theme }) => theme.borderRadius.normal};
 `;

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -20,6 +20,9 @@ module.exports = withTM({
     URL_PREFIX: isProduction ? URL_PREFIX : '',
     BD_VERSION: bdPkg.version,
   },
+  images: {
+    unoptimized: true,
+  },
   webpack: (config) => {
     return {
       ...config,

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -25,6 +25,7 @@
     "@bigcommerce/big-design": "workspace:^",
     "@bigcommerce/big-design-icons": "workspace:^",
     "@bigcommerce/big-design-theme": "workspace:^",
+    "@radix-ui/react-scroll-area": "^1.0.5",
     "clipboard-copy": "^4.0.1",
     "next-transpile-modules": "^10.0.0",
     "prettier": "^2.4.0",

--- a/packages/docs/pages/_app.tsx
+++ b/packages/docs/pages/_app.tsx
@@ -21,13 +21,13 @@ const theme = createTheme();
 
 const gridTemplate = {
   mobile: `
-    "nav" 80px
+    "nav" ${theme.helpers.remCalc(80)}
     "main" min-content
     / 100%;
   `,
   tablet: `
-    ". nav main ." 1fr
-    / 1fr 210px minmax(0, 1050px) 1fr;
+    "nav main" 1fr
+    / minmax(${theme.helpers.remCalc(210)}, ${theme.helpers.remCalc(300)}) 1fr;
   `,
 };
 
@@ -63,10 +63,9 @@ const App = ({ Component, pageProps }) => {
       </Head>
       <style global jsx>
         {`
-          html,
-          body,
-          #__next {
-            height: 100%;
+          body {
+            min-height: 100vh;
+            background-color: ${theme.colors.secondary10};
           }
         `}
       </style>
@@ -96,29 +95,31 @@ const App = ({ Component, pageProps }) => {
           {router.query.noNav ? (
             <Component {...pageProps} />
           ) : (
-            <>
-              <Grid
-                backgroundColor="secondary10"
-                gridGap="0"
-                gridTemplate={gridTemplate}
-                style={{ minHeight: '100%' }}
+            <Grid
+              gridGap="0"
+              gridTemplate={gridTemplate}
+              marginHorizontal="auto"
+              paddingHorizontal={{ tablet: 'medium' }}
+              style={{
+                minHeight: '100vh',
+                maxWidth: '1400px',
+                position: 'relative',
+              }}
+            >
+              <SideNav />
+              <GridItem
+                as="main"
+                gridArea="main"
+                marginHorizontal={{ mobile: 'small', tablet: 'xxLarge' }}
+                marginVertical="medium"
+                paddingTop={{ tablet: 'large' }}
+                style={{ maxWidth: '100%' }}
               >
-                <GridItem gridArea="nav" paddingTop="medium">
-                  <SideNav />
-                </GridItem>
-                <GridItem
-                  gridArea="main"
-                  marginHorizontal={{ mobile: 'small', tablet: 'xxLarge' }}
-                  marginVertical="medium"
-                  paddingTop="large"
-                  style={{ maxWidth: '100%' }}
-                >
-                  <StoryWrapper>
-                    <Component {...pageProps} />
-                  </StoryWrapper>
-                </GridItem>
-              </Grid>
-            </>
+                <StoryWrapper>
+                  <Component {...pageProps} />
+                </StoryWrapper>
+              </GridItem>
+            </Grid>
           )}
         </>
       </ThemeProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,9 @@ importers:
       '@bigcommerce/big-design-theme':
         specifier: workspace:^
         version: link:../big-design-theme
+      '@radix-ui/react-scroll-area':
+        specifier: ^1.0.5
+        version: 1.0.5(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0)(react@18.2.0)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -3423,6 +3426,175 @@ packages:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
     dev: false
 
+  /@radix-ui/number@1.0.1:
+    resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
+    dependencies:
+      '@babel/runtime': 7.24.4
+    dev: false
+
+  /@radix-ui/primitive@1.0.1:
+    resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
+    dependencies:
+      '@babel/runtime': 7.24.4
+    dev: false
+
+  /@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.73)(react@18.2.0):
+    resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@types/react': 18.2.73
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-context@1.0.1(@types/react@18.2.73)(react@18.2.0):
+    resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@types/react': 18.2.73
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-direction@1.0.1(@types/react@18.2.73)(react@18.2.0):
+    resolution: {integrity: sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@types/react': 18.2.73
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-presence@1.0.1(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.73)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.73)(react@18.2.0)
+      '@types/react': 18.2.73
+      '@types/react-dom': 18.2.23
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-primitive@1.0.3(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.73)(react@18.2.0)
+      '@types/react': 18.2.73
+      '@types/react-dom': 18.2.23
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-scroll-area@1.0.5(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.73)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.73)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.73)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.73)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.73)(react@18.2.0)
+      '@types/react': 18.2.73
+      '@types/react-dom': 18.2.23
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-slot@1.0.2(@types/react@18.2.73)(react@18.2.0):
+    resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.73)(react@18.2.0)
+      '@types/react': 18.2.73
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.73)(react@18.2.0):
+    resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@types/react': 18.2.73
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.73)(react@18.2.0):
+    resolution: {integrity: sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@types/react': 18.2.73
+      react: 18.2.0
+    dev: false
+
   /@rushstack/eslint-patch@1.1.4:
     resolution: {integrity: sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==}
     dev: true
@@ -4122,7 +4294,6 @@ packages:
     resolution: {integrity: sha512-ZQ71wgGOTmDYpnav2knkjr3qXdAFu0vsk8Ci5w3pGAIdj7/kKAyn+VsQDhXsmzzzepAiI9leWMmubXz690AI/A==}
     dependencies:
       '@types/react': 18.2.73
-    dev: true
 
   /@types/react-redux@7.1.16:
     resolution: {integrity: sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==}


### PR DESCRIPTION
## What?

Updates the side nav on the docs side to use a radix-ui scroll area. Alongside that, I had to adjust a few layout bits in order to accommodate this new component. This helped clean up a few bits of legacy code that we should've removed a while ago. 

Some of the layout changes:
- Added more width to the content and side nav
- Removed helpful links and hoisted the Github link up since I know it's used a lot.

## Why?

The scroll bar was continuously present which was a bit annoying. Using radix allows it to auto-hide and customize the scroll bar with cross-browser support. Increasing the width of the content and side-nav also helps make the docs look nicer.

## Screenshots/Screen Recordings

### Before
![Screenshot 2024-04-12 at 16 25 25](https://github.com/bigcommerce/big-design/assets/10539418/f9947d5f-f0d9-4afc-814a-1c12ab7218d5)

### After

https://github.com/bigcommerce/big-design/assets/10539418/d9152fe1-9cab-4f64-8875-979ef581a6b9
