### PR TITLE
chore: use turborepo instead of lerna + nx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           keys:
             - big-design-icons-<<parameters.cache-version>>-{{ .Branch }}
             - big-design-icons-<<parameters.cache-version>>
-      - run: pnpm -F @bigcommerce/big-design-icons run build
+      - run: pnpm build --filter @bigcommerce/big-design-icons
       - save_cache:
           name: 'Saving build cache'
           key: big-design-icons-<<parameters.cache-version>>-{{ .Branch }}
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - pre-setup
-      - run: pnpm -F @bigcommerce/big-design-theme run build
+      - run: pnpm build --filter @bigcommerce/big-design-theme
 
   build-big-design:
     <<: *default_executor
@@ -93,7 +93,7 @@ jobs:
     steps:
       - pre-setup
       - attach-built-icons
-      - run: pnpm -F @bigcommerce/big-design run build
+      - run: pnpm build --filter @bigcommerce/big-design
 
   build-examples:
     <<: *default_executor
@@ -101,7 +101,7 @@ jobs:
     steps:
       - pre-setup
       - attach-built-icons
-      - run: pnpm -F @bigcommerce/examples run build
+      - run: pnpm build --filter @bigcommerce/examples
 
   build-docs:
     <<: *default_executor
@@ -120,7 +120,7 @@ jobs:
             - nextjs-<<parameters.cache-version>>-{{ checksum "package.json" }}-{{ checksum "pnpm-lock.yaml" }}
             - nextjs-<<parameters.cache-version>>-{{ checksum "package.json" }}
             - nextjs-<<parameters.cache-version>>
-      - run: pnpm -F @bigcommerce/docs run build
+      - run: pnpm build --filter @bigcommerce/docs
       - save_cache:
           key: nextjs-<<parameters.cache-version>>-{{ checksum "package.json" }}-{{ checksum "pnpm-lock.yaml" }}
           paths:
@@ -132,7 +132,7 @@ jobs:
     steps:
       - pre-setup
       - attach-built-icons
-      - run: pnpm run typecheck
+      - run: pnpm typecheck
 
   lint:
     <<: *default_executor
@@ -140,7 +140,7 @@ jobs:
     steps:
       - pre-setup
       - attach-built-icons
-      - run: pnpm run lint
+      - run: pnpm lint
 
   test:
     <<: *default_executor
@@ -148,7 +148,7 @@ jobs:
     steps:
       - pre-setup
       - attach-built-icons
-      - run: pnpm run ci:test
+      - run: pnpm ci:test
 
 #################################################################################
 # Workflows

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ packages/docs/pages/dev.tsx
 .tsbuildinfo
 .env*.local
 .swc
+.turbo

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "packageManager": "pnpm@8.15.8",
   "scripts": {
-    "build": "lerna run build --stream",
-    "build:icons": "pnpm -F @bigcommerce/big-design-icons run build",
-    "ci:test": "lerna run test --stream -- --maxWorkers=2 --coverage",
+    "build": "turbo build",
+    "build:icons": "turbo build --filter @bigcommerce/big-design-icons",
+    "ci:test": "turbo test -- --maxWorkers=2 --coverage",
     "lint": "eslint . --ext .ts,.tsx,.js,.mdx --max-warnings 0",
-    "start": "pnpm -F @bigcommerce/docs run start",
-    "test": "lerna run test --stream",
-    "typecheck": "lerna run typecheck --stream",
+    "start": "turbo start --filter @bigcommerce/docs",
+    "test": "turbo test",
+    "typecheck": "turbo typecheck",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -29,6 +29,7 @@
     "husky": "^9.0.11",
     "lerna": "^8.1.2",
     "lint-staged": "^15.2.2",
+    "turbo": "^2.0.14",
     "typescript": "^5.4.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       lint-staged:
         specifier: ^15.2.2
         version: 15.2.7
+      turbo:
+        specifier: ^2.0.14
+        version: 2.0.14
       typescript:
         specifier: ^5.4.5
         version: 5.5.4
@@ -638,7 +641,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/generator@7.24.4:
     resolution: {integrity: sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==}
@@ -999,14 +1001,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.25.2
-
-  /@babel/parser@7.24.8:
-    resolution: {integrity: sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.25.2
-    dev: true
 
   /@babel/parser@7.25.3:
     resolution: {integrity: sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==}
@@ -2314,15 +2308,6 @@ packages:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
-
-  /@babel/types@7.24.9:
-    resolution: {integrity: sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
-    dev: true
 
   /@babel/types@7.25.2:
     resolution: {integrity: sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==}
@@ -13153,6 +13138,66 @@ packages:
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /turbo-darwin-64@2.0.14:
+    resolution: {integrity: sha512-kwfDmjNwlNfvtrvT29+ZBg5n1Wvxl891bFHchMJyzMoR0HOE9N1NSNdSZb9wG3e7sYNIu4uDkNk+VBEqJW0HzQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-darwin-arm64@2.0.14:
+    resolution: {integrity: sha512-m3LXYEshCx3wc4ZClM6gb01KYpFmtjQ9IBF3A7ofjb6ahux3xlYZJZ3uFCLAGHuvGLuJ3htfiPbwlDPTdknqqw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-linux-64@2.0.14:
+    resolution: {integrity: sha512-7vBzCPdoTtR92SNn2JMgj1FlMmyonGmpMaQdgAB1OVYtuQ6NVGoh7/lODfaILqXjpvmFSVbpBIDrKOT6EvcprQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-linux-arm64@2.0.14:
+    resolution: {integrity: sha512-jwH+c0bfjpBf26K/tdEFatmnYyXwGROjbr6bZmNcL8R+IkGAc/cglL+OToqJnQZTgZvH7uDGbeSyUo7IsHyjuA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-windows-64@2.0.14:
+    resolution: {integrity: sha512-w9/XwkHSzvLjmioo6cl3S1yRfI6swxsV1j1eJwtl66JM4/pn0H2rBa855R0n7hZnmI6H5ywLt/nLt6Ae8RTDmw==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-windows-arm64@2.0.14:
+    resolution: {integrity: sha512-XaQlyYk+Rf4xS5XWCo8XCMIpssgGGy8blzLfolN6YBp4baElIWMlkLZHDbGyiFmCbNf9I9gJI64XGRG+LVyyjA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo@2.0.14:
+    resolution: {integrity: sha512-00JjdCMD/cpsjP0Izkjcm8Oaor5yUCfDwODtaLb+WyblyadkaDEisGhy3Dbd5az9n+5iLSPiUgf+WjPbns6MRg==}
+    hasBin: true
+    optionalDependencies:
+      turbo-darwin-64: 2.0.14
+      turbo-darwin-arm64: 2.0.14
+      turbo-linux-64: 2.0.14
+      turbo-linux-arm64: 2.0.14
+      turbo-windows-64: 2.0.14
+      turbo-windows-arm64: 2.0.14
     dev: true
 
   /type-check@0.3.2:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalPassThroughEnv": ["NEXT_PUBLIC_GTM_ID"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "", ".next/**", "!.next/cache/**", "out/**"]
+    },
+    "ci:test": {
+      "outputs": ["coverage/**"]
+    },
+    "start": {
+      "cache": false,
+      "persistent": true
+    },
+    "typecheck": {},
+    "test": {}
+  }
+}


### PR DESCRIPTION
## What?

Switches the repo over to using `turbo` instead of `lerna`'s built-in `nx` caching functionality. Also updates CI to use the caching benefit using remote caching.

## Why?

This is part of the path to removing lerna from the repo.

## Screenshots/Screen Recordings

N/A

## Testing/Proof
Latest test run in CI is using Turbo Remote Caching.
