### PR TITLE
refactor(docs): replace next-transpile-modules package

### DIFF
--- a/.changeset/nervous-ants-nail.md
+++ b/.changeset/nervous-ants-nail.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/docs': patch
+---
+
+Replaces the `next-transpile-modules` package with the native built-in Next.js functionality.

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -1,19 +1,13 @@
-const withTM = require('next-transpile-modules')([
-  '@bigcommerce/big-design',
-  '@bigcommerce/big-design-theme',
-]);
-
 const bdPkg = require('../big-design/package.json');
 const examplesPkg = require('../examples/package.json');
-
-const pkg = require('./package.json');
 
 const isProduction = process.env.NODE_ENV === 'production';
 const isDev = !isProduction;
 const URL_PREFIX = '/big-design';
 const EXAMPLES_VERSION = examplesPkg.version;
 
-module.exports = withTM({
+/** @type {import('next').NextConfig} */
+module.exports = {
   basePath: isProduction ? URL_PREFIX : '',
   output: 'export',
   env: {
@@ -21,6 +15,11 @@ module.exports = withTM({
     URL_PREFIX: isProduction ? URL_PREFIX : '',
     BD_VERSION: bdPkg.version,
   },
+  transpilePackages: [
+    '@bigcommerce/big-design',
+    '@bigcommerce/big-design-theme',
+    '@bigcommerce/big-design-icons',
+  ],
   images: {
     unoptimized: true,
   },
@@ -53,4 +52,4 @@ module.exports = withTM({
 
     return rest;
   },
-});
+};

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -27,7 +27,6 @@
     "@bigcommerce/big-design-theme": "workspace:^",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "clipboard-copy": "^4.0.1",
-    "next-transpile-modules": "^10.0.0",
     "prettier": "^2.4.0",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,9 +419,6 @@ importers:
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
-      next-transpile-modules:
-        specifier: ^10.0.0
-        version: 10.0.1
       prettier:
         specifier: ^2.4.0
         version: 2.8.8
@@ -7192,6 +7189,7 @@ packages:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+    dev: true
 
   /enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
@@ -8417,6 +8415,7 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    dev: true
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -10922,12 +10921,6 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /next-transpile-modules@10.0.1:
-    resolution: {integrity: sha512-4VX/LCMofxIYAVV58UmD+kr8jQflpLWvas/BQ4Co0qWLWzVh06FoZkECkrX5eEZT6oJFqie6+kfbTA3EZCVtdQ==}
-    dependencies:
-      enhanced-resolve: 5.12.0
-    dev: false
-
   /next@14.2.1(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-SF3TJnKdH43PMkCcErLPv+x/DY1YCklslk3ZmwaVoyUfDgHKexuKlf9sEfBQ69w+ue8jQ3msLb+hSj1T19hGag==}
     engines: {node: '>=18.17.0'}
@@ -13057,6 +13050,7 @@ packages:
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}


### PR DESCRIPTION
## What?

Uses the native module transpilation instead of the `next-transpile-modules` package.

## Why?

This functionality has been built in since `next@13`. That means the package is EOL:
https://github.com/martpie/next-transpile-modules/releases/tag/the-end

## Screenshots/Screen Recordings

N/A

## Testing/Proof

![Screenshot 2024-08-19 at 14 09 42](https://github.com/user-attachments/assets/0a597e36-af02-4700-aa3c-07430fab0209)

