### PR TITLE
chore: only update peer deps when out of range

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,8 @@
   },
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/tough-melons-trade.md
+++ b/.changeset/tough-melons-trade.md
@@ -1,5 +1,0 @@
----
-'@bigcommerce/big-design-patterns': minor
----
-
-Update big-design peer deps to be locked to v1. An issue with changesets was causing the package to be released as a major version: https://github.com/changesets/changesets/blob/main/docs/decisions.md#the-versioning-of-peer-dependencies

--- a/packages/big-design-patterns/package.json
+++ b/packages/big-design-patterns/package.json
@@ -36,9 +36,9 @@
     "@babel/runtime": "^7.26.0"
   },
   "peerDependencies": {
-    "@bigcommerce/big-design": "^1.0.0",
-    "@bigcommerce/big-design-icons": "^1.0.0",
-    "@bigcommerce/big-design-theme": "^1.0.0",
+    "@bigcommerce/big-design": "workspace:^",
+    "@bigcommerce/big-design-icons": "workspace:^",
+    "@bigcommerce/big-design-theme": "workspace:^",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "styled-components": "^5.3.5"


### PR DESCRIPTION
## What/why?

Reverts previous PR and adds an experimental option for changeset to only update peer deps when they are out of range. See documentation: https://github.com/changesets/changesets/blob/baf56448606e005577dbe2fb1e78ff457dcaaefd/docs/experimental-options.md?plain=1#L13-L17

## Screenshots/Screen Recordings
N/A

## Testing/Proof

Can only be tested in the version PR.