### PR TITLE
fix(patterns): remove unused PropsWithChildren type

### DIFF
--- a/.changeset/silent-feet-punch.md
+++ b/.changeset/silent-feet-punch.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design-patterns': patch
+---
+
+Removes unused PropsWithChildren type.

--- a/packages/big-design-patterns/src/components/Header/Header.tsx
+++ b/packages/big-design-patterns/src/components/Header/Header.tsx
@@ -12,12 +12,7 @@ import {
   Text,
 } from '@bigcommerce/big-design';
 import { ArrowBackIcon } from '@bigcommerce/big-design-icons';
-import React, {
-  ComponentPropsWithoutRef,
-  isValidElement,
-  PropsWithChildren,
-  ReactNode,
-} from 'react';
+import React, { ComponentPropsWithoutRef, isValidElement, ReactNode } from 'react';
 
 import { warning } from '../../utils';
 
@@ -119,7 +114,7 @@ const Description = ({ description }: DescriptionProps) => {
   return null;
 };
 
-export interface HeaderProps extends PropsWithChildren {
+export interface HeaderProps {
   actions?: Array<ActionButtonProps | ActionDropdownProps>;
   backLink?: BackLinkProps;
   badge?: BadgeProps;


### PR DESCRIPTION
## What/Why?

Remove unused PropsWithChildren type as we don't actually consume `children` within the `Header` component.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

N/A
