### PR TITLE
feat(patterns): implement the Header component

### DIFF
--- a/.changeset/brown-bags-complain.md
+++ b/.changeset/brown-bags-complain.md
@@ -3,3 +3,6 @@
 ---
 
 Releases `@bigcommerce/big-design-pattern`, a collections of useful patterns for BigDesign.
+
+Included components in this release:
+- `Header`

--- a/packages/big-design-patterns/src/components/Header/Header.tsx
+++ b/packages/big-design-patterns/src/components/Header/Header.tsx
@@ -1,0 +1,174 @@
+import {
+  Badge,
+  BadgeProps,
+  Button,
+  ButtonProps,
+  Dropdown,
+  DropdownProps,
+  excludeMarginProps,
+  Flex,
+  FlexItem,
+  H1,
+  Text,
+} from '@bigcommerce/big-design';
+import { ArrowBackIcon } from '@bigcommerce/big-design-icons';
+import React, {
+  ComponentPropsWithoutRef,
+  isValidElement,
+  PropsWithChildren,
+  ReactNode,
+} from 'react';
+
+import { warning } from '../../utils';
+
+import { StyledBackLink } from './styled';
+
+interface BackLinkProps extends ComponentPropsWithoutRef<'a'> {
+  text: string;
+}
+
+const BackLink = ({ text, className, style, ...props }: BackLinkProps) => {
+  return (
+    <StyledBackLink {...props}>
+      <ArrowBackIcon />
+      {text}
+    </StyledBackLink>
+  );
+};
+
+interface ActionButtonProps extends Omit<ButtonProps, 'children' | 'mobileWidth'> {
+  text: string;
+}
+
+interface ActionDropdownProps extends Omit<DropdownProps, 'toggle'> {
+  toggle: ActionButtonProps;
+}
+
+interface ActionProps {
+  actions: Array<ActionButtonProps | ActionDropdownProps>;
+}
+
+function validateActions(actions: Array<ActionButtonProps | ActionDropdownProps>) {
+  if (actions.length > 3) {
+    warning('Header should not have more than 3 actions.');
+  }
+
+  const primaryButtonActions = actions.filter((action) => {
+    if ('toggle' in action) {
+      return action.toggle.variant === 'primary';
+    }
+
+    return action.variant === 'primary';
+  });
+
+  if (primaryButtonActions.length > 1) {
+    warning('Header should not have more than 1 primary action.');
+  }
+}
+
+const Actions = ({ actions }: ActionProps) => {
+  validateActions(actions);
+
+  return (
+    <>
+      {actions.slice(0, 3).map((action, i) => {
+        if ('toggle' in action) {
+          const { toggle, ...dropdownProps } = action;
+          const { text, ...buttonProps } = toggle;
+
+          return (
+            <Dropdown
+              key={i}
+              {...dropdownProps}
+              toggle={
+                <Button {...excludeMarginProps(buttonProps)} mobileWidth="100%">
+                  {text}
+                </Button>
+              }
+            />
+          );
+        }
+
+        const { text, ...buttonProps } = action;
+
+        return (
+          <Button key={i} {...excludeMarginProps(buttonProps)} mobileWidth="100%">
+            {text}
+          </Button>
+        );
+      })}
+    </>
+  );
+};
+
+type Description = string | ReactNode;
+
+interface DescriptionProps {
+  description: Description;
+}
+
+const Description = ({ description }: DescriptionProps) => {
+  if (typeof description === 'string') {
+    return <Text>{description}</Text>;
+  }
+
+  if (isValidElement(description) && description.type === Text) {
+    return description;
+  }
+
+  return null;
+};
+
+export interface HeaderProps extends PropsWithChildren {
+  actions?: Array<ActionButtonProps | ActionDropdownProps>;
+  backLink?: BackLinkProps;
+  badge?: BadgeProps;
+  description?: Description;
+  icon?: ReactNode;
+  title: string;
+}
+
+export const Header = ({
+  actions,
+  backLink,
+  badge,
+  description,
+  icon = null,
+  title,
+}: HeaderProps) => {
+  return (
+    <Flex as="header" flexDirection={{ mobile: 'column', tablet: 'row' }} flexWrap="wrap">
+      {backLink && (
+        <FlexItem flexBasis="100%">
+          <BackLink {...backLink} />
+        </FlexItem>
+      )}
+      <Flex
+        as={(props) => <FlexItem {...props} flexGrow={1} />}
+        flexDirection={{ mobile: 'column', tablet: 'row' }}
+      >
+        <FlexItem
+          flexGrow={1}
+          marginBottom={{ mobile: 'xxLarge', tablet: 'none' }}
+          marginRight={{ mobile: 'none', tablet: 'xxLarge' }}
+        >
+          <Flex alignItems="center" flexDirection="row" flexGap="1rem" marginBottom="xxSmall">
+            {icon}
+            <H1 marginBottom="none">{title}</H1>
+            {badge ? <Badge {...excludeMarginProps(badge)} /> : null}
+          </Flex>
+          <Description description={description} />
+        </FlexItem>
+        {actions ? (
+          <Flex
+            flexDirection={{ mobile: 'column-reverse', tablet: 'row-reverse' }}
+            flexGap={{ mobile: '.75rem', tablet: '0.625rem' }}
+            marginBottom="xLarge"
+          >
+            <Actions actions={actions} />
+          </Flex>
+        ) : null}
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/big-design-patterns/src/components/Header/index.ts
+++ b/packages/big-design-patterns/src/components/Header/index.ts
@@ -1,0 +1,1 @@
+export { Header, type HeaderProps } from './Header';

--- a/packages/big-design-patterns/src/components/Header/spec.tsx
+++ b/packages/big-design-patterns/src/components/Header/spec.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { Header } from './Header';
+
+test('renders basic header', () => {
+  render(<Header title="Page heading" />);
+
+  expect(screen.getByRole('heading', { level: 1, name: 'Page heading' })).toBeInTheDocument();
+});

--- a/packages/big-design-patterns/src/components/Header/spec.tsx
+++ b/packages/big-design-patterns/src/components/Header/spec.tsx
@@ -1,5 +1,10 @@
+import { H1, Text } from '@bigcommerce/big-design';
+import { AddIcon } from '@bigcommerce/big-design-icons';
 import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import React from 'react';
+
+import { warning } from '../../utils';
 
 import { Header } from './Header';
 
@@ -7,4 +12,133 @@ test('renders basic header', () => {
   render(<Header title="Page heading" />);
 
   expect(screen.getByRole('heading', { level: 1, name: 'Page heading' })).toBeInTheDocument();
+});
+
+test('renders with back link', () => {
+  render(<Header backLink={{ text: 'Back', href: '/back' }} title="Page heading" />);
+
+  const backLink = screen.getByRole('link', { name: 'Back' });
+
+  expect(backLink).toBeInTheDocument();
+  expect(backLink).toHaveAttribute('href', '/back');
+});
+
+test('renders with button actions', () => {
+  render(
+    <Header
+      actions={[
+        { text: 'Action 1', variant: 'primary', onClick: jest.fn() },
+        { text: 'Action 2', variant: 'secondary', onClick: jest.fn() },
+      ]}
+      title="Page heading"
+    />,
+  );
+
+  expect(screen.getByRole('button', { name: 'Action 1' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Action 2' })).toBeInTheDocument();
+});
+
+test('renders with dropdown action', async () => {
+  const dropdownItemCallback = jest.fn();
+
+  render(
+    <Header
+      actions={[
+        {
+          items: [{ content: 'Action 1', onItemClick: dropdownItemCallback }],
+          toggle: { text: 'Open menu', variant: 'primary' },
+        },
+      ]}
+      backLink={{ text: 'Back', href: '/back' }}
+      title="Page heading"
+    />,
+  );
+
+  await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+  await userEvent.click(screen.getByRole('option', { name: 'Action 1' }));
+
+  expect(dropdownItemCallback).toHaveBeenCalled();
+});
+
+test('renders with both button and dropdown actions', () => {
+  render(
+    <Header
+      actions={[
+        { text: 'Action 1', variant: 'primary', onClick: jest.fn() },
+        {
+          items: [{ content: 'Action 2', onItemClick: jest.fn() }],
+          toggle: { text: 'Open menu', variant: 'secondary' },
+        },
+      ]}
+      title="Page heading"
+    />,
+  );
+
+  expect(screen.getByRole('button', { name: 'Action 1' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Open menu' })).toBeInTheDocument();
+});
+
+test('renders header with badge', () => {
+  render(<Header badge={{ label: 'Beta', variant: 'primary' }} title="Page heading" />);
+
+  expect(screen.getByText('Beta')).toBeInTheDocument();
+});
+
+test('warns when more than 3 actions are provided', () => {
+  render(
+    <Header
+      actions={[
+        { text: 'Action 1', variant: 'primary', onClick: jest.fn() },
+        { text: 'Action 2', variant: 'secondary', onClick: jest.fn() },
+        { text: 'Action 3', variant: 'secondary', onClick: jest.fn() },
+        { text: 'Action 4', variant: 'secondary', onClick: jest.fn() },
+      ]}
+      title="Page heading"
+    />,
+  );
+
+  expect(warning).toHaveBeenCalledWith('Header should not have more than 3 actions.');
+});
+
+test('warns when more than 1 primary action is provided', () => {
+  render(
+    <Header
+      actions={[
+        { text: 'Action 1', variant: 'primary', onClick: jest.fn() },
+        { text: 'Action 2', variant: 'primary', onClick: jest.fn() },
+      ]}
+      title="Page heading"
+    />,
+  );
+
+  expect(warning).toHaveBeenCalledWith('Header should not have more than 1 primary action.');
+});
+
+test('renders with icon', () => {
+  render(<Header icon={<AddIcon data-testid="header-icon" />} title="Page heading" />);
+
+  expect(screen.getByTestId('header-icon')).toBeInTheDocument();
+});
+
+test('renders with description', () => {
+  render(<Header description="Page description" title="Page heading" />);
+
+  expect(screen.getByText('Page description')).toBeInTheDocument();
+});
+
+test('renders a custom Text component for the description', () => {
+  render(
+    <Header
+      description={<Text data-testid="test-text">Page description</Text>}
+      title="Page heading"
+    />,
+  );
+
+  expect(screen.getByTestId('test-text')).toBeInTheDocument();
+});
+
+test('does not render a description if incorrect component type is used', () => {
+  render(<Header description={<H1>Page description</H1>} title="Page heading" />);
+
+  expect(screen.queryByRole('heading', { name: 'Page description' })).not.toBeInTheDocument();
 });

--- a/packages/big-design-patterns/src/components/Header/styled.tsx
+++ b/packages/big-design-patterns/src/components/Header/styled.tsx
@@ -1,0 +1,22 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled from 'styled-components';
+
+export const StyledBackLink = styled.a.attrs({ theme: defaultTheme })`
+  color: ${({ theme }) => theme.colors.secondary50};
+  display: inline-flex;
+  font-size: ${({ theme }) => theme.typography.fontSize.medium};
+  font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
+  gap: ${({ theme }) => theme.spacing.xxSmall};
+  line-height: ${({ theme }) => theme.lineHeight.medium};
+  padding-inline-end: ${({ theme }) => theme.spacing.xxSmall};
+  padding-block: ${({ theme }) => theme.spacing.xxSmall};
+  text-decoration: none;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.primary};
+  }
+
+  &:focus {
+    outline: 4px solid ${({ theme }) => theme.colors.primary20};
+  }
+`;

--- a/packages/big-design-patterns/src/components/index.ts
+++ b/packages/big-design-patterns/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './Header';

--- a/packages/big-design-patterns/src/index.ts
+++ b/packages/big-design-patterns/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components';

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -24,6 +24,7 @@
     "@babel/standalone": "^7.24.4",
     "@bigcommerce/big-design": "workspace:^",
     "@bigcommerce/big-design-icons": "workspace:^",
+    "@bigcommerce/big-design-patterns": "workspace:^",
     "@bigcommerce/big-design-theme": "workspace:^",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "clipboard-copy": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,6 +510,9 @@ importers:
       '@bigcommerce/big-design-icons':
         specifier: workspace:^
         version: link:../big-design-icons
+      '@bigcommerce/big-design-patterns':
+        specifier: workspace:^
+        version: link:../big-design-patterns
       '@bigcommerce/big-design-theme':
         specifier: workspace:^
         version: link:../big-design-theme


### PR DESCRIPTION
## What?

Adds the `Header` component to `@bigcomerce/big-design-patterns`!

## Why?

To create consistency in our Headers across the control panel.

## Screenshots/Screen Recordings

![Screenshot 2024-08-22 at 17 09 56](https://github.com/user-attachments/assets/43f3e6f5-3473-47b0-bebc-89f41716c974)


## Testing/Proof

Manual testing, but @deini will come through and write the tests.

Code used to test it out:
```tsx
<Header
  actions={[
    {
      text: 'Main action',
      variant: 'primary',
      iconLeft: <AddIcon />,
    },
    {
      items: [],
      toggle: {
        text: 'Secondary',
        variant: 'secondary',
        iconRight: <ArrowDropDownIcon />,
      },
    },
    {
      items: [],
      toggle: {
        text: 'Tertiary',
        variant: 'subtle',
        iconRight: <ArrowDropDownIcon />,
      },
    },
  ]}
  backLink={{
    text: 'Back link',
    href: '#',
    onClick: (event) => {
      event.preventDefault();

      window.alert('Back button clicked');
    },
  }}
  badge={{
    variant: 'success',
    label: 'Beta',
  }}
  description={
    <Text>
      Main description of the page. It provides a comprehensive overview, accurately capturing
      the essence of the topic in a concise manner.{' '}
      <Link external={true} href="#" target="_blank">
        Learn more
      </Link>
    </Text>
  }
  icon={<CodeIcon size="xxxLarge" />}
  title="Page Title"
/>
```
