### PR TITLE
chore(patterns): lock peer deps to v1 of big-design

### DIFF
--- a/.changeset/tough-melons-trade.md
+++ b/.changeset/tough-melons-trade.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design-patterns': minor
+---
+
+Update big-design peer deps to be locked to v1. An issue with changesets was causing the package to be released as a major version: https://github.com/changesets/changesets/blob/main/docs/decisions.md#the-versioning-of-peer-dependencies

--- a/packages/big-design-patterns/package.json
+++ b/packages/big-design-patterns/package.json
@@ -36,9 +36,9 @@
     "@babel/runtime": "^7.26.0"
   },
   "peerDependencies": {
-    "@bigcommerce/big-design": "workspace:^",
-    "@bigcommerce/big-design-icons": "workspace:^",
-    "@bigcommerce/big-design-theme": "workspace:^",
+    "@bigcommerce/big-design": "^1.0.0",
+    "@bigcommerce/big-design-icons": "^1.0.0",
+    "@bigcommerce/big-design-theme": "^1.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "styled-components": "^5.3.5"


### PR DESCRIPTION
## What?

When using `workspace:^` as a `peerDependencies` in a package, `changesets` bumps it as a major version every release. This is not ideal in our current workflow.

https://github.com/changesets/changesets/blob/main/docs/decisions.md#the-versioning-of-peer-dependencies

## Why?

Locks patterns to use `^1.0.0` for big-design et. al packages in `peerDependencies`.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

Have to merge this PR and check the Version PR to see if it works correctly.