### PR TITLE
fix(patterns): override consective button margins

### DIFF
--- a/.changeset/rotten-boxes-drum.md
+++ b/.changeset/rotten-boxes-drum.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design-patterns': patch
+'@bigcommerce/docs': patch
+---
+
+Overrides the consecutive button margins within the page header component. The flex wrapper should handle the gap between the buttons.

--- a/packages/big-design-patterns/src/components/Header/Header.tsx
+++ b/packages/big-design-patterns/src/components/Header/Header.tsx
@@ -16,7 +16,7 @@ import React, { ComponentPropsWithoutRef, isValidElement, memo, ReactNode } from
 
 import { warning } from '../../utils';
 
-import { StyledBackLink } from './styled';
+import { StyledActionsWrapper, StyledBackLink } from './styled';
 
 interface BackLinkProps extends ComponentPropsWithoutRef<'a'> {
   text: string;
@@ -149,13 +149,13 @@ export const Header = memo(
             <Description description={description} />
           </FlexItem>
           {actions ? (
-            <Flex
+            <StyledActionsWrapper
               flexDirection={{ mobile: 'column-reverse', tablet: 'row-reverse' }}
               flexGap={{ mobile: '.75rem', tablet: '0.625rem' }}
               marginBottom="xLarge"
             >
               <Actions actions={actions} />
-            </Flex>
+            </StyledActionsWrapper>
           ) : null}
         </Flex>
       </Flex>

--- a/packages/big-design-patterns/src/components/Header/styled.tsx
+++ b/packages/big-design-patterns/src/components/Header/styled.tsx
@@ -1,3 +1,4 @@
+import { Flex } from '@bigcommerce/big-design';
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
@@ -18,5 +19,12 @@ export const StyledBackLink = styled.a.attrs({ theme: defaultTheme })`
 
   &:focus {
     outline: 4px solid ${({ theme }) => theme.colors.primary20};
+  }
+`;
+
+export const StyledActionsWrapper = styled(Flex).attrs({ theme: defaultTheme })`
+  & > .bd-button + .bd-button {
+    margin-block-start ${({ theme }) => theme.spacing.none};
+    margin-inline-start: ${({ theme }) => theme.spacing.none};
   }
 `;

--- a/packages/docs/next-env.d.ts
+++ b/packages/docs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What?

Overrides the consecutive button margins.

## Why?

These margins were causing inconsistent spacing within the page header component when using consecutive buttons.

## Screenshots/Screen Recordings

See testing below.

## Testing/Proof

Desktop:
![Screenshot 2025-03-03 at 11 28 11](https://github.com/user-attachments/assets/bb538dd3-fcc0-4d7a-b438-f50ca88d8e7d)

Mobile:
![Screenshot 2025-03-03 at 11 28 18](https://github.com/user-attachments/assets/532ae393-333b-4742-b08b-df2655d0dbf0)

