### PR TITLE
fix(release): update next env to include routes types

### DIFF
--- a/packages/docs/next-env.d.ts
+++ b/packages/docs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What?

Load the routes type definitions in the way Next + ESLint want.

## Why?

Broken builds are bad.

## Testing/Proof

CircleCI.