### PR TITLE
fix(component): PillTabs no longer submit form

### DIFF
--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -96,7 +96,9 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       >
         <Dropdown
           items={dropdownItems}
-          toggle={<Button iconOnly={<MoreHorizIcon title="add" />} variant="subtle" />}
+          toggle={
+            <Button iconOnly={<MoreHorizIcon title="add" />} type="button" variant="subtle" />
+          }
         />
       </StyledFlexItem>
     );
@@ -149,6 +151,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
               isActive={activePills.includes(item.id)}
               marginRight="xSmall"
               onClick={() => onPillClick(item.id)}
+              type="button"
               variant="subtle"
             >
               {item.title}

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -305,6 +305,7 @@ exports[`dropdown is not visible if items fit 1`] = `
   >
     <button
       class="c3 "
+      type="button"
     >
       <span
         class="c4"
@@ -330,6 +331,7 @@ exports[`dropdown is not visible if items fit 1`] = `
         id=":r3:-toggle-button"
         role="button"
         tabindex="0"
+        type="button"
       >
         <span
           class="c4"
@@ -684,6 +686,7 @@ exports[`it renders the given tabs 1`] = `
   >
     <button
       class="c3 "
+      type="button"
     >
       <span
         class="c4"
@@ -709,6 +712,7 @@ exports[`it renders the given tabs 1`] = `
         id=":r0:-toggle-button"
         role="button"
         tabindex="0"
+        type="button"
       >
         <span
           class="c4"
@@ -1063,6 +1067,7 @@ exports[`only the pills that fit are visible 1`] = `
   >
     <button
       class="c3 "
+      type="button"
     >
       <span
         class="c4"
@@ -1079,6 +1084,7 @@ exports[`only the pills that fit are visible 1`] = `
     <button
       class="c3 "
       disabled=""
+      type="button"
     >
       <span
         class="c4"
@@ -1095,6 +1101,7 @@ exports[`only the pills that fit are visible 1`] = `
     <button
       class="c3 "
       disabled=""
+      type="button"
     >
       <span
         class="c4"
@@ -1120,6 +1127,7 @@ exports[`only the pills that fit are visible 1`] = `
         id=":rc:-toggle-button"
         role="button"
         tabindex="0"
+        type="button"
       >
         <span
           class="c4"
@@ -1474,6 +1482,7 @@ exports[`only the pills that fit are visible 2 1`] = `
   >
     <button
       class="c3 "
+      type="button"
     >
       <span
         class="c4"
@@ -1489,6 +1498,7 @@ exports[`only the pills that fit are visible 2 1`] = `
   >
     <button
       class="c3 "
+      type="button"
     >
       <span
         class="c4"
@@ -1505,6 +1515,7 @@ exports[`only the pills that fit are visible 2 1`] = `
     <button
       class="c3 "
       disabled=""
+      type="button"
     >
       <span
         class="c4"
@@ -1530,6 +1541,7 @@ exports[`only the pills that fit are visible 2 1`] = `
         id=":rf:-toggle-button"
         role="button"
         tabindex="0"
+        type="button"
       >
         <span
           class="c4"
@@ -1884,6 +1896,7 @@ exports[`renders all the filters if they fit 1`] = `
   >
     <button
       class="c3 "
+      type="button"
     >
       <span
         class="c4"
@@ -1899,6 +1912,7 @@ exports[`renders all the filters if they fit 1`] = `
   >
     <button
       class="c3 "
+      type="button"
     >
       <span
         class="c4"
@@ -1914,6 +1928,7 @@ exports[`renders all the filters if they fit 1`] = `
   >
     <button
       class="c3 "
+      type="button"
     >
       <span
         class="c4"
@@ -1939,6 +1954,7 @@ exports[`renders all the filters if they fit 1`] = `
         id=":r9:-toggle-button"
         role="button"
         tabindex="0"
+        type="button"
       >
         <span
           class="c4"
@@ -2294,6 +2310,7 @@ exports[`renders dropdown if items do not fit 1`] = `
     <button
       class="c4 "
       disabled=""
+      type="button"
     >
       <span
         class="c5"
@@ -2310,6 +2327,7 @@ exports[`renders dropdown if items do not fit 1`] = `
     <button
       class="c4 "
       disabled=""
+      type="button"
     >
       <span
         class="c5"
@@ -2335,6 +2353,7 @@ exports[`renders dropdown if items do not fit 1`] = `
         id=":r6:-toggle-button"
         role="button"
         tabindex="0"
+        type="button"
       >
         <span
           class="c5"


### PR DESCRIPTION
## What?

Ensure PillTabs use buttons of type button rather than submit

## Why?

This resolves #1573 so that using PillTabs do not submit any form they are contained by. 

## Testing/Proof

Manually tested by wrapping PillTabs in a form and ensuring it is no longer submitted. 