### PR TITLE
fix(component): add conditional rendering for tree component

### DIFF
--- a/.changeset/five-monkeys-provide.md
+++ b/.changeset/five-monkeys-provide.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+fix(component): add conditional rendering for tree component

--- a/packages/big-design/src/components/StatefulTree/spec.tsx
+++ b/packages/big-design/src/components/StatefulTree/spec.tsx
@@ -40,23 +40,27 @@ const nodes: Array<TreeNodeProps<number>> = [
   },
 ];
 
+const parentNodes = ['0', '1', '3', '4', '5'];
+
 const getSimpleTree = (props: Partial<StatefulTreeProps<number>> = {}) => (
   <StatefulTree nodes={nodes} {...props} />
 );
 
 test('renders non-selectable Tree by default', () => {
-  const { container, getAllByRole } = render(getSimpleTree());
+  const { container, getAllByRole } = render(getSimpleTree({ defaultExpanded: parentNodes }));
 
   expect(container.querySelectorAll('label')).toHaveLength(0);
-  expect(getAllByRole('treeitem', { hidden: true })).toHaveLength(10);
+  expect(getAllByRole('treeitem')).toHaveLength(10);
 });
 
 test('defaultExpanded items are expanded by default', () => {
-  const { getAllByRole, getByText } = render(getSimpleTree({ defaultExpanded: ['0'] }));
+  const { getAllByRole, getByText, queryByText } = render(
+    getSimpleTree({ defaultExpanded: ['0'] }),
+  );
 
   expect(getAllByRole('treeitem')).toHaveLength(6);
   expect(getByText('Test Node 5')).toBeVisible();
-  expect(getByText('Test Node 6')).not.toBeVisible();
+  expect(queryByText('Test Node 6')).toBeNull();
 });
 
 test('onExpandedChange gets called when an item expansion happens', () => {
@@ -83,7 +87,9 @@ test('onNodeClick gets called when an item click happens', () => {
 
 describe('selectable = multi', () => {
   test('renders nodes with checkboxes', () => {
-    const { container } = render(getSimpleTree({ selectable: 'multi' }));
+    const { container } = render(
+      getSimpleTree({ selectable: 'multi', defaultExpanded: parentNodes }),
+    );
 
     const checkboxes = container.querySelectorAll('label');
 
@@ -92,7 +98,9 @@ describe('selectable = multi', () => {
   });
 
   test('no items are selected by default', () => {
-    const { container } = render(getSimpleTree({ selectable: 'multi' }));
+    const { container } = render(
+      getSimpleTree({ selectable: 'multi', defaultExpanded: parentNodes }),
+    );
 
     const checkboxes = container.querySelectorAll('label');
 
@@ -105,7 +113,11 @@ describe('selectable = multi', () => {
 
   test('defaultSelected items are selected by default', () => {
     const { container } = render(
-      getSimpleTree({ selectable: 'multi', defaultSelected: ['0', '6'] }),
+      getSimpleTree({
+        selectable: 'multi',
+        defaultSelected: ['0', '6'],
+        defaultExpanded: parentNodes,
+      }),
     );
 
     const selectedNodes = container.querySelectorAll('[aria-selected="true"]');
@@ -131,7 +143,9 @@ describe('selectable = multi', () => {
 
 describe('selectable = radio', () => {
   test('renders nodes with radios', () => {
-    const { container } = render(getSimpleTree({ selectable: 'radio' }));
+    const { container } = render(
+      getSimpleTree({ selectable: 'radio', defaultExpanded: parentNodes }),
+    );
 
     const checkboxes = container.querySelectorAll('label');
 
@@ -140,7 +154,9 @@ describe('selectable = radio', () => {
   });
 
   test('first selectable item is selected by default', () => {
-    const { container } = render(getSimpleTree({ selectable: 'radio' }));
+    const { container } = render(
+      getSimpleTree({ selectable: 'radio', defaultExpanded: parentNodes }),
+    );
 
     const selectedNode = container.querySelector('[aria-selected="true"]');
     const deselectedNodes = container.querySelectorAll('[aria-selected="false"]');
@@ -150,7 +166,9 @@ describe('selectable = radio', () => {
   });
 
   test('defaultSelected item is selected by default', () => {
-    const { container } = render(getSimpleTree({ selectable: 'radio', defaultSelected: ['2'] }));
+    const { container } = render(
+      getSimpleTree({ selectable: 'radio', defaultSelected: ['2'], defaultExpanded: parentNodes }),
+    );
 
     const selectedNode = container.querySelector('[aria-selected="true"]');
     const deselectedNodes = container.querySelectorAll('[aria-selected="false"]');
@@ -162,7 +180,11 @@ describe('selectable = radio', () => {
 
   test('first defaultSelected item is selected by default from list', () => {
     const { container } = render(
-      getSimpleTree({ selectable: 'radio', defaultSelected: ['2', '6'] }),
+      getSimpleTree({
+        selectable: 'radio',
+        defaultSelected: ['2', '6'],
+        defaultExpanded: parentNodes,
+      }),
     );
 
     const selectedNode = container.querySelector('[aria-selected="true"]');

--- a/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
@@ -145,8 +145,9 @@ const InternalTreeNode = <T,>({
 
   const renderedChildren = useMemo(
     () =>
-      children && (
-        <StyledUl role="group" show={isExpanded}>
+      children &&
+      isExpanded && (
+        <StyledUl role="group">
           {children.map((child, index) => (
             <TreeNode {...child} key={index} />
           ))}

--- a/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders simple tree 1`] = `
 <ul
   aria-multiselectable="false"
-  class="styled__StyledUl-sc-e29d38cf-0 geBXdY"
+  class="styled__StyledUl-sc-3526f150-0 jXgIr"
   role="tree"
   style="overflow: hidden;"
 >
@@ -70,123 +70,6 @@ exports[`renders simple tree 1`] = `
         Test Node 0
       </span>
     </div>
-    <ul
-      class="styled__StyledUl-sc-e29d38cf-0 iCwCEx"
-      role="group"
-    >
-      <li
-        aria-expanded="false"
-        class="styled__StyledLi-sc-912cb84-0 ddOgUf"
-        role="treeitem"
-        tabindex="-1"
-      >
-        <div
-          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
-        >
-          <div
-            class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledArrowWrapper-sc-912cb84-1 lpeGLF"
-          >
-            <svg
-              aria-hidden="true"
-              class="base__StyledIcon-sc-a9u0e1-0 PHcub"
-              color="secondary60"
-              fill="currentColor"
-              focusable="false"
-              height="24"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M0 0h24v24H0z"
-                fill="none"
-              />
-              <path
-                d="M9.29 6.71a.996.996 0 0 0 0 1.41L13.17 12l-3.88 3.88a.996.996 0 1 0 1.41 1.41l4.59-4.59a.996.996 0 0 0 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01"
-              />
-            </svg>
-          </div>
-          <div
-            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
-          >
-            <svg
-              aria-hidden="true"
-              class="base__StyledIcon-sc-a9u0e1-0 cjbLvM"
-              color="primary30"
-              fill="currentColor"
-              height="24"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M0 0h24v24H0z"
-                fill="none"
-              />
-              <path
-                d="M10.59 4.59C10.21 4.21 9.7 4 9.17 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8z"
-              />
-            </svg>
-          </div>
-          <span
-            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
-            color="secondary70"
-          >
-            Test Node 5
-          </span>
-        </div>
-        <ul
-          class="styled__StyledUl-sc-e29d38cf-0 iCwCEx"
-          role="group"
-        >
-          <li
-            aria-expanded="false"
-            class="styled__StyledLi-sc-912cb84-0 ddOgUf"
-            role="treeitem"
-            tabindex="-1"
-          >
-            <div
-              class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
-            >
-              <div
-                class="styled__StyledGap-sc-912cb84-5 jrVihD"
-              />
-              <div
-                class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 cjbLvM"
-                  color="primary30"
-                  fill="currentColor"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M10.59 4.59C10.21 4.21 9.7 4 9.17 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8z"
-                  />
-                </svg>
-              </div>
-              <span
-                class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
-                color="secondary70"
-              >
-                Test Node 9
-              </span>
-            </div>
-          </li>
-        </ul>
-      </li>
-    </ul>
   </li>
   <li
     aria-expanded="false"
@@ -251,54 +134,6 @@ exports[`renders simple tree 1`] = `
         Test Node 1
       </span>
     </div>
-    <ul
-      class="styled__StyledUl-sc-e29d38cf-0 iCwCEx"
-      role="group"
-    >
-      <li
-        aria-expanded="false"
-        class="styled__StyledLi-sc-912cb84-0 ddOgUf"
-        role="treeitem"
-        tabindex="-1"
-      >
-        <div
-          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
-        >
-          <div
-            class="styled__StyledGap-sc-912cb84-5 jrVihD"
-          />
-          <div
-            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
-          >
-            <svg
-              aria-hidden="true"
-              class="base__StyledIcon-sc-a9u0e1-0 cjbLvM"
-              color="primary30"
-              fill="currentColor"
-              height="24"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M0 0h24v24H0z"
-                fill="none"
-              />
-              <path
-                d="M10.59 4.59C10.21 4.21 9.7 4 9.17 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8z"
-              />
-            </svg>
-          </div>
-          <span
-            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
-            color="secondary70"
-          >
-            Test Node 6
-          </span>
-        </div>
-      </li>
-    </ul>
   </li>
   <li
     aria-expanded="false"
@@ -406,54 +241,6 @@ exports[`renders simple tree 1`] = `
         Test Node 3
       </span>
     </div>
-    <ul
-      class="styled__StyledUl-sc-e29d38cf-0 iCwCEx"
-      role="group"
-    >
-      <li
-        aria-expanded="false"
-        class="styled__StyledLi-sc-912cb84-0 ddOgUf"
-        role="treeitem"
-        tabindex="-1"
-      >
-        <div
-          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
-        >
-          <div
-            class="styled__StyledGap-sc-912cb84-5 jrVihD"
-          />
-          <div
-            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
-          >
-            <svg
-              aria-hidden="true"
-              class="base__StyledIcon-sc-a9u0e1-0 cjbLvM"
-              color="primary30"
-              fill="currentColor"
-              height="24"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M0 0h24v24H0z"
-                fill="none"
-              />
-              <path
-                d="M10.59 4.59C10.21 4.21 9.7 4 9.17 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8z"
-              />
-            </svg>
-          </div>
-          <span
-            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
-            color="secondary70"
-          >
-            Test Node 7
-          </span>
-        </div>
-      </li>
-    </ul>
   </li>
   <li
     aria-expanded="false"
@@ -518,54 +305,6 @@ exports[`renders simple tree 1`] = `
         Test Node 4
       </span>
     </div>
-    <ul
-      class="styled__StyledUl-sc-e29d38cf-0 iCwCEx"
-      role="group"
-    >
-      <li
-        aria-expanded="false"
-        class="styled__StyledLi-sc-912cb84-0 ddOgUf"
-        role="treeitem"
-        tabindex="-1"
-      >
-        <div
-          class="styled__StyledBox-sc-12d4dbf-0 imudcb styled__StyledFlex-sc-3a1154b6-0 dNPsOo styled__StyledFlex-sc-912cb84-3 gknWxS"
-        >
-          <div
-            class="styled__StyledGap-sc-912cb84-5 jrVihD"
-          />
-          <div
-            class="styled__StyledBox-sc-12d4dbf-0 jlecRx styled__StyledFlexItem-sc-2b88929e-0 jCGHbT styled__StyledFlexItem-sc-912cb84-4 eopNjs"
-          >
-            <svg
-              aria-hidden="true"
-              class="base__StyledIcon-sc-a9u0e1-0 cjbLvM"
-              color="primary30"
-              fill="currentColor"
-              height="24"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M0 0h24v24H0z"
-                fill="none"
-              />
-              <path
-                d="M10.59 4.59C10.21 4.21 9.7 4 9.17 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8z"
-              />
-            </svg>
-          </div>
-          <span
-            class="styled__StyledText-sc-218b28a9-5 styled__StyledText-sc-912cb84-6 ffENPD ebpimB"
-            color="secondary70"
-          >
-            Test Node 8
-          </span>
-        </div>
-      </li>
-    </ul>
   </li>
 </ul>
 `;

--- a/packages/big-design/src/components/Tree/spec.tsx
+++ b/packages/big-design/src/components/Tree/spec.tsx
@@ -199,11 +199,11 @@ test('renders expanded nodes', () => {
   });
 
   const node5 = screen.getByText('Test Node 5');
-  const node6 = screen.getByText('Test Node 6');
+  const node6 = screen.queryByText('Test Node 6');
   const node9 = screen.getByText('Test Node 9');
 
   expect(node5).toBeVisible();
-  expect(node6).not.toBeVisible();
+  expect(node6).toBeNull();
   expect(node9).toBeVisible();
 });
 

--- a/packages/big-design/src/components/Tree/styled.ts
+++ b/packages/big-design/src/components/Tree/styled.ts
@@ -1,5 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 export const StyledUl = styled.ul<{ show?: boolean }>`
   list-style-type: none;
@@ -11,12 +11,6 @@ export const StyledUl = styled.ul<{ show?: boolean }>`
     padding-left: ${({ theme }) =>
       theme.helpers.addValues(theme.spacing.xLarge, theme.spacing.xxSmall)};
   }
-
-  ${({ show }) =>
-    show === false &&
-    css`
-      display: none;
-    `}
 `;
 
 StyledUl.defaultProps = { theme: defaultTheme };


### PR DESCRIPTION
## What?
- Add `conditional rendering` for the `TreeNode` instead of display: none to improve initial rendering performance;
- Regenerate snapshots
- Fix `Tree` tests according to the new changes.

## Why?
Browser can't handle big tree structure on initial rendering.

## Screenshots/Screen Recordings
No UI changes.

## Testing/Proof
Existing tests + updated tests.
