### PR TITLE
fix(component): fix button group initial render flicker

### DIFF
--- a/.changeset/loose-baths-fix.md
+++ b/.changeset/loose-baths-fix.md
@@ -2,4 +2,9 @@
 '@bigcommerce/big-design': patch
 ---
 
-fix button group initial render flicker
+Fix button group initial render flicker
+
+Before: buttons would briefly appear in overflow and then disappear,
+causing a flicker on mount.
+
+After: overflowed buttons are hidden synchronously via `useLayoutEffect`, eliminating the flicker.

--- a/.changeset/loose-baths-fix.md
+++ b/.changeset/loose-baths-fix.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design': patch
+---
+
+fix button group initial render flicker

--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -4,7 +4,7 @@ import React, {
   createRef,
   memo,
   useCallback,
-  useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
 } from 'react';
@@ -54,17 +54,13 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
     const parentRef = createRef<HTMLDivElement>();
     const dropdownRef = createRef<HTMLDivElement>();
     const [isMenuVisible, setIsMenuVisible] = useState(false);
-    const [actionsState, setActionsState] = useState<ActionsState[]>([]);
-
-    useEffect(() => {
-      setActionsState(
-        actions.map((action) => ({
-          isVisible: true,
-          action: excludeIconProps(action),
-          ref: createRef<HTMLDivElement>(),
-        })),
-      );
-    }, [actions]);
+    const [actionsState, setActionsState] = useState<ActionsState[]>(() => {
+      return actions.map((action) => ({
+        isVisible: true,
+        action: excludeIconProps(action),
+        ref: createRef<HTMLDivElement>(),
+      }));
+    });
 
     const hideOverflowedActions = useCallback(() => {
       const parentWidth = parentRef.current?.offsetWidth ?? 0;
@@ -163,7 +159,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
       [actionsState],
     );
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       const nextIsMenuVisible = actionsState.some(({ isVisible }) => !isVisible);
 
       if (nextIsMenuVisible !== isMenuVisible) {
@@ -171,7 +167,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
       }
     }, [actionsState, isMenuVisible]);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       hideOverflowedActions();
     }, [actions, parentRef, hideOverflowedActions]);
 

--- a/packages/big-design/src/components/ButtonGroup/spec.tsx
+++ b/packages/big-design/src/components/ButtonGroup/spec.tsx
@@ -163,3 +163,27 @@ test('renders localized labels', async () => {
 
   expect(trigger).toBeVisible();
 });
+
+test('hide overflowed buttons and show a "more" dropdown', async () => {
+  render(
+    <ButtonGroup
+      actions={[
+        { text: 'A' },
+        { text: 'B' },
+        { text: 'C' },
+        { text: 'D' },
+        { text: 'E' },
+        { text: 'F' },
+      ]}
+    />,
+  );
+
+  expect(await screen.findByRole('button', { name: /A/ })).toBeVisible();
+  expect(screen.getByRole('button', { name: /B/ })).toBeVisible();
+  expect(screen.getByRole('button', { name: /C/ })).toBeVisible();
+  expect(screen.getByRole('button', { name: /more/ })).toBeVisible();
+
+  expect(screen.queryByRole('button', { name: /D/ })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /E/ })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /F/ })).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What?

	Refactored the ButtonGroup component to eliminate initial-render flicker:
- Switched from per-render createRef + full ActionsState[] to a single useRef array of stable refs
- Replaced the complex object state with a simple boolean[] (visible) to track each button’s visibility
- Moved overflow calculations into useLayoutEffect so hidden buttons are determined before the first paint.
- Switched setVisible to the functional form to avoid including visible in the useCallback 

## Why?

Prevent flicker: In the old implementation, all buttons briefly rendered on mount (and after any state change) before the overflow logic hid the extras in a second render. This caused a visible “flash” of too many buttons.

This is a component library so we love visually looking at changes! If this applies to your pull request, show us your hard work in action.

Run logic pre-paint: Moving the hide/overflow logic into useLayoutEffect ensures the DOM is updated before the browser paints, eliminating the two-step render

Stable refs & memoization: Ensures that refs don’t reset on every render and that we only regenerate the action and dropdown elements when truly needed


## Screenshots/Screen Recordings

before:

https://github.com/user-attachments/assets/cea8b94c-66d1-4192-a9ca-7acbff1b12f7

after:


https://github.com/user-attachments/assets/4302913e-54fa-457a-a216-25077e85cfea



## Testing/Proof

updated test for ButtonGroup
Manually tested on Version 18.3 (20620.2.4.11.5).
