### PR TITLE
fix(component): avoid displaying NaN in number cell

### DIFF
--- a/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
@@ -46,7 +46,14 @@ export const useEditableCell = <T extends WorksheetItem>(cell: Cell<T>) => {
       const isTextCell = cell?.type === 'text';
 
       if (isNumberCell || isTextCell) {
-        updateItems([cell], [isNumberCell ? Number(event?.target.value) : event?.target.value]);
+        updateItems(
+          [cell],
+          [
+            isNumberCell && !Number.isNaN(Number(event?.target.value))
+              ? Number(event?.target.value)
+              : event?.target.value,
+          ],
+        );
       }
 
       restoreFocus();


### PR DESCRIPTION
## What?

Avoid displaying `NaN` in number cell (Worksheet).

## Why?

`NaN` is technical value, and is not clear for final user.

## Screenshots/Screen Recordings
<img width="731" alt="Screenshot 2024-07-10 at 12 42 34" src="https://github.com/bigcommerce/big-design/assets/84462142/bb3cf7af-b3c3-472d-9bd4-968194a819fe">

## Testing/Proof

Locally.
