### PR TITLE
fix(patterns): fix header wrapping on mobile

### DIFF
--- a/.changeset/nine-papayas-sit.md
+++ b/.changeset/nine-papayas-sit.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design-patterns': patch
+---
+
+Fixed Header component for back link to wrap properly on mobile screens

--- a/packages/big-design-patterns/src/components/Header/Header.tsx
+++ b/packages/big-design-patterns/src/components/Header/Header.tsx
@@ -132,7 +132,7 @@ export const Header = ({
   title,
 }: HeaderProps) => {
   return (
-    <Flex as="header" flexDirection={{ mobile: 'column', tablet: 'row' }} flexWrap="wrap">
+    <Flex as="header" flexDirection={{ mobile: 'column', tablet: 'row' }} flexWrap={{ mobile: 'nowrap', tablet: 'wrap' }}>
       {backLink && (
         <FlexItem flexBasis="100%">
           <BackLink {...backLink} />


### PR DESCRIPTION
## What?

Fixed header wrapping on mobile screens

## Why?

The back link in the header component was aligning side to side with the Main heading and description on mobile screens.

## Screenshots/Screen Recordings

### Before
![Screenshot 2024-09-12 at 4 46 38 PM](https://github.com/user-attachments/assets/c1fb9c6f-5e4d-4d14-996f-9db543f43303)

### After
![Screenshot 2024-09-12 at 4 46 51 PM](https://github.com/user-attachments/assets/25388ab9-ce2e-447f-9c13-7dfa5145b459)


## Testing/Proof

Add the sample in your dev.tsx and shrink the window to mobile size.

<details>
<summary><code>dev.tsx</code> code</summary>

```tsx
import { Page, Header, ActionBar } from '@bigcommerce/big-design-patterns';
import { Panel, Text } from '@bigcommerce/big-design';
import { AddIcon } from '@bigcommerce/big-design-icons';

const PageWithActionBar = () => {
  return (
    <Page
      actionBar={
        <ActionBar
          actions={[
            {
              text: 'Main action',
              variant: 'primary',
            },
            {
              text: 'Dismiss',
              variant: 'subtle',
            },
          ]}
        />
      }
      header={
        <Header
          actions={[
            {
              text: 'Secondary',
              variant: 'secondary',
              iconLeft: <AddIcon />,
            },
          ]}
          description="Page description (optional)"
          title="Page with action bar"
          backLink={{
            text: "Back to patterns",
            onClick: () => window.alert("Back link clicked"),
            href: "#",
          }}
        />
      }
    >
      <Panel header="Page contents">
        <Text>Hello</Text>
      </Panel>
    </Page>
  );
};

export default PageWithActionBar;
```

</details>
