### PR TITLE
fix(component): fix formatting of the worksheet cell with the default type

### DIFF
--- a/packages/big-design/src/components/Worksheet/Row/Row.tsx
+++ b/packages/big-design/src/components/Worksheet/Row/Row.tsx
@@ -58,7 +58,12 @@ const InternalRow = <T extends WorksheetItem>({ columns, rowIndex }: RowProps<T>
     (
       column: InternalWorksheetColumn<T>,
     ): column is WorksheetTextColumn<T> | WorksheetNumberColumn<T> | WorksheetModalColumn<T> => {
-      return column.type === 'text' || column.type === 'number' || column.type === 'modal';
+      return (
+        column.type === undefined ||
+        column.type === 'text' ||
+        column.type === 'number' ||
+        column.type === 'modal'
+      );
     },
     [],
   );


### PR DESCRIPTION
## What?

Fix formatting of the worksheet cell with the default type

## Why?

When there is no explicitly defined type of the worksheet column, the column has type 'text', and formatting should work for such columns type, but it does not work.


## Screenshots/Screen Recordings

https://github.com/bigcommerce/big-design/assets/84462142/9d6968cb-f25e-4dd1-a6ba-d39909700864



## Testing/Proof
Locally.