### PR TITLE
Simplify PillTab component implementation (refactoring only)

### DIFF
--- a/.changeset/pretty-crabs-tease.md
+++ b/.changeset/pretty-crabs-tease.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design': patch
+---
+
+PillTabs implementation refactor

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -22,7 +22,6 @@ export interface PillTabsProps {
 export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillClick }) => {
   const parentRef = createRef<HTMLDivElement>();
   const dropdownRef = createRef<HTMLDivElement>();
-  const [isMenuVisible, setIsMenuVisible] = useState(false);
   const [pillsState, setPillsState] = useState(
     items.map((item) => ({
       isVisible: true,
@@ -30,6 +29,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       ref: createRef<HTMLDivElement>(),
     })),
   );
+  const isMenuVisible = pillsState.some(({ isVisible }) => !isVisible);
 
   const hideOverflowedPills = useCallback(() => {
     const parentWidth = parentRef.current?.offsetWidth;
@@ -67,7 +67,6 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     const newVisiblePills = newState.filter((stateObj) => stateObj.isVisible);
 
     if (visiblePills.length !== newVisiblePills.length) {
-      setIsMenuVisible(newVisiblePills.length !== items.length);
       setPillsState(newState);
     }
   }, [items, parentRef, dropdownRef, pillsState]);

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -60,16 +60,13 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
   const isMenuVisible = pills.some(({ isVisible }) => !isVisible);
 
   const dropdownItems = pills
-    .filter((stateObj) => !stateObj.isVisible)
-    .map((stateObj) => {
-      const item = items.find(({ title }) => title === stateObj.title);
-      const isActive = item ? activePills.includes(item.id) : false;
-
+    .filter((pill) => !pill.isVisible)
+    .map((pill) => {
       return {
-        content: stateObj.title,
-        onItemClick: () => onPillClick(stateObj.id),
-        hash: stateObj.title.toLowerCase(),
-        icon: isActive ? <CheckIcon /> : undefined,
+        content: pill.title,
+        onItemClick: () => onPillClick(pill.id),
+        hash: pill.title.toLowerCase(),
+        icon: activePills.includes(pill.id) ? <CheckIcon /> : undefined,
       };
     });
 
@@ -77,7 +74,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
 
   useWindowResizeListener(updateAvailableWidth);
 
-  if (items.length === 0) {
+  if (pills.length === 0) {
     return null;
   }
 
@@ -89,13 +86,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       ref={parentRef}
       role="list"
     >
-      {items.map((item, index) => {
-        const pill = pills[index];
-
-        if (!pill) {
-          return;
-        }
-
+      {pills.map((pill, index) => {
         return (
           <StyledFlexItem
             data-testid={`pilltabs-pill-${index}`}
@@ -106,13 +97,13 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
           >
             <StyledPillTab
               disabled={!pill.isVisible}
-              isActive={activePills.includes(item.id)}
+              isActive={activePills.includes(pill.id)}
               marginRight="xSmall"
-              onClick={() => onPillClick(item.id)}
+              onClick={() => onPillClick(pill.id)}
               type="button"
               variant="subtle"
             >
-              {item.title}
+              {pill.title}
             </StyledPillTab>
           </StyledFlexItem>
         );

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -25,7 +25,8 @@ export interface PillTabsProps {
 }
 
 export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillClick }) => {
-  const availableWidth = useAvailableWidth();
+  const refs = { parent: createRef<HTMLDivElement>(), dropdown: createRef<HTMLDivElement>() };
+  const availableWidth = useAvailableWidth(refs);
 
   const itemsWithRefs = useMemo(
     () => items.map((item) => ({ ...item, isVisible: true, ref: createRef<HTMLDivElement>() })),
@@ -40,7 +41,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
 
       return { pills: [...acc.pills, updatedPill], widthBudget };
     },
-    { pills: [], widthBudget: availableWidth.value },
+    { pills: [], widthBudget: availableWidth },
   );
 
   const dropdownItems = pills
@@ -61,7 +62,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       data-testid="pilltabs-wrapper"
       flexDirection="row"
       flexWrap="nowrap"
-      ref={availableWidth.refs.parent}
+      ref={refs.parent}
       role="list"
     >
       {pills.map(({ id, isVisible, ref, title }, index) => (
@@ -87,7 +88,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       <StyledFlexItem
         data-testid="pilltabs-dropdown-toggle"
         isVisible={pills.some(({ isVisible }) => !isVisible)}
-        ref={availableWidth.refs.dropdown}
+        ref={refs.dropdown}
         role="listitem"
       >
         <Dropdown

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -39,29 +39,20 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       return;
     }
 
-    let remainingWidth = parentWidth - dropdownWidth;
+    const remainingWidth = parentWidth - dropdownWidth;
 
-    const newState = pillsState.map((stateObj) => {
-      const pillWidth = stateObj.ref.current?.offsetWidth;
+    const [newState] = pillsState.reduce<[typeof pillsState, number]>(
+      ([processedItems, widthBudget], currentItem) => {
+        const currentItemWidth = currentItem.ref.current?.offsetWidth || 0;
+        const updatedWidthBudget = widthBudget - currentItemWidth;
 
-      if (!pillWidth) {
-        return stateObj;
-      }
-
-      if (remainingWidth - pillWidth >= 0) {
-        remainingWidth -= pillWidth;
-
-        return {
-          ...stateObj,
-          isVisible: true,
-        };
-      }
-
-      return {
-        ...stateObj,
-        isVisible: false,
-      };
-    });
+        return [
+          [...processedItems, { ...currentItem, isVisible: updatedWidthBudget >= 0 }],
+          updatedWidthBudget,
+        ];
+      },
+      [[], remainingWidth],
+    );
 
     const visiblePills = pillsState.filter((stateObj) => stateObj.isVisible);
     const newVisiblePills = newState.filter((stateObj) => stateObj.isVisible);

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -39,7 +39,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       return;
     }
 
-    let remainingWidth = parentWidth;
+    let remainingWidth = parentWidth - dropdownWidth;
 
     const newState = pillsState.map((stateObj) => {
       const pillWidth = stateObj.ref.current?.offsetWidth;
@@ -48,7 +48,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
         return stateObj;
       }
 
-      if (remainingWidth - pillWidth > dropdownWidth) {
+      if (remainingWidth - pillWidth >= 0) {
         remainingWidth -= pillWidth;
 
         return {

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -13,6 +13,11 @@ export interface PillTabItem {
   title: string;
 }
 
+interface Pill extends PillTabItem {
+  isVisible: boolean;
+  ref: React.RefObject<HTMLDivElement>;
+}
+
 export interface PillTabsProps {
   items: PillTabItem[];
   activePills: string[];
@@ -27,22 +32,16 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     [items],
   );
 
-  const pills = useMemo(() => {
-    const [newState] = itemsWithRefs.reduce<[typeof itemsWithRefs, number]>(
-      ([processedItems, widthBudget], currentItem) => {
-        const currentItemWidth = currentItem.ref.current?.offsetWidth || 0;
-        const updatedWidthBudget = widthBudget - currentItemWidth;
+  const { pills } = itemsWithRefs.reduce<{ pills: Pill[]; widthBudget: number }>(
+    (acc, pill) => {
+      const pillWidth = pill.ref.current?.offsetWidth || 0;
+      const widthBudget = acc.widthBudget - pillWidth;
+      const updatedPill = { ...pill, isVisible: widthBudget >= 0 };
 
-        return [
-          [...processedItems, { ...currentItem, isVisible: updatedWidthBudget >= 0 }],
-          updatedWidthBudget,
-        ];
-      },
-      [[], availableWidth.value],
-    );
-
-    return newState;
-  }, [itemsWithRefs, availableWidth]);
+      return { pills: [...acc.pills, updatedPill], widthBudget };
+    },
+    { pills: [], widthBudget: availableWidth.value },
+  );
 
   const isMenuVisible = pills.some(({ isVisible }) => !isVisible);
 

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -61,14 +61,12 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
 
   const dropdownItems = pills
     .filter(({ isVisible }) => !isVisible)
-    .map(({ title, id }) => {
-      return {
-        content: title,
-        onItemClick: () => onPillClick(id),
-        hash: title.toLowerCase(),
-        icon: activePills.includes(id) ? <CheckIcon /> : undefined,
-      };
-    });
+    .map(({ title, id }) => ({
+      content: title,
+      onItemClick: () => onPillClick(id),
+      hash: title.toLowerCase(),
+      icon: activePills.includes(id) ? <CheckIcon /> : undefined,
+    }));
 
   useEffect(updateAvailableWidth, [updateAvailableWidth]);
 
@@ -86,28 +84,26 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       ref={parentRef}
       role="list"
     >
-      {pills.map(({ id, isVisible, ref, title }, index) => {
-        return (
-          <StyledFlexItem
-            data-testid={`pilltabs-pill-${index}`}
-            isVisible={isVisible}
-            key={index}
-            ref={ref}
-            role="listitem"
+      {pills.map(({ id, isVisible, ref, title }, index) => (
+        <StyledFlexItem
+          data-testid={`pilltabs-pill-${index}`}
+          isVisible={isVisible}
+          key={index}
+          ref={ref}
+          role="listitem"
+        >
+          <StyledPillTab
+            disabled={!isVisible}
+            isActive={activePills.includes(id)}
+            marginRight="xSmall"
+            onClick={() => onPillClick(id)}
+            type="button"
+            variant="subtle"
           >
-            <StyledPillTab
-              disabled={!isVisible}
-              isActive={activePills.includes(id)}
-              marginRight="xSmall"
-              onClick={() => onPillClick(id)}
-              type="button"
-              variant="subtle"
-            >
-              {title}
-            </StyledPillTab>
-          </StyledFlexItem>
-        );
-      })}
+            {title}
+          </StyledPillTab>
+        </StyledFlexItem>
+      ))}
       <StyledFlexItem
         data-testid="pilltabs-dropdown-toggle"
         isVisible={isMenuVisible}

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -169,7 +169,11 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     hideOverflowedPills();
   });
 
-  return items.length > 0 ? (
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
     <Flex
       data-testid="pilltabs-wrapper"
       flexDirection="row"
@@ -180,7 +184,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       {renderedPills}
       {renderedDropdown}
     </Flex>
-  ) : null;
+  );
 };
 
 PillTabs.displayName = 'Pill Tabs';

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -85,24 +85,6 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       };
     });
 
-  const renderedDropdown = useMemo(() => {
-    return (
-      <StyledFlexItem
-        data-testid="pilltabs-dropdown-toggle"
-        isVisible={isMenuVisible}
-        ref={dropdownRef}
-        role="listitem"
-      >
-        <Dropdown
-          items={dropdownItems}
-          toggle={
-            <Button iconOnly={<MoreHorizIcon title="add" />} type="button" variant="subtle" />
-          }
-        />
-      </StyledFlexItem>
-    );
-  }, [items, pillsState, isMenuVisible, dropdownRef, activePills, onPillClick]);
-
   useEffect(() => {
     const itemIds = items.map((item) => item.id);
     const stateIds = pillsState.map((stateItem) => stateItem.item.id);
@@ -176,7 +158,19 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
           </StyledFlexItem>
         );
       })}
-      {renderedDropdown}
+      <StyledFlexItem
+        data-testid="pilltabs-dropdown-toggle"
+        isVisible={isMenuVisible}
+        ref={dropdownRef}
+        role="listitem"
+      >
+        <Dropdown
+          items={dropdownItems}
+          toggle={
+            <Button iconOnly={<MoreHorizIcon title="add" />} type="button" variant="subtle" />
+          }
+        />
+      </StyledFlexItem>
     </Flex>
   );
 };

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -43,8 +43,6 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     { pills: [], widthBudget: availableWidth.value },
   );
 
-  const isMenuVisible = pills.some(({ isVisible }) => !isVisible);
-
   const dropdownItems = pills
     .filter(({ isVisible }) => !isVisible)
     .map(({ title, id }) => ({
@@ -88,7 +86,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       ))}
       <StyledFlexItem
         data-testid="pilltabs-dropdown-toggle"
-        isVisible={isMenuVisible}
+        isVisible={pills.some(({ isVisible }) => !isVisible)}
         ref={availableWidth.refs.dropdown}
         role="listitem"
       >

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -71,21 +71,21 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     }
   }, [items, parentRef, dropdownRef, pillsState]);
 
+  const dropdownItems = pillsState
+    .filter((stateObj) => !stateObj.isVisible)
+    .map((stateObj) => {
+      const item = items.find(({ title }) => title === stateObj.item.title);
+      const isActive = item ? activePills.includes(item.id) : false;
+
+      return {
+        content: stateObj.item.title,
+        onItemClick: () => onPillClick(stateObj.item.id),
+        hash: stateObj.item.title.toLowerCase(),
+        icon: isActive ? <CheckIcon /> : undefined,
+      };
+    });
+
   const renderedDropdown = useMemo(() => {
-    const dropdownItems = pillsState
-      .filter((stateObj) => !stateObj.isVisible)
-      .map((stateObj) => {
-        const item = items.find(({ title }) => title === stateObj.item.title);
-        const isActive = item ? activePills.includes(item.id) : false;
-
-        return {
-          content: stateObj.item.title,
-          onItemClick: () => onPillClick(stateObj.item.id),
-          hash: stateObj.item.title.toLowerCase(),
-          icon: isActive ? <CheckIcon /> : undefined,
-        };
-      });
-
     return (
       <StyledFlexItem
         data-testid="pilltabs-dropdown-toggle"

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -40,7 +40,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     [items],
   );
 
-  const pillsState = useMemo(() => {
+  const pills = useMemo(() => {
     const [newState] = itemsWithRefs.reduce<[typeof itemsWithRefs, number]>(
       ([processedItems, widthBudget], currentItem) => {
         const currentItemWidth = currentItem.ref.current?.offsetWidth || 0;
@@ -57,9 +57,9 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     return newState;
   }, [itemsWithRefs, availableWidth]);
 
-  const isMenuVisible = pillsState.some(({ isVisible }) => !isVisible);
+  const isMenuVisible = pills.some(({ isVisible }) => !isVisible);
 
-  const dropdownItems = pillsState
+  const dropdownItems = pills
     .filter((stateObj) => !stateObj.isVisible)
     .map((stateObj) => {
       const item = items.find(({ title }) => title === stateObj.item.title);
@@ -90,7 +90,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       role="list"
     >
       {items.map((item, index) => {
-        const pill = pillsState[index];
+        const pill = pills[index];
 
         if (!pill) {
           return;

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -128,9 +128,27 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     }
   }, [items, pillsState]);
 
-  const renderedPills = useMemo(
-    () =>
-      items.map((item, index) => {
+  useEffect(() => {
+    hideOverflowedPills();
+  }, [items, parentRef, pillsState, hideOverflowedPills]);
+
+  useWindowResizeListener(() => {
+    hideOverflowedPills();
+  });
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <Flex
+      data-testid="pilltabs-wrapper"
+      flexDirection="row"
+      flexWrap="nowrap"
+      ref={parentRef}
+      role="list"
+    >
+      {items.map((item, index) => {
         const pill = pillsState[index];
 
         if (!pill) {
@@ -157,31 +175,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
             </StyledPillTab>
           </StyledFlexItem>
         );
-      }),
-    [items, pillsState, activePills, onPillClick],
-  );
-
-  useEffect(() => {
-    hideOverflowedPills();
-  }, [items, parentRef, pillsState, hideOverflowedPills]);
-
-  useWindowResizeListener(() => {
-    hideOverflowedPills();
-  });
-
-  if (items.length === 0) {
-    return null;
-  }
-
-  return (
-    <Flex
-      data-testid="pilltabs-wrapper"
-      flexDirection="row"
-      flexWrap="nowrap"
-      ref={parentRef}
-      role="list"
-    >
-      {renderedPills}
+      })}
       {renderedDropdown}
     </Flex>
   );

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -1,12 +1,12 @@
 import { CheckIcon, MoreHorizIcon } from '@bigcommerce/big-design-icons';
-import React, { createRef, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { createRef, useMemo } from 'react';
 
-import { useWindowResizeListener } from '../../hooks';
 import { Button } from '../Button';
 import { Dropdown } from '../Dropdown';
 import { Flex } from '../Flex';
 
 import { StyledFlexItem, StyledPillTab } from './styled';
+import { useAvailableWidth } from './useAvailableWidth';
 
 export interface PillTabItem {
   id: string;
@@ -18,32 +18,6 @@ export interface PillTabsProps {
   activePills: string[];
   onPillClick: (itemId: string) => void;
 }
-
-const useAvailableWidth = () => {
-  const parentRef = createRef<HTMLDivElement>();
-  const dropdownRef = createRef<HTMLDivElement>();
-
-  const [value, setValue] = useState<number>(Infinity);
-  const update = useCallback(() => {
-    const parentWidth = parentRef.current?.offsetWidth;
-    const dropdownWidth = dropdownRef.current?.offsetWidth;
-
-    if (!parentWidth || !dropdownWidth) {
-      return;
-    }
-
-    setValue(parentWidth - dropdownWidth);
-  }, [parentRef, dropdownRef]);
-
-  useEffect(update, [update]);
-
-  useWindowResizeListener(update);
-
-  return useMemo(
-    () => ({ refs: { parent: parentRef, dropdown: dropdownRef }, value }),
-    [value, parentRef, dropdownRef],
-  );
-};
 
 export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillClick }) => {
   const availableWidth = useAvailableWidth();

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -36,7 +36,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
   }, [parentRef, dropdownRef]);
 
   const itemsWithRefs = useMemo(
-    () => items.map((item) => ({ isVisible: true, item, ref: createRef<HTMLDivElement>() })),
+    () => items.map((item) => ({ ...item, isVisible: true, ref: createRef<HTMLDivElement>() })),
     [items],
   );
 
@@ -62,13 +62,13 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
   const dropdownItems = pills
     .filter((stateObj) => !stateObj.isVisible)
     .map((stateObj) => {
-      const item = items.find(({ title }) => title === stateObj.item.title);
+      const item = items.find(({ title }) => title === stateObj.title);
       const isActive = item ? activePills.includes(item.id) : false;
 
       return {
-        content: stateObj.item.title,
-        onItemClick: () => onPillClick(stateObj.item.id),
-        hash: stateObj.item.title.toLowerCase(),
+        content: stateObj.title,
+        onItemClick: () => onPillClick(stateObj.id),
+        hash: stateObj.title.toLowerCase(),
         icon: isActive ? <CheckIcon /> : undefined,
       };
     });

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -60,13 +60,13 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
   const isMenuVisible = pills.some(({ isVisible }) => !isVisible);
 
   const dropdownItems = pills
-    .filter((pill) => !pill.isVisible)
-    .map((pill) => {
+    .filter(({ isVisible }) => !isVisible)
+    .map(({ title, id }) => {
       return {
-        content: pill.title,
-        onItemClick: () => onPillClick(pill.id),
-        hash: pill.title.toLowerCase(),
-        icon: activePills.includes(pill.id) ? <CheckIcon /> : undefined,
+        content: title,
+        onItemClick: () => onPillClick(id),
+        hash: title.toLowerCase(),
+        icon: activePills.includes(id) ? <CheckIcon /> : undefined,
       };
     });
 
@@ -86,24 +86,24 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       ref={parentRef}
       role="list"
     >
-      {pills.map((pill, index) => {
+      {pills.map(({ id, isVisible, ref, title }, index) => {
         return (
           <StyledFlexItem
             data-testid={`pilltabs-pill-${index}`}
-            isVisible={pill.isVisible}
+            isVisible={isVisible}
             key={index}
-            ref={pill.ref}
+            ref={ref}
             role="listitem"
           >
             <StyledPillTab
-              disabled={!pill.isVisible}
-              isActive={activePills.includes(pill.id)}
+              disabled={!isVisible}
+              isActive={activePills.includes(id)}
               marginRight="xSmall"
-              onClick={() => onPillClick(pill.id)}
+              onClick={() => onPillClick(id)}
               type="button"
               variant="subtle"
             >
-              {pill.title}
+              {title}
             </StyledPillTab>
           </StyledFlexItem>
         );

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -1986,7 +1986,7 @@ exports[`renders all the filters if they fit 1`] = `
       </button>
       <div
         class="c9"
-        style="position: absolute; left: 0px; top: 0px;"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c10"

--- a/packages/big-design/src/components/PillTabs/spec.tsx
+++ b/packages/big-design/src/components/PillTabs/spec.tsx
@@ -524,3 +524,9 @@ test('sends the right id to the handler after swapping', async () => {
 
   expect(onClick).toHaveBeenCalledWith(item4.id);
 });
+
+test('it does not render when provided an empty list of items', () => {
+  const { container } = render(<PillTabs activePills={[]} items={[]} onPillClick={jest.fn()} />);
+
+  expect(container.firstChild).toBeNull();
+});

--- a/packages/big-design/src/components/PillTabs/useAvailableWidth.tsx
+++ b/packages/big-design/src/components/PillTabs/useAvailableWidth.tsx
@@ -1,29 +1,28 @@
-import { createRef, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useWindowResizeListener } from '../../hooks';
 
-export const useAvailableWidth = () => {
-  const parentRef = createRef<HTMLDivElement>();
-  const dropdownRef = createRef<HTMLDivElement>();
+interface Refs {
+  parent: React.RefObject<HTMLElement>;
+  dropdown: React.RefObject<HTMLElement>;
+}
 
+export const useAvailableWidth = ({ parent, dropdown }: Refs) => {
   const [value, setValue] = useState<number>(Infinity);
   const update = useCallback(() => {
-    const parentWidth = parentRef.current?.offsetWidth;
-    const dropdownWidth = dropdownRef.current?.offsetWidth;
+    const parentWidth = parent.current?.offsetWidth;
+    const dropdownWidth = dropdown.current?.offsetWidth;
 
     if (!parentWidth || !dropdownWidth) {
       return;
     }
 
     setValue(parentWidth - dropdownWidth);
-  }, [parentRef, dropdownRef]);
+  }, [parent, dropdown]);
 
   useEffect(update, [update]);
 
   useWindowResizeListener(update);
 
-  return useMemo(
-    () => ({ refs: { parent: parentRef, dropdown: dropdownRef }, value }),
-    [value, parentRef, dropdownRef],
-  );
+  return value;
 };

--- a/packages/big-design/src/components/PillTabs/useAvailableWidth.tsx
+++ b/packages/big-design/src/components/PillTabs/useAvailableWidth.tsx
@@ -1,0 +1,29 @@
+import { createRef, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useWindowResizeListener } from '../../hooks';
+
+export const useAvailableWidth = () => {
+  const parentRef = createRef<HTMLDivElement>();
+  const dropdownRef = createRef<HTMLDivElement>();
+
+  const [value, setValue] = useState<number>(Infinity);
+  const update = useCallback(() => {
+    const parentWidth = parentRef.current?.offsetWidth;
+    const dropdownWidth = dropdownRef.current?.offsetWidth;
+
+    if (!parentWidth || !dropdownWidth) {
+      return;
+    }
+
+    setValue(parentWidth - dropdownWidth);
+  }, [parentRef, dropdownRef]);
+
+  useEffect(update, [update]);
+
+  useWindowResizeListener(update);
+
+  return useMemo(
+    () => ({ refs: { parent: parentRef, dropdown: dropdownRef }, value }),
+    [value, parentRef, dropdownRef],
+  );
+};


### PR DESCRIPTION
**N.B.** individual commits used for easier review, will be squash-merged

## What?

- Refactor `PillTabs` component to a simpler implementation

## Why?

- This component was full of indirection and states on top of states, making it hard to follow
- This should make it easier to extend the component to take a notion of "grouped pills" in an upcoming PR

## Screenshots/Screen Recordings

### Basic "selected" state

https://github.com/user-attachments/assets/127d13d2-dd9a-4fac-a480-e030ef48c900

### Overflowing into the dropdown menu on resize

https://github.com/user-attachments/assets/2868120d-a74d-4c00-8c60-8b0d5a153269


## Testing/Proof

- Unchanged, passing tests + 1 additional new test (proves a pre-existing behaviour, previously not covered)
- Manual testing
