### PR TITLE
fix(component): set tooltip position to auto for worksheet notation

### DIFF
--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -283,7 +283,7 @@ const InternalCell = <T extends WorksheetItem>({
     return (
       <Tooltip
         id={tooltipId}
-        placement="right"
+        placement="auto"
         trigger={<CellNote color={note.color} role="note" />}
       >
         {note.description}


### PR DESCRIPTION
## What?
Set tooltip position to `auto` for worksheet `notation`.

## Why?
To provide correct placement when it does not fit.


## Screenshots/Screen Recordings
<img width="366" height="214" alt="Screenshot 2025-07-11 at 14 13 01" src="https://github.com/user-attachments/assets/25b1b49e-c36d-4841-a211-1d6161a38141" />
## Testing/Proof

Explain how you tested your new feature or bugfix. Please refrain from one-liners like, `Added tests.`; expand upon how you tested your changes like, `Added local tests to the new component and ensured test coverage was met. Manually tested on Safari@x.x.x.`.
