### PR TITLE
feat: add wide breakpoint for large screens

### DIFF
--- a/.changeset/lazy-glasses-relax.md
+++ b/.changeset/lazy-glasses-relax.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design-theme': minor
+'@bigcommerce/docs': minor
+---
+
+Added wide breakpoint to theme definition to best adapt responsive features to wide screens

--- a/packages/big-design-theme/src/system/breakpoints.ts
+++ b/packages/big-design-theme/src/system/breakpoints.ts
@@ -2,24 +2,28 @@ export interface BreakpointValues {
   mobile: string;
   tablet: string;
   desktop: string;
+  wide: string;
 }
 
 export interface Breakpoints {
   mobile: string;
   tablet: string;
   desktop: string;
+  wide: string;
 }
 
 export const breakpointValues: BreakpointValues = {
   mobile: `0px`,
   tablet: `720px`,
   desktop: `1025px`,
+  wide: `1500px`,
 };
 
 export const breakpoints: Breakpoints = {
   mobile: `@media (min-width: ${breakpointValues.mobile})`,
   tablet: `@media (min-width: ${breakpointValues.tablet})`,
   desktop: `@media (min-width: ${breakpointValues.desktop})`,
+  wide: `@media (min-width: ${breakpointValues.wide})`,
 };
 
-export const breakpointsOrder: Array<keyof Breakpoints> = ['mobile', 'tablet', 'desktop'];
+export const breakpointsOrder: Array<keyof Breakpoints> = ['mobile', 'tablet', 'desktop', 'wide'];

--- a/packages/docs/pages/breakpoints.tsx
+++ b/packages/docs/pages/breakpoints.tsx
@@ -21,8 +21,9 @@ const BreakpointsPage = () => (
         <Code primary>breakpointValues</Code> that can be used to create responsive layouts and
         components. Our breakpoints include <Code primary>mobile</Code>, <Code primary>tablet</Code>{' '}
         and <Code primary>desktop</Code>. For each breakpoint, the breakpoint values are{' '}
-        <Code>{breakpointValues.mobile}</Code>, <Code>{breakpointValues.tablet}</Code>, and{' '}
-        <Code>{breakpointValues.desktop}</Code> respectively.
+        <Code>{breakpointValues.mobile}</Code>, <Code>{breakpointValues.tablet}</Code>,{' '}
+        <Code>{breakpointValues.desktop}</Code> and <Code>{breakpointValues.wide}</Code>{' '}
+        respectively.
       </Text>
     </Panel>
 
@@ -44,7 +45,14 @@ const BreakpointsPage = () => (
 
                 <CodePreview scope={{ Box }}>
                   {/* jsx-to-string:start */}
-                  <Box padding={{ mobile: 'none', tablet: 'small', desktop: 'xLarge' }}>
+                  <Box
+                    padding={{
+                      mobile: 'none',
+                      tablet: 'small',
+                      desktop: 'xLarge',
+                      wide: 'xxLarge',
+                    }}
+                  >
                     This box has responsive props!
                   </Box>
                   {/* jsx-to-string:end */}
@@ -82,11 +90,15 @@ const BreakpointsPage = () => (
                       width: 100%;
 
                       ${({ theme }) => theme.breakpoints.tablet} {
-                        width: 60%;
+                        width: 75%;
                       }
 
                       ${({ theme }) => theme.breakpoints.desktop} {
-                        width: 30%;
+                        width: 50%;
+                      }
+
+                      ${({ theme }) => theme.breakpoints.wide} {
+                        width: 25%;
                       }
                     `;
 


### PR DESCRIPTION
## What?

Adding a wide breakpoint for large screen definitions

## Why?

We have gathered through analytics that the majority of users use wide monitors, being 1920x1080 the most common screen resolution. Our form pages look too narrow on this case. We are to use this definition in patterns moving forward.
