### PR TITLE
fix(patterns): remove unused actionBar prop

### DIFF
--- a/packages/big-design-patterns/src/components/Page/Page.tsx
+++ b/packages/big-design-patterns/src/components/Page/Page.tsx
@@ -52,7 +52,6 @@ const PageMessage = ({ message }: Required<Pick<PageProps, 'message'>>) => {
 export const Page = ({ actionBar, background, children, header, message }: PageProps) => {
   return (
     <StyledPageBackground
-      actionBar={actionBar}
       background={background}
       backgroundColor="secondary10"
       gridGap="0"

--- a/packages/big-design-patterns/src/components/Page/styled.tsx
+++ b/packages/big-design-patterns/src/components/Page/styled.tsx
@@ -11,7 +11,6 @@ export interface Background {
 
 export const StyledPageBackground = styled(Grid).attrs({ theme: defaultTheme })<{
   background?: Background;
-  actionBar?: React.ReactNode;
 }>`
   position: relative;
   min-height: 100dvh;


### PR DESCRIPTION
## What?

Removes an unused `actionBar` prop that was passed into `StyledPageBackground`.

## Why?

Unused 🤷 

Changeset not required as `ActionBar` is not released yet.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

N/A
