### PR TITLE
Allow for option dropdown items to be added to a PillTab

### DIFF
--- a/.changeset/swift-ants-juggle.md
+++ b/.changeset/swift-ants-juggle.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design': minor
+'@bigcommerce/docs': minor
+---
+
+Optional dropdown items added to PillTabs component

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -16,7 +16,7 @@ import { List } from '../List';
 import { StyledBox } from './styled';
 import { DropdownItem, DropdownItemGroup, DropdownLinkItem, DropdownProps } from './types';
 
-export const isGroups = (
+export const isDropdownItemGroupArray = (
   items: Array<DropdownItemGroup | DropdownItem | DropdownLinkItem>,
 ): items is DropdownItemGroup[] =>
   items.every((items) => 'items' in items && !('content' in items));
@@ -39,7 +39,7 @@ export const Dropdown = memo(
     const dropdownUniqueId = useId();
 
     const flattenItems = useCallback((items: DropdownProps['items']) => {
-      return isGroups(items)
+      return isDropdownItemGroupArray(items)
         ? items.map((group) => group.items).reduce((acum, curr) => acum.concat(curr), [])
         : items;
     }, []);

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -16,6 +16,11 @@ import { List } from '../List';
 import { StyledBox } from './styled';
 import { DropdownItem, DropdownItemGroup, DropdownLinkItem, DropdownProps } from './types';
 
+export const isGroups = (
+  items: Array<DropdownItemGroup | DropdownItem | DropdownLinkItem>,
+): items is DropdownItemGroup[] =>
+  items.every((items) => 'items' in items && !('content' in items));
+
 export const Dropdown = memo(
   ({
     autoWidth = false,
@@ -34,11 +39,6 @@ export const Dropdown = memo(
     const dropdownUniqueId = useId();
 
     const flattenItems = useCallback((items: DropdownProps['items']) => {
-      const isGroups = (
-        items: Array<DropdownItemGroup | DropdownItem | DropdownLinkItem>,
-      ): items is DropdownItemGroup[] =>
-        items.every((items) => 'items' in items && !('content' in items));
-
       return isGroups(items)
         ? items.map((group) => group.items).reduce((acum, curr) => acum.concat(curr), [])
         : items;

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -2,12 +2,13 @@ import { MoreHorizIcon } from '@bigcommerce/big-design-icons';
 import React, { createRef, useMemo } from 'react';
 
 import { Button } from '../Button';
-import { Dropdown } from '../Dropdown';
+import { Dropdown, DropdownProps } from '../Dropdown';
 import { Flex } from '../Flex';
 
 import { StyledFlexItem, StyledPillTab } from './styled';
-import { useAvailableWidth } from './useAvailableWidth';
 import { toDropdownItem } from './toDropDownItem';
+import { toDropdownItemGroups } from './toDropdownItemGroups';
+import { useAvailableWidth } from './useAvailableWidth';
 
 export interface PillTabItem {
   id: string;
@@ -26,9 +27,15 @@ export interface PillTabsProps {
   items: PillTabItem[];
   activePills: string[];
   onPillClick: (itemId: string) => void;
+  dropdownItems?: DropdownProps['items'];
 }
 
-export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillClick }) => {
+export const PillTabs: React.FC<PillTabsProps> = ({
+  activePills,
+  items,
+  onPillClick,
+  dropdownItems: customDropdownItems = [],
+}) => {
   const refs = { parent: createRef<HTMLDivElement>(), dropdown: createRef<HTMLDivElement>() };
   const availableWidth = useAvailableWidth(refs);
 
@@ -54,7 +61,10 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
     { pills: [], widthBudget: availableWidth },
   );
 
-  const dropdownItems = pills.filter(({ isVisible }) => !isVisible).map(toDropdownItem);
+  const dropdownItemGroups = toDropdownItemGroups({
+    overflow: pills.filter(({ isVisible }) => !isVisible).map(toDropdownItem),
+    custom: customDropdownItems,
+  });
 
   if (pills.length === 0) {
     return null;
@@ -90,12 +100,12 @@ export const PillTabs: React.FC<PillTabsProps> = ({ activePills, items, onPillCl
       ))}
       <StyledFlexItem
         data-testid="pilltabs-dropdown-toggle"
-        isVisible={pills.some(({ isVisible }) => !isVisible)}
+        isVisible={dropdownItemGroups.length > 0}
         ref={refs.dropdown}
         role="listitem"
       >
         <Dropdown
-          items={dropdownItems}
+          items={dropdownItemGroups}
           toggle={
             <Button iconOnly={<MoreHorizIcon title="add" />} type="button" variant="subtle" />
           }

--- a/packages/big-design/src/components/PillTabs/toDropDownItem.tsx
+++ b/packages/big-design/src/components/PillTabs/toDropDownItem.tsx
@@ -1,0 +1,16 @@
+import { CheckIcon } from '@bigcommerce/big-design-icons';
+import React from 'react';
+import { DropdownItem } from '../Dropdown';
+
+interface Pill {
+  title: string;
+  onClick: () => void;
+  isActive: boolean;
+}
+
+export const toDropdownItem = ({ title, onClick, isActive }: Pill): DropdownItem => ({
+  content: title,
+  onItemClick: onClick,
+  hash: title.toLowerCase(),
+  icon: isActive ? <CheckIcon /> : undefined,
+});

--- a/packages/big-design/src/components/PillTabs/toDropDownItem.tsx
+++ b/packages/big-design/src/components/PillTabs/toDropDownItem.tsx
@@ -1,5 +1,6 @@
 import { CheckIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
+
 import { DropdownItem } from '../Dropdown';
 
 interface Pill {

--- a/packages/big-design/src/components/PillTabs/toDropdownItemGroups.ts
+++ b/packages/big-design/src/components/PillTabs/toDropdownItemGroups.ts
@@ -1,9 +1,10 @@
 import { DropdownItemGroup, DropdownProps } from '../Dropdown';
-import { isGroups } from '../Dropdown/Dropdown';
+import { isDropdownItemGroupArray } from '../Dropdown/Dropdown';
 
 type Items = DropdownProps['items'];
 
-const toGroups = (items: Items): DropdownItemGroup[] => (isGroups(items) ? items : [{ items }]);
+const toGroups = (items: Items): DropdownItemGroup[] =>
+  isDropdownItemGroupArray(items) ? items : [{ items }];
 
 type ToDropDownItemGroups = (items: { overflow: Items; custom: Items }) => DropdownItemGroup[];
 

--- a/packages/big-design/src/components/PillTabs/toDropdownItemGroups.ts
+++ b/packages/big-design/src/components/PillTabs/toDropdownItemGroups.ts
@@ -1,0 +1,21 @@
+import { DropdownItemGroup, DropdownProps } from '../Dropdown';
+import { isGroups } from '../Dropdown/Dropdown';
+
+type Items = DropdownProps['items'];
+
+const toGroups = (items: Items): DropdownItemGroup[] => (isGroups(items) ? items : [{ items }]);
+
+type ToDropDownItemGroups = (items: { overflow: Items; custom: Items }) => DropdownItemGroup[];
+
+export const toDropdownItemGroups: ToDropDownItemGroups = ({ overflow, custom }) => {
+  const overflowGroups = toGroups(overflow);
+  const customGroups = toGroups(custom);
+
+  return [
+    ...overflowGroups,
+    ...customGroups.map(({ separated, ...rest }, index) => ({
+      ...rest,
+      separated: separated || (index === 0 && overflow.length > 0),
+    })),
+  ].filter(({ items }) => items.length > 0);
+};

--- a/packages/docs/PropTables/PillTabsPropTable.tsx
+++ b/packages/docs/PropTables/PillTabsPropTable.tsx
@@ -32,6 +32,15 @@ const pillTabsPropTable: Prop[] = [
     description: 'Function that will get called when a pill tab is clicked.',
     required: true,
   },
+  {
+    name: 'dropdownItems',
+    types: 'Array<DropdownItem | DropdownLinkItem> | Array<DropdownItemGroup>',
+    description: (
+      <>
+        See the <NextLink href="/dropdown">Dropdown</NextLink> component for usage.
+      </>
+    ),
+  },
 ];
 
 export const PillTabsPropTable: React.FC<PropTableWrapper> = (props) => (

--- a/packages/docs/pages/pill-tabs.tsx
+++ b/packages/docs/pages/pill-tabs.tsx
@@ -1,4 +1,5 @@
 import { Flex, FlexItem, H1, Link, Panel, PillTabs, Text } from '@bigcommerce/big-design';
+import { DeleteIcon } from '@bigcommerce/big-design-icons';
 import React, { useState } from 'react';
 
 import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
@@ -109,6 +110,60 @@ const PillTabsPage = () => {
                           ))}
                         </Flex>
                       </>
+                    );
+                  }}
+                  {/* jsx-to-string:end */}
+                </CodePreview>
+              ),
+            },
+            {
+              id: 'with-dropdown-items',
+              title: 'Dropdown Items',
+              render: () => (
+                <CodePreview>
+                  {/* jsx-to-string:start */}
+                  {function Example() {
+                    const [activePills, setActivePills] = useState<string[]>([]);
+
+                    const items = [
+                      { title: 'Shipping', id: 'shipping' },
+                      { title: 'Orders', id: 'orders' },
+                    ];
+
+                    const onPillClick = (pillId: string) => {
+                      const isPillActive = !activePills.includes(pillId);
+                      const updatedPills = isPillActive
+                        ? [...activePills, pillId]
+                        : activePills.filter((activePillId) => activePillId !== pillId);
+
+                      setActivePills(updatedPills);
+                    };
+
+                    const dropdownItems = [
+                      {
+                        type: 'link' as const,
+                        content: 'Find out more',
+                        url: '#',
+                      },
+                      {
+                        content: 'Create new item',
+                        onItemClick: () => undefined,
+                      },
+                      {
+                        content: 'Delete all items',
+                        onItemClick: () => undefined,
+                        icon: <DeleteIcon />,
+                        actionType: 'destructive' as const,
+                      },
+                    ];
+
+                    return (
+                      <PillTabs
+                        activePills={activePills}
+                        dropdownItems={dropdownItems}
+                        items={items}
+                        onPillClick={onPillClick}
+                      />
                     );
                   }}
                   {/* jsx-to-string:end */}

--- a/packages/docs/pages/pill-tabs.tsx
+++ b/packages/docs/pages/pill-tabs.tsx
@@ -25,83 +25,98 @@ const PillTabsPage = () => {
       </Panel>
 
       <Panel header="Implementation" headerId="implementation">
-        <CodePreview>
-          {/* jsx-to-string:start */}
-          {function Example() {
-            const [activePills, setActivePills] = useState<string[]>([]);
-            const Card: React.FC<{ name: string; description: string }> = ({
-              name,
-              description,
-            }) => (
-              <Flex
-                border="box"
-                borderRadius="normal"
-                flexDirection="column"
-                margin="xxSmall"
-                padding="medium"
-              >
-                <FlexItem marginBottom="xxSmall">
-                  <Text bold>{name}</Text>
-                </FlexItem>
-                <FlexItem flexGrow={1}>
-                  <Text>{description}</Text>
-                </FlexItem>
-                <FlexItem>
-                  <Link href="#">Install</Link>
-                </FlexItem>
-              </Flex>
-            );
-            const items = [
-              { title: 'Shipping', id: 'shipping' },
-              { title: 'Orders', id: 'orders' },
-            ];
-            const onPillClick = (pillId: string) => {
-              const isPillActive = !activePills.includes(pillId);
-              const updatedPills = isPillActive
-                ? [...activePills, pillId]
-                : activePills.filter((activePillId) => activePillId !== pillId);
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <CodePreview>
+                  {/* jsx-to-string:start */}
+                  {function Example() {
+                    const [activePills, setActivePills] = useState<string[]>([]);
+                    const Card: React.FC<{ name: string; description: string }> = ({
+                      name,
+                      description,
+                    }) => (
+                      <Flex
+                        border="box"
+                        borderRadius="normal"
+                        flexDirection="column"
+                        margin="xxSmall"
+                        padding="medium"
+                      >
+                        <FlexItem marginBottom="xxSmall">
+                          <Text bold>{name}</Text>
+                        </FlexItem>
+                        <FlexItem flexGrow={1}>
+                          <Text>{description}</Text>
+                        </FlexItem>
+                        <FlexItem>
+                          <Link href="#">Install</Link>
+                        </FlexItem>
+                      </Flex>
+                    );
+                    const items = [
+                      { title: 'Shipping', id: 'shipping' },
+                      { title: 'Orders', id: 'orders' },
+                    ];
+                    const onPillClick = (pillId: string) => {
+                      const isPillActive = !activePills.includes(pillId);
+                      const updatedPills = isPillActive
+                        ? [...activePills, pillId]
+                        : activePills.filter((activePillId) => activePillId !== pillId);
 
-              setActivePills(updatedPills);
-            };
-            const cards = [
-              {
-                name: 'Shipping App Pro',
-                description: 'All your shipping needs in a one stop shop.',
-                type: 'shipping',
-              },
-              {
-                name: 'Order Tracker Deluxe',
-                description: 'Track your orders across all your devices.',
-                type: 'orders',
-              },
-              {
-                name: 'Expedited Shipper',
-                description: 'The best rush rates in the country.',
-                type: 'shipping',
-              },
-              {
-                name: 'Inventory Wizard',
-                description: 'Inventory tracking app to cover all your needs.',
-                type: 'other',
-              },
-            ];
-            const isFiltered = Boolean(activePills.length);
-            const filteredCards = cards.filter((card) => activePills.includes(card.type));
-            const appCards = isFiltered ? filteredCards : cards;
+                      setActivePills(updatedPills);
+                    };
+                    const cards = [
+                      {
+                        name: 'Shipping App Pro',
+                        description: 'All your shipping needs in a one stop shop.',
+                        type: 'shipping',
+                      },
+                      {
+                        name: 'Order Tracker Deluxe',
+                        description: 'Track your orders across all your devices.',
+                        type: 'orders',
+                      },
+                      {
+                        name: 'Expedited Shipper',
+                        description: 'The best rush rates in the country.',
+                        type: 'shipping',
+                      },
+                      {
+                        name: 'Inventory Wizard',
+                        description: 'Inventory tracking app to cover all your needs.',
+                        type: 'other',
+                      },
+                    ];
+                    const isFiltered = Boolean(activePills.length);
+                    const filteredCards = cards.filter((card) => activePills.includes(card.type));
+                    const appCards = isFiltered ? filteredCards : cards;
 
-            return (
-              <>
-                <PillTabs activePills={activePills} items={items} onPillClick={onPillClick} />
-                <Flex>
-                  {appCards.map(({ name, description }) => (
-                    <Card description={description} key={name} name={name} />
-                  ))}
-                </Flex>
-              </>
-            );
-          }}
-          {/* jsx-to-string:end */}
-        </CodePreview>
+                    return (
+                      <>
+                        <PillTabs
+                          activePills={activePills}
+                          items={items}
+                          onPillClick={onPillClick}
+                        />
+                        <Flex>
+                          {appCards.map(({ name, description }) => (
+                            <Card description={description} key={name} name={name} />
+                          ))}
+                        </Flex>
+                      </>
+                    );
+                  }}
+                  {/* jsx-to-string:end */}
+                </CodePreview>
+              ),
+            },
+          ]}
+        />
       </Panel>
 
       <Panel header="Props" headerId="props">


### PR DESCRIPTION
## What?

Add new, optional `dropdownItems` prop to `PillTabs` to allow users to add drop down items.
The new prop takes the same items as `items` from the `Dropdown` component.

### Commits

1. Light refactoring to make upcoming changes easier
2. Functionality and tests for the new `dropdownItems`
3. Documentation detailing the new functionality and props

## Why?

Allows users to add 'meta' options to the `PillTabs`, for example if the Pills are depicting filters a user might use the new `dropdownItems` to add options to manage those filters.

## Screenshots/Screen Recordings

### Basic use of dropdown items

https://github.com/user-attachments/assets/84a9ae3d-c674-4646-b02d-876704259e7c


### Resizing and overflow behaviour with dropdown items

https://github.com/user-attachments/assets/865ee322-0eee-485d-beee-dd354995e208


## Testing/Proof

1. Existing tests still passing
2. New tests protecting new functionality 
