### PR TITLE
fix(docs): typo on display docs page

### DIFF
--- a/packages/docs/pages/display.tsx
+++ b/packages/docs/pages/display.tsx
@@ -101,7 +101,7 @@ const DisplayPage = () => {
           discouraged={[
             <>
               Don't use <Code>display="none"</Code> directly on a component, instead don't render
-              the it.
+              it.
             </>,
           ]}
           recommended={['Use the display prop for responsiveness.']}


### PR DESCRIPTION
## What?

Fixes a small typo on the docs in the display page:

<img width="1056" alt="Screenshot 2024-06-12 at 10 38 53 AM" src="https://github.com/bigcommerce/big-design/assets/6025510/9c430754-2a2e-41f8-861c-977b713f2539">


## Why?

To use proper grammar

## Screenshots/Screen Recordings

N/A

## Testing/Proof

N/A
