### PR TITLE
chore(deps): remove babel setup for docs

### DIFF
--- a/packages/docs/.babelrc
+++ b/packages/docs/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": [["styled-components", { "ssr": true }]]
-}

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -23,6 +23,9 @@ module.exports = withTM({
   images: {
     unoptimized: true,
   },
+  compiler: {
+    styledComponents: true,
+  },
   webpack: (config) => {
     return {
       ...config,

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -47,7 +47,6 @@
     "@types/react-beautiful-dnd": "^13.1.8",
     "@types/react-dom": "^18.2.23",
     "@types/styled-components": "^5.1.34",
-    "babel-plugin-styled-components": "^2.0.7",
     "jsx-to-string-loader": "^1.2.0",
     "next": "^14.2.1",
     "push-dir": "^0.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,9 +474,6 @@ importers:
       '@types/styled-components':
         specifier: ^5.1.34
         version: 5.1.34
-      babel-plugin-styled-components:
-        specifier: ^2.0.7
-        version: 2.1.4(@babel/core@7.24.4)(styled-components@5.3.11)
       jsx-to-string-loader:
         specifier: ^1.2.0
         version: 1.2.0


### PR DESCRIPTION
## What?

Removes the custom babel setup for the docs site.

## Why?

SWC has full support now for styled-components: https://github.com/vercel/next.js/issues/30802

## Screenshots/Screen Recordings

N/A

## Testing/Proof

CI + ran it locally and didn't get any console issues.