### PR TITLE
fix(component): remove excess margin from contentless Panel

### DIFF
--- a/packages/big-design/src/components/AccordionPanel/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/AccordionPanel/__snapshots__/spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`it renders accordion panel header 1`] = `
 <h2
-  class="styled__StyledH2-sc-218b28a9-2 styled__StyledH2-sc-93a30afd-1 bEMKfq jbcAKv"
+  class="styled__StyledH2-sc-218b28a9-2 styled__StyledH2-sc-93a30afd-1 hCxYWp jbcAKv"
 >
   Accordion Panel Header
 </h2>

--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -4,6 +4,7 @@ import { MarginProps } from '../../helpers';
 import { excludePaddingProps } from '../../helpers/paddings/paddings';
 import { warning } from '../../utils';
 import { Badge, BadgeProps } from '../Badge/Badge';
+import { Box } from '../Box';
 import { Button, ButtonProps } from '../Button';
 import { Flex } from '../Flex';
 import { Text } from '../Typography';
@@ -40,12 +41,10 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
       return null;
     }
 
-    const headerBottomMargin = description ? 'xxSmall' : props.children ? 'medium' : 'none';
-
     return (
       <Flex flexDirection="row">
         {Boolean(header) && (
-          <StyledH2 id={headerId} marginBottom={headerBottomMargin}>
+          <StyledH2 id={headerId} marginBottom="none">
             {header}
             {badge && <Badge marginLeft="xSmall" {...badge} />}
           </StyledH2>
@@ -61,7 +60,11 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
     }
 
     if (typeof description === 'string') {
-      return <Text color="secondary60">{description}</Text>;
+      return (
+        <Text color="secondary60" marginBottom="none" marginTop={header ? 'xxSmall' : 'none'}>
+          {description}
+        </Text>
+      );
     }
 
     if (isValidElement(description)) {
@@ -82,7 +85,7 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
     >
       {renderHeader()}
       {renderDescription()}
-      {children}
+      {children !== undefined && <Box marginTop="medium">{children}</Box>}
     </StyledPanel>
   );
 });

--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -40,10 +40,12 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
       return null;
     }
 
+    const headerBottomMargin = description ? 'xxSmall' : props.children ? 'medium' : 'none';
+
     return (
       <Flex flexDirection="row">
         {Boolean(header) && (
-          <StyledH2 id={headerId} marginBottom={description ? 'xxSmall' : 'medium'}>
+          <StyledH2 id={headerId} marginBottom={headerBottomMargin}>
             {header}
             {badge && <Badge marginLeft="xSmall" {...badge} />}
           </StyledH2>

--- a/packages/big-design/src/components/Panel/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Panel/__snapshots__/spec.tsx.snap
@@ -9,6 +9,11 @@ exports[`render panel 1`] = `
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
 }
 
+.c2 {
+  margin-top: 1rem;
+  box-sizing: border-box;
+}
+
 .c1 {
   border-radius: 0;
 }
@@ -34,7 +39,11 @@ exports[`render panel 1`] = `
 <div
   class="c0 c1"
 >
-  Dolore proident eiusmod sint est enim laboris anim minim quis ut adipisicing consectetur officia ex. Ipsum eiusmod fugiat amet pariatur culpa tempor aliquip tempor nisi. Irure esse deserunt nostrud ipsum id adipisicing enim velit labore. Nulla exercitation laborum laboris Lorem irure sit esse nulla mollit aliquip consectetur velit
+  <div
+    class="c2"
+  >
+    Dolore proident eiusmod sint est enim laboris anim minim quis ut adipisicing consectetur officia ex. Ipsum eiusmod fugiat amet pariatur culpa tempor aliquip tempor nisi. Irure esse deserunt nostrud ipsum id adipisicing enim velit labore. Nulla exercitation laborum laboris Lorem irure sit esse nulla mollit aliquip consectetur velit
+  </div>
 </div>
 `;
 

--- a/packages/big-design/src/components/Panel/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Panel/__snapshots__/spec.tsx.snap
@@ -37,3 +37,98 @@ exports[`render panel 1`] = `
   Dolore proident eiusmod sint est enim laboris anim minim quis ut adipisicing consectetur officia ex. Ipsum eiusmod fugiat amet pariatur culpa tempor aliquip tempor nisi. Irure esse deserunt nostrud ipsum id adipisicing enim velit labore. Nulla exercitation laborum laboris Lorem irure sit esse nulla mollit aliquip consectetur velit
 </div>
 `;
+
+exports[`render panel with only a heading and no content 1`] = `
+.c4 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 2rem;
+  margin-bottom: 0;
+}
+
+.c0 {
+  margin-bottom: 1rem;
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+}
+
+.c2 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  border-radius: 0;
+}
+
+.c5 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c5 ~ .bd-button {
+  width: auto;
+  margin-top: 0;
+}
+
+@media (min-width:0px) {
+  .c0 {
+    padding: 1rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c0 {
+    padding: 1.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c1 {
+    border-radius: 0.25rem;
+  }
+}
+
+<div
+  class="c0 c1"
+>
+  <div
+    class="c2 c3"
+  >
+    <h2
+      class="c4 c5"
+    >
+      Test Header
+    </h2>
+  </div>
+</div>
+`;

--- a/packages/big-design/src/components/Panel/spec.tsx
+++ b/packages/big-design/src/components/Panel/spec.tsx
@@ -21,6 +21,12 @@ test('render panel', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
+test('render panel with only a heading and no content', () => {
+  const { container } = render(<Panel header="Test Header" />);
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
 test('does not forward styles', () => {
   const { container } = render(
     <Panel className="test" style={{ background: 'red' }}>


### PR DESCRIPTION
## What?

Currently a contentless (or `children`-less) `Panel` component renders with excessive margin under its header.
This PR removes that extra margin.

## Why?

I am not sure if a contentless use of `Panel` was originally envisioned, but the prop is optional and design are looking to use it for 'placeholders'. For example, the `Shipping` panel on Manual Orders remains empty until preceding mandatory sections are filled.

## Screenshots/Screen Recordings

### Before (left) After (right) 

Note: only the final variant is affected by this change

<img width="1458" alt="Screenshot 2024-05-17 at 1 30 05 PM" src="https://github.com/bigcommerce/big-design/assets/56807262/711face8-46f3-4fff-af3d-9a8b5df1a0c2">


## Testing/Proof

- Screenshots from documentation app above
- Passing existing tests, proving no other scenarios were affected
- New snapshot test to defend the new conditional styling

