### PR TITLE
fix(component): active filters not maintained on StatefulTable

### DIFF
--- a/.changeset/twenty-lemons-obey.md
+++ b/.changeset/twenty-lemons-obey.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design': patch
+---
+
+Fix a bug in the StatefulTable component where filtered rows were not preserved when changing the number of rows.  
+

--- a/packages/big-design/src/components/StatefulTable/reducer.ts
+++ b/packages/big-design/src/components/StatefulTable/reducer.ts
@@ -144,7 +144,9 @@ export const createReducer =
       case 'ITEMS_PER_PAGE_CHANGE': {
         const currentPage = 1;
         const itemsPerPage = action.itemsPerPage;
-        const currentItems = getItems(state.items, true, {
+        const hasActivePills = state.activePills.length > 0 || !!state.searchValue;
+        const items = hasActivePills ? state.filteredItems : state.items;
+        const currentItems = getItems(items, true, {
           currentPage,
           itemsPerPage,
         });

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import React from 'react';
 import 'jest-styled-components';
 
@@ -472,6 +473,31 @@ test('can undo stacked filter actions', async () => {
   rows = await findAllByRole('row');
 
   expect(rows).toHaveLength(105);
+});
+
+test('maintains filtered state when pagination is enabled', async () => {
+  const filters: StatefulTablePillTabFilter<TestItem> = {
+    pillTabs: [{ title: 'Low stock', id: 'in_stock' }],
+    filter: (_itemId, items) => items.filter((item) => item.stock < 5),
+  };
+  const { findByText, findAllByRole } = render(getSimpleTable({ filters, pagination: true }));
+
+  let rows = await findAllByRole('row');
+  expect(rows).toHaveLength(26);
+
+  // Click on filter pill
+  const filterPill = await findByText('Low stock');
+  fireEvent.click(filterPill);
+
+  rows = await findAllByRole('row');
+  expect(rows).toHaveLength(5);
+
+  const itemsPerPageButton = await findByText('1 - 4 of 4');
+  fireEvent.click(itemsPerPageButton);
+  await userEvent.keyboard('{ArrowDown}{Enter}');
+
+  rows = await findAllByRole('row');
+  expect(rows).toHaveLength(5);
 });
 
 describe('test search in the StatefulTable', () => {

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -483,20 +483,25 @@ test('maintains filtered state when pagination is enabled', async () => {
   const { findByText, findAllByRole } = render(getSimpleTable({ filters, pagination: true }));
 
   let rows = await findAllByRole('row');
+
   expect(rows).toHaveLength(26);
 
   // Click on filter pill
   const filterPill = await findByText('Low stock');
+
   fireEvent.click(filterPill);
 
   rows = await findAllByRole('row');
+
   expect(rows).toHaveLength(5);
 
   const itemsPerPageButton = await findByText('1 - 4 of 4');
+
   fireEvent.click(itemsPerPageButton);
   await userEvent.keyboard('{ArrowDown}{Enter}');
 
   rows = await findAllByRole('row');
+
   expect(rows).toHaveLength(5);
 });
 

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -557,29 +557,26 @@ describe('test search in the StatefulTable', () => {
       pillTabs: [{ title: 'Low stock', id: 'low_stock' }],
       filter: (_itemId, items) => items.filter((item) => item.stock !== 0 && item.stock < 10),
     };
-    const { findByText, findAllByRole, getByPlaceholderText, getByText } = render(
-      getSimpleTable({ filters, pagination: true, search: true }),
-    );
+
+    render(getSimpleTable({ filters, pagination: true, search: true }));
 
     // Click on filter pill
-    fireEvent.click(getByText('Low stock'));
+    await userEvent.click(screen.getByText('Low stock'));
 
     // Add search term
-    const input = getByPlaceholderText('Search');
+    await userEvent.type(screen.getByPlaceholderText('Search'), 'Product B');
+    await userEvent.click(screen.getByText('Search'));
 
-    fireEvent.change(input, { target: { value: 'Product B' } });
-    fireEvent.click(getByText('Search'));
-
-    let rows = await findAllByRole('row');
+    let rows = await screen.findAllByRole('row');
 
     expect(rows).toHaveLength(2);
 
-    const itemsPerPageButton = await findByText('1 of 1');
+    const itemsPerPageButton = await screen.findByText('1 of 1');
 
-    fireEvent.click(itemsPerPageButton);
+    await userEvent.click(itemsPerPageButton);
     await userEvent.keyboard('{ArrowDown}{Enter}');
 
-    rows = await findAllByRole('row');
+    rows = await screen.findAllByRole('row');
 
     expect(rows).toHaveLength(2);
   });
@@ -590,46 +587,42 @@ describe('test search in the StatefulTable', () => {
       filter: (_itemId, items) => items.filter((item) => item.stock < 5),
     };
 
-    const { findByText, findAllByRole, getByText } = render(
-      getSimpleTable({ filters, pagination: true }),
-    );
+    render(getSimpleTable({ filters, pagination: true }));
 
     // Click on filter pill
-    fireEvent.click(getByText('Low stock'));
+    await userEvent.click(screen.getByText('Low stock'));
 
-    let rows = await findAllByRole('row');
+    let rows = await screen.findAllByRole('row');
 
     expect(rows).toHaveLength(5);
 
-    const itemsPerPageButton = await findByText('1 - 4 of 4');
+    const itemsPerPageButton = await screen.findByText('1 - 4 of 4');
 
-    fireEvent.click(itemsPerPageButton);
+    await userEvent.click(itemsPerPageButton);
     await userEvent.keyboard('{ArrowDown}{Enter}');
 
-    rows = await findAllByRole('row');
+    rows = await screen.findAllByRole('row');
 
     expect(rows).toHaveLength(5);
   });
 
   test('maintains filtered state when only search is active & items per page is changed', async () => {
-    const { findAllByRole, getByPlaceholderText, getByText, findByText } = render(
-      getSimpleTable({ search: true, pagination: true }),
-    );
-    const input = getByPlaceholderText('Search');
+    render(getSimpleTable({ search: true, pagination: true }));
 
-    fireEvent.change(input, { target: { value: 'Product B' } });
-    fireEvent.click(getByText('Search'));
+    await userEvent.type(screen.getByPlaceholderText('Search'), 'Product B');
 
-    let rows = await findAllByRole('row');
+    await userEvent.click(screen.getByText('Search'));
+
+    let rows = await screen.findAllByRole('row');
 
     expect(rows).toHaveLength(5);
 
-    const itemsPerPageButton = await findByText('1 - 4 of 4');
+    const itemsPerPageButton = await screen.findByText('1 - 4 of 4');
 
-    fireEvent.click(itemsPerPageButton);
+    await userEvent.click(itemsPerPageButton);
     await userEvent.keyboard('{ArrowDown}{Enter}');
 
-    rows = await findAllByRole('row');
+    rows = await screen.findAllByRole('row');
 
     expect(rows).toHaveLength(5);
   });


### PR DESCRIPTION
## What?

Fix StatefulTable component on items per page change

## Why?

This PR is to address the issue where the active filtered rows or search results are not maintained when the items per page changes. 

https://github.com/user-attachments/assets/d3c25f8d-1e67-4a14-bacf-1c0c19bccd19

## Screenshots/Screen Recordings

https://github.com/user-attachments/assets/8b57bcad-0f7e-45b4-8663-57b655af70ae

## Testing/Proof

- Added new test case to check if the number of filtered rows are maintained
- Successful build on local env (check recording above)  

- <details>
	<summary>Test results</summary>

	![Screenshot 2025-04-09 at 3 21 25 PM](https://github.com/user-attachments/assets/8bae8742-e214-4acc-b1e9-88ee8e6ac01b)
	![Screenshot 2025-04-09 at 3 21 09 PM](https://github.com/user-attachments/assets/d3676632-a9f1-4537-be28-26a2d568e08b)

	</details>