### PR TITLE
chore: give write-all permissions for releasing

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -7,11 +7,7 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
-  pull-requests: write
+permissions: write-all
 
 jobs:
   release:


### PR DESCRIPTION
## What/why?

After doing a bit more digging into permissions for GitHub Actions, by default we are given read/write permissions for most scopes: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

However, when we set the `permissions` key, it unsets the rest of the scope to no access:

>When the permissions key is used, all unspecified permissions are set to no access, with the exception of the metadata scope, which always gets read access.

Changesets works with the default permissions and they don't provide a lot of guidance on which scopes they need. The existing scopes (pre-pull request) were part of some speculation in [a GitHub issue](https://github.com/changesets/action/issues/179#issuecomment-1139116421) on what changesets needs, but it's not the case anymore.

For the `actions/deploy-page` action we have every scope we need in the default permissions, besides `id-token` which we need to verify that the deployment was successful. This gives the token all the permissions it need in order to run the action.


