### PR TITLE
fix(component): fix extra body scroll due to multi-select without visual regression

### DIFF
--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -69,10 +69,6 @@ export const StyledListItem = styled.li<
   label {
     cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   }
-
-  input[type='checkbox'] {
-    position: initial;
-  }
 `;
 
 export const StyledLink = styled.a`

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -20,7 +20,7 @@ import { SelectAction, SelectOption, SelectOptionGroup, SelectProps } from '../S
 import { ListGroupHeader } from './GroupHeader';
 import { ListGroupSeparator } from './GroupSeparator';
 import { ListItem } from './Item';
-import { StyledList } from './styled';
+import { StyledList, StyledListOverflowWrapper } from './styled';
 
 export interface ListProps<T> extends ComponentPropsWithoutRef<'ul'> {
   action?: SelectAction;
@@ -208,26 +208,28 @@ const StyleableList = typedMemo(
     }, [action, items, renderAction, renderGroup, renderItems]);
 
     return (
-      <StyledList
-        {...getMenuProps({
-          ...props,
-          onKeyDown: (event) => {
-            if (event.key === 'Enter') {
-              const element = event.currentTarget.children[highlightedIndex];
-              const link = element.querySelector('a');
+      <StyledListOverflowWrapper>
+        <StyledList
+          {...getMenuProps({
+            ...props,
+            onKeyDown: (event) => {
+              if (event.key === 'Enter') {
+                const element = event.currentTarget.children[highlightedIndex];
+                const link = element.querySelector('a');
 
-              // We want to click the link if it is selected
-              if (link && !link.getAttribute('disabled')) {
-                link.click();
+                // We want to click the link if it is selected
+                if (link && !link.getAttribute('disabled')) {
+                  link.click();
+                }
               }
-            }
-          },
-          ref: forwardedRef,
-        })}
-        maxHeight={maxHeight}
-      >
-        {isOpen && renderChildren}
-      </StyledList>
+            },
+            ref: forwardedRef,
+          })}
+          maxHeight={maxHeight}
+        >
+          {isOpen && renderChildren}
+        </StyledList>
+      </StyledListOverflowWrapper>
     );
   },
 );

--- a/packages/big-design/src/components/List/styled.tsx
+++ b/packages/big-design/src/components/List/styled.tsx
@@ -3,6 +3,16 @@ import styled from 'styled-components';
 
 import { ListProps } from './List';
 
+export const StyledListOverflowWrapper = styled.div`
+  ${({ theme }) => theme.shadow.raised}
+
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+`;
+
+StyledListOverflowWrapper.defaultProps = { theme: defaultTheme };
+
 export const StyledList = styled.ul<Partial<ListProps<unknown>>>`
   ${({ theme }) => theme.shadow.raised};
 

--- a/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Pagination/__snapshots__/spec.tsx.snap
@@ -133,7 +133,7 @@ exports[`render pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c9 {
+.c10 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -182,32 +182,32 @@ exports[`render pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c9 + .bd-button {
+.c10 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c9:active {
+.c10:active {
   background-color: #DBE3FE;
 }
 
-.c9:focus {
+.c10:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9:hover:not(:active) {
+.c10:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -226,6 +226,14 @@ exports[`render pagination component 1`] = `
 }
 
 .c8 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
@@ -261,14 +269,14 @@ exports[`render pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c9 + .bd-button {
+  .c10 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c9 {
+  .c10 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -325,12 +333,16 @@ exports[`render pagination component 1`] = `
         class="c7"
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
-        <ul
-          aria-labelledby=":r0:-label"
+        <div
           class="c8"
-          id=":r0:-menu"
-          role="menu"
-        />
+        >
+          <ul
+            aria-labelledby=":r0:-label"
+            class="c9"
+            id=":r0:-menu"
+            role="menu"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -338,7 +350,7 @@ exports[`render pagination component 1`] = `
     class="c0 c2"
   >
     <button
-      class="c9 c5"
+      class="c10 c5"
       disabled=""
       type="button"
     >
@@ -371,7 +383,7 @@ exports[`render pagination component 1`] = `
       </span>
     </button>
     <button
-      class="c9 c5"
+      class="c10 c5"
       type="button"
     >
       <span
@@ -539,7 +551,7 @@ exports[`render pagination component with invalid page info 1`] = `
   color: #D9DCE9;
 }
 
-.c9 {
+.c10 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -588,32 +600,32 @@ exports[`render pagination component with invalid page info 1`] = `
   color: #3C64F4;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c9 + .bd-button {
+.c10 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c9:active {
+.c10:active {
   background-color: #DBE3FE;
 }
 
-.c9:focus {
+.c10:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9:hover:not(:active) {
+.c10:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -632,6 +644,14 @@ exports[`render pagination component with invalid page info 1`] = `
 }
 
 .c8 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
@@ -667,14 +687,14 @@ exports[`render pagination component with invalid page info 1`] = `
 }
 
 @media (min-width:720px) {
-  .c9 + .bd-button {
+  .c10 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c9 {
+  .c10 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -731,12 +751,16 @@ exports[`render pagination component with invalid page info 1`] = `
         class="c7"
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
-        <ul
-          aria-labelledby=":r5:-label"
+        <div
           class="c8"
-          id=":r5:-menu"
-          role="menu"
-        />
+        >
+          <ul
+            aria-labelledby=":r5:-label"
+            class="c9"
+            id=":r5:-menu"
+            role="menu"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -744,7 +768,7 @@ exports[`render pagination component with invalid page info 1`] = `
     class="c0 c2"
   >
     <button
-      class="c9 c5"
+      class="c10 c5"
       disabled=""
       type="button"
     >
@@ -777,7 +801,7 @@ exports[`render pagination component with invalid page info 1`] = `
       </span>
     </button>
     <button
-      class="c9 c5"
+      class="c10 c5"
       type="button"
     >
       <span
@@ -945,7 +969,7 @@ exports[`render pagination component with invalid range info 1`] = `
   color: #D9DCE9;
 }
 
-.c9 {
+.c10 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -994,32 +1018,32 @@ exports[`render pagination component with invalid range info 1`] = `
   color: #3C64F4;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c9 + .bd-button {
+.c10 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c9:active {
+.c10:active {
   background-color: #DBE3FE;
 }
 
-.c9:focus {
+.c10:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9:hover:not(:active) {
+.c10:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -1038,6 +1062,14 @@ exports[`render pagination component with invalid range info 1`] = `
 }
 
 .c8 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
@@ -1073,14 +1105,14 @@ exports[`render pagination component with invalid range info 1`] = `
 }
 
 @media (min-width:720px) {
-  .c9 + .bd-button {
+  .c10 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c9 {
+  .c10 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -1137,12 +1169,16 @@ exports[`render pagination component with invalid range info 1`] = `
         class="c7"
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
-        <ul
-          aria-labelledby=":ra:-label"
+        <div
           class="c8"
-          id=":ra:-menu"
-          role="menu"
-        />
+        >
+          <ul
+            aria-labelledby=":ra:-label"
+            class="c9"
+            id=":ra:-menu"
+            role="menu"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1150,7 +1186,7 @@ exports[`render pagination component with invalid range info 1`] = `
     class="c0 c2"
   >
     <button
-      class="c9 c5"
+      class="c10 c5"
       disabled=""
       type="button"
     >
@@ -1183,7 +1219,7 @@ exports[`render pagination component with invalid range info 1`] = `
       </span>
     </button>
     <button
-      class="c9 c5"
+      class="c10 c5"
       disabled=""
       type="button"
     >
@@ -1352,7 +1388,7 @@ exports[`render pagination component with no items 1`] = `
   color: #D9DCE9;
 }
 
-.c9 {
+.c10 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -1401,32 +1437,32 @@ exports[`render pagination component with no items 1`] = `
   color: #3C64F4;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c9 + .bd-button {
+.c10 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c9:active {
+.c10:active {
   background-color: #DBE3FE;
 }
 
-.c9:focus {
+.c10:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9:hover:not(:active) {
+.c10:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -1445,6 +1481,14 @@ exports[`render pagination component with no items 1`] = `
 }
 
 .c8 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
@@ -1480,14 +1524,14 @@ exports[`render pagination component with no items 1`] = `
 }
 
 @media (min-width:720px) {
-  .c9 + .bd-button {
+  .c10 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c9 {
+  .c10 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -1544,12 +1588,16 @@ exports[`render pagination component with no items 1`] = `
         class="c7"
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
-        <ul
-          aria-labelledby=":rf:-label"
+        <div
           class="c8"
-          id=":rf:-menu"
-          role="menu"
-        />
+        >
+          <ul
+            aria-labelledby=":rf:-label"
+            class="c9"
+            id=":rf:-menu"
+            role="menu"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1557,7 +1605,7 @@ exports[`render pagination component with no items 1`] = `
     class="c0 c2"
   >
     <button
-      class="c9 c5"
+      class="c10 c5"
       disabled=""
       type="button"
     >
@@ -1590,7 +1638,7 @@ exports[`render pagination component with no items 1`] = `
       </span>
     </button>
     <button
-      class="c9 c5"
+      class="c10 c5"
       disabled=""
       type="button"
     >

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -231,6 +231,14 @@ exports[`dropdown is not visible if items fit 1`] = `
 .c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
   color: #313440;
   margin: 0;
@@ -349,12 +357,16 @@ exports[`dropdown is not visible if items fit 1`] = `
         class="c8"
         style="position: absolute; left: 0px; top: 0px;"
       >
-        <ul
-          aria-labelledby=":r3:-label"
+        <div
           class="c9"
-          id=":r3:-menu"
-          role="menu"
-        />
+        >
+          <ul
+            aria-labelledby=":r3:-label"
+            class="c10"
+            id=":r3:-menu"
+            role="menu"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -592,6 +604,14 @@ exports[`it renders the given tabs 1`] = `
 .c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
   color: #313440;
   margin: 0;
@@ -710,12 +730,16 @@ exports[`it renders the given tabs 1`] = `
         class="c8"
         style="position: absolute; left: 0px; top: 0px;"
       >
-        <ul
-          aria-labelledby=":r0:-label"
+        <div
           class="c9"
-          id=":r0:-menu"
-          role="menu"
-        />
+        >
+          <ul
+            aria-labelledby=":r0:-label"
+            class="c10"
+            id=":r0:-menu"
+            role="menu"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -953,6 +977,14 @@ exports[`only the pills that fit are visible 1`] = `
 .c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
   color: #313440;
   margin: 0;
@@ -1103,12 +1135,16 @@ exports[`only the pills that fit are visible 1`] = `
         class="c8"
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
-        <ul
-          aria-labelledby=":rc:-label"
+        <div
           class="c9"
-          id=":rc:-menu"
-          role="menu"
-        />
+        >
+          <ul
+            aria-labelledby=":rc:-label"
+            class="c10"
+            id=":rc:-menu"
+            role="menu"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1346,6 +1382,14 @@ exports[`only the pills that fit are visible 2 1`] = `
 .c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
   color: #313440;
   margin: 0;
@@ -1495,12 +1539,16 @@ exports[`only the pills that fit are visible 2 1`] = `
         class="c8"
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
-        <ul
-          aria-labelledby=":rf:-label"
+        <div
           class="c9"
-          id=":rf:-menu"
-          role="menu"
-        />
+        >
+          <ul
+            aria-labelledby=":rf:-label"
+            class="c10"
+            id=":rf:-menu"
+            role="menu"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1738,6 +1786,14 @@ exports[`renders all the filters if they fit 1`] = `
 .c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
   color: #313440;
   margin: 0;
@@ -1886,12 +1942,16 @@ exports[`renders all the filters if they fit 1`] = `
         class="c8"
         style="position: absolute; left: 0px; top: 0px;"
       >
-        <ul
-          aria-labelledby=":r9:-label"
+        <div
           class="c9"
-          id=":r9:-menu"
-          role="menu"
-        />
+        >
+          <ul
+            aria-labelledby=":r9:-label"
+            class="c10"
+            id=":r9:-menu"
+            role="menu"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -2129,6 +2189,14 @@ exports[`renders dropdown if items do not fit 1`] = `
 .c9 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
   color: #313440;
   margin: 0;
@@ -2264,12 +2332,16 @@ exports[`renders dropdown if items do not fit 1`] = `
         class="c8"
         style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
-        <ul
-          aria-labelledby=":r6:-label"
+        <div
           class="c9"
-          id=":r6:-menu"
-          role="menu"
-        />
+        >
+          <ul
+            aria-labelledby=":r6:-label"
+            class="c10"
+            id=":r6:-menu"
+            role="menu"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -152,7 +152,7 @@ exports[`renders a pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c12 {
+.c13 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -201,32 +201,32 @@ exports[`renders a pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c12:focus {
+.c13:focus {
   outline: none;
 }
 
-.c12[disabled] {
+.c13[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c12 + .bd-button {
+.c13 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c12:active {
+.c13:active {
   background-color: #DBE3FE;
 }
 
-.c12:focus {
+.c13:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c12:hover:not(:active) {
+.c13:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c12[disabled] {
+.c13[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -245,6 +245,14 @@ exports[`renders a pagination component 1`] = `
 }
 
 .c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c12 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
@@ -304,14 +312,14 @@ exports[`renders a pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c12 + .bd-button {
+  .c13 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c12 {
+  .c13 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -375,12 +383,16 @@ exports[`renders a pagination component 1`] = `
             class="c10"
             style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
           >
-            <ul
-              aria-labelledby=":r13:-label"
+            <div
               class="c11"
-              id=":r13:-menu"
-              role="menu"
-            />
+            >
+              <ul
+                aria-labelledby=":r13:-label"
+                class="c12"
+                id=":r13:-menu"
+                role="menu"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -388,7 +400,7 @@ exports[`renders a pagination component 1`] = `
         class="c1 c5"
       >
         <button
-          class="c12 c8"
+          class="c13 c8"
           disabled=""
           type="button"
         >
@@ -421,7 +433,7 @@ exports[`renders a pagination component 1`] = `
           </span>
         </button>
         <button
-          class="c12 c8"
+          class="c13 c8"
           type="button"
         >
           <span

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -152,7 +152,7 @@ exports[`pagination renders a pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c12 {
+.c13 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -201,32 +201,32 @@ exports[`pagination renders a pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c12:focus {
+.c13:focus {
   outline: none;
 }
 
-.c12[disabled] {
+.c13[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c12 + .bd-button {
+.c13 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c12:active {
+.c13:active {
   background-color: #DBE3FE;
 }
 
-.c12:focus {
+.c13:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c12:hover:not(:active) {
+.c13:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c12[disabled] {
+.c13[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -245,6 +245,14 @@ exports[`pagination renders a pagination component 1`] = `
 }
 
 .c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c12 {
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
   background-color: #FFFFFF;
@@ -304,14 +312,14 @@ exports[`pagination renders a pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c12 + .bd-button {
+  .c13 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c12 {
+  .c13 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -375,12 +383,16 @@ exports[`pagination renders a pagination component 1`] = `
             class="c10"
             style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
           >
-            <ul
-              aria-labelledby=":r13:-label"
+            <div
               class="c11"
-              id=":r13:-menu"
-              role="menu"
-            />
+            >
+              <ul
+                aria-labelledby=":r13:-label"
+                class="c12"
+                id=":r13:-menu"
+                role="menu"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -388,7 +400,7 @@ exports[`pagination renders a pagination component 1`] = `
         class="c1 c5"
       >
         <button
-          class="c12 c8"
+          class="c13 c8"
           disabled=""
           type="button"
         >
@@ -421,7 +433,7 @@ exports[`pagination renders a pagination component 1`] = `
           </span>
         </button>
         <button
-          class="c12 c8"
+          class="c13 c8"
           type="button"
         >
           <span


### PR DESCRIPTION
## What?

This is an attempted fix for #1441 but alternative suggestions welcome. 

This removes [the fix](https://github.com/bigcommerce/big-design/pull/1322) for body scroll in long multi-selects because it conflicts with the [hideVisually](https://polished.js.org/docs/#hidevisually) helper that's being used to hide the native browser input. 

## Why?

See #1441

## Screenshots/Screen Recordings

Before:

https://share.descript.com/view/uD0QKyXLOUM

After:

https://share.descript.com/view/pp4SbBeHmtN

Regression test on Select https://share.descript.com/view/R56Sgg2B4yR
