### PR TITLE
Incorporate StatelessPagination to Table and TableNext

### DIFF
--- a/.changeset/soft-files-know.md
+++ b/.changeset/soft-files-know.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design': minor
+'@bigcommerce/docs': minor
+---
+
+Consumers of the Table component can now choose to use the 'Stateless' form of Pagination. This enables the use of Table with cursor-based forms of pagination.

--- a/packages/big-design/src/components/Table/Actions/Actions.tsx
+++ b/packages/big-design/src/components/Table/Actions/Actions.tsx
@@ -34,15 +34,15 @@ const InternalActions = <T extends TableItem>({
   ...props
 }: ActionsProps<T>) => {
   const isSelectable = typeof onSelectionChange === 'function';
-  const statelessPagination = pagination?.type === 'stateless';
-  const totalItems = pagination && !statelessPagination ? pagination.totalItems : items.length;
+  const paginationWithoutTotal = pagination && pagination.totalItems === undefined;
+  const totalItems = pagination?.totalItems ?? items.length;
 
   const renderItemName = () => {
     if (typeof itemName !== 'string') {
       return null;
     }
 
-    const text = isSelectable || statelessPagination ? itemName : `${totalItems} ${itemName}`;
+    const text = isSelectable || paginationWithoutTotal ? itemName : `${totalItems} ${itemName}`;
 
     return (
       <FlexItem flexShrink={0} marginRight="medium">
@@ -71,7 +71,7 @@ const InternalActions = <T extends TableItem>({
         items={items}
         onChange={onSelectionChange}
         selectedItems={selectedItems}
-        totalItems={!statelessPagination ? totalItems : undefined}
+        totalItems={!paginationWithoutTotal ? totalItems : undefined}
       />
       {renderItemName()}
       {renderActions()}

--- a/packages/big-design/src/components/Table/Actions/Actions.tsx
+++ b/packages/big-design/src/components/Table/Actions/Actions.tsx
@@ -59,10 +59,11 @@ const InternalActions = <T extends TableItem>({
     <StyledFlex
       alignItems="center"
       aria-controls={tableId}
-      data-testid="table-controls"
+      aria-label="Table Controls"
       flexDirection="row"
       justifyContent="stretch"
       ref={forwardedRef}
+      role="toolbar"
       stickyHeader={stickyHeader}
       {...props}
     >

--- a/packages/big-design/src/components/Table/Actions/Actions.tsx
+++ b/packages/big-design/src/components/Table/Actions/Actions.tsx
@@ -5,7 +5,7 @@ import { FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
 import { SelectAll } from '../SelectAll';
 import { TablePagination } from '../TablePagination';
-import { TableItem, TablePaginationProps, TableSelectable } from '../types';
+import { DiscriminatedTablePaginationProps, TableItem, TableSelectable } from '../types';
 
 import { StyledFlex } from './styled';
 
@@ -14,7 +14,7 @@ export interface ActionsProps<T> {
   forwardedRef: RefObject<HTMLDivElement>;
   itemName?: string;
   items: T[];
-  pagination?: TablePaginationProps;
+  pagination?: DiscriminatedTablePaginationProps;
   onSelectionChange?: TableSelectable<T>['onSelectionChange'];
   selectedItems: Set<T>;
   stickyHeader?: boolean;
@@ -34,14 +34,15 @@ const InternalActions = <T extends TableItem>({
   ...props
 }: ActionsProps<T>) => {
   const isSelectable = typeof onSelectionChange === 'function';
-  const totalItems = pagination ? pagination.totalItems : items.length;
+  const statelessPagination = pagination?.type === 'stateless';
+  const totalItems = pagination && !statelessPagination ? pagination.totalItems : items.length;
 
   const renderItemName = () => {
     if (typeof itemName !== 'string') {
       return null;
     }
 
-    const text = isSelectable ? itemName : `${totalItems} ${itemName}`;
+    const text = isSelectable || statelessPagination ? itemName : `${totalItems} ${itemName}`;
 
     return (
       <FlexItem flexShrink={0} marginRight="medium">
@@ -58,6 +59,7 @@ const InternalActions = <T extends TableItem>({
     <StyledFlex
       alignItems="center"
       aria-controls={tableId}
+      data-testid="table-controls"
       flexDirection="row"
       justifyContent="stretch"
       ref={forwardedRef}
@@ -68,7 +70,7 @@ const InternalActions = <T extends TableItem>({
         items={items}
         onChange={onSelectionChange}
         selectedItems={selectedItems}
-        totalItems={totalItems}
+        totalItems={!statelessPagination ? totalItems : undefined}
       />
       {renderItemName()}
       {renderActions()}

--- a/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
@@ -54,7 +54,7 @@ export const SelectAll = <T extends TableItem>({
 
   const label = allInPageSelected ? 'Deselect All' : 'Select All';
 
-  const nonSelectionSummary = totalItems || '';
+  const nonSelectionSummary = totalItems ?? '';
   const selectionSummary = totalItems ? `${totalSelectedItems}/${totalItems}` : totalSelectedItems;
 
   return (

--- a/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
@@ -7,7 +7,7 @@ import { TableItem, TablePaginationProps, TableSelectable } from '../types';
 
 export interface SelectAllProps<T> {
   items: T[];
-  totalItems: number;
+  totalItems?: number;
   onChange?: TableSelectable<T>['onSelectionChange'];
   pagination?: TablePaginationProps;
   selectedItems: Set<T>;
@@ -54,6 +54,9 @@ export const SelectAll = <T extends TableItem>({
 
   const label = allInPageSelected ? 'Deselect All' : 'Select All';
 
+  const nonSelectionSummary = totalItems || '';
+  const selectionSummary = totalItems ? `${totalSelectedItems}/${totalItems}` : totalSelectedItems;
+
   return (
     <FlexItem flexShrink={0} marginRight="xxSmall">
       <Flex flexDirection="row">
@@ -65,7 +68,7 @@ export const SelectAll = <T extends TableItem>({
           onChange={handleSelectAll}
         />
         <Text marginLeft="small">
-          {totalSelectedItems === 0 ? `${totalItems}` : `${totalSelectedItems}/${totalItems}`}
+          {totalSelectedItems === 0 ? nonSelectionSummary : selectionSummary}
         </Text>
       </Flex>
     </FlexItem>

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useEffect, useId, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 
 import { MarginProps } from '../../helpers';
@@ -7,6 +7,7 @@ import { typedMemo } from '../../utils';
 
 import { Actions } from './Actions';
 import { Body } from './Body';
+import { discriminatePagination } from './discriminatePagination';
 import { Head } from './Head';
 import { HeaderCell } from './HeaderCell';
 import { DragIconHeaderCell, HeaderCheckboxCell } from './HeaderCell/HeaderCell';
@@ -39,7 +40,7 @@ const InternalTable = <T extends TableItem>(
     keyField = 'id',
     localization = defaultLocalization,
     onRowDrop,
-    pagination,
+    pagination: undiscriminatedPagination,
     selectable,
     sortable,
     stickyHeader,
@@ -47,6 +48,10 @@ const InternalTable = <T extends TableItem>(
     ...rest
   } = props;
 
+  const pagination = useMemo(
+    () => undiscriminatedPagination && discriminatePagination(undiscriminatedPagination),
+    [undiscriminatedPagination],
+  );
   const actionsRef = useRef<HTMLDivElement>(null);
   const uniqueTableId = useId();
   const tableIdRef = useRef(id || uniqueTableId);

--- a/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
@@ -1,36 +1,19 @@
 import React, { memo } from 'react';
 
 import { OffsetPagination } from '../../OffsetPagination';
-import { TablePaginationProps } from '../types';
+import { StatelessPagination } from '../../StatelessPagination';
+import { DiscriminatedTablePaginationProps } from '../types';
 
 import { StyledPaginationContainer } from './styled';
 
-export const TablePagination: React.FC<TablePaginationProps> = memo(
-  ({
-    currentPage,
-    itemsPerPage,
-    itemsPerPageOptions,
-    onItemsPerPageChange,
-    onPageChange,
-    totalItems,
-    label,
-    localization,
-    getRangeLabel,
-  }) => {
-    return (
-      <StyledPaginationContainer flexShrink={0}>
-        <OffsetPagination
-          currentPage={currentPage}
-          getRangeLabel={getRangeLabel}
-          itemsPerPage={itemsPerPage}
-          itemsPerPageOptions={itemsPerPageOptions}
-          label={label}
-          localization={localization}
-          onItemsPerPageChange={onItemsPerPageChange}
-          onPageChange={onPageChange}
-          totalItems={totalItems}
-        />
-      </StyledPaginationContainer>
-    );
-  },
-);
+export const TablePagination: React.FC<DiscriminatedTablePaginationProps> = memo((props) => {
+  return (
+    <StyledPaginationContainer flexShrink={0}>
+      {props.type === 'offset' ? (
+        <OffsetPagination {...props} />
+      ) : (
+        <StatelessPagination {...props} />
+      )}
+    </StyledPaginationContainer>
+  );
+});

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -340,8 +340,9 @@ exports[`offset pagination renders a pagination component 1`] = `
 
 <div
   aria-controls=":r12:"
+  aria-label="Table Controls"
   class="c0"
-  data-testid="table-controls"
+  role="toolbar"
 >
   <div
     class="c1 c2 c3"
@@ -949,8 +950,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 
 <div
   aria-controls=":r35:"
+  aria-label="Table Controls"
   class="c0"
-  data-testid="table-controls"
+  role="toolbar"
 >
   <div
     class="c1 c2"

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a pagination component 1`] = `
+exports[`offset pagination renders a pagination component 1`] = `
 .c10 {
   vertical-align: middle;
   height: 2rem;
@@ -341,6 +341,7 @@ exports[`renders a pagination component 1`] = `
 <div
   aria-controls=":r12:"
   class="c0"
+  data-testid="table-controls"
 >
   <div
     class="c1 c2 c3"
@@ -947,8 +948,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls=":r1k:"
+  aria-controls=":r35:"
   class="c0"
+  data-testid="table-controls"
 >
   <div
     class="c1 c2"
@@ -961,15 +963,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r1m:"
+          aria-labelledby=":r37:"
           class="c6 c7"
-          id=":r1l:"
+          id=":r36:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r1l:"
+          for=":r36:"
         >
           <svg
             aria-hidden="true"
@@ -995,9 +997,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c12 c13"
-            for=":r1l:"
+            for=":r36:"
             hidden=""
-            id=":r1m:"
+            id=":r37:"
           >
             Select All
           </label>

--- a/packages/big-design/src/components/Table/discriminatePagination.ts
+++ b/packages/big-design/src/components/Table/discriminatePagination.ts
@@ -1,0 +1,17 @@
+import { DiscriminatedTablePaginationProps, TablePaginationProps } from './types';
+
+export const discriminatePagination = (
+  pagination: TablePaginationProps,
+): DiscriminatedTablePaginationProps => {
+  if ('onPageChange' in pagination) {
+    return {
+      type: 'offset' as const,
+      ...pagination,
+    };
+  }
+
+  return {
+    type: 'stateless' as const,
+    ...pagination,
+  };
+};

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -404,7 +404,7 @@ describe('stateless pagination', () => {
         />,
       );
 
-      const tableControls = screen.getByTestId('table-controls');
+      const tableControls = screen.getByRole('toolbar', { name: 'Table Controls' });
 
       expect(within(tableControls).queryByText('2/6')).not.toBeInTheDocument();
       expect(within(tableControls).getByText('2')).toBeInTheDocument();

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import React, { CSSProperties } from 'react';
 import 'jest-styled-components';
@@ -197,90 +197,219 @@ test('renders the total number of items + item name', () => {
   expect(itemNameNode).toBeInTheDocument();
 });
 
-test('renders a pagination component', async () => {
-  const onItemsPerPageChange = jest.fn();
-  const onPageChange = jest.fn();
+describe('offset pagination', () => {
+  test('renders a pagination component', async () => {
+    const onItemsPerPageChange = jest.fn();
+    const onPageChange = jest.fn();
 
-  const { container, findByTitle } = render(
-    <Table
-      columns={[
-        { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
-        { header: 'Name', hash: 'name', render: ({ name }) => name },
-        { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
-      ]}
-      items={[
-        { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
-        { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
-        { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
-        { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
-        { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
-      ]}
-      pagination={{
-        currentPage: 1,
-        itemsPerPage: 3,
-        totalItems: 5,
-        itemsPerPageOptions: [3, 5, 10],
-        onItemsPerPageChange,
-        onPageChange,
-      }}
-    />,
-  );
+    const { container, findByTitle } = render(
+      <Table
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={[
+          { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+          { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+          { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+          { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+          { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+        ]}
+        pagination={{
+          currentPage: 1,
+          itemsPerPage: 3,
+          totalItems: 5,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange,
+          onPageChange,
+        }}
+      />,
+    );
 
-  const nextPage = await findByTitle('Next page');
+    const nextPage = await findByTitle('Next page');
 
-  await userEvent.click(nextPage);
+    await userEvent.click(nextPage);
 
-  expect(onPageChange).toHaveBeenCalledWith(2);
-  expect(container.firstChild).toMatchSnapshot();
+    expect(onPageChange).toHaveBeenCalledWith(2);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('renders a pagination component with custom button labels', async () => {
+    const getRangeLabel = (first: number, last: number, totalItems: number) => {
+      return `[Custom label] ${first}-${last} of ${totalItems}`;
+    };
+    const onItemsPerPageChange = jest.fn();
+    const onPageChange = jest.fn();
+
+    const { findByRole } = render(
+      <Table
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={[
+          { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+          { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+          { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+          { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+          { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+        ]}
+        pagination={{
+          currentPage: 1,
+          itemsPerPage: 3,
+          totalItems: 5,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange,
+          onPageChange,
+          getRangeLabel,
+          label: '[Custom] Pagination',
+          localization: {
+            previousPage: '[Custom] Previous page',
+            nextPage: '[Custom] Next page',
+          },
+        }}
+      />,
+    );
+
+    const navigation = await findByRole('navigation', { name: '[Custom] Pagination' });
+    const paginationDropdown = await findByRole('button', { name: '[Custom label] 1-3 of 5' });
+    const previousButtonPage = await findByRole('button', { name: '[Custom] Previous page' });
+    const nextButtonPage = await findByRole('button', { name: '[Custom] Next page' });
+
+    expect(navigation).toBeVisible();
+    expect(paginationDropdown).toBeVisible();
+    expect(previousButtonPage).toBeVisible();
+    expect(nextButtonPage).toBeVisible();
+  });
 });
 
-test('renders a pagination component with custom button labels', async () => {
-  const getRangeLabel = (first: number, last: number, totalItems: number) => {
-    return `[Custom label] ${first}-${last} of ${totalItems}`;
-  };
-  const onItemsPerPageChange = jest.fn();
-  const onPageChange = jest.fn();
+describe('stateless pagination', () => {
+  test('renders a pagination component', async () => {
+    const onItemsPerPageChange = jest.fn();
+    const onNext = jest.fn();
 
-  const { findByRole } = render(
-    <Table
-      columns={[
-        { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
-        { header: 'Name', hash: 'name', render: ({ name }) => name },
-        { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
-      ]}
-      items={[
-        { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
-        { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
-        { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+    render(
+      <Table
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={[
+          { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+          { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+          { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+          { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+          { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+        ]}
+        pagination={{
+          currentPage: 1,
+          itemsPerPage: 3,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange,
+          onNext,
+          onPrevious: jest.fn(),
+        }}
+      />,
+    );
+
+    await userEvent.click(await screen.findByTitle('Next page'));
+
+    expect(onNext).toHaveBeenCalled();
+  });
+
+  test('renders a pagination component with custom button labels', async () => {
+    render(
+      <Table
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={[
+          { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+          { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+          { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+          { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+          { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+        ]}
+        pagination={{
+          currentPage: 1,
+          itemsPerPage: 3,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange: jest.fn(),
+          onNext: jest.fn(),
+          onPrevious: jest.fn(),
+          localization: {
+            label: '[Custom] Pagination',
+            previousPage: '[Custom] Previous page',
+            nextPage: '[Custom] Next page',
+            rangeLabel: '[Custom] Change items per page',
+          },
+        }}
+      />,
+    );
+
+    const navigation = await screen.findByRole('navigation', { name: '[Custom] Pagination' });
+    const paginationDropdown = await screen.findByRole('button', {
+      name: '[Custom] Change items per page',
+    });
+    const previousButtonPage = await screen.findByRole('button', {
+      name: '[Custom] Previous page',
+    });
+    const nextButtonPage = await screen.findByRole('button', { name: '[Custom] Next page' });
+
+    expect(navigation).toBeVisible();
+    expect(paginationDropdown).toBeVisible();
+    expect(previousButtonPage).toBeVisible();
+    expect(nextButtonPage).toBeVisible();
+  });
+
+  describe('selectable', () => {
+    test('renders a summary of the selected items, without reference to the total number of items', () => {
+      const selectedItems = [
         { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
         { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
-      ]}
-      pagination={{
-        currentPage: 1,
-        itemsPerPage: 3,
-        totalItems: 5,
-        itemsPerPageOptions: [3, 5, 10],
-        onItemsPerPageChange,
-        onPageChange,
-        getRangeLabel,
-        label: '[Custom] Pagination',
-        localization: {
-          previousPage: '[Custom] Previous page',
-          nextPage: '[Custom] Next page',
-        },
-      }}
-    />,
-  );
+      ];
 
-  const navigation = await findByRole('navigation', { name: '[Custom] Pagination' });
-  const paginationDropdown = await findByRole('button', { name: '[Custom label] 1-3 of 5' });
-  const previousButtonPage = await findByRole('button', { name: '[Custom] Previous page' });
-  const nextButtonPage = await findByRole('button', { name: '[Custom] Next page' });
+      render(
+        <Table
+          columns={[
+            { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+            { header: 'Name', hash: 'name', render: ({ name }) => name },
+            { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+          ]}
+          itemName="Product"
+          items={[
+            { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+            { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+            { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+            { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+            ...selectedItems,
+          ]}
+          pagination={{
+            currentPage: 1,
+            itemsPerPage: 3,
+            itemsPerPageOptions: [3, 5, 10],
+            onItemsPerPageChange: jest.fn(),
+            onNext: jest.fn(),
+            onPrevious: jest.fn(),
+          }}
+          selectable={{
+            onSelectionChange: jest.fn(),
+            selectedItems,
+          }}
+        />,
+      );
 
-  expect(navigation).toBeVisible();
-  expect(paginationDropdown).toBeVisible();
-  expect(previousButtonPage).toBeVisible();
-  expect(nextButtonPage).toBeVisible();
+      const tableControls = screen.getByTestId('table-controls');
+
+      expect(within(tableControls).queryByText('2/6')).not.toBeInTheDocument();
+      expect(within(tableControls).getByText('2')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('selectable', () => {

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -41,13 +41,15 @@ export interface TableColumn<T> extends TableColumnDisplayProps {
 
 type WithoutMarginProps<T> = Omit<T, keyof MarginProps>;
 
+type StatelessPaginationPropsWithItemTotal = StatelessPaginationProps & { totalItems?: number };
+
 export type DiscriminatedTablePaginationProps =
   | (WithoutMarginProps<OffsetPaginationProps> & { type: 'offset' })
-  | (WithoutMarginProps<StatelessPaginationProps> & { type: 'stateless' });
+  | (WithoutMarginProps<StatelessPaginationPropsWithItemTotal> & { type: 'stateless' });
 
 export type TablePaginationProps =
   | WithoutMarginProps<OffsetPaginationProps>
-  | WithoutMarginProps<StatelessPaginationProps>;
+  | WithoutMarginProps<StatelessPaginationPropsWithItemTotal>;
 
 interface Localization {
   ascendingOrder: string;

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -2,6 +2,7 @@ import { ComponentPropsWithoutRef, ReactNode } from 'react';
 
 import { MarginProps } from '../../helpers';
 import { OffsetPaginationProps } from '../OffsetPagination';
+import { StatelessPaginationProps } from '../StatelessPagination';
 
 import { TableColumnDisplayProps } from './helpers';
 
@@ -38,7 +39,15 @@ export interface TableColumn<T> extends TableColumnDisplayProps {
   withPadding?: boolean;
 }
 
-export type TablePaginationProps = Omit<OffsetPaginationProps, keyof MarginProps>;
+type WithoutMarginProps<T> = Omit<T, keyof MarginProps>;
+
+export type DiscriminatedTablePaginationProps =
+  | (WithoutMarginProps<OffsetPaginationProps> & { type: 'offset' })
+  | (WithoutMarginProps<StatelessPaginationProps> & { type: 'stateless' });
+
+export type TablePaginationProps =
+  | WithoutMarginProps<OffsetPaginationProps>
+  | WithoutMarginProps<StatelessPaginationProps>;
 
 interface Localization {
   ascendingOrder: string;

--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -75,10 +75,11 @@ const InternalActions = <T extends TableItem>({
     <StyledFlex
       alignItems="center"
       aria-controls={tableId}
-      data-testid="table-controls"
+      aria-label="Table Controls"
       flexDirection="row"
       justifyContent="stretch"
       ref={forwardedRef}
+      role="toolbar"
       stickyHeader={stickyHeader}
       {...props}
     >

--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -50,15 +50,15 @@ const InternalActions = <T extends TableItem>({
   ...props
 }: ActionsProps<T>) => {
   const isSelectable = typeof onSelectionChange === 'function';
-  const statelessPagination = pagination?.type === 'stateless';
-  const totalItems = pagination && !statelessPagination ? pagination.totalItems : items.length;
+  const paginationWithoutTotal = pagination && pagination.totalItems === undefined;
+  const totalItems = pagination?.totalItems ?? items.length;
 
   const renderItemName = () => {
     if (typeof itemName !== 'string') {
       return null;
     }
 
-    const text = isSelectable || statelessPagination ? itemName : `${totalItems} ${itemName}`;
+    const text = isSelectable || paginationWithoutTotal ? itemName : `${totalItems} ${itemName}`;
 
     return (
       <FlexItem flexShrink={0} marginRight="medium">
@@ -94,7 +94,7 @@ const InternalActions = <T extends TableItem>({
           selectedItems={selectedItems}
           selectedParentRowsCrossPages={selectedParentRowsCrossPages}
           setSelectedParentRowsCrossPages={setSelectedParentRowsCrossPages}
-          totalItems={!statelessPagination ? totalItems : undefined}
+          totalItems={!paginationWithoutTotal ? totalItems : undefined}
         />
       )}
       {renderItemName()}

--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -6,9 +6,9 @@ import { Text } from '../../Typography';
 import { SelectAll } from '../SelectAll';
 import { TablePagination } from '../TablePagination';
 import {
+  DiscriminatedTablePaginationProps,
   TableExpandable,
   TableItem,
-  TablePaginationProps,
   TableProps,
   TableSelectable,
 } from '../types';
@@ -20,7 +20,7 @@ export interface ActionsProps<T> {
   forwardedRef: RefObject<HTMLDivElement>;
   itemName?: string;
   items: T[];
-  pagination?: TablePaginationProps;
+  pagination?: DiscriminatedTablePaginationProps;
   selectedItems: TableSelectable['selectedItems'];
   stickyHeader?: boolean;
   tableId: string;
@@ -50,14 +50,15 @@ const InternalActions = <T extends TableItem>({
   ...props
 }: ActionsProps<T>) => {
   const isSelectable = typeof onSelectionChange === 'function';
-  const totalItems = pagination ? pagination.totalItems : items.length;
+  const statelessPagination = pagination?.type === 'stateless';
+  const totalItems = pagination && !statelessPagination ? pagination.totalItems : items.length;
 
   const renderItemName = () => {
     if (typeof itemName !== 'string') {
       return null;
     }
 
-    const text = isSelectable ? itemName : `${totalItems} ${itemName}`;
+    const text = isSelectable || statelessPagination ? itemName : `${totalItems} ${itemName}`;
 
     return (
       <FlexItem flexShrink={0} marginRight="medium">
@@ -74,6 +75,7 @@ const InternalActions = <T extends TableItem>({
     <StyledFlex
       alignItems="center"
       aria-controls={tableId}
+      data-testid="table-controls"
       flexDirection="row"
       justifyContent="stretch"
       ref={forwardedRef}
@@ -91,7 +93,7 @@ const InternalActions = <T extends TableItem>({
           selectedItems={selectedItems}
           selectedParentRowsCrossPages={selectedParentRowsCrossPages}
           setSelectedParentRowsCrossPages={setSelectedParentRowsCrossPages}
-          totalItems={totalItems}
+          totalItems={!statelessPagination ? totalItems : undefined}
         />
       )}
       {renderItemName()}

--- a/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
@@ -18,7 +18,7 @@ export interface SelectAllProps<T> {
   items: T[];
   onChange?: TableSelectable['onSelectionChange'];
   selectedItems: TableSelectable['selectedItems'];
-  totalItems: number;
+  totalItems?: number;
   pagination?: TablePaginationProps;
   getRowId: NonNullable<TableProps<T>['getRowId']>;
   setSelectedParentRowsCrossPages: Dispatch<SetStateAction<Set<string>>>;
@@ -32,6 +32,9 @@ export const SelectAll = <T extends TableItem>(props: SelectAllProps<T>) => {
 
   const { totalItems } = props;
 
+  const nonSelectionSummary = totalItems || '';
+  const selectionSummary = totalItems ? `${totalSelectedItems}/${totalItems}` : totalSelectedItems;
+
   return (
     <FlexItem flexShrink={0} marginRight="xxSmall">
       <Flex flexDirection="row">
@@ -43,7 +46,7 @@ export const SelectAll = <T extends TableItem>(props: SelectAllProps<T>) => {
           onChange={handleSelectAll}
         />
         <Text marginLeft="small">
-          {totalSelectedItems === 0 ? `${totalItems}` : `${totalSelectedItems}/${totalItems}`}
+          {totalSelectedItems === 0 ? nonSelectionSummary : selectionSummary}
         </Text>
       </Flex>
     </FlexItem>

--- a/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
@@ -32,7 +32,7 @@ export const SelectAll = <T extends TableItem>(props: SelectAllProps<T>) => {
 
   const { totalItems } = props;
 
-  const nonSelectionSummary = totalItems || '';
+  const nonSelectionSummary = totalItems ?? '';
   const selectionSummary = totalItems ? `${totalSelectedItems}/${totalItems}` : totalSelectedItems;
 
   return (

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useId, useRef, useState } from 'react';
+import React, { memo, useCallback, useId, useMemo, useRef, useState } from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 
 import { MarginProps } from '../../helpers';
@@ -6,6 +6,7 @@ import { typedMemo } from '../../utils';
 
 import { Actions } from './Actions';
 import { Body } from './Body';
+import { discriminatePagination } from './discriminatePagination';
 import { Head } from './Head';
 import { HeaderCell } from './HeaderCell';
 import {
@@ -44,7 +45,7 @@ const InternalTableNext = <T extends TableItem>(
     items,
     keyField = 'id',
     localization = defaultLocalization,
-    pagination,
+    pagination: undiscriminatedPagination,
     selectable,
     sortable,
     stickyHeader,
@@ -60,6 +61,10 @@ const InternalTableNext = <T extends TableItem>(
     ...rest
   } = props;
 
+  const pagination = useMemo(
+    () => undiscriminatedPagination && discriminatePagination(undiscriminatedPagination),
+    [undiscriminatedPagination],
+  );
   const actionsRef = useRef<HTMLDivElement>(null);
   const uniqueTableId = useId();
   const tableIdRef = useRef(id || uniqueTableId);

--- a/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
@@ -1,36 +1,19 @@
 import React, { memo } from 'react';
 
 import { OffsetPagination } from '../../OffsetPagination';
-import { TablePaginationProps } from '../types';
+import { StatelessPagination } from '../../StatelessPagination';
+import { DiscriminatedTablePaginationProps } from '../types';
 
 import { StyledPaginationContainer } from './styled';
 
-export const TablePagination: React.FC<TablePaginationProps> = memo(
-  ({
-    currentPage,
-    itemsPerPage,
-    itemsPerPageOptions,
-    onItemsPerPageChange,
-    onPageChange,
-    totalItems,
-    label,
-    localization,
-    getRangeLabel,
-  }) => {
-    return (
-      <StyledPaginationContainer flexShrink={0}>
-        <OffsetPagination
-          currentPage={currentPage}
-          getRangeLabel={getRangeLabel}
-          itemsPerPage={itemsPerPage}
-          itemsPerPageOptions={itemsPerPageOptions}
-          label={label}
-          localization={localization}
-          onItemsPerPageChange={onItemsPerPageChange}
-          onPageChange={onPageChange}
-          totalItems={totalItems}
-        />
-      </StyledPaginationContainer>
-    );
-  },
-);
+export const TablePagination: React.FC<DiscriminatedTablePaginationProps> = memo((props) => {
+  return (
+    <StyledPaginationContainer flexShrink={0}>
+      {props.type === 'offset' ? (
+        <OffsetPagination {...props} />
+      ) : (
+        <StatelessPagination {...props} />
+      )}
+    </StyledPaginationContainer>
+  );
+});

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -340,8 +340,9 @@ exports[`offset pagination renders a pagination component 1`] = `
 
 <div
   aria-controls=":r12:"
+  aria-label="Table Controls"
   class="c0"
-  data-testid="table-controls"
+  role="toolbar"
 >
   <div
     class="c1 c2 c3"
@@ -1009,8 +1010,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 
 <div
   aria-controls=":r8j:"
+  aria-label="Table Controls"
   class="c0"
-  data-testid="table-controls"
+  role="toolbar"
 >
   <div
     class="c1 c2"
@@ -1304,8 +1306,9 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
 
 <div
   aria-controls=":r99:"
+  aria-label="Table Controls"
   class="c0"
-  data-testid="table-controls"
+  role="toolbar"
 >
   <div
     class="c1 c2"
@@ -1599,8 +1602,9 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
 
 <div
   aria-controls=":rd0:"
+  aria-label="Table Controls"
   class="c0"
-  data-testid="table-controls"
+  role="toolbar"
 >
   <div
     class="c1 c2"

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pagination renders a pagination component 1`] = `
+exports[`offset pagination renders a pagination component 1`] = `
 .c10 {
   vertical-align: middle;
   height: 2rem;
@@ -341,6 +341,7 @@ exports[`pagination renders a pagination component 1`] = `
 <div
   aria-controls=":r12:"
   class="c0"
+  data-testid="table-controls"
 >
   <div
     class="c1 c2 c3"
@@ -1007,8 +1008,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls=":r76:"
+  aria-controls=":r8j:"
   class="c0"
+  data-testid="table-controls"
 >
   <div
     class="c1 c2"
@@ -1021,15 +1023,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r78:"
+          aria-labelledby=":r8l:"
           class="c6 c7"
-          id=":r77:"
+          id=":r8k:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r77:"
+          for=":r8k:"
         >
           <svg
             aria-hidden="true"
@@ -1055,9 +1057,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c12 c13"
-            for=":r77:"
+            for=":r8k:"
             hidden=""
-            id=":r78:"
+            id=":r8l:"
           >
             Select All
           </label>
@@ -1301,8 +1303,9 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
 }
 
 <div
-  aria-controls=":r7s:"
+  aria-controls=":r99:"
   class="c0"
+  data-testid="table-controls"
 >
   <div
     class="c1 c2"
@@ -1315,15 +1318,15 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r7u:"
+          aria-labelledby=":r9b:"
           class="c6 c7"
-          id=":r7t:"
+          id=":r9a:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r7t:"
+          for=":r9a:"
         >
           <svg
             aria-hidden="true"
@@ -1349,9 +1352,9 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
         >
           <label
             class="c12 c13"
-            for=":r7t:"
+            for=":r9a:"
             hidden=""
-            id=":r7u:"
+            id=":r9b:"
           >
             Select All
           </label>
@@ -1595,8 +1598,9 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
 }
 
 <div
-  aria-controls=":rbj:"
+  aria-controls=":rd0:"
   class="c0"
+  data-testid="table-controls"
 >
   <div
     class="c1 c2"
@@ -1609,15 +1613,15 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
       >
         <input
           aria-checked="false"
-          aria-labelledby=":rbl:"
+          aria-labelledby=":rd2:"
           class="c6 c7"
-          id=":rbk:"
+          id=":rd1:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":rbk:"
+          for=":rd1:"
         >
           <svg
             aria-hidden="true"
@@ -1643,9 +1647,9 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
         >
           <label
             class="c12 c13"
-            for=":rbk:"
+            for=":rd1:"
             hidden=""
-            id=":rbl:"
+            id=":rd2:"
           >
             Select All
           </label>

--- a/packages/big-design/src/components/TableNext/discriminatePagination.ts
+++ b/packages/big-design/src/components/TableNext/discriminatePagination.ts
@@ -1,0 +1,17 @@
+import { DiscriminatedTablePaginationProps, TablePaginationProps } from './types';
+
+export const discriminatePagination = (
+  pagination: TablePaginationProps,
+): DiscriminatedTablePaginationProps => {
+  if ('onPageChange' in pagination) {
+    return {
+      type: 'offset' as const,
+      ...pagination,
+    };
+  }
+
+  return {
+    type: 'stateless' as const,
+    ...pagination,
+  };
+};

--- a/packages/big-design/src/components/TableNext/helpers/pagination/index.ts
+++ b/packages/big-design/src/components/TableNext/helpers/pagination/index.ts
@@ -1,7 +1,7 @@
 import { TablePaginationProps } from '../../types';
 
 export function getPagedIndex(index: number, pagination?: TablePaginationProps) {
-  const { currentPage, itemsPerPage } = pagination ?? { currentPage: 1, itemsPerPage: 0 };
+  const { currentPage, itemsPerPage } = { currentPage: 1, itemsPerPage: 0, ...pagination };
 
   return index + (currentPage - 1) * itemsPerPage;
 }

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -803,7 +803,7 @@ describe('stateless pagination', () => {
       await userEvent.click(within(rowOfCanvasLaundryCart).getByRole('checkbox'));
       await userEvent.click(within(rowOfLaundryDetergent).getByRole('checkbox'));
 
-      const tableControls = screen.getByTestId('table-controls');
+      const tableControls = screen.getByRole('toolbar', { name: 'Table Controls' });
 
       expect(within(tableControls).queryByText('2/6')).not.toBeInTheDocument();
       expect(within(tableControls).getByText('2')).toBeInTheDocument();

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -220,7 +220,7 @@ test('renders the total number of items + item name', () => {
   expect(itemNameNode).toBeInTheDocument();
 });
 
-describe('pagination', () => {
+describe('offset pagination', () => {
   test('renders a pagination component', async () => {
     const onItemsPerPageChange = jest.fn();
     const onPageChange = jest.fn();
@@ -683,6 +683,131 @@ describe('pagination', () => {
     const selectedItems = await screen.findByText('3/5');
 
     expect(selectedItems).toBeInTheDocument();
+  });
+});
+
+describe('stateless pagination', () => {
+  test('renders a pagination component', async () => {
+    const onItemsPerPageChange = jest.fn();
+    const onNext = jest.fn();
+
+    render(
+      <TableNext
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={[
+          { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+          { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+          { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+          { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+          { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+        ]}
+        pagination={{
+          currentPage: 1,
+          itemsPerPage: 3,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange,
+          onNext,
+          onPrevious: jest.fn(),
+        }}
+      />,
+    );
+
+    await userEvent.click(await screen.findByTitle('Next page'));
+
+    expect(onNext).toHaveBeenCalled();
+  });
+
+  test('renders a pagination component with custom button labels', async () => {
+    render(
+      <TableNext
+        columns={[
+          { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+          { header: 'Name', hash: 'name', render: ({ name }) => name },
+          { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+        ]}
+        items={[
+          { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+          { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+          { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+          { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+          { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+        ]}
+        pagination={{
+          currentPage: 1,
+          itemsPerPage: 3,
+          itemsPerPageOptions: [3, 5, 10],
+          onItemsPerPageChange: jest.fn(),
+          onNext: jest.fn(),
+          onPrevious: jest.fn(),
+          localization: {
+            label: '[Custom] Pagination',
+            previousPage: '[Custom] Previous page',
+            nextPage: '[Custom] Next page',
+            rangeLabel: '[Custom] Change items per page',
+          },
+        }}
+      />,
+    );
+
+    const navigation = await screen.findByRole('navigation', { name: '[Custom] Pagination' });
+    const paginationDropdown = await screen.findByRole('button', {
+      name: '[Custom] Change items per page',
+    });
+    const previousButtonPage = await screen.findByRole('button', {
+      name: '[Custom] Previous page',
+    });
+    const nextButtonPage = await screen.findByRole('button', { name: '[Custom] Next page' });
+
+    expect(navigation).toBeVisible();
+    expect(paginationDropdown).toBeVisible();
+    expect(previousButtonPage).toBeVisible();
+    expect(nextButtonPage).toBeVisible();
+  });
+
+  describe('selectable', () => {
+    test('renders a summary of the selected items, without reference to the total number of items', async () => {
+      render(
+        <TableNext
+          columns={[
+            { header: 'Sku', hash: 'sku', render: ({ sku }) => sku },
+            { header: 'Name', hash: 'name', render: ({ name }) => name },
+            { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
+          ]}
+          itemName="Product"
+          items={[
+            { sku: 'SM13', name: '[Sample] Smith Journal 13', stock: 25 },
+            { sku: 'DPB', name: '[Sample] Dustpan & Brush', stock: 34 },
+            { sku: 'OFSUC', name: '[Sample] Utility Caddy', stock: 45 },
+            { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
+            { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
+          ]}
+          pagination={{
+            currentPage: 1,
+            itemsPerPage: 3,
+            itemsPerPageOptions: [3, 5, 10],
+            onItemsPerPageChange: jest.fn(),
+            onNext: jest.fn(),
+            onPrevious: jest.fn(),
+          }}
+          selectable={{ selectedItems: {}, onSelectionChange: jest.fn() }}
+        />,
+      );
+
+      const rowOfCanvasLaundryCart = screen.getByRole('row', { name: /Canvas Laundry Cart/ });
+      const rowOfLaundryDetergent = screen.getByRole('row', { name: /Laundry Detergent/ });
+
+      await userEvent.click(within(rowOfCanvasLaundryCart).getByRole('checkbox'));
+      await userEvent.click(within(rowOfLaundryDetergent).getByRole('checkbox'));
+
+      const tableControls = screen.getByTestId('table-controls');
+
+      expect(within(tableControls).queryByText('2/6')).not.toBeInTheDocument();
+      expect(within(tableControls).getByText('2')).toBeInTheDocument();
+    });
   });
 });
 

--- a/packages/big-design/src/components/TableNext/types.ts
+++ b/packages/big-design/src/components/TableNext/types.ts
@@ -57,13 +57,15 @@ export interface TableColumn<T> extends TableColumnDisplayProps {
 
 type WithoutMarginProps<T> = Omit<T, keyof MarginProps>;
 
+type StatelessPaginationPropsWithItemTotal = StatelessPaginationProps & { totalItems?: number };
+
 export type DiscriminatedTablePaginationProps =
   | (WithoutMarginProps<OffsetPaginationProps> & { type: 'offset' })
-  | (WithoutMarginProps<StatelessPaginationProps> & { type: 'stateless' });
+  | (WithoutMarginProps<StatelessPaginationPropsWithItemTotal> & { type: 'stateless' });
 
 export type TablePaginationProps =
   | WithoutMarginProps<OffsetPaginationProps>
-  | WithoutMarginProps<StatelessPaginationProps>;
+  | WithoutMarginProps<StatelessPaginationPropsWithItemTotal>;
 
 interface Localization {
   ascendingOrder: string;

--- a/packages/big-design/src/components/TableNext/types.ts
+++ b/packages/big-design/src/components/TableNext/types.ts
@@ -2,6 +2,7 @@ import React, { ComponentPropsWithoutRef, ReactNode } from 'react';
 
 import { MarginProps } from '../../helpers';
 import { OffsetPaginationProps } from '../OffsetPagination';
+import { StatelessPaginationProps } from '../StatelessPagination';
 
 import { TableColumnDisplayProps } from './helpers';
 
@@ -54,7 +55,15 @@ export interface TableColumn<T> extends TableColumnDisplayProps {
   withPadding?: boolean;
 }
 
-export type TablePaginationProps = Omit<OffsetPaginationProps, keyof MarginProps>;
+type WithoutMarginProps<T> = Omit<T, keyof MarginProps>;
+
+export type DiscriminatedTablePaginationProps =
+  | (WithoutMarginProps<OffsetPaginationProps> & { type: 'offset' })
+  | (WithoutMarginProps<StatelessPaginationProps> & { type: 'stateless' });
+
+export type TablePaginationProps =
+  | WithoutMarginProps<OffsetPaginationProps>
+  | WithoutMarginProps<StatelessPaginationProps>;
 
 interface Localization {
   ascendingOrder: string;

--- a/packages/docs/PropTables/TablePropTable.tsx
+++ b/packages/docs/PropTables/TablePropTable.tsx
@@ -45,8 +45,15 @@ const tableProps: Prop[] = [
   },
   {
     name: 'pagination',
-    types: <NextLink href="/offset-pagination">OffsetPagination</NextLink>,
-    description: 'See offset pagination component for details.',
+    types: [
+      <NextLink href="/offset-pagination" key="offset">
+        OffsetPagination
+      </NextLink>,
+      <NextLink href="/stateless-pagination" key="stateless">
+        StatelessPagination
+      </NextLink>,
+    ],
+    description: 'See the specific pagination components for details.',
   },
   {
     name: 'selectable',

--- a/packages/docs/next-env.d.ts
+++ b/packages/docs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/packages/docs/pages/table.tsx
+++ b/packages/docs/pages/table.tsx
@@ -135,10 +135,10 @@ const TablePage = () => {
               ),
             },
             {
-              id: 'pagination',
-              title: 'Pagination',
+              id: 'offset-pagination',
+              title: 'OffsetPagination',
               render: () => (
-                <CodePreview key="pagination" scope={{ data, columns }}>
+                <CodePreview key="offset-pagination" scope={{ data, columns }}>
                   {/* jsx-to-string:start */}
                   {function Example() {
                     const [currentPage, setCurrentPage] = useState(1);
@@ -172,6 +172,62 @@ const TablePage = () => {
                           itemsPerPageOptions,
                           onItemsPerPageChange,
                           itemsPerPage,
+                        }}
+                        stickyHeader
+                      />
+                    );
+                  }}
+                  {/* jsx-to-string:end */}
+                </CodePreview>
+              ),
+            },
+            {
+              id: 'stateless-pagination',
+              title: 'StatelessPagination',
+              render: () => (
+                <CodePreview key="stateless-pagination" scope={{ data, columns }}>
+                  {/* jsx-to-string:start */}
+                  {function Example() {
+                    const [currentPage, setCurrentPage] = useState(1);
+                    const [itemsPerPageOptions] = useState([5, 10, 20, 30]);
+                    const [itemsPerPage, setItemsPerPage] = useState(5);
+                    const [currentItems, setCurrentItems] = useState<Item[]>([]);
+
+                    const onItemsPerPageChange = (newRange) => {
+                      setCurrentPage(1);
+                      setItemsPerPage(newRange);
+                    };
+
+                    useEffect(() => {
+                      const maxItems = currentPage * itemsPerPage;
+                      const lastItem = Math.min(maxItems, data.length);
+                      const firstItem = Math.max(0, maxItems - itemsPerPage);
+
+                      setCurrentItems(data.slice(firstItem, lastItem));
+                    }, [currentPage, itemsPerPage]);
+
+                    const notFirstPage = currentPage !== 1;
+                    const onPrevious = notFirstPage
+                      ? () => setCurrentPage((currentPage) => currentPage - 1)
+                      : undefined;
+
+                    const notLastPage = currentPage < data.length / itemsPerPage;
+                    const onNext = notLastPage
+                      ? () => setCurrentPage((currentPage) => currentPage + 1)
+                      : undefined;
+
+                    return (
+                      <Table
+                        columns={columns}
+                        itemName="Products"
+                        items={currentItems}
+                        keyField="sku"
+                        pagination={{
+                          itemsPerPage,
+                          itemsPerPageOptions,
+                          onItemsPerPageChange,
+                          onNext,
+                          onPrevious,
                         }}
                         stickyHeader
                       />


### PR DESCRIPTION
**N.B.**

- best read with `Hide whitespace` enabled as some nesting/spacing has changed
- the duplication across `Table` and `TableNext` is intentional and required
  - the long term plan is to eventually move everyone to `TableNext`, duplication prevents entanglement

## What?

- Enable our `Table` component to make use of `StatelessPagination`
- Additive change where a `Table`'s pagination prop can be either those of `OffsetPagination` _or_ `StatelessPagination`
  - the developer adheres to either signature, which is then discriminated within the `Table` component

## Why?

- Allows `Table` consumers to make use of cursor-based, or more opinionated, versions of pagination 

## Screenshots/Screen Recordings

### New `Stateless` example with the `Table` docs

https://github.com/user-attachments/assets/2aed49d0-1783-483e-b73c-344f10583f3a


### Selection behaviour differences between the pagination types
(the examples used in the video were _not_ added to this PR for brevity within the docs)


https://github.com/user-attachments/assets/6d76758e-6ba2-4c16-9e95-6b2ca5acc786



## Testing/Proof

- New tests within `Table` and `TableNext`
- Unchanged, passing tests within `Table` and `TableNext` proving current features are unaffected 
