### PR TITLE
chore(ci): apply correct permissions for release action

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -7,13 +7,15 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## What/why?

Elevates the `permissions` field to the root workflow to extend the default permissions rather than reset them (by being in a job).


