### PR TITLE
fix(component): fix onBlur and onFocus support for Datepicker

### DIFF
--- a/packages/big-design/src/components/Datepicker/Datepicker.tsx
+++ b/packages/big-design/src/components/Datepicker/Datepicker.tsx
@@ -37,6 +37,8 @@ const RawDatepicker: React.FC<DatepickerProps & PrivateProps> = ({
   required,
   placeholder,
   value,
+  onBlur,
+  onFocus,
   ...props
 }) => {
   const [selected, setSelected] = useState<Date>();
@@ -65,7 +67,9 @@ const RawDatepicker: React.FC<DatepickerProps & PrivateProps> = ({
         locale={locale}
         maxDate={max ? new Date(max) : undefined}
         minDate={min ? new Date(min) : undefined}
+        onBlur={onBlur}
         onChange={updateDate}
+        onFocus={onFocus}
         placeholderText={placeholder}
         popperModifiers={[
           {

--- a/packages/big-design/src/components/Datepicker/spec.tsx
+++ b/packages/big-design/src/components/Datepicker/spec.tsx
@@ -130,3 +130,28 @@ test('renders localized labels', () => {
 
   expect(label).toHaveStyleRule('content', "' (opcional)'", { modifier: '::after' });
 });
+
+test('calls an optional onFocus callback upon focus', async () => {
+  const onFocus = jest.fn();
+
+  render(<Datepicker onDateChange={jest.fn()} onFocus={onFocus} />);
+
+  const input = await screen.findByRole('textbox');
+
+  await userEvent.click(input);
+
+  expect(onFocus).toHaveBeenCalled();
+});
+
+test('calls an optional onBlur callback upon blur', async () => {
+  const onBlur = jest.fn();
+
+  render(<Datepicker onBlur={onBlur} onDateChange={jest.fn()} />);
+
+  const input = await screen.findByRole('textbox');
+
+  await userEvent.click(input);
+  await userEvent.tab();
+
+  expect(onBlur).toHaveBeenCalled();
+});


### PR DESCRIPTION
## What?

- Ensure that `onBlur` and `onFocus` callbacks are honoured and ran by the `Datepicker`


## Why?

- Both `onBlur` and `onFocus` appear as current valid `Datepicker` props
- Useful to have them for form libraries and custom validation logic

## Screenshots/Screen Recordings

(Misalignment of next/previous month caused by zooming in for the video)

https://github.com/user-attachments/assets/09a86450-b320-40a4-8bff-c0c46c6a183b



## Testing/Proof

- New test proving behaviour: https://github.com/bigcommerce/big-design/pull/1478/files#diff-406d20a98aca0b8a48dc23571b83cb154592e97c22365d041b8ab32e8e016f7bR134-R157
