### PR TITLE
feat(component): Add action props to FileUploader

### DIFF
--- a/packages/big-design/src/components/FileUploader/DropZone.tsx
+++ b/packages/big-design/src/components/FileUploader/DropZone.tsx
@@ -13,15 +13,17 @@ import React, {
   useState,
 } from 'react';
 
+import { excludeMarginProps } from '../../helpers';
 import { Box } from '../Box';
 import { Flex } from '../Flex';
 import { Small, Text } from '../Typography';
 
 import { StyledButton, StyledDropzone } from './styled';
-import { Localization } from './types';
+import { Action, Localization } from './types';
 import { validateFileFormat } from './utils';
 
 export interface Props extends ComponentPropsWithoutRef<'input'> {
+  action?: Action;
   description?: string;
   viewType?: 'row' | 'block';
   icon?: React.ReactNode;
@@ -32,6 +34,7 @@ export interface Props extends ComponentPropsWithoutRef<'input'> {
 
 export const DropZone = ({
   accept,
+  action,
   description,
   disabled,
   icon = <DraftIcon />,
@@ -149,6 +152,34 @@ export const DropZone = ({
     );
   }, [description]);
 
+  const renderedAction = useMemo(() => {
+    if (!action) {
+      return null;
+    }
+
+    const { label, onClick, style, ...actionProps } = action;
+
+    return (
+      <StyledButton
+        {...excludeMarginProps(actionProps)}
+        color="secondary"
+        marginTop={isRowView ? 'none' : 'medium'}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (onClick) {
+            onClick(event);
+          }
+        }}
+        type="button"
+        variant="subtle"
+      >
+        {label}
+      </StyledButton>
+    );
+  }, [action, isRowView]);
+
   /* istanbul ignore next */
   return (
     <StyledDropzone
@@ -191,15 +222,19 @@ export const DropZone = ({
               {renderedDescription}
             </Flex>
           </Flex>
-          <StyledButton
-            color="secondary"
-            disabled={disabled}
-            marginTop={isRowView ? 'none' : 'medium'}
-            onClick={(e) => e.preventDefault()}
-            variant="subtle"
-          >
-            {localization.upload}
-          </StyledButton>
+          <Flex flexDirection="row">
+            {renderedAction}
+            <StyledButton
+              color="secondary"
+              disabled={disabled}
+              marginTop={isRowView ? 'none' : 'medium'}
+              onClick={(e) => e.preventDefault()}
+              type="button"
+              variant="subtle"
+            >
+              {localization.upload}
+            </StyledButton>
+          </Flex>
         </>
       )}
     </StyledDropzone>

--- a/packages/big-design/src/components/FileUploader/FileUploader.tsx
+++ b/packages/big-design/src/components/FileUploader/FileUploader.tsx
@@ -20,7 +20,7 @@ import { InlineMessage } from '../InlineMessage';
 import { defaultLocalization } from './constants';
 import { File } from './File';
 import { StyledDropZoneWrapper, StyledFileUploaderWrapper, StyledList } from './styled';
-import type { Localization, ValidatorConfig } from './types';
+import { Action, Localization, ValidatorConfig } from './types';
 import { getImagesPreview, validateFiles } from './utils';
 
 export interface FileAction extends Omit<DropdownItem, 'onItemClick'> {
@@ -28,6 +28,7 @@ export interface FileAction extends Omit<DropdownItem, 'onItemClick'> {
 }
 
 interface DropzoneConfig {
+  action?: Action;
   description?: string;
   emptyHeight?: number;
   icon?: React.ReactNode;
@@ -257,6 +258,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
       })),
     [actions],
   );
+
   const renderedFiles = useMemo(() => {
     if (previewHidden) {
       return null;
@@ -320,6 +322,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
     return (
       <StyledDropZoneWrapper
         accept={accept}
+        action={dropzoneConfig.action}
         description={dropzoneConfig.description}
         disabled={disabled}
         emptyHeight={files.length ? undefined : dropzoneConfig.emptyHeight}
@@ -334,6 +337,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
     );
   }, [
     accept,
+    dropzoneConfig.action,
     disabled,
     dropzoneConfig.description,
     dropzoneConfig.emptyHeight,

--- a/packages/big-design/src/components/FileUploader/spec.tsx
+++ b/packages/big-design/src/components/FileUploader/spec.tsx
@@ -11,7 +11,7 @@ import { defaultLocalization } from './constants';
 import { DropZone } from './DropZone';
 import { File as FileComponent } from './File';
 import { FileUploader } from './FileUploader';
-import { type ValidatorConfig } from './types';
+import { Action, ValidatorConfig } from './types';
 
 import 'jest-styled-components';
 
@@ -371,6 +371,83 @@ describe('FileUploader', () => {
     await userEvent.click(screen.getByRole('button', { name: /show more/i }));
 
     expect(screen.getAllByText('File name is too long')).toHaveLength(15);
+  });
+
+  it('renders additional action', async () => {
+    const mockOnClick = jest.fn();
+
+    render(
+      <FileUploader
+        dropzoneConfig={{
+          action: {
+            label: 'Upload by URL',
+            onClick: mockOnClick,
+          },
+        }}
+        files={[]}
+        label="Upload your images"
+        multiple
+        onFilesChange={jest.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /upload by url/i }));
+
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  it('does not forward styles', () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    render(
+      <FileUploader
+        dropzoneConfig={{
+          action: {
+            label: 'Upload by URL',
+            onClick: jest.fn(),
+            style: { backgroundColor: 'red' },
+          },
+        }}
+        files={[]}
+        label="Upload your images"
+        multiple
+        onFilesChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /upload by url/i })).not.toHaveStyle(
+      'background: red',
+    );
+  });
+
+  it('does not forward variant', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const action = {
+      label: 'Upload by URL',
+      variant: 'primary',
+      onClick: jest.fn(),
+    } as Action;
+
+    render(
+      <FileUploader
+        dropzoneConfig={{
+          action,
+        }}
+        files={[]}
+        label="Upload your images"
+        multiple
+        onFilesChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /upload by url/i })).not.toHaveStyle(
+      'background-color: rgb(60, 100, 244)',
+    );
+    expect(screen.getByRole('button', { name: /upload by url/i })).toHaveStyle(
+      'background-color: transparent',
+    );
   });
 });
 

--- a/packages/big-design/src/components/FileUploader/types.ts
+++ b/packages/big-design/src/components/FileUploader/types.ts
@@ -1,3 +1,6 @@
+import { MarginProps } from '../../helpers';
+import { ButtonProps } from '../Button';
+
 export interface Localization {
   upload: string;
   optional: string;
@@ -10,4 +13,12 @@ export interface ValidatorConfig {
   message?: string;
   type: string;
   validator: (file: File) => boolean;
+}
+
+export interface Action
+  extends Omit<
+    ButtonProps,
+    'variant' | 'children' | 'iconOnly' | 'iconRight' | 'iconLeft' | 'isLoading' | keyof MarginProps
+  > {
+  label: string;
 }

--- a/packages/docs/PropTables/DropdownPropTable.tsx
+++ b/packages/docs/PropTables/DropdownPropTable.tsx
@@ -130,7 +130,7 @@ const dropdownItemProps: Prop[] = [
   {
     name: 'tooltip',
     types: 'string',
-    description: <>Adds tooltip for disabled item.</>,
+    description: 'Adds tooltip for disabled item.',
   },
   {
     name: 'type',

--- a/packages/docs/PropTables/FileUploaderPropTable.tsx
+++ b/packages/docs/PropTables/FileUploaderPropTable.tsx
@@ -4,6 +4,27 @@ import { Code, NextLink, Prop, PropTable, PropTableWrapper } from '../components
 
 const fileUploaderProps: Prop[] = [
   {
+    name: 'actions',
+    types: (
+      <>
+        <NextLink
+          href={{
+            hash: 'file-uploader-file-actions-prop-table',
+            query: { props: 'file-uploader-file-actions' },
+          }}
+        >
+          FileAction
+        </NextLink>
+        []
+      </>
+    ),
+    description: (
+      <>
+        Value for the <Code primary>FileUploader</Code>. Only accepts <Code>File[]</Code>.
+      </>
+    ),
+  },
+  {
     name: 'accept',
     types: 'string',
     description: (
@@ -33,8 +54,20 @@ const fileUploaderProps: Prop[] = [
   },
   {
     name: 'dropzoneConfig',
-    types: '{ label?: string; description?: string; icon?: ReactNode }',
-    description: 'Adds a label and a description to the drop-zone box.',
+    types: (
+      <>
+        <NextLink
+          href={{
+            hash: 'file-uploader-dropzone-config-prop-table',
+            query: { props: 'file-uploader-dropzone-config' },
+          }}
+        >
+          DropzoneConfig
+        </NextLink>
+        []
+      </>
+    ),
+    description: <>Adds a label and a description to the drop-zone box.</>,
   },
   {
     name: 'error',
@@ -157,6 +190,70 @@ const fileUploaderValidatorProps: Prop[] = [
   },
 ];
 
+const fileActionsProps: Prop[] = [
+  {
+    name: 'actionType',
+    types: ['normal', 'destructive'],
+    defaultValue: 'normal',
+    description: "Indicates whether your item's action is of normal or destructive nature.",
+  },
+  {
+    name: 'content',
+    types: 'string',
+    required: true,
+    description: (
+      <>
+        Sets the text content of the <Code>DropdownItem</Code>.
+      </>
+    ),
+  },
+  {
+    name: 'description',
+    types: 'string',
+    description: (
+      <>
+        Sets the content description of the <Code>DropdownItem</Code>.
+      </>
+    ),
+  },
+  {
+    name: 'disabled',
+    types: 'boolean',
+    description: 'Sets the item to disabled.',
+  },
+  {
+    name: 'hash',
+    types: 'string',
+    description: 'Stored hash of the item.',
+  },
+  {
+    name: 'icon',
+    types: <NextLink href="/icons">Icon</NextLink>,
+    description: (
+      <>
+        Pass in an <NextLink href="/icons">Icon</NextLink> component to display to the left of the
+        text.
+      </>
+    ),
+  },
+  {
+    name: 'onItemClick',
+    types: '(name: File, idx: number) => void',
+    required: true,
+    description: 'Triggers when clicking on action item.',
+  },
+  {
+    name: 'tooltip',
+    types: 'string',
+    description: <>Adds tooltip for disabled item.</>,
+  },
+  {
+    name: 'type',
+    types: "'text'",
+    description: 'Type of the item.',
+  },
+];
+
 const fileUploaderErrorProps: Prop[] = [
   {
     name: 'file',
@@ -180,6 +277,39 @@ const fileUploaderErrorProps: Prop[] = [
   },
 ];
 
+const dropzoneConfigProps: Prop[] = [
+  {
+    name: 'action',
+    types: 'object',
+    description: (
+      <>
+        Accepts an object with <NextLink href="/button">Button</NextLink> props and additional{' '}
+        <Code>label</Code> prop and exclude <Code>variant</Code> prop.
+      </>
+    ),
+  },
+  {
+    name: 'description',
+    types: 'string',
+    description: 'Short description for the dropzone.',
+  },
+  {
+    name: 'emptyHeight',
+    types: 'number',
+    description: 'Set height for the dropzone when there are no files.',
+  },
+  {
+    name: 'icon',
+    types: 'React.ReactNode',
+    description: 'Adds icon to the dropzone.',
+  },
+  {
+    name: 'label',
+    types: 'string',
+    description: 'Adds a label to the field.',
+  },
+];
+
 export const FileUploaderPropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable
     nativeElement={['input', 'most']}
@@ -195,4 +325,12 @@ export const FileUploaderValidatorPropTable: React.FC<PropTableWrapper> = (props
 
 export const FileUploaderErrorPropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable propList={fileUploaderErrorProps} title="Error" {...props} />
+);
+
+export const FileUploaderFileActionPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable propList={fileActionsProps} title="FileAction" {...props} />
+);
+
+export const FileUploaderFileDropzoneConfigPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable propList={dropzoneConfigProps} title="DropzoneConfig" {...props} />
 );

--- a/packages/docs/pages/file-uploader.tsx
+++ b/packages/docs/pages/file-uploader.tsx
@@ -4,6 +4,8 @@ import React, { useState } from 'react';
 import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
 import {
   FileUploaderErrorPropTable,
+  FileUploaderFileActionPropTable,
+  FileUploaderFileDropzoneConfigPropTable,
   FileUploaderPropTable,
   FileUploaderValidatorPropTable,
 } from '../PropTables';
@@ -43,6 +45,10 @@ const FileUploaderPage = () => {
                   <FileUploader
                     dropzoneConfig={{
                       label: 'Drag and drop image here',
+                      action: {
+                        label: 'Upload by URL',
+                        onClick: () => null,
+                      },
                     }}
                     files={files}
                     label="Upload files"
@@ -84,6 +90,20 @@ const FileUploaderPage = () => {
               id: 'file-uploader-error',
               title: 'Error',
               render: () => <FileUploaderErrorPropTable id="file-uploader-error-prop-table" />,
+            },
+            {
+              id: 'file-uploader-file-actions',
+              title: 'FileAction',
+              render: () => (
+                <FileUploaderFileActionPropTable id="file-uploader-file-actions-prop-table" />
+              ),
+            },
+            {
+              id: 'file-uploader-dropzone-config',
+              title: 'DropzoneConfig',
+              render: () => (
+                <FileUploaderFileDropzoneConfigPropTable id="file-uploader-dropzone-config-prop-table" />
+              ),
             },
           ]}
         />


### PR DESCRIPTION
## What?

Add `action` prop to FileUploader.

## Why?

To be able to pass the custom action for `FileUploader` component.

## Screenshots/Screen Recordings
<img width="452" alt="Screenshot 2024-10-16 at 15 57 29" src="https://github.com/user-attachments/assets/fe868af6-6f7e-48a5-93cc-77352fef46a9">

<img width="1057" alt="Screenshot 2024-10-16 at 15 57 57" src="https://github.com/user-attachments/assets/43100f30-0148-4e0e-bf9d-74bb434e3196">

## Testing/Proof

Locally + UT.