### PR TITLE
fix(component): remove vertical margin for collapse button

### DIFF
--- a/.changeset/beige-lemons-sin.md
+++ b/.changeset/beige-lemons-sin.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design': patch
+'@bigcommerce/docs': patch
+---
+
+Remove vertical margin for collapse button

--- a/packages/big-design/src/components/Collapse/Collapse.tsx
+++ b/packages/big-design/src/components/Collapse/Collapse.tsx
@@ -40,7 +40,6 @@ export const Collapse: React.FC<CollapseProps> = ({
         iconRight={<ExpandMoreIcon title={title} />}
         id={triggerId}
         isOpen={isOpen}
-        marginVertical="small"
         onClick={handleTitleClick}
         type="button"
         variant="subtle"


### PR DESCRIPTION
## What?
Remove vertical margin for collapse button

## Why?
With the margin built in, the component is less flexible to use. Margin can be easily added back with a wrapping container

## Screenshots/Screen Recordings
Before margin is removed:
<img width="1434" alt="Screenshot 2024-12-27 at 11 57 33 AM" src="https://github.com/user-attachments/assets/a5899485-c489-4ba7-8781-5d9321f9e216" />

<img width="1441" alt="Screenshot 2024-12-27 at 12 20 39 PM" src="https://github.com/user-attachments/assets/49ebe7db-1fd8-45de-9220-a7933e9bd2aa" />



With margin removed:
<img width="1438" alt="Screenshot 2024-12-27 at 12 06 56 PM" src="https://github.com/user-attachments/assets/4658064b-fe97-41d0-8d8a-cfaad004a8dd" />


## Testing/Proof
Added above
