### PR TITLE
fix: add eslint ignore to examples repo

### DIFF
--- a/packages/examples/.eslintrc.js
+++ b/packages/examples/.eslintrc.js
@@ -2,4 +2,5 @@
 module.exports = {
   root: true,
   extends: ['@bigcommerce/eslint-config'],
+  ignorePatterns: ['node_modules/', 'dist/'],
 };


### PR DESCRIPTION
## What/why?

We were accidentally linting node_modules and the dist files causing a long lint task to run. This ignores those folders.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

See CI.
