### PR TITLE
feat(component):  implement `select all` for multi-select component

### DIFF
--- a/packages/big-design/src/components/List/Item/Item.tsx
+++ b/packages/big-design/src/components/List/Item/Item.tsx
@@ -18,6 +18,7 @@ export interface ListItemProps<T> extends ComponentPropsWithoutRef<'li'> {
   isAction?: boolean;
   isChecked?: boolean;
   isHighlighted: boolean;
+  isIndeterminate?: boolean;
   isSelected?: boolean;
   item: DropdownItem | DropdownLinkItem | SelectOption<T> | SelectAction;
   getItemProps:
@@ -41,6 +42,7 @@ const StyleableListItem = typedMemo(
     isChecked = false,
     isHighlighted,
     isSelected = false,
+    isIndeterminate = false,
     item,
     getItemProps,
     addItem,
@@ -77,6 +79,7 @@ const StyleableListItem = typedMemo(
           checked={isChecked}
           description={item.description}
           disabled={item.disabled}
+          isIndeterminate={isIndeterminate}
           label={item.content}
           onChange={() => null}
           onClick={(event) => event.preventDefault()}

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -15,6 +15,7 @@ import { useIsomorphicLayoutEffect, useWindowSize } from '../../hooks';
 import { typedMemo } from '../../utils';
 import { Box } from '../Box';
 import { DropdownItem, DropdownItemGroup, DropdownLinkItem, DropdownProps } from '../Dropdown';
+import { MultiSelectLocalization } from '../MultiSelect/types';
 import { SelectAction, SelectOption, SelectOptionGroup, SelectProps } from '../Select';
 
 import { ListGroupHeader } from './GroupHeader';
@@ -43,6 +44,7 @@ export interface ListProps<T> extends ComponentPropsWithoutRef<'ul'> {
     | UseSelectPropGetters<any>['getMenuProps']
     | UseComboboxPropGetters<any>['getMenuProps'];
   update: (() => Promise<Partial<State>>) | null;
+  localization?: { selectAll: MultiSelectLocalization['selectAll'] };
   removeItem?(item: SelectOption<T>): void;
 }
 
@@ -69,6 +71,7 @@ const StyleableList = typedMemo(
     selectedItems,
     selectAll,
     update,
+    localization = { selectAll: 'Select All' },
     removeItem,
     ...props
   }: ListProps<T> & PrivateProps): ReturnType<React.FC<ListProps<T> & PrivateProps>> => {
@@ -89,15 +92,19 @@ const StyleableList = typedMemo(
 
     const handleSelectAll = useCallback(
       (listItems: Array<SelectOption<T>>) => {
-        const enabledItems = listItems.filter((item) => !item.disabled);
+        if (updateItems) {
+          const enabledItems = listItems.filter((item) => !item.disabled);
 
-        updateItems && updateItems(enabledItems);
+          updateItems(enabledItems);
+        }
       },
       [updateItems],
     );
 
     const handleUnselectAll = useCallback(() => {
-      updateItems && updateItems([]);
+      if (updateItems) {
+        updateItems([]);
+      }
     }, [updateItems]);
 
     const renderSelectAll = useCallback(
@@ -123,7 +130,7 @@ const StyleableList = typedMemo(
               isChecked={isAllSelected}
               isHighlighted={highlightedIndex === key}
               isIndeterminate={isSomeSelected && !isAllSelected}
-              item={{ content: 'Select All', value: 'select-all' }}
+              item={{ content: localization?.selectAll, value: 'select-all' }}
               key="select-all"
               removeItem={handleUnselectAll}
             />
@@ -138,6 +145,7 @@ const StyleableList = typedMemo(
         selectedItems,
         handleSelectAll,
         handleUnselectAll,
+        localization?.selectAll,
       ],
     );
 

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -27,7 +27,12 @@ import { List } from '../List';
 import { SelectAction, SelectOption, SelectOptionGroup } from '../Select';
 import { DropdownButton, StyledDropdownIcon, StyledInputContainer } from '../Select/styled';
 
-import { MultiSelectProps } from './types';
+import { MultiSelectLocalization, MultiSelectProps } from './types';
+
+export const defaultLocalization: MultiSelectLocalization = {
+  optional: 'optional',
+  selectAll: 'Select All',
+};
 
 export const MultiSelect = typedMemo(
   <T,>({
@@ -42,7 +47,7 @@ export const MultiSelect = typedMemo(
     inputRef,
     label,
     labelId,
-    localization,
+    localization = defaultLocalization,
     maxHeight,
     onClose,
     onOpen,
@@ -284,7 +289,7 @@ export const MultiSelect = typedMemo(
       items: [
         ...(selectAll
           ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            ([{ content: 'Select All', value: 'select-all' }] as Array<SelectOption<T>>)
+            ([{ content: localization?.selectAll, value: 'select-all' }] as Array<SelectOption<T>>)
           : []),
         ...filteredOptions,
       ],
@@ -489,6 +494,7 @@ export const MultiSelect = typedMemo(
             highlightedIndex={highlightedIndex}
             isOpen={isOpen}
             items={options}
+            localization={{ selectAll: localization.selectAll }}
             maxHeight={maxHeight}
             removeItem={removeItem}
             selectAll={selectAll}

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -37,6 +37,7 @@ export const MultiSelect = typedMemo(
     className,
     disabled,
     filterable = true,
+    selectAll = false,
     id,
     inputRef,
     label,
@@ -280,7 +281,13 @@ export const MultiSelect = typedMemo(
       inputId: id,
       inputValue,
       itemToString: (option) => (option ? option.content : ''),
-      items: filteredOptions,
+      items: [
+        ...(selectAll
+          ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            ([{ content: 'Select All', value: 'select-all' }] as Array<SelectOption<T>>)
+          : []),
+        ...filteredOptions,
+      ],
       labelId,
       onInputValueChange: handleSetInputValue,
       onIsOpenChange: handleOnIsOpenChange,
@@ -460,6 +467,12 @@ export const MultiSelect = typedMemo(
       selectedOptions,
     ]);
 
+    const handleUpdateItems = (items: Array<SelectOption<T>>) =>
+      onOptionsChange(
+        items.map((option) => option.value),
+        items,
+      );
+
     return (
       <div>
         {renderLabel}
@@ -478,8 +491,10 @@ export const MultiSelect = typedMemo(
             items={options}
             maxHeight={maxHeight}
             removeItem={removeItem}
+            selectAll={selectAll}
             selectedItems={selectedOptions}
             update={update}
+            updateItems={selectAll ? handleUpdateItems : undefined}
           />
         </Box>
       </div>

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -1067,7 +1067,7 @@ test('renders localized labels', async () => {
   render(
     <MultiSelect
       label="Countries"
-      localization={{ optional: 'opcional' }}
+      localization={{ optional: 'opcional', selectAll: 'Select all' }}
       onOptionsChange={onChange}
       options={[
         { value: 'us', content: 'United States' },
@@ -1083,6 +1083,105 @@ test('renders localized labels', async () => {
   const label = await screen.findByText('Countries');
 
   expect(label).toHaveStyleRule('content', "' (opcional)'", { modifier: '::after' });
+});
+
+test('selects all triggers onOptionsChange with available options', async () => {
+  const onOptionsChangeMock = jest.fn();
+
+  render(
+    <MultiSelect
+      data-testid="multi-select"
+      label="Countries"
+      onOptionsChange={onOptionsChangeMock}
+      options={[
+        { value: 'us', content: 'United States' },
+        { value: 'en', content: 'England' },
+        { value: 'fr', content: 'France', disabled: true },
+      ]}
+      placeholder="Choose country"
+      selectAll
+    />,
+  );
+
+  const input = await screen.findByTestId('multi-select');
+
+  await userEvent.click(input);
+
+  const selectAll = await screen.findByRole('option', { name: 'Select All' });
+
+  await userEvent.click(selectAll);
+
+  expect(onOptionsChangeMock).toHaveBeenCalledWith(
+    ['us', 'en'],
+    [
+      { content: 'United States', value: 'us' },
+      { content: 'England', value: 'en' },
+    ],
+  );
+});
+
+test('unselects all triggers onOptionsChange with empty list', async () => {
+  const onOptionsChangeMock = jest.fn();
+
+  render(
+    <MultiSelect
+      data-testid="multi-select"
+      label="Countries"
+      onOptionsChange={onOptionsChangeMock}
+      options={[
+        { value: 'us', content: 'United States' },
+        { value: 'en', content: 'England' },
+      ]}
+      placeholder="Choose country"
+      selectAll
+      value={['us', 'en']}
+    />,
+  );
+
+  const input = await screen.findByTestId('multi-select');
+
+  await userEvent.click(input);
+
+  const selectAll = await screen.findByRole('option', { name: 'Select All' });
+
+  await userEvent.click(selectAll);
+
+  expect(onOptionsChangeMock).toHaveBeenCalledWith([], []);
+});
+
+test('select all triggers onOptionsChange with all options', async () => {
+  const onOptionsChangeMock = jest.fn();
+
+  render(
+    <MultiSelect
+      data-testid="multi-select"
+      label="Countries"
+      onOptionsChange={onOptionsChangeMock}
+      options={[
+        { value: 'us', content: 'United States' },
+        { value: 'en', content: 'England' },
+      ]}
+      placeholder="Choose country"
+      selectAll
+      value={['us']}
+    />,
+  );
+
+  const input = await screen.findByTestId('multi-select');
+
+  await userEvent.click(input);
+
+  const selectAll = await screen.findByRole('option', { name: 'Select All' });
+
+  await userEvent.click(selectAll);
+
+  expect(onOptionsChangeMock).toHaveBeenCalledWith(
+    ['us', 'en'],
+    [
+      { content: 'United States', value: 'us' },
+      { content: 'England', value: 'en' },
+    ],
+  );
 });
 
 describe('aria-labelledby', () => {

--- a/packages/big-design/src/components/MultiSelect/types.ts
+++ b/packages/big-design/src/components/MultiSelect/types.ts
@@ -27,9 +27,15 @@ interface BaseSelect extends Omit<ComponentPropsWithoutRef<'input'>, 'children' 
   onOpen?(): void;
 }
 
+export interface MultiSelectLocalization {
+  optional: string;
+  selectAll: string;
+}
+
 export interface MultiSelectProps<T> extends BaseSelect {
   options: Array<SelectOption<T>> | Array<SelectOptionGroup<T>>;
   value?: T[];
   selectAll?: boolean;
+  localization?: MultiSelectLocalization;
   onOptionsChange(value: T[], option: Array<SelectOption<T>>): void;
 }

--- a/packages/big-design/src/components/MultiSelect/types.ts
+++ b/packages/big-design/src/components/MultiSelect/types.ts
@@ -30,5 +30,6 @@ interface BaseSelect extends Omit<ComponentPropsWithoutRef<'input'>, 'children' 
 export interface MultiSelectProps<T> extends BaseSelect {
   options: Array<SelectOption<T>> | Array<SelectOptionGroup<T>>;
   value?: T[];
+  selectAll?: boolean;
   onOptionsChange(value: T[], option: Array<SelectOption<T>>): void;
 }

--- a/packages/docs/PropTables/MultiSelectPropTable.tsx
+++ b/packages/docs/PropTables/MultiSelectPropTable.tsx
@@ -135,6 +135,16 @@ const selectProps: Prop[] = [
     ),
   },
   {
+    name: 'selectAll',
+    types: 'boolean',
+    required: false,
+    description: (
+      <>
+        If set, a <Code>Select All</Code> option will be added to the top of the list.
+      </>
+    ),
+  },
+  {
     name: 'required',
     types: 'boolean',
     description: 'Sets the field as required.',


### PR DESCRIPTION
## What?
Implement `select all` for multi-select component;


## Why?

To be able to select/unselect all options by one click.

## Screenshots/Screen Recordings

https://github.com/bigcommerce/big-design/assets/84462142/a8df07b7-0bd7-447a-a369-0c9aa48fcb99



## Testing/Proof

Locally + UT.
