### PR TITLE
feat(payment): [Authorize.net] UX Debt - copy issues

### DIFF
--- a/.changeset/shiny-mugs-jam.md
+++ b/.changeset/shiny-mugs-jam.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design': major
+---
+
+Added possibility to render tooltip in Panel component.

--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -1,4 +1,12 @@
-import React, { ComponentPropsWithoutRef, forwardRef, isValidElement, memo, Ref } from 'react';
+import { BaselineHelpIcon } from '@bigcommerce/big-design-icons';
+import React, {
+  ComponentPropsWithoutRef,
+  forwardRef,
+  isValidElement,
+  memo,
+  Ref,
+  useId,
+} from 'react';
 
 import { MarginProps } from '../../helpers';
 import { excludePaddingProps } from '../../helpers/paddings/paddings';
@@ -7,6 +15,7 @@ import { Badge, BadgeProps } from '../Badge/Badge';
 import { Box } from '../Box';
 import { Button, ButtonProps } from '../Button';
 import { Flex } from '../Flex';
+import { Tooltip } from '../Tooltip';
 import { Text } from '../Typography';
 
 import { StyledH2, StyledPanel } from './styled';
@@ -26,11 +35,14 @@ export interface PanelProps extends ComponentPropsWithoutRef<'div'>, MarginProps
   headerId?: string;
   action?: PanelAction;
   badge?: BadgeProps;
+  tooltip?: string;
 }
 
 export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRef, ...props }) => {
   const filteredProps = excludePaddingProps(props);
-  const { action, children, description, header, headerId, badge, ...rest } = filteredProps;
+  const { action, children, description, header, headerId, badge, tooltip, ...rest } =
+    filteredProps;
+  const tooltipId = useId();
 
   const renderHeader = () => {
     if (!header && !action) {
@@ -47,11 +59,38 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
           <StyledH2 id={headerId} marginBottom="none">
             {header}
             {badge && <Badge marginLeft="xSmall" {...badge} />}
+            {renderTooltip()}
           </StyledH2>
         )}
         {action && <Button {...action}>{action.text}</Button>}
       </Flex>
     );
+  };
+
+  const renderTooltip = () => {
+    if (typeof tooltip === 'string' && tooltip.length > 0) {
+      return (
+        <Tooltip
+          id={tooltipId}
+          placement="right"
+          trigger={
+            <Box as="span" marginLeft="xSmall" marginVertical="large">
+              <BaselineHelpIcon
+                aria-describedby={tooltipId}
+                data-testid="tooltipIcon"
+                size="large"
+                style={{ verticalAlign: 'revert-layer' }}
+                title="Hover or focus for additional context."
+              />
+            </Box>
+          }
+        >
+          {tooltip}
+        </Tooltip>
+      );
+    }
+
+    return null;
   };
 
   const renderDescription = () => {

--- a/packages/big-design/src/components/Panel/spec.tsx
+++ b/packages/big-design/src/components/Panel/spec.tsx
@@ -80,6 +80,25 @@ test('renders a badge and header', () => {
   expect(badge).toBeInTheDocument();
 });
 
+test('renders a header and tooltip', () => {
+  const { getByRole, getByTestId } = render(
+    <Panel header="Test Header" tooltip="Test tooltip content">
+      Dolore proident eiusmod sint est enim laboris anim minim quis ut adipisicing consectetur
+      officia ex. Ipsum eiusmod fugiat amet pariatur culpa tempor aliquip tempor nisi. Irure esse
+      deserunt nostrud ipsum id adipisicing enim velit labore. Nulla exercitation laborum laboris
+      Lorem irure sit esse nulla mollit aliquip consectetur velit
+    </Panel>,
+  );
+
+  const header = getByRole('heading');
+
+  expect(header).toBeInTheDocument();
+
+  const tooltip = getByTestId('tooltipIcon');
+
+  expect(tooltip).toBeInTheDocument();
+});
+
 describe('description', () => {
   test('renders string description', async () => {
     render(


### PR DESCRIPTION
## What?

Added possibility to render tooltip in Panel component.

## Why?

As part of UI/UX Debt project one of the request was to add tooltips in Panel after the header

## Screenshots/Screen Recordings
**Panel**

https://github.com/user-attachments/assets/f044a30c-9de2-421c-a93a-506d9fcc045f


## Testing/Proof
Tested manually on:
- Chrome 138.0.7204.184
- Safari 18.3
Added unit tests
