### PR TITLE
chore: patch @changesets/assemble-release-plan

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,8 +10,5 @@
   },
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
-  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "onlyUpdatePeerDependentsWhenOutOfRange": true
-  }
+  "ignore": []
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "turbo typecheck"
   },
   "devDependencies": {
+    "@changesets/assemble-release-plan": "^6.0.4",
     "@changesets/changelog-git": "^0.2.0",
     "@changesets/cli": "^2.27.9",
     "@commitlint/cli": "^19.5.0",
@@ -20,5 +21,10 @@
     "@types/babel__standalone": "^7.1.4",
     "turbo": "^2.2.3",
     "typescript": "^5.6.3"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@changesets/assemble-release-plan": "patches/@changesets__assemble-release-plan.patch"
+    }
   }
 }

--- a/patches/@changesets__assemble-release-plan.patch
+++ b/patches/@changesets__assemble-release-plan.patch
@@ -1,0 +1,38 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index 4f7b5e5b37bb05874a5c1d8e583e29d4a9593ecf..9dc53e5c0a612e5adcd97a06571b50a605fd3a83 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -345,7 +345,7 @@ function shouldBumpMajor({
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
+   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
+-  return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && ( // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
++  return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && nextRelease.type !== "minor" && ( // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+   // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
+   !onlyUpdatePeerDependentsWhenOutOfRange || !semverSatisfies__default["default"](incrementVersion(nextRelease, preInfo), versionRange)) && ( // bump major only if the dependent doesn't already has a major release.
+   !releases.has(dependent) || releases.has(dependent) && releases.get(dependent).type !== "major");
+diff --git a/dist/changesets-assemble-release-plan.esm.js b/dist/changesets-assemble-release-plan.esm.js
+index a327d9e4c709a6698f505d60d8bbf0046d4bde74..773be3b1baf72a6a154347fe78a5a175ce6323b5 100644
+--- a/dist/changesets-assemble-release-plan.esm.js
++++ b/dist/changesets-assemble-release-plan.esm.js
+@@ -334,7 +334,7 @@ function shouldBumpMajor({
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
+   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
+-  return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && ( // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
++  return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && nextRelease.type !== "minor" && ( // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+   // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
+   !onlyUpdatePeerDependentsWhenOutOfRange || !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange)) && ( // bump major only if the dependent doesn't already has a major release.
+   !releases.has(dependent) || releases.has(dependent) && releases.get(dependent).type !== "major");
+diff --git a/src/determine-dependents.ts b/src/determine-dependents.ts
+index 4fc6508482d1a6e3ac1af875e1ac1c15f7555fbc..71c50d4b4be64316681eb633e5be1afb3aeac8cb 100644
+--- a/src/determine-dependents.ts
++++ b/src/determine-dependents.ts
+@@ -234,6 +234,7 @@ function shouldBumpMajor({
+     depType === "peerDependencies" &&
+     nextRelease.type !== "none" &&
+     nextRelease.type !== "patch" &&
++    nextRelease.type !== "minor" &&
+     // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+     // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
+     (!onlyUpdatePeerDependentsWhenOutOfRange ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@changesets/assemble-release-plan':
+    hash: xzcvubffr4z7sr2vdv6qrveb5q
+    path: patches/@changesets__assemble-release-plan.patch
+
 importers:
 
   .:
     devDependencies:
+      '@changesets/assemble-release-plan':
+        specifier: ^6.0.4
+        version: 6.0.4(patch_hash=xzcvubffr4z7sr2vdv6qrveb5q)
       '@changesets/changelog-git':
         specifier: ^0.2.0
         version: 0.2.0
@@ -7236,7 +7244,7 @@ snapshots:
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-gettext: 1.2.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jest: 28.6.0(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@20.14.11))(typescript@5.6.3)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.0)
       eslint-plugin-jsdoc: 48.0.5(eslint@8.57.0)
@@ -7317,7 +7325,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.6.3
 
-  '@changesets/assemble-release-plan@6.0.4':
+  '@changesets/assemble-release-plan@6.0.4(patch_hash=xzcvubffr4z7sr2vdv6qrveb5q)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.2
@@ -7333,7 +7341,7 @@ snapshots:
   '@changesets/cli@2.27.9':
     dependencies:
       '@changesets/apply-release-plan': 7.0.5
-      '@changesets/assemble-release-plan': 6.0.4
+      '@changesets/assemble-release-plan': 6.0.4(patch_hash=xzcvubffr4z7sr2vdv6qrveb5q)
       '@changesets/changelog-git': 0.2.0
       '@changesets/config': 3.0.3
       '@changesets/errors': 0.2.0
@@ -7384,7 +7392,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.4':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.4
+      '@changesets/assemble-release-plan': 6.0.4(patch_hash=xzcvubffr4z7sr2vdv6qrveb5q)
       '@changesets/config': 3.0.3
       '@changesets/pre': 2.0.1
       '@changesets/read': 0.6.1
@@ -9739,7 +9747,7 @@ snapshots:
       enhanced-resolve: 5.12.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -9813,7 +9821,7 @@ snapshots:
     dependencies:
       gettext-parser: 4.2.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5


### PR DESCRIPTION
## What/Why?

Patches @changesets/assemble-release-plan since it causes peer deps to bump to a major version.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

Running `pnpm changeset version` locally:
![Screenshot 2024-11-12 at 12 08 38](https://github.com/user-attachments/assets/1a5783e8-213a-4c37-bdc1-d9385c3b9f82)

