### PR TITLE
fix(patterns): adjust flex layout for header

### DIFF
--- a/.changeset/gentle-goats-cheer.md
+++ b/.changeset/gentle-goats-cheer.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design-patterns': patch
+---
+
+Fix header wrapping on smaller screens

--- a/packages/big-design-patterns/src/components/Header/Header.tsx
+++ b/packages/big-design-patterns/src/components/Header/Header.tsx
@@ -132,7 +132,7 @@ export const Header = ({
   title,
 }: HeaderProps) => {
   return (
-    <Flex as="header" flexDirection={{ mobile: 'column', tablet: 'row' }} flexWrap="wrap">
+    <Flex as="header" flexDirection="row" flexWrap="wrap">
       {backLink && (
         <FlexItem flexBasis="100%">
           <BackLink {...backLink} />


### PR DESCRIPTION
## What/Why?

When adding support for iframes #1525, we introduced a bug where the header doesn't wrap correctly. This fixes that issue.

## Screenshots/Screen Recordings

### Before

![Screenshot 2024-09-12 at 17 00 56](https://github.com/user-attachments/assets/197203de-359d-4c1e-8cf4-c1db3ef279fa)

### After

![Screenshot 2024-09-12 at 16 59 46](https://github.com/user-attachments/assets/27f367ab-87dc-465c-9156-888289e60625)


## Testing/Proof

Local testing proof.
