### PR TITLE
docs: add header pattern documentation

### DIFF
--- a/.changeset/cyan-games-pump.md
+++ b/.changeset/cyan-games-pump.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/docs': patch
+---
+
+Added Header component documentation

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Workspaces are inside the [packages](https://github.com/bigcommerce/big-design/b
 - [big-design](https://github.com/bigcommerce/big-design/blob/main/packages/big-design): React component library.
 - [big-design-theme](https://github.com/bigcommerce/big-design/blob/main/packages/big-design-theme): Default Theme.
 - [big-design-icons](https://github.com/bigcommerce/big-design/blob/main/packages/big-design-icons): Icons library.
+- [big-design-patterns](https://github.com/bigcommerce/big-design/tree/main/packages/big-design-patterns): Pattern library.
 - [docs](https://github.com/bigcommerce/big-design/blob/main/packages/docs): Documentation live here.
 - [configs](https://github.com/bigcommerce/big-design/blob/main/packages/configs): (internal) Shared configs between packages.
 
@@ -68,6 +69,7 @@ As this is a monorepo, each package has it's own Changelog. Links for each can b
 - [big-design](https://github.com/bigcommerce/big-design/blob/main/packages/big-design/CHANGELOG.md)
 - [big-design-theme](https://github.com/bigcommerce/big-design/blob/main/packages/big-design-theme/CHANGELOG.md)
 - [big-design-icons](https://github.com/bigcommerce/big-design/blob/main/packages/big-design-icons/CHANGELOG.md)
+- [big-design-patterns](https://github.com/bigcommerce/big-design/blob/main/packages/big-design-patterns/CHANGELOG.md)
 - [configs](https://github.com/bigcommerce/big-design/tree/main/packages/configs)
 - [docs](https://github.com/bigcommerce/big-design/blob/main/packages/docs/CHANGELOG.md)
 

--- a/packages/docs/PropTables/HeaderPropTable.tsx
+++ b/packages/docs/PropTables/HeaderPropTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Prop, PropTable, PropTableWrapper } from '../components';
+import { NextLink, Prop, PropTable, PropTableWrapper } from '../components';
 
 const headerProps: Prop[] = [
   {
@@ -11,33 +11,58 @@ const headerProps: Prop[] = [
   },
   {
     name: 'actions',
-    types: 'Array<ActionButtonProps | ActionDropdownProps>',
+    types: (
+      <>
+        {'Array<'}
+        <NextLink href={{ hash: 'action-button-prop-table', query: { props: 'action-button' } }}>
+          ActionButton
+        </NextLink>
+        {' | '}
+        <NextLink
+          href={{ hash: 'action-dropdown-prop-table', query: { props: 'action-dropdown' } }}
+        >
+          ActionDropdown
+        </NextLink>
+        {'>'}
+      </>
+    ),
     description: 'An array of actions to display in the header. Can include buttons or dropdowns.',
   },
   {
     name: 'backLink',
-    types: 'BackLinkProps',
+    types: (
+      <NextLink href={{ hash: 'backlink-prop-table', query: { props: 'back-link' } }}>
+        BackLink
+      </NextLink>
+    ),
     description: 'Configuration for a back link displayed at the top left of the header.',
   },
   {
     name: 'badge',
-    types: 'BadgeProps',
+    types: (
+      <NextLink href="/badge#props" key="badge-type">
+        BadgeProps
+      </NextLink>
+    ),
     description: 'Props to display a badge next to the title.',
   },
   {
     name: 'description',
-    types: 'string | ReactNode',
+    types: [
+      'string',
+      <NextLink
+        href={{ pathname: '/typography', query: { implementation: 'text', props: 'text' } }}
+        key="text-type"
+      >
+        Text
+      </NextLink>,
+    ],
     description: 'A description to display under the title.',
   },
   {
     name: 'icon',
     types: 'ReactNode',
     description: 'An icon to display to the left of the title.',
-  },
-  {
-    name: 'children',
-    types: 'ReactNode',
-    description: 'Any additional content to render inside the header.',
   },
 ];
 
@@ -52,12 +77,6 @@ const actionButtonProps: Prop[] = [
     description: 'The text content of the button.',
     required: true,
   },
-  {
-    name: 'variant',
-    types: `'primary' | 'secondary' | 'danger'`,
-    description: 'The style variant of the button.',
-    required: true,
-  },
 ];
 
 export const ActionButtonPropsTable: React.FC<PropTableWrapper> = (props) => (
@@ -67,14 +86,12 @@ export const ActionButtonPropsTable: React.FC<PropTableWrapper> = (props) => (
 const actionDropdownProps: Prop[] = [
   {
     name: 'toggle',
-    types: 'ActionButtonProps',
+    types: (
+      <NextLink href={{ hash: 'action-button-prop-table', query: { props: 'action-button' } }}>
+        ActionButton
+      </NextLink>
+    ),
     description: 'The button used to toggle the dropdown.',
-    required: true,
-  },
-  {
-    name: 'items',
-    types: 'Array<{ content: ReactNode, onClick: () => void }>',
-    description: 'The dropdown menu items.',
     required: true,
   },
 ];

--- a/packages/docs/PropTables/HeaderPropTable.tsx
+++ b/packages/docs/PropTables/HeaderPropTable.tsx
@@ -93,5 +93,5 @@ const backLinkProps: Prop[] = [
 ];
 
 export const BackLinkPropsTable: React.FC<PropTableWrapper> = (props) => (
-  <PropTable propList={backLinkProps} title="Header[BackLink]" nativeElement="a" {...props} />
+  <PropTable propList={backLinkProps} title="Header[BackLink]" nativeElement={['a', 'all']} {...props} />
 );

--- a/packages/docs/PropTables/HeaderPropTable.tsx
+++ b/packages/docs/PropTables/HeaderPropTable.tsx
@@ -93,5 +93,10 @@ const backLinkProps: Prop[] = [
 ];
 
 export const BackLinkPropsTable: React.FC<PropTableWrapper> = (props) => (
-  <PropTable propList={backLinkProps} title="Header[BackLink]" nativeElement={['a', 'all']} {...props} />
+  <PropTable
+    nativeElement={['a', 'all']}
+    propList={backLinkProps}
+    title="Header[BackLink]"
+    {...props}
+  />
 );

--- a/packages/docs/PropTables/HeaderPropTable.tsx
+++ b/packages/docs/PropTables/HeaderPropTable.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import { Prop, PropTable, PropTableWrapper } from '../components';
+
+const headerProps: Prop[] = [
+  {
+    name: 'title',
+    types: 'string',
+    description: 'The main title of the header.',
+    required: true,
+  },
+  {
+    name: 'actions',
+    types: 'Array<ActionButtonProps | ActionDropdownProps>',
+    description: 'An array of actions to display in the header. Can include buttons or dropdowns.',
+  },
+  {
+    name: 'backLink',
+    types: 'BackLinkProps',
+    description: 'Configuration for a back link displayed at the top left of the header.',
+  },
+  {
+    name: 'badge',
+    types: 'BadgeProps',
+    description: 'Props to display a badge next to the title.',
+  },
+  {
+    name: 'description',
+    types: 'string | ReactNode',
+    description: 'A description to display under the title.',
+  },
+  {
+    name: 'icon',
+    types: 'ReactNode',
+    description: 'An icon to display to the left of the title.',
+  },
+  {
+    name: 'children',
+    types: 'ReactNode',
+    description: 'Any additional content to render inside the header.',
+  },
+];
+
+export const HeaderPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable propList={headerProps} title="Header" {...props} />
+);
+
+const actionButtonProps: Prop[] = [
+  {
+    name: 'text',
+    types: 'string',
+    description: 'The text content of the button.',
+    required: true,
+  },
+  {
+    name: 'variant',
+    types: `'primary' | 'secondary' | 'danger'`,
+    description: 'The style variant of the button.',
+    required: true,
+  },
+];
+
+export const ActionButtonPropsTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable propList={actionButtonProps} title="Header[ActionButton]" {...props} />
+);
+
+const actionDropdownProps: Prop[] = [
+  {
+    name: 'toggle',
+    types: 'ActionButtonProps',
+    description: 'The button used to toggle the dropdown.',
+    required: true,
+  },
+  {
+    name: 'items',
+    types: 'Array<{ content: ReactNode, onClick: () => void }>',
+    description: 'The dropdown menu items.',
+    required: true,
+  },
+];
+
+export const ActionDropdownPropsTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable propList={actionDropdownProps} title="Header[ActionDropdown]" {...props} />
+);

--- a/packages/docs/PropTables/HeaderPropTable.tsx
+++ b/packages/docs/PropTables/HeaderPropTable.tsx
@@ -82,3 +82,16 @@ const actionDropdownProps: Prop[] = [
 export const ActionDropdownPropsTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable propList={actionDropdownProps} title="Header[ActionDropdown]" {...props} />
 );
+
+const backLinkProps: Prop[] = [
+  {
+    name: 'text',
+    types: 'string',
+    description: 'The text content of the back link.',
+    required: true,
+  },
+];
+
+export const BackLinkPropsTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable propList={backLinkProps} title="Header[BackLink]" nativeElement="a" {...props} />
+);

--- a/packages/docs/components/CodePreview/CodePreview.tsx
+++ b/packages/docs/components/CodePreview/CodePreview.tsx
@@ -1,6 +1,7 @@
 import { transform } from '@babel/standalone';
 import * as BigDesign from '@bigcommerce/big-design';
 import * as BigDesignIcons from '@bigcommerce/big-design-icons';
+import * as BigDesignPatterns from '@bigcommerce/big-design-patterns';
 import clipboardCopy from 'clipboard-copy';
 import parser from 'prettier/parser-babel';
 import { format } from 'prettier/standalone';
@@ -16,6 +17,7 @@ import { StyledLiveError } from './styled';
 const defaultScope = {
   ...BigDesign,
   ...BigDesignIcons,
+  ...BigDesignPatterns,
   React,
   useEffect,
   useState,

--- a/packages/docs/components/PropTable/PropTable.tsx
+++ b/packages/docs/components/PropTable/PropTable.tsx
@@ -41,10 +41,10 @@ export const PropTable: FC<PropTableProps> = (props) => {
                 header: 'Prop name',
                 hash: 'propName',
                 render: ({ name, required }) => (
-                  <>
+                  <span style={{ whiteSpace: 'nowrap' }}>
                     <Code primary>{name}</Code>
                     {required ? <b> *</b> : null}
-                  </>
+                  </span>
                 ),
               },
               {

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -102,6 +102,10 @@ export const SideNav: React.FC = () => {
                 <SideNavLink href="/tooltip">Tooltip</SideNavLink>
               </SideNavGroup>
 
+              <SideNavGroup title="Patterns">
+                <SideNavLink href="/header">Header</SideNavLink>
+              </SideNavGroup>
+
               <SideNavGroup title="Utilities">
                 <SideNavLink href="/box">Box</SideNavLink>
                 <SideNavLink href="/breakpoints">Breakpoints</SideNavLink>

--- a/packages/docs/pages/header.tsx
+++ b/packages/docs/pages/header.tsx
@@ -14,8 +14,8 @@ import {
 import {
   ActionButtonPropsTable,
   ActionDropdownPropsTable,
-  HeaderPropTable,
   BackLinkPropsTable,
+  HeaderPropTable,
 } from '../PropTables/HeaderPropTable';
 
 const HeaderPage = () => {
@@ -45,39 +45,37 @@ const HeaderPage = () => {
         </Fragment>
         <CodePreview>
           {/* jsx-to-string:start */}
-          {
-            <Header
-              actions={[
-                {
-                  text: 'Main',
-                  variant: 'primary',
-                  iconLeft: <AddIcon />,
+          <Header
+            actions={[
+              {
+                text: 'Main',
+                variant: 'primary',
+                iconLeft: <AddIcon />,
+              },
+              {
+                items: [
+                  { content: 'Option 1', onItemClick: (item) => item },
+                  { content: 'Option 2', onItemClick: (item) => item },
+                ],
+                toggle: {
+                  text: 'Secondary',
+                  variant: 'secondary',
+                  iconRight: <ArrowDropDownIcon />,
                 },
-                {
-                  items: [
-                    { content: 'Option 1', onItemClick: (item) => item },
-                    { content: 'Option 2', onItemClick: (item) => item },
-                  ],
-                  toggle: {
-                    text: 'Secondary',
-                    variant: 'secondary',
-                    iconRight: <ArrowDropDownIcon />,
-                  },
-                },
-                {
-                  text: 'Tertiary',
-                  variant: 'subtle',
-                },
-              ]}
-              backLink={{
-                text: 'Back to Dashboard',
-                href: '/dashboard',
-              }}
-              badge={{ label: 'New', variant: 'success' }}
-              description="This is a description of the page content."
-              title="Page Title"
-            />
-          }
+              },
+              {
+                text: 'Tertiary',
+                variant: 'subtle',
+              },
+            ]}
+            backLink={{
+              text: 'Back to Dashboard',
+              href: '/dashboard',
+            }}
+            badge={{ label: 'New', variant: 'success' }}
+            description="This is a description of the page content."
+            title="Page Title"
+          />
           {/* jsx-to-string:end */}
         </CodePreview>
       </Panel>

--- a/packages/docs/pages/header.tsx
+++ b/packages/docs/pages/header.tsx
@@ -15,6 +15,7 @@ import {
   ActionButtonPropsTable,
   ActionDropdownPropsTable,
   HeaderPropTable,
+  BackLinkPropsTable,
 } from '../PropTables/HeaderPropTable';
 
 const HeaderPage = () => {
@@ -103,6 +104,11 @@ const HeaderPage = () => {
               id: 'action-dropdown-props',
               title: 'ActionDropdown',
               render: () => <ActionDropdownPropsTable />,
+            },
+            {
+              id: 'backlink-dropdown-props',
+              title: 'BackLink',
+              render: () => <BackLinkPropsTable />,
             },
           ]}
         />

--- a/packages/docs/pages/header.tsx
+++ b/packages/docs/pages/header.tsx
@@ -11,6 +11,7 @@ import {
   GuidelinesTable,
   List,
 } from '../components';
+import { ButtonPropTable, DropdownPropTable } from '../PropTables';
 import {
   ActionButtonPropsTable,
   ActionDropdownPropsTable,
@@ -85,24 +86,34 @@ const HeaderPage = () => {
           id="props"
           routes={[
             {
-              id: 'header-props',
+              id: 'header',
               title: 'Header',
               render: () => <HeaderPropTable />,
             },
             {
-              id: 'action-button-props',
+              id: 'action-button',
               title: 'ActionButton',
-              render: () => <ActionButtonPropsTable />,
+              render: () => (
+                <ActionButtonPropsTable
+                  id="action-button-prop-table"
+                  inheritedProps={<ButtonPropTable collapsible />}
+                />
+              ),
             },
             {
-              id: 'action-dropdown-props',
+              id: 'action-dropdown',
               title: 'ActionDropdown',
-              render: () => <ActionDropdownPropsTable />,
+              render: () => (
+                <ActionDropdownPropsTable
+                  id="action-dropdown-prop-table"
+                  inheritedProps={<DropdownPropTable collapsible />}
+                />
+              ),
             },
             {
-              id: 'backlink-dropdown-props',
+              id: 'back-link',
               title: 'BackLink',
-              render: () => <BackLinkPropsTable />,
+              render: () => <BackLinkPropsTable id="backlink-prop-table" />,
             },
           ]}
         />
@@ -111,14 +122,14 @@ const HeaderPage = () => {
       <Panel header="Do's and Don'ts" headerId="guidelines">
         <GuidelinesTable
           discouraged={[
-            <>Don’t overload the header with too many actions or content.</>,
-            <>Don’t use more than one primary action button.</>,
-            <>Avoid unrelated or non-contextual content in the header.</>,
+            'Don’t overload the header with too many actions or content.',
+            'Don’t use more than one primary action button.',
+            'Avoid unrelated or non-contextual content in the header.',
           ]}
           recommended={[
-            <>Use the header to provide a clear overview of the page’s purpose.</>,
-            <>Limit the number of actions to three.</>,
-            <>Utilize the back link option for easy navigation.</>,
+            'Use the header to provide a clear overview of the page’s purpose.',
+            'Limit the number of actions to three.',
+            'Utilize the back link option for easy navigation.',
           ]}
         />
       </Panel>

--- a/packages/docs/pages/header.tsx
+++ b/packages/docs/pages/header.tsx
@@ -45,43 +45,39 @@ const HeaderPage = () => {
         </Fragment>
         <CodePreview>
           {/* jsx-to-string:start */}
-          {function Example() {
-            const backLink = {
-              text: 'Back to Dashboard',
-              href: '/dashboard',
-            };
-
-            return (
-              <Header
-                actions={[
-                  {
-                    text: 'Main',
-                    variant: 'primary',
-                    iconLeft: <AddIcon />,
+          {
+            <Header
+              actions={[
+                {
+                  text: 'Main',
+                  variant: 'primary',
+                  iconLeft: <AddIcon />,
+                },
+                {
+                  items: [
+                    { content: 'Option 1', onItemClick: (item) => item },
+                    { content: 'Option 2', onItemClick: (item) => item },
+                  ],
+                  toggle: {
+                    text: 'Secondary',
+                    variant: 'secondary',
+                    iconRight: <ArrowDropDownIcon />,
                   },
-                  {
-                    items: [
-                      { content: 'Option 1', onItemClick: (item) => item },
-                      { content: 'Option 2', onItemClick: (item) => item },
-                    ],
-                    toggle: {
-                      text: 'Secondary',
-                      variant: 'secondary',
-                      iconRight: <ArrowDropDownIcon />,
-                    },
-                  },
-                  {
-                    text: 'Tertiary',
-                    variant: 'subtle',
-                  },
-                ]}
-                backLink={backLink}
-                badge={{ label: 'New', variant: 'success' }}
-                description="This is a description of the page content."
-                title="Page Title"
-              />
-            );
-          }}
+                },
+                {
+                  text: 'Tertiary',
+                  variant: 'subtle',
+                },
+              ]}
+              backLink={{
+                text: 'Back to Dashboard',
+                href: '/dashboard',
+              }}
+              badge={{ label: 'New', variant: 'success' }}
+              description="This is a description of the page content."
+              title="Page Title"
+            />
+          }
           {/* jsx-to-string:end */}
         </CodePreview>
       </Panel>

--- a/packages/docs/pages/header.tsx
+++ b/packages/docs/pages/header.tsx
@@ -1,0 +1,129 @@
+import { H1, Panel, Text } from '@bigcommerce/big-design';
+import { AddIcon, ArrowDropDownIcon } from '@bigcommerce/big-design-icons';
+import { Header } from '@bigcommerce/big-design-patterns';
+import React, { Fragment } from 'react';
+
+import {
+  Code,
+  CodePreview,
+  CodeSnippet,
+  ContentRoutingTabs,
+  GuidelinesTable,
+  List,
+} from '../components';
+import {
+  ActionButtonPropsTable,
+  ActionDropdownPropsTable,
+  HeaderPropTable,
+} from '../PropTables/HeaderPropTable';
+
+const HeaderPage = () => {
+  return (
+    <>
+      <H1>Header</H1>
+
+      <Panel header="Overview" headerId="overview">
+        <Text>
+          <Code primary>Header</Code> is a layout component that provides a standard structure for
+          page titles, descriptions, icons, badges, and actions.
+        </Text>
+
+        <Text bold>When to use:</Text>
+        <List>
+          <List.Item>To display a title and related actions at the top of a page.</List.Item>
+          <List.Item>To provide context and quick actions for users.</List.Item>
+        </List>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <Fragment key="basic">
+          <Text>
+            To use <Code primary>Header</Code> import the component from the package:
+          </Text>
+          <CodeSnippet>{`import { Header } from '@bigcommerce/big-design-patterns';`}</CodeSnippet>
+        </Fragment>
+        <CodePreview>
+          {/* jsx-to-string:start */}
+          {function Example() {
+            const backLink = {
+              text: 'Back to Dashboard',
+              href: '/dashboard',
+            };
+
+            return (
+              <Header
+                actions={[
+                  {
+                    text: 'Main',
+                    variant: 'primary',
+                    iconLeft: <AddIcon />,
+                  },
+                  {
+                    items: [
+                      { content: 'Option 1', onItemClick: (item) => item },
+                      { content: 'Option 2', onItemClick: (item) => item },
+                    ],
+                    toggle: {
+                      text: 'Secondary',
+                      variant: 'secondary',
+                      iconRight: <ArrowDropDownIcon />,
+                    },
+                  },
+                  {
+                    text: 'Tertiary',
+                    variant: 'subtle',
+                  },
+                ]}
+                backLink={backLink}
+                badge={{ label: 'New', variant: 'success' }}
+                description="This is a description of the page content."
+                title="Page Title"
+              />
+            );
+          }}
+          {/* jsx-to-string:end */}
+        </CodePreview>
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <ContentRoutingTabs
+          id="props"
+          routes={[
+            {
+              id: 'header-props',
+              title: 'Header',
+              render: () => <HeaderPropTable />,
+            },
+            {
+              id: 'action-button-props',
+              title: 'ActionButton',
+              render: () => <ActionButtonPropsTable />,
+            },
+            {
+              id: 'action-dropdown-props',
+              title: 'ActionDropdown',
+              render: () => <ActionDropdownPropsTable />,
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Do's and Don'ts" headerId="guidelines">
+        <GuidelinesTable
+          discouraged={[
+            <>Don’t overload the header with too many actions or content.</>,
+            <>Don’t use more than one primary action button.</>,
+            <>Avoid unrelated or non-contextual content in the header.</>,
+          ]}
+          recommended={[
+            <>Use the header to provide a clear overview of the page’s purpose.</>,
+            <>Limit the number of actions to three.</>,
+            <>Utilize the back link option for easy navigation.</>,
+          ]}
+        />
+      </Panel>
+    </>
+  );
+};
+
+export default HeaderPage;


### PR DESCRIPTION
## What?

Adding the header pattern component documentation

## Why?

To guide developers on how to use the header component

## Screenshots/Screen Recordings

![header-docs](https://github.com/user-attachments/assets/5934911b-1740-4924-8dc1-d409b6ab1f83)

