### PR TITLE
fix: add default theme to styled components

### DIFF
--- a/.changeset/neat-phones-bow.md
+++ b/.changeset/neat-phones-bow.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design': patch
+---
+
+Adds default props to styled-components

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -76,3 +76,5 @@ export const StyledCheckbox = styled.label<StyledCheckboxProps>`
 
 StyledCheckbox.defaultProps = { theme: defaultTheme };
 CheckboxLabelContainer.defaultProps = { theme: defaultTheme };
+CheckboxContainer.defaultProps = { theme: defaultTheme };
+HiddenCheckbox.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/FileUploader/DropZone.tsx
+++ b/packages/big-design/src/components/FileUploader/DropZone.tsx
@@ -17,7 +17,7 @@ import { Box } from '../Box';
 import { Flex } from '../Flex';
 import { Small, Text } from '../Typography';
 
-import { ButtonStyled, DropzoneStyled } from './styled';
+import { StyledButton, StyledDropzone } from './styled';
 import { Localization } from './types';
 import { validateFileFormat } from './utils';
 
@@ -151,7 +151,7 @@ export const DropZone = ({
 
   /* istanbul ignore next */
   return (
-    <DropzoneStyled
+    <StyledDropzone
       {...props}
       alignItems="center"
       aria-label="dropzone"
@@ -191,7 +191,7 @@ export const DropZone = ({
               {renderedDescription}
             </Flex>
           </Flex>
-          <ButtonStyled
+          <StyledButton
             color="secondary"
             disabled={disabled}
             marginTop={isRowView ? 'none' : 'medium'}
@@ -199,9 +199,9 @@ export const DropZone = ({
             variant="subtle"
           >
             {localization.upload}
-          </ButtonStyled>
+          </StyledButton>
         </>
       )}
-    </DropzoneStyled>
+    </StyledDropzone>
   );
 };

--- a/packages/big-design/src/components/FileUploader/File.tsx
+++ b/packages/big-design/src/components/FileUploader/File.tsx
@@ -5,7 +5,7 @@ import { Button } from '../Button';
 import { Dropdown } from '../Dropdown';
 import { DropdownItem } from '../Dropdown/types';
 
-import { FileStyled, ImageStyled, TextEllipsed } from './styled';
+import { StyledFile, StyledImage, StyledText } from './styled';
 
 interface Props extends ComponentPropsWithoutRef<'div'> {
   actions?: DropdownItem[];
@@ -19,7 +19,7 @@ interface Props extends ComponentPropsWithoutRef<'div'> {
 export const File = ({ actions, name, idx, isValid, previewSrc, onRemove, ...props }: Props) => {
   const renderedFilePreview = useMemo(() => {
     if (previewSrc) {
-      return <ImageStyled alt="preview" src={previewSrc} />;
+      return <StyledImage alt="preview" src={previewSrc} />;
     }
 
     return (
@@ -56,7 +56,7 @@ export const File = ({ actions, name, idx, isValid, previewSrc, onRemove, ...pro
   }, [actions, name, onRemove]);
 
   return (
-    <FileStyled
+    <StyledFile
       {...props}
       alignItems="center"
       isValid={isValid}
@@ -64,10 +64,10 @@ export const File = ({ actions, name, idx, isValid, previewSrc, onRemove, ...pro
       paddingHorizontal="small"
     >
       {renderedFilePreview}
-      <TextEllipsed marginBottom="none" marginLeft="xSmall" marginRight="auto">
+      <StyledText marginBottom="none" marginLeft="xSmall" marginRight="auto">
         {name}
-      </TextEllipsed>
+      </StyledText>
       {renderedActions}
-    </FileStyled>
+    </StyledFile>
   );
 };

--- a/packages/big-design/src/components/FileUploader/FileUploader.tsx
+++ b/packages/big-design/src/components/FileUploader/FileUploader.tsx
@@ -19,7 +19,7 @@ import { InlineMessage } from '../InlineMessage';
 
 import { defaultLocalization } from './constants';
 import { File } from './File';
-import { DropZoneWrapper, StyledFileUploaderWrapper, StyledList } from './styled';
+import { StyledDropZoneWrapper, StyledFileUploaderWrapper, StyledList } from './styled';
 import type { Localization, ValidatorConfig } from './types';
 import { getImagesPreview, validateFiles } from './utils';
 
@@ -318,7 +318,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
       !files.length && (dropzoneConfig.emptyHeight ?? 0) >= minBlockHeight ? 'block' : 'row';
 
     return (
-      <DropZoneWrapper
+      <StyledDropZoneWrapper
         accept={accept}
         description={dropzoneConfig.description}
         disabled={disabled}

--- a/packages/big-design/src/components/FileUploader/styled.ts
+++ b/packages/big-design/src/components/FileUploader/styled.ts
@@ -2,9 +2,9 @@ import { theme as defaultTheme, remCalc } from '@bigcommerce/big-design-theme';
 import { ellipsis } from 'polished';
 import styled, { css } from 'styled-components';
 
-import { StyledButton } from '../Button/styled';
+import { StyledButton as StyleableButton } from '../Button/styled';
 import { Flex } from '../Flex';
-import { StyledText } from '../Typography/styled';
+import { StyledText as StyleableText } from '../Typography/styled';
 
 import { DropZone, Props } from './DropZone';
 
@@ -12,7 +12,7 @@ const defaultDropZoneHeight = 68;
 const getDropZoneHeight = (height = defaultDropZoneHeight) =>
   Math.max(height, defaultDropZoneHeight);
 
-export const DropzoneStyled = styled(Flex)<{
+export const StyledDropzone = styled(Flex)<{
   disabled?: boolean;
   isDragOver: boolean;
   isValid: boolean;
@@ -66,14 +66,14 @@ export const DropzoneStyled = styled(Flex)<{
   }
 `;
 
-export const FileStyled = styled(Flex)<{ isValid: boolean }>`
+export const StyledFile = styled(Flex)<{ isValid: boolean }>`
   height: ${remCalc(68)};
   border: ${({ theme, isValid }) => (isValid ? theme.border.box : theme.border.boxError)};
   border-radius: ${({ theme }) => theme.borderRadius.normal};
   background-color: ${({ theme }) => theme.colors.white};
 `;
 
-export const ImageStyled = styled.img`
+export const StyledImage = styled.img`
   height: ${remCalc(40)};
   width: ${remCalc(40)};
 `;
@@ -83,11 +83,11 @@ export const StyledFileUploaderWrapper = styled.div`
   flex-direction: column;
 `;
 
-export const TextEllipsed = styled(StyledText)`
+export const StyledText = styled(StyleableText)`
   ${ellipsis()};
 `;
 
-export const ButtonStyled = styled(StyledButton)`
+export const StyledButton = styled(StyleableButton)`
   color: ${({ theme, disabled }) =>
     disabled ? theme.colors.secondary60 : theme.colors.primary} !important;
 `;
@@ -102,10 +102,15 @@ export const StyledList = styled.ul`
   }
 `;
 
-export const DropZoneWrapper = styled(DropZone)<Props & { emptyHeight?: number }>`
+export const StyledDropZoneWrapper = styled(DropZone)<Props & { emptyHeight?: number }>`
   height: ${({ emptyHeight }) => remCalc(getDropZoneHeight(emptyHeight))};
 `;
 
 StyledList.defaultProps = { theme: defaultTheme };
-DropzoneStyled.defaultProps = { theme: defaultTheme };
-FileStyled.defaultProps = { theme: defaultTheme };
+StyledFileUploaderWrapper.defaultProps = { theme: defaultTheme };
+StyledDropzone.defaultProps = { theme: defaultTheme };
+StyledButton.defaultProps = { theme: defaultTheme };
+StyledDropZoneWrapper.defaultProps = { theme: defaultTheme };
+StyledFile.defaultProps = { theme: defaultTheme };
+StyledText.defaultProps = { theme: defaultTheme };
+StyledImage.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Grid/Item/styled.tsx
+++ b/packages/big-design/src/components/Grid/Item/styled.tsx
@@ -1,3 +1,4 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { Box } from '../../Box';
@@ -5,7 +6,8 @@ import { withGridedItems } from '../withGrid';
 
 import { GridItemProps } from './Item';
 
-// TODO: Remove the `forwardedAs` manual prop definition when @types get updated
-export const StyledGridItem = styled(Box)<GridItemProps & { forwardedAs?: GridItemProps['as'] }>`
+export const StyledGridItem = styled(Box)<GridItemProps>`
   ${withGridedItems()}
 `;
+
+StyledGridItem.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Radio/Radio.tsx
+++ b/packages/big-design/src/components/Radio/Radio.tsx
@@ -12,7 +12,12 @@ import { typedMemo, warning } from '../../utils';
 import { FormControlDescription, FormControlDescriptionLinkProps } from '../Form';
 
 import { RadioLabel } from './Label';
-import { HiddenRadio, RadioContainer, RadioLabelContainer, StyledRadio } from './styled';
+import {
+  StyledHiddenRadio,
+  StyledRadio,
+  StyledRadioContainer,
+  StyledRadioLabelContainer,
+} from './styled';
 
 interface Props {
   label: React.ReactChild;
@@ -79,8 +84,8 @@ const RawRadio: React.FC<RadioProps & PrivateProps> = ({
   }, [description]);
 
   return (
-    <RadioContainer className={className} style={style}>
-      <HiddenRadio
+    <StyledRadioContainer className={className} style={style}>
+      <StyledHiddenRadio
         checked={checked}
         disabled={disabled}
         id={id}
@@ -90,11 +95,11 @@ const RawRadio: React.FC<RadioProps & PrivateProps> = ({
         ref={forwardedRef}
       />
       <StyledRadio aria-hidden={true} checked={checked} disabled={disabled} htmlFor={id} />
-      <RadioLabelContainer>
+      <StyledRadioLabelContainer>
         {renderedLabel}
         {renderedDescription}
-      </RadioLabelContainer>
-    </RadioContainer>
+      </StyledRadioLabelContainer>
+    </StyledRadioContainer>
   );
 };
 

--- a/packages/big-design/src/components/Radio/styled.tsx
+++ b/packages/big-design/src/components/Radio/styled.tsx
@@ -9,16 +9,16 @@ interface StyledRadioProps {
   disabled?: boolean;
 }
 
-export const RadioLabelContainer = styled.div`
+export const StyledRadioLabelContainer = styled.div`
   margin-left: ${({ theme }) => theme.spacing.xSmall};
 `;
 
-export const RadioContainer = styled.div`
+export const StyledRadioContainer = styled.div`
   align-items: flex-start;
   display: flex;
 `;
 
-export const HiddenRadio = styled.input`
+export const StyledHiddenRadio = styled.input`
   ${hideVisually()}
 `;
 
@@ -52,7 +52,7 @@ export const StyledRadio = styled.label<StyledRadioProps>`
       !disabled && (checked ? theme.colors.primary50 : theme.colors.secondary40)};
   }
 
-  ${HiddenRadio}:focus + & {
+  ${StyledHiddenRadio}:focus + & {
     box-shadow: ${({ theme }) => `0 0 0 ${theme.spacing.xxSmall} ${theme.colors.primary20}`};
   }
 
@@ -82,4 +82,6 @@ export const StyledRadio = styled.label<StyledRadioProps>`
 `;
 
 StyledRadio.defaultProps = { theme: defaultTheme };
-RadioLabelContainer.defaultProps = { theme: defaultTheme };
+StyledRadioLabelContainer.defaultProps = { theme: defaultTheme };
+StyledRadioContainer.defaultProps = { theme: defaultTheme };
+StyledHiddenRadio.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Tree/TreeNode/styled.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/styled.tsx
@@ -82,3 +82,7 @@ export const StyledText = styled(StyleableText)`
 StyledArrowWrapper.defaultProps = { theme: defaultTheme };
 StyledFlex.defaultProps = { theme: defaultTheme };
 StyledGap.defaultProps = { theme: defaultTheme };
+StyledLi.defaultProps = { theme: defaultTheme };
+StyledSelectableWrapper.defaultProps = { theme: defaultTheme };
+StyledFlexItem.defaultProps = { theme: defaultTheme };
+StyledText.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
@@ -9,15 +9,15 @@ exports[`renders simple tree 1`] = `
 >
   <li
     aria-expanded="false"
-    class="styled__StyledLi-sc-e02805a5-0 flbtme"
+    class="styled__StyledLi-sc-912cb84-0 ddOgUf"
     role="treeitem"
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-e02805a5-3 fdAGpv"
+      class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
     >
       <div
-        class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-e02805a5-1 iQqnLM"
+        class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-912cb84-1 lpeGLF"
       >
         <svg
           aria-hidden="true"
@@ -41,7 +41,7 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <div
-        class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-e02805a5-4 QUWcN"
+        class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
       >
         <svg
           aria-hidden="true"
@@ -64,7 +64,7 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <span
-        class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-e02805a5-6 ffENPD ibWQSc"
+        class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
         color="secondary70"
       >
         Test Node 0
@@ -76,15 +76,15 @@ exports[`renders simple tree 1`] = `
     >
       <li
         aria-expanded="false"
-        class="styled__StyledLi-sc-e02805a5-0 flbtme"
+        class="styled__StyledLi-sc-912cb84-0 ddOgUf"
         role="treeitem"
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-e02805a5-3 fdAGpv"
+          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
         >
           <div
-            class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-e02805a5-1 iQqnLM"
+            class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-912cb84-1 lpeGLF"
           >
             <svg
               aria-hidden="true"
@@ -108,7 +108,7 @@ exports[`renders simple tree 1`] = `
             </svg>
           </div>
           <div
-            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-e02805a5-4 QUWcN"
+            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
           >
             <svg
               aria-hidden="true"
@@ -131,7 +131,7 @@ exports[`renders simple tree 1`] = `
             </svg>
           </div>
           <span
-            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-e02805a5-6 ffENPD ibWQSc"
+            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
             color="secondary70"
           >
             Test Node 5
@@ -143,18 +143,18 @@ exports[`renders simple tree 1`] = `
         >
           <li
             aria-expanded="false"
-            class="styled__StyledLi-sc-e02805a5-0 flbtme"
+            class="styled__StyledLi-sc-912cb84-0 ddOgUf"
             role="treeitem"
             tabindex="-1"
           >
             <div
-              class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-e02805a5-3 fdAGpv"
+              class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
             >
               <div
-                class="styled__StyledGap-sc-e02805a5-5 ryxSq"
+                class="styled__StyledGap-sc-912cb84-5 jrVihD"
               />
               <div
-                class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-e02805a5-4 QUWcN"
+                class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
               >
                 <svg
                   aria-hidden="true"
@@ -177,7 +177,7 @@ exports[`renders simple tree 1`] = `
                 </svg>
               </div>
               <span
-                class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-e02805a5-6 ffENPD ibWQSc"
+                class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
                 color="secondary70"
               >
                 Test Node 9
@@ -190,15 +190,15 @@ exports[`renders simple tree 1`] = `
   </li>
   <li
     aria-expanded="false"
-    class="styled__StyledLi-sc-e02805a5-0 flbtme"
+    class="styled__StyledLi-sc-912cb84-0 ddOgUf"
     role="treeitem"
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-e02805a5-3 fdAGpv"
+      class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
     >
       <div
-        class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-e02805a5-1 iQqnLM"
+        class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-912cb84-1 lpeGLF"
       >
         <svg
           aria-hidden="true"
@@ -222,7 +222,7 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <div
-        class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-e02805a5-4 QUWcN"
+        class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
       >
         <svg
           aria-hidden="true"
@@ -245,7 +245,7 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <span
-        class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-e02805a5-6 ffENPD ibWQSc"
+        class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
         color="secondary70"
       >
         Test Node 1
@@ -257,18 +257,18 @@ exports[`renders simple tree 1`] = `
     >
       <li
         aria-expanded="false"
-        class="styled__StyledLi-sc-e02805a5-0 flbtme"
+        class="styled__StyledLi-sc-912cb84-0 ddOgUf"
         role="treeitem"
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-e02805a5-3 fdAGpv"
+          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
         >
           <div
-            class="styled__StyledGap-sc-e02805a5-5 ryxSq"
+            class="styled__StyledGap-sc-912cb84-5 jrVihD"
           />
           <div
-            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-e02805a5-4 QUWcN"
+            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
           >
             <svg
               aria-hidden="true"
@@ -291,7 +291,7 @@ exports[`renders simple tree 1`] = `
             </svg>
           </div>
           <span
-            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-e02805a5-6 ffENPD ibWQSc"
+            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
             color="secondary70"
           >
             Test Node 6
@@ -302,18 +302,18 @@ exports[`renders simple tree 1`] = `
   </li>
   <li
     aria-expanded="false"
-    class="styled__StyledLi-sc-e02805a5-0 flbtme"
+    class="styled__StyledLi-sc-912cb84-0 ddOgUf"
     role="treeitem"
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-e02805a5-3 fdAGpv"
+      class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
     >
       <div
-        class="styled__StyledGap-sc-e02805a5-5 ryxSq"
+        class="styled__StyledGap-sc-912cb84-5 jrVihD"
       />
       <div
-        class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-e02805a5-4 QUWcN"
+        class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
       >
         <svg
           aria-hidden="true"
@@ -336,7 +336,7 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <span
-        class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-e02805a5-6 ffENPD ibWQSc"
+        class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
         color="secondary70"
       >
         Category
@@ -345,15 +345,15 @@ exports[`renders simple tree 1`] = `
   </li>
   <li
     aria-expanded="false"
-    class="styled__StyledLi-sc-e02805a5-0 flbtme"
+    class="styled__StyledLi-sc-912cb84-0 ddOgUf"
     role="treeitem"
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-e02805a5-3 fdAGpv"
+      class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
     >
       <div
-        class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-e02805a5-1 iQqnLM"
+        class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-912cb84-1 lpeGLF"
       >
         <svg
           aria-hidden="true"
@@ -377,7 +377,7 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <div
-        class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-e02805a5-4 QUWcN"
+        class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
       >
         <svg
           aria-hidden="true"
@@ -400,7 +400,7 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <span
-        class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-e02805a5-6 ffENPD ibWQSc"
+        class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
         color="secondary70"
       >
         Test Node 3
@@ -412,18 +412,18 @@ exports[`renders simple tree 1`] = `
     >
       <li
         aria-expanded="false"
-        class="styled__StyledLi-sc-e02805a5-0 flbtme"
+        class="styled__StyledLi-sc-912cb84-0 ddOgUf"
         role="treeitem"
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-e02805a5-3 fdAGpv"
+          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
         >
           <div
-            class="styled__StyledGap-sc-e02805a5-5 ryxSq"
+            class="styled__StyledGap-sc-912cb84-5 jrVihD"
           />
           <div
-            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-e02805a5-4 QUWcN"
+            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
           >
             <svg
               aria-hidden="true"
@@ -446,7 +446,7 @@ exports[`renders simple tree 1`] = `
             </svg>
           </div>
           <span
-            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-e02805a5-6 ffENPD ibWQSc"
+            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
             color="secondary70"
           >
             Test Node 7
@@ -457,15 +457,15 @@ exports[`renders simple tree 1`] = `
   </li>
   <li
     aria-expanded="false"
-    class="styled__StyledLi-sc-e02805a5-0 flbtme"
+    class="styled__StyledLi-sc-912cb84-0 ddOgUf"
     role="treeitem"
     tabindex="-1"
   >
     <div
-      class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-e02805a5-3 fdAGpv"
+      class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
     >
       <div
-        class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-e02805a5-1 iQqnLM"
+        class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-912cb84-1 lpeGLF"
       >
         <svg
           aria-hidden="true"
@@ -489,7 +489,7 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <div
-        class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-e02805a5-4 QUWcN"
+        class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
       >
         <svg
           aria-hidden="true"
@@ -512,7 +512,7 @@ exports[`renders simple tree 1`] = `
         </svg>
       </div>
       <span
-        class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-e02805a5-6 ffENPD ibWQSc"
+        class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
         color="secondary70"
       >
         Test Node 4
@@ -524,18 +524,18 @@ exports[`renders simple tree 1`] = `
     >
       <li
         aria-expanded="false"
-        class="styled__StyledLi-sc-e02805a5-0 flbtme"
+        class="styled__StyledLi-sc-912cb84-0 ddOgUf"
         role="treeitem"
         tabindex="-1"
       >
         <div
-          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-e02805a5-3 fdAGpv"
+          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
         >
           <div
-            class="styled__StyledGap-sc-e02805a5-5 ryxSq"
+            class="styled__StyledGap-sc-912cb84-5 jrVihD"
           />
           <div
-            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-e02805a5-4 QUWcN"
+            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
           >
             <svg
               aria-hidden="true"
@@ -558,7 +558,7 @@ exports[`renders simple tree 1`] = `
             </svg>
           </div>
           <span
-            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-e02805a5-6 ffENPD ibWQSc"
+            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
             color="secondary70"
           >
             Test Node 8

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`renders worksheet 1`] = `
 <div
-  class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledBox-sc-d2466db4-2 dNtpdW"
+  class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledBox-sc-711f67c7-2 fmfpbK"
 >
   <table
-    class="styled__Table-sc-d2466db4-0 cUQlAe"
+    class="styled__Table-sc-711f67c7-0 gEDboG"
     tabindex="0"
   >
     <thead>
@@ -14,31 +14,31 @@ exports[`renders worksheet 1`] = `
           class="styled__Status-sc-2431d177-0 lenCpg"
         />
         <th
-          class="styled__Header-sc-d2466db4-1 euimQx"
+          class="styled__Header-sc-711f67c7-1 FUSjx"
         >
           Product name
            
         </th>
         <th
-          class="styled__Header-sc-d2466db4-1 ffKzm"
+          class="styled__Header-sc-711f67c7-1 gVWKKe"
         >
           Visible on storefront
            
         </th>
         <th
-          class="styled__Header-sc-d2466db4-1 euimQx"
+          class="styled__Header-sc-711f67c7-1 FUSjx"
         >
           Other field
            
         </th>
         <th
-          class="styled__Header-sc-d2466db4-1 euimQx"
+          class="styled__Header-sc-711f67c7-1 FUSjx"
         >
           Other field
            
         </th>
         <th
-          class="styled__Header-sc-d2466db4-1 bSNCtU"
+          class="styled__Header-sc-711f67c7-1 dOcXBY"
         >
           Number field
            
@@ -102,19 +102,19 @@ exports[`renders worksheet 1`] = `
             class="styled__CheckboxWrapper-sc-d2cd6b9d-0 csJrJK"
           >
             <div
-              class="styled__CheckboxContainer-sc-566c5da0-1 dcMSmV"
+              class="styled__CheckboxContainer-sc-efcd57e0-1 bKZHnM"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":r5:"
                 checked=""
-                class="styled__HiddenCheckbox-sc-566c5da0-2 cxCvuZ"
+                class="styled__HiddenCheckbox-sc-efcd57e0-2 VVPRk"
                 id=":r4:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="styled__StyledCheckbox-sc-566c5da0-3 dLUWKY"
+                class="styled__StyledCheckbox-sc-efcd57e0-3 ipYoRM"
                 for=":r4:"
               >
                 <svg
@@ -137,7 +137,7 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="styled__CheckboxLabelContainer-sc-566c5da0-0 ectoJw"
+                class="styled__CheckboxLabelContainer-sc-efcd57e0-0 bRrtAF"
               >
                 <label
                   aria-hidden="false"
@@ -250,19 +250,19 @@ exports[`renders worksheet 1`] = `
             class="styled__CheckboxWrapper-sc-d2cd6b9d-0 csJrJK"
           >
             <div
-              class="styled__CheckboxContainer-sc-566c5da0-1 dcMSmV"
+              class="styled__CheckboxContainer-sc-efcd57e0-1 bKZHnM"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":rd:"
                 checked=""
-                class="styled__HiddenCheckbox-sc-566c5da0-2 cxCvuZ"
+                class="styled__HiddenCheckbox-sc-efcd57e0-2 VVPRk"
                 id=":rc:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="styled__StyledCheckbox-sc-566c5da0-3 dLUWKY"
+                class="styled__StyledCheckbox-sc-efcd57e0-3 ipYoRM"
                 for=":rc:"
               >
                 <svg
@@ -285,7 +285,7 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="styled__CheckboxLabelContainer-sc-566c5da0-0 ectoJw"
+                class="styled__CheckboxLabelContainer-sc-efcd57e0-0 bRrtAF"
               >
                 <label
                   aria-hidden="false"
@@ -398,18 +398,18 @@ exports[`renders worksheet 1`] = `
             class="styled__CheckboxWrapper-sc-d2cd6b9d-0 csJrJK"
           >
             <div
-              class="styled__CheckboxContainer-sc-566c5da0-1 dcMSmV"
+              class="styled__CheckboxContainer-sc-efcd57e0-1 bKZHnM"
             >
               <input
                 aria-checked="false"
                 aria-labelledby=":rl:"
-                class="styled__HiddenCheckbox-sc-566c5da0-2 cxCvuZ"
+                class="styled__HiddenCheckbox-sc-efcd57e0-2 VVPRk"
                 id=":rk:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="styled__StyledCheckbox-sc-566c5da0-3 diAvvX"
+                class="styled__StyledCheckbox-sc-efcd57e0-3 eccGNz"
                 for=":rk:"
               >
                 <svg
@@ -432,7 +432,7 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="styled__CheckboxLabelContainer-sc-566c5da0-0 ectoJw"
+                class="styled__CheckboxLabelContainer-sc-efcd57e0-0 bRrtAF"
               >
                 <label
                   aria-hidden="false"
@@ -543,19 +543,19 @@ exports[`renders worksheet 1`] = `
             class="styled__CheckboxWrapper-sc-d2cd6b9d-0 csJrJK"
           >
             <div
-              class="styled__CheckboxContainer-sc-566c5da0-1 dcMSmV"
+              class="styled__CheckboxContainer-sc-efcd57e0-1 bKZHnM"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":rt:"
                 checked=""
-                class="styled__HiddenCheckbox-sc-566c5da0-2 cxCvuZ"
+                class="styled__HiddenCheckbox-sc-efcd57e0-2 VVPRk"
                 id=":rs:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="styled__StyledCheckbox-sc-566c5da0-3 dLUWKY"
+                class="styled__StyledCheckbox-sc-efcd57e0-3 ipYoRM"
                 for=":rs:"
               >
                 <svg
@@ -578,7 +578,7 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="styled__CheckboxLabelContainer-sc-566c5da0-0 ectoJw"
+                class="styled__CheckboxLabelContainer-sc-efcd57e0-0 bRrtAF"
               >
                 <label
                   aria-hidden="false"
@@ -689,17 +689,17 @@ exports[`renders worksheet 1`] = `
             class="styled__CheckboxWrapper-sc-d2cd6b9d-0 csJrJK"
           >
             <div
-              class="styled__CheckboxContainer-sc-566c5da0-1 dcMSmV"
+              class="styled__CheckboxContainer-sc-efcd57e0-1 bKZHnM"
             >
               <input
                 aria-labelledby=":r15:"
-                class="styled__HiddenCheckbox-sc-566c5da0-2 cxCvuZ"
+                class="styled__HiddenCheckbox-sc-efcd57e0-2 VVPRk"
                 id=":r14:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="styled__StyledCheckbox-sc-566c5da0-3 diAvvX"
+                class="styled__StyledCheckbox-sc-efcd57e0-3 eccGNz"
                 for=":r14:"
               >
                 <svg
@@ -722,7 +722,7 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="styled__CheckboxLabelContainer-sc-566c5da0-0 ectoJw"
+                class="styled__CheckboxLabelContainer-sc-efcd57e0-0 bRrtAF"
               >
                 <label
                   aria-hidden="false"
@@ -829,19 +829,19 @@ exports[`renders worksheet 1`] = `
             class="styled__CheckboxWrapper-sc-d2cd6b9d-0 csJrJK"
           >
             <div
-              class="styled__CheckboxContainer-sc-566c5da0-1 dcMSmV"
+              class="styled__CheckboxContainer-sc-efcd57e0-1 bKZHnM"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":r1d:"
                 checked=""
-                class="styled__HiddenCheckbox-sc-566c5da0-2 cxCvuZ"
+                class="styled__HiddenCheckbox-sc-efcd57e0-2 VVPRk"
                 id=":r1c:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="styled__StyledCheckbox-sc-566c5da0-3 dLUWKY"
+                class="styled__StyledCheckbox-sc-efcd57e0-3 ipYoRM"
                 for=":r1c:"
               >
                 <svg
@@ -864,7 +864,7 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="styled__CheckboxLabelContainer-sc-566c5da0-0 ectoJw"
+                class="styled__CheckboxLabelContainer-sc-efcd57e0-0 bRrtAF"
               >
                 <label
                   aria-hidden="false"
@@ -977,18 +977,18 @@ exports[`renders worksheet 1`] = `
             class="styled__CheckboxWrapper-sc-d2cd6b9d-0 csJrJK"
           >
             <div
-              class="styled__CheckboxContainer-sc-566c5da0-1 dcMSmV"
+              class="styled__CheckboxContainer-sc-efcd57e0-1 bKZHnM"
             >
               <input
                 aria-checked="false"
                 aria-labelledby=":r1l:"
-                class="styled__HiddenCheckbox-sc-566c5da0-2 cxCvuZ"
+                class="styled__HiddenCheckbox-sc-efcd57e0-2 VVPRk"
                 id=":r1k:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="styled__StyledCheckbox-sc-566c5da0-3 diAvvX"
+                class="styled__StyledCheckbox-sc-efcd57e0-3 eccGNz"
                 for=":r1k:"
               >
                 <svg
@@ -1011,7 +1011,7 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="styled__CheckboxLabelContainer-sc-566c5da0-0 ectoJw"
+                class="styled__CheckboxLabelContainer-sc-efcd57e0-0 bRrtAF"
               >
                 <label
                   aria-hidden="false"
@@ -1124,19 +1124,19 @@ exports[`renders worksheet 1`] = `
             class="styled__CheckboxWrapper-sc-d2cd6b9d-0 csJrJK"
           >
             <div
-              class="styled__CheckboxContainer-sc-566c5da0-1 dcMSmV"
+              class="styled__CheckboxContainer-sc-efcd57e0-1 bKZHnM"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":r1t:"
                 checked=""
-                class="styled__HiddenCheckbox-sc-566c5da0-2 cxCvuZ"
+                class="styled__HiddenCheckbox-sc-efcd57e0-2 VVPRk"
                 id=":r1s:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="styled__StyledCheckbox-sc-566c5da0-3 dLUWKY"
+                class="styled__StyledCheckbox-sc-efcd57e0-3 ipYoRM"
                 for=":r1s:"
               >
                 <svg
@@ -1159,7 +1159,7 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="styled__CheckboxLabelContainer-sc-566c5da0-0 ectoJw"
+                class="styled__CheckboxLabelContainer-sc-efcd57e0-0 bRrtAF"
               >
                 <label
                   aria-hidden="false"
@@ -1272,19 +1272,19 @@ exports[`renders worksheet 1`] = `
             class="styled__CheckboxWrapper-sc-d2cd6b9d-0 csJrJK"
           >
             <div
-              class="styled__CheckboxContainer-sc-566c5da0-1 dcMSmV"
+              class="styled__CheckboxContainer-sc-efcd57e0-1 bKZHnM"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":r25:"
                 checked=""
-                class="styled__HiddenCheckbox-sc-566c5da0-2 cxCvuZ"
+                class="styled__HiddenCheckbox-sc-efcd57e0-2 VVPRk"
                 id=":r24:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="styled__StyledCheckbox-sc-566c5da0-3 dLUWKY"
+                class="styled__StyledCheckbox-sc-efcd57e0-3 ipYoRM"
                 for=":r24:"
               >
                 <svg
@@ -1307,7 +1307,7 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="styled__CheckboxLabelContainer-sc-566c5da0-0 ectoJw"
+                class="styled__CheckboxLabelContainer-sc-efcd57e0-0 bRrtAF"
               >
                 <label
                   aria-hidden="false"

--- a/packages/big-design/src/components/Worksheet/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/styled.tsx
@@ -73,3 +73,4 @@ export const StyledBox = styled(Box)`
 `;
 
 Header.defaultProps = { theme: defaultTheme };
+StyledBox.defaultProps = { theme: defaultTheme };


### PR DESCRIPTION
## What/why?

Adds `defaultProps` to styled-components so they can be used without wrapping them in a theme provider.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

See CI.

