### PR TITLE
fix(worksheet): optional chain for selectedCell

### DIFF
--- a/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useKeyEvents/useKeyEvents.ts
@@ -105,7 +105,7 @@ export const useKeyEvents = () => {
             if (selectedCell && !selectedCell.disabled) {
               editSelectedCell({});
 
-              if (selectedCell.type === 'checkbox') {
+              if (selectedCell?.type === 'checkbox') {
                 navigate({ rowIndex: 1, columnIndex: 0 });
               }
             }
@@ -120,7 +120,7 @@ export const useKeyEvents = () => {
             break;
 
           case 'ArrowUp':
-            if (isShiftPressed && selectedCells.length > 1) {
+            if (isShiftPressed && selectedCells?.length > 1) {
               setSelectedCells(selectedCells.slice(0, -1));
 
               break;
@@ -188,7 +188,7 @@ export const useKeyEvents = () => {
             if (
               key !== 'Escape' &&
               key.length === 1 &&
-              (selectedCell.type === 'text' || selectedCell.type === 'number')
+              (selectedCell?.type === 'text' || selectedCell?.type === 'number')
             ) {
               event.preventDefault();
               editSelectedCell({ editWithValue: key });


### PR DESCRIPTION
## What?
Fix for the issue when the user has focused the table, not the sell, and starts typing, so at that moment `selectedCell` is not defined yet.

Set optional chain for `selectedCell` field in worksheet.

## Why?

To fix app crash that was caught by `sentry`.


## Screenshots/Screen Recordings

<img width="841" alt="Screenshot 2025-07-07 at 15 03 23" src="https://github.com/user-attachments/assets/0c9cb1d8-2a47-47cd-9e66-f259882ee2e8" />

## Testing/Proof
**Before fix:**

https://github.com/user-attachments/assets/a483477a-f3ac-4ff7-856f-d8f83fdd5c23

**After fix:** 

https://github.com/user-attachments/assets/b6d259a7-edf8-44c3-9cc5-758fa2f1d102

