### PR TITLE
refactor(docs): use local file to get examples version

### DIFF
--- a/.changeset/polite-swans-happen.md
+++ b/.changeset/polite-swans-happen.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/docs': patch
+---
+
+Uses the package.json version from the `@bigcommerce/examples` package instead of relying on a dependency from the docs `package.json`.

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -4,19 +4,20 @@ const withTM = require('next-transpile-modules')([
 ]);
 
 const bdPkg = require('../big-design/package.json');
+const examplesPkg = require('../examples/package.json');
 
 const pkg = require('./package.json');
 
 const isProduction = process.env.NODE_ENV === 'production';
 const isDev = !isProduction;
 const URL_PREFIX = '/big-design';
-const examplesVersion = pkg.devDependencies['@bigcommerce/examples'].replace('^', '');
+const EXAMPLES_VERSION = examplesPkg.version;
 
 module.exports = withTM({
   basePath: isProduction ? URL_PREFIX : '',
   output: 'export',
   env: {
-    CODE_SANDBOX_URL: `https://codesandbox.io/s/github/bigcommerce/big-design/tree/%40bigcommerce/examples%40${examplesVersion}/packages/examples`,
+    CODE_SANDBOX_URL: `https://codesandbox.io/s/github/bigcommerce/big-design/tree/%40bigcommerce/examples%40${EXAMPLES_VERSION}/packages/examples`,
     URL_PREFIX: isProduction ? URL_PREFIX : '',
     BD_VERSION: bdPkg.version,
   },

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@bigcommerce/configs": "workspace:^",
-    "@bigcommerce/examples": "^1.0.3",
     "@styled/typescript-styled-plugin": "^1.0.1",
     "@types/gtag.js": "^0.0.20",
     "@types/node": "^20.12.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,9 +447,6 @@ importers:
       '@bigcommerce/configs':
         specifier: workspace:^
         version: link:../configs
-      '@bigcommerce/examples':
-        specifier: ^1.0.3
-        version: link:../examples
       '@styled/typescript-styled-plugin':
         specifier: ^1.0.1
         version: 1.0.1


### PR DESCRIPTION
## What?

Uses the version from `package.json` to inject the examples version for the codesandbox link.

## Why?

When changesets bumps the versions of packages, it'll also update the package.json in the docs repo. `changesets` doesn't update the `pnpm-lock.yaml` which causes a mismatch when trying to install with `--frozen-lockfile`.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

![Screenshot 2024-08-19 at 11 54 17](https://github.com/user-attachments/assets/ff773731-4fac-485c-99c1-9cd443a25f6a)

