### PR TITLE
Add new StatelessPagination component and documentation

### DIFF
--- a/.changeset/four-toes-rush.md
+++ b/.changeset/four-toes-rush.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design': minor
+'@bigcommerce/docs': minor
+---
+
+Pagination component marked as deprecated and re-exported as a new OffsetPagination component. Consumers of the original Pagination component should replace it with an import of OffsetPagination. All props, aesthetics, and functionality remain the same.

--- a/.changeset/purple-shirts-promise.md
+++ b/.changeset/purple-shirts-promise.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design': minor
+'@bigcommerce/docs': minor
+---
+
+New StatelessPagination component added. This component can be used for cursor-based pagination or for when consumers require more control over page changes. Its aesthetics and functionality are very similar to OffsetPagination (previous named Pagination), however its props are different. Please refer to the documentation for more information.

--- a/packages/big-design/src/components/StatelessPagination/StatelessPagination.tsx
+++ b/packages/big-design/src/components/StatelessPagination/StatelessPagination.tsx
@@ -1,0 +1,102 @@
+import {
+  ArrowDropDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from '@bigcommerce/big-design-icons';
+import React, { memo } from 'react';
+
+import { MarginProps } from '../../helpers';
+import { Dropdown, DropdownItem } from '../Dropdown';
+import { Flex, FlexItem } from '../Flex';
+
+import { StyledButton } from './styled';
+
+export interface StatelessPaginationLocalization {
+  previousPage: string;
+  nextPage: string;
+}
+
+const defaultLocalization: StatelessPaginationLocalization = {
+  previousPage: 'Previous page',
+  nextPage: 'Next page',
+};
+
+export interface StatelessPaginationProps extends MarginProps {
+  itemsPerPage: number;
+  itemsPerPageOptions: number[];
+  onItemsPerPageChange(range: number): void;
+  disableNext?: boolean;
+  onNext(): void;
+  disablePrevious?: boolean;
+  onPrevious(): void;
+  label?: string;
+  rangeLabel?: string;
+  localization?: StatelessPaginationLocalization;
+}
+
+export const StatelessPagination: React.FC<StatelessPaginationProps> = memo(
+  ({
+    itemsPerPage,
+    itemsPerPageOptions,
+    disableNext = false,
+    onNext,
+    disablePrevious = false,
+    onPrevious,
+    onItemsPerPageChange,
+    label = 'pagination',
+    localization = defaultLocalization,
+    rangeLabel,
+  }) => {
+    const handleRangeChange = (item: DropdownItem) => {
+      onItemsPerPageChange(Number(item.hash));
+    };
+
+    return (
+      <Flex aria-label={label} flexDirection="row" role="navigation">
+        <FlexItem>
+          <Dropdown
+            items={itemsPerPageOptions.map((range) => ({
+              content: `${range}`,
+              hash: `${range}`,
+              onItemClick: handleRangeChange,
+            }))}
+            positionFixed={true}
+            selectedItem={{
+              content: `${itemsPerPage}`,
+              hash: `${itemsPerPage}`,
+              onItemClick: handleRangeChange,
+            }}
+            toggle={
+              <StyledButton
+                iconRight={<ArrowDropDownIcon size="xxLarge" />}
+                type="button"
+                variant="subtle"
+              >
+                {rangeLabel || `Show ${itemsPerPage} items`}
+              </StyledButton>
+            }
+          />
+        </FlexItem>
+        <FlexItem>
+          <StyledButton
+            disabled={disablePrevious}
+            iconOnly={<ChevronLeftIcon title={localization.previousPage} />}
+            onClick={() => onPrevious()}
+            type="button"
+            variant="subtle"
+          />
+
+          <StyledButton
+            disabled={disableNext}
+            iconOnly={<ChevronRightIcon title={localization.nextPage} />}
+            onClick={() => onNext()}
+            type="button"
+            variant="subtle"
+          />
+        </FlexItem>
+      </Flex>
+    );
+  },
+);
+
+StatelessPagination.displayName = 'StatelessPagination';

--- a/packages/big-design/src/components/StatelessPagination/StatelessPagination.tsx
+++ b/packages/big-design/src/components/StatelessPagination/StatelessPagination.tsx
@@ -3,7 +3,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
 } from '@bigcommerce/big-design-icons';
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 
 import { MarginProps } from '../../helpers';
 import { Dropdown, DropdownItem } from '../Dropdown';
@@ -12,14 +12,20 @@ import { Flex, FlexItem } from '../Flex';
 import { StyledButton } from './styled';
 
 export interface StatelessPaginationLocalization {
-  previousPage: string;
-  nextPage: string;
+  previousPage?: string;
+  nextPage?: string;
+  rangeLabel?: string;
+  label?: string;
 }
 
-const defaultLocalization: StatelessPaginationLocalization = {
+const getDefaultLocalization = (
+  itemsPerPage: number,
+): Required<StatelessPaginationLocalization> => ({
   previousPage: 'Previous page',
   nextPage: 'Next page',
-};
+  label: 'pagination',
+  rangeLabel: `Show ${itemsPerPage} items`,
+});
 
 export interface StatelessPaginationProps extends MarginProps {
   itemsPerPage: number;
@@ -29,8 +35,6 @@ export interface StatelessPaginationProps extends MarginProps {
   onNext(): void;
   disablePrevious?: boolean;
   onPrevious(): void;
-  label?: string;
-  rangeLabel?: string;
   localization?: StatelessPaginationLocalization;
 }
 
@@ -43,16 +47,19 @@ export const StatelessPagination: React.FC<StatelessPaginationProps> = memo(
     disablePrevious = false,
     onPrevious,
     onItemsPerPageChange,
-    label = 'pagination',
-    localization = defaultLocalization,
-    rangeLabel = `Show ${itemsPerPage} items`,
+    localization: customLocalization,
   }) => {
+    const localization: Required<StatelessPaginationLocalization> = useMemo(
+      () => ({ ...getDefaultLocalization(itemsPerPage), ...customLocalization }),
+      [customLocalization, itemsPerPage],
+    );
+
     const handleRangeChange = (item: DropdownItem) => {
       onItemsPerPageChange(Number(item.hash));
     };
 
     return (
-      <Flex aria-label={label} flexDirection="row" role="navigation">
+      <Flex aria-label={localization.label} flexDirection="row" role="navigation">
         <FlexItem>
           <Dropdown
             items={itemsPerPageOptions.map((range) => ({
@@ -72,7 +79,7 @@ export const StatelessPagination: React.FC<StatelessPaginationProps> = memo(
                 type="button"
                 variant="subtle"
               >
-                {rangeLabel}
+                {localization.rangeLabel}
               </StyledButton>
             }
           />

--- a/packages/big-design/src/components/StatelessPagination/StatelessPagination.tsx
+++ b/packages/big-design/src/components/StatelessPagination/StatelessPagination.tsx
@@ -45,7 +45,7 @@ export const StatelessPagination: React.FC<StatelessPaginationProps> = memo(
     onItemsPerPageChange,
     label = 'pagination',
     localization = defaultLocalization,
-    rangeLabel,
+    rangeLabel = `Show ${itemsPerPage} items`,
   }) => {
     const handleRangeChange = (item: DropdownItem) => {
       onItemsPerPageChange(Number(item.hash));
@@ -72,7 +72,7 @@ export const StatelessPagination: React.FC<StatelessPaginationProps> = memo(
                 type="button"
                 variant="subtle"
               >
-                {rangeLabel || `Show ${itemsPerPage} items`}
+                {rangeLabel}
               </StyledButton>
             }
           />

--- a/packages/big-design/src/components/StatelessPagination/StatelessPagination.tsx
+++ b/packages/big-design/src/components/StatelessPagination/StatelessPagination.tsx
@@ -31,10 +31,8 @@ export interface StatelessPaginationProps extends MarginProps {
   itemsPerPage: number;
   itemsPerPageOptions: number[];
   onItemsPerPageChange(range: number): void;
-  disableNext?: boolean;
-  onNext(): void;
-  disablePrevious?: boolean;
-  onPrevious(): void;
+  onNext?(): void;
+  onPrevious?(): void;
   localization?: StatelessPaginationLocalization;
 }
 
@@ -42,9 +40,7 @@ export const StatelessPagination: React.FC<StatelessPaginationProps> = memo(
   ({
     itemsPerPage,
     itemsPerPageOptions,
-    disableNext = false,
     onNext,
-    disablePrevious = false,
     onPrevious,
     onItemsPerPageChange,
     localization: customLocalization,
@@ -86,17 +82,17 @@ export const StatelessPagination: React.FC<StatelessPaginationProps> = memo(
         </FlexItem>
         <FlexItem>
           <StyledButton
-            disabled={disablePrevious}
+            disabled={!onPrevious}
             iconOnly={<ChevronLeftIcon title={localization.previousPage} />}
-            onClick={() => onPrevious()}
+            onClick={() => onPrevious?.()}
             type="button"
             variant="subtle"
           />
 
           <StyledButton
-            disabled={disableNext}
+            disabled={!onNext}
             iconOnly={<ChevronRightIcon title={localization.nextPage} />}
-            onClick={() => onNext()}
+            onClick={() => onNext?.()}
             type="button"
             variant="subtle"
           />

--- a/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
@@ -1,0 +1,430 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render Stateless pagination component 1`] = `
+.c7 {
+  vertical-align: middle;
+  height: 2rem;
+  width: 2rem;
+}
+
+.c12 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c0 {
+  box-sizing: border-box;
+}
+
+.c8 {
+  box-sizing: border-box;
+  z-index: 1060;
+}
+
+.c1 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.c4 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  padding-right: 0.5rem;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c4 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c4:active {
+  background-color: #DBE3FE;
+}
+
+.c4:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c4:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c4[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c11 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c11 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c11:active {
+  background-color: #DBE3FE;
+}
+
+.c11:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c11:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c11[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c6 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+}
+
+.c9 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
+.c3 {
+  position: relative;
+}
+
+.c5 {
+  color: #313440;
+  width: auto;
+}
+
+@media (min-width:720px) {
+  .c4 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c4 {
+    width: auto;
+  }
+}
+
+@media (min-width:720px) {
+  .c11 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c11 {
+    width: auto;
+    padding: 0;
+    min-width: 2.25rem;
+  }
+}
+
+<div
+  aria-label="pagination"
+  class="c0 c1"
+  role="navigation"
+>
+  <div
+    class="c0 c2"
+  >
+    <div
+      class="c0 c3"
+    >
+      <button
+        aria-activedescendant=""
+        aria-controls=":r0:-menu"
+        aria-expanded="false"
+        aria-haspopup="menu"
+        class="c4 c5"
+        id=":r0:-toggle-button"
+        role="button"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="c6"
+        >
+          Show 3 items
+          <svg
+            aria-hidden="true"
+            class="c7"
+            fill="currentColor"
+            height="24"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+            <path
+              d="m8.71 11.71 2.59 2.59c.39.39 1.02.39 1.41 0l2.59-2.59c.63-.63.18-1.71-.71-1.71H9.41c-.89 0-1.33 1.08-.7 1.71"
+            />
+          </svg>
+        </span>
+      </button>
+      <div
+        class="c8"
+        style="position: fixed; left: 0px; top: 0px;"
+      >
+        <div
+          class="c9"
+        >
+          <ul
+            aria-labelledby=":r0:-label"
+            class="c10"
+            id=":r0:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c0 c2"
+  >
+    <button
+      class="c11 c5"
+      type="button"
+    >
+      <span
+        class="c6"
+      >
+        <svg
+          aria-labelledby=":r3:"
+          class="c12"
+          fill="currentColor"
+          height="24"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <title
+            id=":r3:"
+          >
+            Previous page
+          </title>
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M14.71 6.71a.996.996 0 0 0-1.41 0L8.71 11.3a.996.996 0 0 0 0 1.41l4.59 4.59a.996.996 0 1 0 1.41-1.41L10.83 12l3.88-3.88c.39-.39.38-1.03 0-1.41"
+          />
+        </svg>
+      </span>
+    </button>
+    <button
+      class="c11 c5"
+      type="button"
+    >
+      <span
+        class="c6"
+      >
+        <svg
+          aria-labelledby=":r4:"
+          class="c12"
+          fill="currentColor"
+          height="24"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <title
+            id=":r4:"
+          >
+            Next page
+          </title>
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M9.29 6.71a.996.996 0 0 0 0 1.41L13.17 12l-3.88 3.88a.996.996 0 1 0 1.41 1.41l4.59-4.59a.996.996 0 0 0 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+</div>
+`;

--- a/packages/big-design/src/components/StatelessPagination/index.ts
+++ b/packages/big-design/src/components/StatelessPagination/index.ts
@@ -1,0 +1,1 @@
+export { StatelessPagination, type StatelessPaginationProps } from './StatelessPagination';

--- a/packages/big-design/src/components/StatelessPagination/spec.tsx
+++ b/packages/big-design/src/components/StatelessPagination/spec.tsx
@@ -49,7 +49,7 @@ test('render Stateless pagination component while overriding button labels', asy
 
 test('trigger range change', async () => {
   const changeRange = jest.fn();
-  const { findByText } = render(
+  const { findByRole } = render(
     <StatelessPagination
       itemsPerPage={2}
       itemsPerPageOptions={[2, 3, 5]}
@@ -59,13 +59,10 @@ test('trigger range change', async () => {
     />,
   );
 
-  const option = await findByText('Show 2 items');
+  await userEvent.click(await findByRole('button', { name: 'Show 2 items' }));
+  await userEvent.click(await screen.findByRole('option', { name: '3' }));
 
-  await userEvent.click(option);
-  await userEvent.keyboard('{ArrowDown}{Enter}');
-
-  expect(changeRange).toHaveBeenCalled();
-  expect(option).toBeInTheDocument();
+  expect(changeRange).toHaveBeenCalledWith(3);
 });
 
 test('triggers onPrevious callback', async () => {

--- a/packages/big-design/src/components/StatelessPagination/spec.tsx
+++ b/packages/big-design/src/components/StatelessPagination/spec.tsx
@@ -7,7 +7,7 @@ import 'jest-styled-components';
 import { StatelessPagination } from './index';
 
 test('render Stateless pagination component', async () => {
-  const { findByRole } = render(
+  render(
     <StatelessPagination
       itemsPerPage={3}
       itemsPerPageOptions={[2, 3, 5]}
@@ -17,7 +17,7 @@ test('render Stateless pagination component', async () => {
     />,
   );
 
-  const pagination = await findByRole('navigation');
+  const pagination = await screen.findByRole('navigation');
 
   expect(pagination).toMatchSnapshot();
 });
@@ -49,7 +49,7 @@ test('render Stateless pagination component while overriding button labels', asy
 
 test('trigger range change', async () => {
   const changeRange = jest.fn();
-  const { findByRole } = render(
+  render(
     <StatelessPagination
       itemsPerPage={2}
       itemsPerPageOptions={[2, 3, 5]}
@@ -59,7 +59,7 @@ test('trigger range change', async () => {
     />,
   );
 
-  await userEvent.click(await findByRole('button', { name: 'Show 2 items' }));
+  await userEvent.click(await screen.findByRole('button', { name: 'Show 2 items' }));
   await userEvent.click(await screen.findByRole('option', { name: '3' }));
 
   expect(changeRange).toHaveBeenCalledWith(3);
@@ -103,7 +103,7 @@ test('trigger onNext callback', async () => {
 
 describe('when "disableNext" is set to "true"', () => {
   test('render Stateless pagination component with next disabled', async () => {
-    const { findByRole } = render(
+    render(
       <StatelessPagination
         disableNext={true}
         itemsPerPage={-5}
@@ -114,13 +114,13 @@ describe('when "disableNext" is set to "true"', () => {
       />,
     );
 
-    expect(await findByRole('button', { name: 'Next page' })).toBeDisabled();
+    expect(await screen.findByRole('button', { name: 'Next page' })).toBeDisabled();
   });
 });
 
 describe('when "disablePrevious" is set to "true"', () => {
   test('render Stateless pagination component with previous disabled', async () => {
-    const { findByRole } = render(
+    render(
       <StatelessPagination
         disablePrevious={true}
         itemsPerPage={-5}
@@ -131,7 +131,7 @@ describe('when "disablePrevious" is set to "true"', () => {
       />,
     );
 
-    expect(await findByRole('button', { name: 'Previous page' })).toBeDisabled();
+    expect(await screen.findByRole('button', { name: 'Previous page' })).toBeDisabled();
   });
 });
 

--- a/packages/big-design/src/components/StatelessPagination/spec.tsx
+++ b/packages/big-design/src/components/StatelessPagination/spec.tsx
@@ -77,15 +77,16 @@ test('trigger onNext callback', async () => {
   expect(onNext).toHaveBeenCalled();
 });
 
-describe('when "disableNext" is set to "true"', () => {
+describe('when "onNext" is not provided', () => {
   test('render Stateless pagination component with next disabled', async () => {
+    const onNext = undefined;
+
     render(
       <StatelessPagination
-        disableNext={true}
         itemsPerPage={-5}
         itemsPerPageOptions={[2, 3, 5]}
         onItemsPerPageChange={jest.fn()}
-        onNext={jest.fn()}
+        onNext={onNext}
         onPrevious={jest.fn()}
       />,
     );
@@ -94,16 +95,17 @@ describe('when "disableNext" is set to "true"', () => {
   });
 });
 
-describe('when "disablePrevious" is set to "true"', () => {
+describe('when "onPrevious" is not provided', () => {
   test('render Stateless pagination component with previous disabled', async () => {
+    const onPrevious = undefined;
+
     render(
       <StatelessPagination
-        disablePrevious={true}
         itemsPerPage={-5}
         itemsPerPageOptions={[2, 3, 5]}
         onItemsPerPageChange={jest.fn()}
         onNext={jest.fn()}
-        onPrevious={jest.fn()}
+        onPrevious={onPrevious}
       />,
     );
 

--- a/packages/big-design/src/components/StatelessPagination/spec.tsx
+++ b/packages/big-design/src/components/StatelessPagination/spec.tsx
@@ -22,33 +22,9 @@ test('render Stateless pagination component', async () => {
   expect(pagination).toMatchSnapshot();
 });
 
-test('render Stateless pagination component while overriding button labels', async () => {
-  render(
-    <StatelessPagination
-      itemsPerPage={3}
-      itemsPerPageOptions={[2, 3, 5]}
-      label="[Custom] Pagination"
-      localization={{ previousPage: 'Pagina previa', nextPage: 'Pagina siguiente' }}
-      onItemsPerPageChange={jest.fn()}
-      onNext={jest.fn()}
-      onPrevious={jest.fn()}
-      rangeLabel="[Custom range label]"
-    />,
-  );
-
-  const pagination = await screen.findByRole('navigation', { name: '[Custom] Pagination' });
-  const dropdown = await screen.findByRole('button', { name: '[Custom range label]' });
-  const prevPage = await screen.findByRole('button', { name: 'Pagina previa' });
-  const nextPage = await screen.findByRole('button', { name: 'Pagina siguiente' });
-
-  expect(pagination).toBeInTheDocument();
-  expect(dropdown).toBeInTheDocument();
-  expect(prevPage).toBeInTheDocument();
-  expect(nextPage).toBeInTheDocument();
-});
-
 test('trigger range change', async () => {
   const changeRange = jest.fn();
+
   render(
     <StatelessPagination
       itemsPerPage={2}
@@ -156,16 +132,21 @@ test('current itemsPerPage highlighted', async () => {
 });
 
 test('renders localized labels', async () => {
+  const customLocalization = {
+    previousPage: 'Pagina previa',
+    nextPage: 'Pagina siguiente',
+    label: 'Paginacion',
+    rangeLabel: 'Mostrar 3 artículos',
+  };
+
   render(
     <StatelessPagination
       itemsPerPage={3}
       itemsPerPageOptions={[2, 3, 5]}
-      label="Paginacion"
-      localization={{ previousPage: 'Pagina previa', nextPage: 'Pagina siguiente' }}
+      localization={customLocalization}
       onItemsPerPageChange={jest.fn()}
       onNext={jest.fn()}
       onPrevious={jest.fn()}
-      rangeLabel="Mostrar 3 artículos"
     />,
   );
 

--- a/packages/big-design/src/components/StatelessPagination/spec.tsx
+++ b/packages/big-design/src/components/StatelessPagination/spec.tsx
@@ -1,0 +1,184 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import React from 'react';
+
+import 'jest-styled-components';
+
+import { StatelessPagination } from './index';
+
+test('render Stateless pagination component', async () => {
+  const { findByRole } = render(
+    <StatelessPagination
+      itemsPerPage={3}
+      itemsPerPageOptions={[2, 3, 5]}
+      onItemsPerPageChange={jest.fn()}
+      onNext={jest.fn()}
+      onPrevious={jest.fn()}
+    />,
+  );
+
+  const pagination = await findByRole('navigation');
+
+  expect(pagination).toMatchSnapshot();
+});
+
+test('render Stateless pagination component while overriding button labels', async () => {
+  render(
+    <StatelessPagination
+      itemsPerPage={3}
+      itemsPerPageOptions={[2, 3, 5]}
+      label="[Custom] Pagination"
+      localization={{ previousPage: 'Pagina previa', nextPage: 'Pagina siguiente' }}
+      onItemsPerPageChange={jest.fn()}
+      onNext={jest.fn()}
+      onPrevious={jest.fn()}
+      rangeLabel="[Custom range label]"
+    />,
+  );
+
+  const pagination = await screen.findByRole('navigation', { name: '[Custom] Pagination' });
+  const dropdown = await screen.findByRole('button', { name: '[Custom range label]' });
+  const prevPage = await screen.findByRole('button', { name: 'Pagina previa' });
+  const nextPage = await screen.findByRole('button', { name: 'Pagina siguiente' });
+
+  expect(pagination).toBeInTheDocument();
+  expect(dropdown).toBeInTheDocument();
+  expect(prevPage).toBeInTheDocument();
+  expect(nextPage).toBeInTheDocument();
+});
+
+test('trigger range change', async () => {
+  const changeRange = jest.fn();
+  const { findByText } = render(
+    <StatelessPagination
+      itemsPerPage={2}
+      itemsPerPageOptions={[2, 3, 5]}
+      onItemsPerPageChange={changeRange}
+      onNext={jest.fn()}
+      onPrevious={jest.fn()}
+    />,
+  );
+
+  const option = await findByText('Show 2 items');
+
+  await userEvent.click(option);
+  await userEvent.keyboard('{ArrowDown}{Enter}');
+
+  expect(changeRange).toHaveBeenCalled();
+  expect(option).toBeInTheDocument();
+});
+
+test('triggers onPrevious callback', async () => {
+  const onPrevious = jest.fn();
+
+  render(
+    <StatelessPagination
+      itemsPerPage={3}
+      itemsPerPageOptions={[2, 3, 5]}
+      onItemsPerPageChange={jest.fn()}
+      onNext={jest.fn()}
+      onPrevious={onPrevious}
+    />,
+  );
+
+  await userEvent.click(screen.getByRole('button', { name: 'Previous page' }));
+
+  expect(onPrevious).toHaveBeenCalled();
+});
+
+test('trigger onNext callback', async () => {
+  const onNext = jest.fn();
+
+  render(
+    <StatelessPagination
+      itemsPerPage={3}
+      itemsPerPageOptions={[2, 3, 5]}
+      onItemsPerPageChange={jest.fn()}
+      onNext={onNext}
+      onPrevious={jest.fn()}
+    />,
+  );
+
+  await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+
+  expect(onNext).toHaveBeenCalled();
+});
+
+describe('when "disableNext" is set to "true"', () => {
+  test('render Stateless pagination component with next disabled', async () => {
+    const { findByRole } = render(
+      <StatelessPagination
+        disableNext={true}
+        itemsPerPage={-5}
+        itemsPerPageOptions={[2, 3, 5]}
+        onItemsPerPageChange={jest.fn()}
+        onNext={jest.fn()}
+        onPrevious={jest.fn()}
+      />,
+    );
+
+    expect(await findByRole('button', { name: 'Next page' })).toBeDisabled();
+  });
+});
+
+describe('when "disablePrevious" is set to "true"', () => {
+  test('render Stateless pagination component with previous disabled', async () => {
+    const { findByRole } = render(
+      <StatelessPagination
+        disablePrevious={true}
+        itemsPerPage={-5}
+        itemsPerPageOptions={[2, 3, 5]}
+        onItemsPerPageChange={jest.fn()}
+        onNext={jest.fn()}
+        onPrevious={jest.fn()}
+      />,
+    );
+
+    expect(await findByRole('button', { name: 'Previous page' })).toBeDisabled();
+  });
+});
+
+test('current itemsPerPage highlighted', async () => {
+  render(
+    <StatelessPagination
+      itemsPerPage={3}
+      itemsPerPageOptions={[2, 3, 5]}
+      onItemsPerPageChange={jest.fn()}
+      onNext={jest.fn()}
+      onPrevious={jest.fn()}
+    />,
+  );
+
+  const button = await screen.findByRole('button', { name: 'Show 3 items' });
+
+  await userEvent.click(button);
+
+  const options = screen.getAllByRole('option');
+
+  expect(button).toHaveAttribute('aria-activedescendant', options[1].id);
+});
+
+test('renders localized labels', async () => {
+  render(
+    <StatelessPagination
+      itemsPerPage={3}
+      itemsPerPageOptions={[2, 3, 5]}
+      label="Paginacion"
+      localization={{ previousPage: 'Pagina previa', nextPage: 'Pagina siguiente' }}
+      onItemsPerPageChange={jest.fn()}
+      onNext={jest.fn()}
+      onPrevious={jest.fn()}
+      rangeLabel="Mostrar 3 artículos"
+    />,
+  );
+
+  const pagination = await screen.findByRole('navigation', { name: 'Paginacion' });
+  const dropdown = await screen.findByRole('button', { name: 'Mostrar 3 artículos' });
+  const prevPage = await screen.findByRole('button', { name: 'Pagina previa' });
+  const nextPage = await screen.findByRole('button', { name: 'Pagina siguiente' });
+
+  expect(pagination).toBeInTheDocument();
+  expect(dropdown).toBeInTheDocument();
+  expect(prevPage).toBeInTheDocument();
+  expect(nextPage).toBeInTheDocument();
+});

--- a/packages/big-design/src/components/StatelessPagination/styled.tsx
+++ b/packages/big-design/src/components/StatelessPagination/styled.tsx
@@ -1,0 +1,11 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled from 'styled-components';
+
+import { StyleableButton } from '../Button/private';
+
+export const StyledButton = styled(StyleableButton)`
+  color: ${({ theme }) => theme.colors.secondary70};
+  width: auto;
+`;
+
+StyledButton.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/StatelessPagination/styled.tsx
+++ b/packages/big-design/src/components/StatelessPagination/styled.tsx
@@ -3,9 +3,7 @@ import styled from 'styled-components';
 
 import { StyleableButton } from '../Button/private';
 
-export const StyledButton = styled(StyleableButton)`
+export const StyledButton = styled(StyleableButton).attrs({ theme: defaultTheme })`
   color: ${({ theme }) => theme.colors.secondary70};
   width: auto;
 `;
-
-StyledButton.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/index.ts
+++ b/packages/big-design/src/components/index.ts
@@ -32,6 +32,7 @@ export * from './Search';
 export * from './Select';
 export * from './StatefulTable';
 export * from './StatefulTree';
+export * from './StatelessPagination';
 export * from './Stepper';
 export * from './Switch';
 export * from './Table';

--- a/packages/docs/PropTables/StatelessPaginationPropTable.tsx
+++ b/packages/docs/PropTables/StatelessPaginationPropTable.tsx
@@ -48,21 +48,8 @@ const statelessPaginationProps: Prop[] = [
     description: 'Function that will be called when the "previous" navigation arrow is clicked.',
   },
   {
-    name: 'label',
-    types: 'string',
-    required: false,
-    defaultValue: 'pagination',
-    description: 'Overrides the aria label of the pagination wrapper navigation element.',
-  },
-  {
-    name: 'rangeLabel',
-    types: 'string',
-    required: false,
-    description: 'Sets the label of the per-page range dropdown.',
-  },
-  {
     name: 'localization',
-    types: '{ of: string, previousPage: string, nextPage: string }',
+    types: '{ previousPage: string, nextPage: string, label: string, rangeLabel: string }',
     required: false,
     description: 'Overrides the labels with localized text.',
   },

--- a/packages/docs/PropTables/StatelessPaginationPropTable.tsx
+++ b/packages/docs/PropTables/StatelessPaginationPropTable.tsx
@@ -22,30 +22,20 @@ const statelessPaginationProps: Prop[] = [
     description: 'Function that will be called when a new per-page range is selected.',
   },
   {
-    name: 'disableNext',
-    types: 'boolean',
-    required: false,
-    defaultValue: 'false',
-    description: 'Set the the "next" navigation arrow to disabled.',
-  },
-  {
     name: 'onNext',
     types: '() => void',
-    required: true,
-    description: 'Function that will be called when the "next" navigation arrow is clicked.',
-  },
-  {
-    name: 'disablePrevious',
-    types: 'boolean',
+    defaultValue: 'undefined',
     required: false,
-    defaultValue: 'false',
-    description: 'Set the the "previous" navigation arrow to disabled.',
+    description:
+      'Function that will be called when the "next" navigation arrow is clicked. Disables the arrow if not provided.',
   },
   {
     name: 'onPrevious',
     types: '() => void',
-    required: true,
-    description: 'Function that will be called when the "previous" navigation arrow is clicked.',
+    defaultValue: 'undefined',
+    required: false,
+    description:
+      'Function that will be called when the "previous" navigation arrow is clicked. Disables the arrow if not provided.',
   },
   {
     name: 'localization',

--- a/packages/docs/PropTables/StatelessPaginationPropTable.tsx
+++ b/packages/docs/PropTables/StatelessPaginationPropTable.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { Prop, PropTable, PropTableWrapper } from '../components';
+
+const statelessPaginationProps: Prop[] = [
+  {
+    name: 'itemsPerPage',
+    types: 'number',
+    required: true,
+    description: 'Indicates how many items are displayed per page.',
+  },
+  {
+    name: 'itemsPerPageOptions',
+    types: 'number[]',
+    required: true,
+    description: 'Indicates options for per-page ranges.',
+  },
+  {
+    name: 'onItemsPerPageChange',
+    types: '(range: number) => void',
+    required: true,
+    description: 'Function that will be called when a new per-page range is selected.',
+  },
+  {
+    name: 'disableNext',
+    types: 'boolean',
+    required: false,
+    defaultValue: 'false',
+    description: 'Set the the "next" navigation arrow to disabled.',
+  },
+  {
+    name: 'onNext',
+    types: '() => void',
+    required: true,
+    description: 'Function that will be called when the "next" navigation arrow is clicked.',
+  },
+  {
+    name: 'disablePrevious',
+    types: 'boolean',
+    required: false,
+    defaultValue: 'false',
+    description: 'Set the the "previous" navigation arrow to disabled.',
+  },
+  {
+    name: 'onPrevious',
+    types: '() => void',
+    required: true,
+    description: 'Function that will be called when the "previous" navigation arrow is clicked.',
+  },
+  {
+    name: 'label',
+    types: 'string',
+    required: false,
+    defaultValue: 'pagination',
+    description: 'Overrides the aria label of the pagination wrapper navigation element.',
+  },
+  {
+    name: 'rangeLabel',
+    types: 'string',
+    required: false,
+    description: 'Sets the label of the per-page range dropdown.',
+  },
+  {
+    name: 'localization',
+    types: '{ of: string, previousPage: string, nextPage: string }',
+    required: false,
+    description: 'Overrides the labels with localized text.',
+  },
+];
+
+export const StatelessPaginationPropTable: React.FC<PropTableWrapper> = (props) => {
+  return <PropTable propList={statelessPaginationProps} title="Pagination" {...props} />;
+};

--- a/packages/docs/PropTables/index.ts
+++ b/packages/docs/PropTables/index.ts
@@ -34,6 +34,7 @@ export * from './SearchPropTable';
 export * from './SelectPropTable';
 export * from './StatefulTablePropTable';
 export * from './StatefulTreePropTable';
+export * from './StatelessPaginationPropTable';
 export * from './StepperPropTable';
 export * from './SwitchPropTable';
 export * from './TablePropTable';

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -64,6 +64,7 @@ export const SideNav: React.FC = () => {
                 <SideNavLink href="/panel">Panel</SideNavLink>
                 <SideNavLink href="/statefulTable">StatefulTable</SideNavLink>
                 <SideNavLink href="/statefulTree">StatefulTree</SideNavLink>
+                <SideNavLink href="/stateless-pagination">StatelessPagination</SideNavLink>
                 <SideNavLink href="/table">Table</SideNavLink>
                 <SideNavLink href="/tabs">Tabs</SideNavLink>
                 <SideNavLink href="/worksheet">Worksheet</SideNavLink>

--- a/packages/docs/pages/stateless-pagination.tsx
+++ b/packages/docs/pages/stateless-pagination.tsx
@@ -50,16 +50,17 @@ const StatelessPaginationPage = () => {
               setCurrentItems(items.slice(firstItem, lastItem));
             }, [page, items, range]);
 
+            const notFirstPage = page !== 1;
+            const notLastPage = page < items.length / range;
+
             return (
               <>
                 <StatelessPagination
-                  disableNext={page >= items.length / range}
-                  disablePrevious={page === 1}
                   itemsPerPage={range}
                   itemsPerPageOptions={ranges}
                   onItemsPerPageChange={onItemsPerPageChange}
-                  onNext={() => setPage((currentPage) => currentPage + 1)}
-                  onPrevious={() => setPage((currentPage) => currentPage - 1)}
+                  onNext={notLastPage ? () => setPage((current) => current + 1) : undefined}
+                  onPrevious={notFirstPage ? () => setPage((current) => current - 1) : undefined}
                 />
                 <ul>
                   {currentItems.map((item) => (

--- a/packages/docs/pages/stateless-pagination.tsx
+++ b/packages/docs/pages/stateless-pagination.tsx
@@ -1,0 +1,102 @@
+import { H1, Panel, StatelessPagination, Text } from '@bigcommerce/big-design';
+import React, { useEffect, useState } from 'react';
+
+import { Code, CodePreview, GuidelinesTable, List } from '../components';
+import { MarginPropTable, StatelessPaginationPropTable } from '../PropTables';
+
+const StatelessPaginationPage = () => {
+  return (
+    <>
+      <H1>StatelessPagination</H1>
+
+      <Panel header="Overview" headerId="overview">
+        <Text>
+          <Code primary>StatelessPagination</Code> is used to divide a long list or table into
+          several pages, indicating other pages exist and allowing the user to access them. This
+          makes the content easier to read and ensures faster loading time. The user can easily
+          navigate through the pages in order. The user can also select the number of results they
+          want to see on each page, giving them more control over the way they view the data.
+        </Text>
+        <Text bold>When to use:</Text>
+        <List>
+          <List.Item>On tables that contain more than 25 number of rows of data/content.</List.Item>
+          <List.Item>
+            When the data/content uses a cursor-based form of pagination or if you wish to add
+            custom logic around pagination.
+          </List.Item>
+        </List>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <CodePreview>
+          {/* jsx-to-string:start */}
+          {function ExampleList() {
+            const [items] = useState(['Item1', 'Item2', 'Item3', 'Item 4', 'Item 5']);
+            const [ranges] = useState([2, 3, 4]);
+            const [range, setRange] = useState(ranges[0]);
+            const [page, setPage] = useState(1);
+            const [currentItems, setCurrentItems] = useState(['']);
+
+            const onItemsPerPageChange = (newRange) => {
+              setPage(1);
+              setRange(newRange);
+            };
+
+            useEffect(() => {
+              const maxItems = page * range;
+              const lastItem = Math.min(maxItems, items.length);
+              const firstItem = Math.max(0, maxItems - range);
+
+              setCurrentItems(items.slice(firstItem, lastItem));
+            }, [page, items, range]);
+
+            return (
+              <>
+                <StatelessPagination
+                  disableNext={page >= items.length / range}
+                  disablePrevious={page === 1}
+                  itemsPerPage={range}
+                  itemsPerPageOptions={ranges}
+                  onItemsPerPageChange={onItemsPerPageChange}
+                  onNext={() => setPage((currentPage) => currentPage + 1)}
+                  onPrevious={() => setPage((currentPage) => currentPage - 1)}
+                />
+                <ul>
+                  {currentItems.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </>
+            );
+          }}
+          {/* jsx-to-string:end */}
+        </CodePreview>
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <StatelessPaginationPropTable inheritedProps={<MarginPropTable collapsible />} />
+      </Panel>
+
+      <Panel header="Do's and Don'ts" headerId="guidelines">
+        <GuidelinesTable
+          discouraged={[
+            <>
+              Don’t place <Code primary>StatelessPagination</Code> below a table.
+            </>,
+            'Don’t show dropdown arrow when there are less than 10 items.',
+          ]}
+          recommended={[
+            <>
+              Place <Code primary>StatelessPagination</Code> directly above the header of the table
+              that it controls, right aligned.
+            </>,
+            'Disable dropdown options greater than the option that will show the total number of results (e.g., if there are 42 results, the highest option should be 50).',
+            'Dropdown increments should be multiples of 10 and in increments that make sense for the context.',
+          ]}
+        />
+      </Panel>
+    </>
+  );
+};
+
+export default StatelessPaginationPage;


### PR DESCRIPTION
## What?

- Add new `StatelessPagination` component
- Add new documentation detailing `StatelessPagination`

### Upcoming

- `StatelessPagination` will be added as an option for the `Table` component in a seperate, upcoming PR
- `OffsetPagination` will be changed to use `StatelessPagination` under the hood in a seperate, upcoming PR

## Why?

- The current `OffsetPagination` component is highly stateful and requires knowable page numbers, these concepts are incompatible with cursor-based pagination
  - cursor-based pagination has very fluid concepts of 'pages' and how many there might be
  - cursor-based pagination `next` and `previous` actions are knowable for the current page only, they cannot be deterministically calculated for _all_ pages ahead of time

### Why not name the component `CursorPagination`?

- The component's props and internals are completely agnostic to cursors being used or not
  - any attempt to do so may unintentionally couple it to a specific, idiosyncratic cursor API 
- Expands the component's potential usage to other forms of pagination or more complicated logic
  - e.g. a paginated form where field states are interrogated before acting on a next or previous navigation 

### Why is the example in the documentation closer to a true cursor implementation?

- Faking a somewhat realistic cursor API takes a _lot_ of boiler plate code which would dominate and confuse the example code
- You can see a full example here: https://github.com/leeBigCommerce/big-design/blob/7568a4f73bbf76dcff5b0e45fd49ba5ebec6ceeb/packages/docs/pages/stateless-pagination.tsx
  - Not a merge candidate, purely for reference
  - Extra ugly as everything is in one file, lodash and other helpful libraries  

## Screenshots/Screen Recordings

https://github.com/user-attachments/assets/c995cec7-e9a8-461a-8a3b-7667094ec89e

## Testing/Proof

- New tests for `StatelessPagination`
