### PR TITLE
fix(patterns): fix page width to occupy available space

### DIFF
--- a/.changeset/mighty-brooms-eat.md
+++ b/.changeset/mighty-brooms-eat.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design-patterns': patch
+---
+
+Fixed page width definition to expand to the available area

--- a/packages/big-design-patterns/src/components/Page/styled.tsx
+++ b/packages/big-design-patterns/src/components/Page/styled.tsx
@@ -36,6 +36,7 @@ export const StyledPageBackground = styled(Grid).attrs({ theme: defaultTheme })<
 
 export const StyledPage = styled(Flex).attrs({ theme: defaultTheme })`
   margin: 0 auto;
+  width: 100%;
 
   ${({ theme }) => theme.breakpoints.desktop} {
     max-width: ${({ theme }) => theme.helpers.remCalc(1120)};


### PR DESCRIPTION
## What?

Fixed the page width css for page to occupy the available width instead of hugging contents

## Why?

To avoid pages to be shrunk to the center of the screen misaligned with action bar and having a consistent experience

## Screenshots/Screen Recordings

### Before
![buggy-page](https://github.com/user-attachments/assets/b4ffd50f-00ca-40de-9449-9ea6f7d03d23)

### After
![corrected-page](https://github.com/user-attachments/assets/649897df-1140-4d5f-92a1-dd2e19223b34)


## Testing/Proof

<details>
<summary><code>dev.tsx</code> code</summary>

```tsx
import { Page, Header, ActionBar } from '@bigcommerce/big-design-patterns';
import { Panel, Text } from '@bigcommerce/big-design';
import { AddIcon } from '@bigcommerce/big-design-icons';

const PageWithActionBar = () => {
  return (
    <Page
      actionBar={
        <ActionBar
          actions={[
            {
              text: 'Main action',
              variant: 'primary',
            },
            {
              text: 'Dismiss',
              variant: 'subtle',
            },
          ]}
        />
      }
      header={
        <Header
          actions={[
            {
              text: 'Secondary',
              variant: 'secondary',
              iconLeft: <AddIcon />,
            },
          ]}
          description="Page description (optional)"
          title="Page with action bar"
        />
      }
    >
      <Panel header="Page contents">
        <Text>Hello</Text>
      </Panel>
    </Page>
  );
};

export default PageWithActionBar;
```

</details>
