### PR TITLE
fix(ci): fix script order for changesets

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,16 +28,16 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build Packages
+        run: pnpm run build
+
+      - name: Test Packages
         run: pnpm run ci:test
 
-      - name: Build Packages
+      - name: Lint Packages
         run: pnpm run lint
 
-      - name: Build Packages
+      - name: Typecheck Packages
         run: pnpm run typecheck
-
-      - name: Build Packages
-        run: pnpm run build
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
## What/Why?

Flips around the script order to account for the repo needing to be built before linted.

## Screenshots/Screen Recordings

N/A