### PR TITLE
fix(component): add portal to dropdown

### DIFF
--- a/.changeset/solid-years-tie.md
+++ b/.changeset/solid-years-tie.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design': patch
+---
+
+add portal to dropdown component

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -129,9 +129,17 @@ export const Dropdown = memo(
       modifiers: [
         {
           name: 'eventListeners',
-          options: { scroll: isOpen, resize: isOpen },
+          options: {
+            scroll: isOpen,
+            resize: isOpen,
+          },
         },
-        { name: 'offset', options: { offset: [0, 4] } },
+        {
+          name: 'offset',
+          options: {
+            offset: [0, 4],
+          },
+        },
       ],
       placement,
       strategy: positionFixed ? 'fixed' : 'absolute',

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -122,6 +122,10 @@ export const Dropdown = memo(
         toggleButtonId: toggle.props.id,
       });
 
+    if (!isOpen) {
+      getMenuProps({}, { suppressRefError: true });
+    }
+
     const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null);
     const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -23,11 +23,6 @@ export const isDropdownItemGroupArray = (
 ): items is DropdownItemGroup[] =>
   items.every((items) => 'items' in items && !('content' in items));
 
-interface PortalProps {
-  portalContainer?: Element | null;
-  renderInPortal?: boolean;
-}
-
 export const Dropdown = memo(
   ({
     autoWidth = false,
@@ -41,10 +36,8 @@ export const Dropdown = memo(
     selectedItem,
     toggle,
     style,
-    portalContainer,
-    renderInPortal = true,
     ...props
-  }: DropdownProps & PortalProps) => {
+  }: DropdownProps) => {
     const dropdownUniqueId = useId();
 
     const flattenItems = useCallback((items: DropdownProps['items']) => {
@@ -153,9 +146,7 @@ export const Dropdown = memo(
 
     useEffect(() => setMounted(true), []);
 
-    const dropdownContainer = mounted
-      ? portalContainer ?? (typeof document !== 'undefined' ? document.body : null)
-      : null;
+    const container = mounted && typeof document !== 'undefined' ? document.body : null;
 
     const clonedToggle =
       isValidElement(toggle) &&
@@ -191,11 +182,7 @@ export const Dropdown = memo(
     return (
       <StyledBox className={className} style={style}>
         {clonedToggle}
-        {isOpen
-          ? renderInPortal && dropdownContainer
-            ? createPortal(popperContent, dropdownContainer)
-            : popperContent
-          : null}
+        {isOpen && container ? createPortal(popperContent, container) : null}
       </StyledBox>
     );
   },

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -153,18 +153,13 @@ export const Dropdown = memo(
         return;
       }
 
-      const body = typeof document !== 'undefined' ? document.body : null;
-
-      if (!body) {
-        return;
-      }
+      const body = document.body;
 
       const recompute = () => {
         if (!body) {
           return;
         }
 
-        let container: Element | null = body;
         let z: number | 'popover' | 'modal' = 'popover';
 
         const openModal =
@@ -181,9 +176,7 @@ export const Dropdown = memo(
           z = 'popover';
         }
 
-        container = body;
-
-        setPortalContainer(container);
+        setPortalContainer(body);
         setZIndexValue(z);
       };
 

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -122,12 +122,10 @@ test('dropdown toggle has aria-expanded when dropdown menu is open', async () =>
   expect(toggle).toHaveAttribute('aria-expanded', 'true');
 });
 
-test('renders the dropdown menu closed', async () => {
+test('renders the dropdown menu closed', () => {
   render(DropdownMock);
 
-  const list = await screen.findByRole('menu');
-
-  expect(list).toBeEmptyDOMElement();
+  expect(screen.queryByRole('menu')).not.toBeInTheDocument();
 });
 
 test('opens/closes dropdown menu when toggle is clicked', async () => {
@@ -135,7 +133,7 @@ test('opens/closes dropdown menu when toggle is clicked', async () => {
 
   const toggle = screen.getByRole('button');
 
-  fireEvent.click(toggle);
+  await userEvent.click(toggle);
 
   const list = await screen.findByRole('menu');
 
@@ -143,7 +141,7 @@ test('opens/closes dropdown menu when toggle is clicked', async () => {
 
   await userEvent.click(toggle);
 
-  expect(list).toBeEmptyDOMElement();
+  expect(screen.queryByRole('menu')).not.toBeInTheDocument();
 });
 
 test('dropdown menu has aria-activedescendant', async () => {
@@ -276,15 +274,11 @@ test('esc should close menu', async () => {
 
   await userEvent.click(toggle);
 
-  const list = await screen.findByRole('menu');
-
-  expect(list).not.toBeEmptyDOMElement();
+  await screen.findByRole('menu');
 
   await userEvent.keyboard('{Escape}');
 
-  await screen.findByRole('menu');
-
-  expect(list).toBeEmptyDOMElement();
+  expect(screen.queryByRole('menu')).not.toBeInTheDocument();
 });
 
 test('home should select first dropdown item', async () => {

--- a/packages/big-design/src/components/Dropdown/types.ts
+++ b/packages/big-design/src/components/Dropdown/types.ts
@@ -1,5 +1,5 @@
 import { Placement } from '@popperjs/core';
-import { ComponentPropsWithoutRef } from 'react';
+import { ComponentPropsWithoutRef, ReactElement } from 'react';
 
 export interface DropdownProps extends Omit<ComponentPropsWithoutRef<'ul'>, 'children'> {
   autoWidth?: boolean;
@@ -9,7 +9,7 @@ export interface DropdownProps extends Omit<ComponentPropsWithoutRef<'ul'>, 'chi
   maxHeight?: number;
   placement?: Placement;
   positionFixed?: boolean;
-  toggle: React.ReactElement<unknown>;
+  toggle: ReactElement<{ id?: string }>;
 }
 
 interface BaseItem extends Omit<ComponentPropsWithoutRef<'li'>, 'value'> {
@@ -17,7 +17,7 @@ interface BaseItem extends Omit<ComponentPropsWithoutRef<'li'>, 'value'> {
   content: string;
   description?: string;
   disabled?: boolean;
-  icon?: React.ReactElement;
+  icon?: ReactElement;
   tooltip?: string;
 }
 

--- a/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`render offset pagination component 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c9 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -15,11 +15,6 @@ exports[`render offset pagination component 1`] = `
 
 .c0 {
   box-sizing: border-box;
-}
-
-.c8 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c1 {
@@ -145,7 +140,7 @@ exports[`render offset pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c8 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -194,32 +189,32 @@ exports[`render offset pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c8:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c8[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c8 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c8:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c8:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c8:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c8[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -235,27 +230,6 @@ exports[`render offset pagination component 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c9 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c3 {
@@ -281,14 +255,14 @@ exports[`render offset pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c8 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c8 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -341,28 +315,13 @@ exports[`render offset pagination component 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c8"
-        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
-      >
-        <div
-          class="c9"
-        >
-          <ul
-            aria-labelledby=":r0:-label"
-            class="c10"
-            id=":r0:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
   <div
     class="c0 c2"
   >
     <button
-      class="c11 c5"
+      class="c8 c5"
       disabled=""
       type="button"
     >
@@ -371,7 +330,7 @@ exports[`render offset pagination component 1`] = `
       >
         <svg
           aria-labelledby=":r3:"
-          class="c12"
+          class="c9"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -395,7 +354,7 @@ exports[`render offset pagination component 1`] = `
       </span>
     </button>
     <button
-      class="c11 c5"
+      class="c8 c5"
       type="button"
     >
       <span
@@ -403,7 +362,7 @@ exports[`render offset pagination component 1`] = `
       >
         <svg
           aria-labelledby=":r4:"
-          class="c12"
+          class="c9"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -437,7 +396,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c9 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -445,11 +404,6 @@ exports[`render offset pagination component with invalid page info 1`] = `
 
 .c0 {
   box-sizing: border-box;
-}
-
-.c8 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c1 {
@@ -575,7 +529,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c8 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -624,32 +578,32 @@ exports[`render offset pagination component with invalid page info 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c8:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c8[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c8 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c8:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c8:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c8:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c8[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -665,27 +619,6 @@ exports[`render offset pagination component with invalid page info 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c9 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c3 {
@@ -711,14 +644,14 @@ exports[`render offset pagination component with invalid page info 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c8 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c8 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -771,28 +704,13 @@ exports[`render offset pagination component with invalid page info 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c8"
-        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
-      >
-        <div
-          class="c9"
-        >
-          <ul
-            aria-labelledby=":r5:-label"
-            class="c10"
-            id=":r5:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
   <div
     class="c0 c2"
   >
     <button
-      class="c11 c5"
+      class="c8 c5"
       disabled=""
       type="button"
     >
@@ -801,7 +719,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
       >
         <svg
           aria-labelledby=":r8:"
-          class="c12"
+          class="c9"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -825,7 +743,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
       </span>
     </button>
     <button
-      class="c11 c5"
+      class="c8 c5"
       type="button"
     >
       <span
@@ -833,7 +751,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
       >
         <svg
           aria-labelledby=":r9:"
-          class="c12"
+          class="c9"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -867,7 +785,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c9 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -875,11 +793,6 @@ exports[`render offset pagination component with invalid range info 1`] = `
 
 .c0 {
   box-sizing: border-box;
-}
-
-.c8 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c1 {
@@ -1005,7 +918,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c8 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -1054,32 +967,32 @@ exports[`render offset pagination component with invalid range info 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c8:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c8[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c8 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c8:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c8:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c8:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c8[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -1095,27 +1008,6 @@ exports[`render offset pagination component with invalid range info 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c9 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c3 {
@@ -1141,14 +1033,14 @@ exports[`render offset pagination component with invalid range info 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c8 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c8 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -1201,28 +1093,13 @@ exports[`render offset pagination component with invalid range info 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c8"
-        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
-      >
-        <div
-          class="c9"
-        >
-          <ul
-            aria-labelledby=":ra:-label"
-            class="c10"
-            id=":ra:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
   <div
     class="c0 c2"
   >
     <button
-      class="c11 c5"
+      class="c8 c5"
       disabled=""
       type="button"
     >
@@ -1231,7 +1108,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
       >
         <svg
           aria-labelledby=":rd:"
-          class="c12"
+          class="c9"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1255,7 +1132,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
       </span>
     </button>
     <button
-      class="c11 c5"
+      class="c8 c5"
       disabled=""
       type="button"
     >
@@ -1264,7 +1141,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
       >
         <svg
           aria-labelledby=":re:"
-          class="c12"
+          class="c9"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1298,7 +1175,7 @@ exports[`render offset pagination component with no items 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c9 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -1306,11 +1183,6 @@ exports[`render offset pagination component with no items 1`] = `
 
 .c0 {
   box-sizing: border-box;
-}
-
-.c8 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c1 {
@@ -1436,7 +1308,7 @@ exports[`render offset pagination component with no items 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c8 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -1485,32 +1357,32 @@ exports[`render offset pagination component with no items 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c8:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c8[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c8 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c8:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c8:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c8:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c8[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -1526,27 +1398,6 @@ exports[`render offset pagination component with no items 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c9 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c3 {
@@ -1572,14 +1423,14 @@ exports[`render offset pagination component with no items 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c8 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c8 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -1632,28 +1483,13 @@ exports[`render offset pagination component with no items 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c8"
-        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
-      >
-        <div
-          class="c9"
-        >
-          <ul
-            aria-labelledby=":rf:-label"
-            class="c10"
-            id=":rf:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
   <div
     class="c0 c2"
   >
     <button
-      class="c11 c5"
+      class="c8 c5"
       disabled=""
       type="button"
     >
@@ -1662,7 +1498,7 @@ exports[`render offset pagination component with no items 1`] = `
       >
         <svg
           aria-labelledby=":ri:"
-          class="c12"
+          class="c9"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1686,7 +1522,7 @@ exports[`render offset pagination component with no items 1`] = `
       </span>
     </button>
     <button
-      class="c11 c5"
+      class="c8 c5"
       disabled=""
       type="button"
     >
@@ -1695,7 +1531,7 @@ exports[`render offset pagination component with no items 1`] = `
       >
         <svg
           aria-labelledby=":rj:"
-          class="c12"
+          class="c9"
           fill="currentColor"
           height="24"
           stroke="currentColor"

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -11,11 +11,6 @@ exports[`dropdown is not visible if items fit 1`] = `
   box-sizing: border-box;
 }
 
-.c9 {
-  box-sizing: border-box;
-  z-index: 1060;
-}
-
 .c1 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
@@ -232,27 +227,6 @@ exports[`dropdown is not visible if items fit 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c11 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c6 {
@@ -361,21 +335,6 @@ exports[`dropdown is not visible if items fit 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c9"
-        style="position: absolute; left: 0px; top: 0px;"
-      >
-        <div
-          class="c10"
-        >
-          <ul
-            aria-labelledby=":r3:-label"
-            class="c11"
-            id=":r3:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
 </div>
@@ -390,11 +349,6 @@ exports[`it renders the given tabs 1`] = `
 
 .c0 {
   box-sizing: border-box;
-}
-
-.c9 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c1 {
@@ -613,27 +567,6 @@ exports[`it renders the given tabs 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c11 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c6 {
@@ -742,21 +675,6 @@ exports[`it renders the given tabs 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c9"
-        style="position: absolute; left: 0px; top: 0px;"
-      >
-        <div
-          class="c10"
-        >
-          <ul
-            aria-labelledby=":r0:-label"
-            class="c11"
-            id=":r0:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
 </div>
@@ -771,11 +689,6 @@ exports[`only the pills that fit are visible 1`] = `
 
 .c0 {
   box-sizing: border-box;
-}
-
-.c9 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c1 {
@@ -994,27 +907,6 @@ exports[`only the pills that fit are visible 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c11 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c6 {
@@ -1157,21 +1049,6 @@ exports[`only the pills that fit are visible 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c9"
-        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
-      >
-        <div
-          class="c10"
-        >
-          <ul
-            aria-labelledby=":rc:-label"
-            class="c11"
-            id=":rc:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
 </div>
@@ -1186,11 +1063,6 @@ exports[`only the pills that fit are visible 2 1`] = `
 
 .c0 {
   box-sizing: border-box;
-}
-
-.c9 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c1 {
@@ -1409,27 +1281,6 @@ exports[`only the pills that fit are visible 2 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c11 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c6 {
@@ -1571,21 +1422,6 @@ exports[`only the pills that fit are visible 2 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c9"
-        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
-      >
-        <div
-          class="c10"
-        >
-          <ul
-            aria-labelledby=":rf:-label"
-            class="c11"
-            id=":rf:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
 </div>
@@ -1600,11 +1436,6 @@ exports[`renders all the filters if they fit 1`] = `
 
 .c0 {
   box-sizing: border-box;
-}
-
-.c9 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c1 {
@@ -1825,27 +1656,6 @@ exports[`renders all the filters if they fit 1`] = `
   grid-gap: 0.5rem;
 }
 
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c11 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
-}
-
 .c6 {
   position: relative;
 }
@@ -1984,21 +1794,6 @@ exports[`renders all the filters if they fit 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c9"
-        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
-      >
-        <div
-          class="c10"
-        >
-          <ul
-            aria-labelledby=":r9:-label"
-            class="c11"
-            id=":r9:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
 </div>
@@ -2013,11 +1808,6 @@ exports[`renders dropdown if items do not fit 1`] = `
 
 .c0 {
   box-sizing: border-box;
-}
-
-.c9 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c1 {
@@ -2238,27 +2028,6 @@ exports[`renders dropdown if items do not fit 1`] = `
   grid-gap: 0.5rem;
 }
 
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c11 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
-}
-
 .c6 {
   position: relative;
 }
@@ -2383,21 +2152,6 @@ exports[`renders dropdown if items do not fit 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c9"
-        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
-      >
-        <div
-          class="c10"
-        >
-          <ul
-            aria-labelledby=":r6:-label"
-            class="c11"
-            id=":r6:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`render Stateless pagination component 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c9 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -15,11 +15,6 @@ exports[`render Stateless pagination component 1`] = `
 
 .c0 {
   box-sizing: border-box;
-}
-
-.c8 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c1 {
@@ -145,7 +140,7 @@ exports[`render Stateless pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c8 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -194,32 +189,32 @@ exports[`render Stateless pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c8:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c8[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c8 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c8:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c8:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c8:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c8[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -235,27 +230,6 @@ exports[`render Stateless pagination component 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c9 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c10 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c3 {
@@ -281,14 +255,14 @@ exports[`render Stateless pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c8 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c8 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -341,28 +315,13 @@ exports[`render Stateless pagination component 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="c8"
-        style="position: fixed; left: 0px; top: 0px;"
-      >
-        <div
-          class="c9"
-        >
-          <ul
-            aria-labelledby=":r0:-label"
-            class="c10"
-            id=":r0:-menu"
-            role="menu"
-          />
-        </div>
-      </div>
     </div>
   </div>
   <div
     class="c0 c2"
   >
     <button
-      class="c11 c5"
+      class="c8 c5"
       type="button"
     >
       <span
@@ -370,7 +329,7 @@ exports[`render Stateless pagination component 1`] = `
       >
         <svg
           aria-labelledby=":r3:"
-          class="c12"
+          class="c9"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -394,7 +353,7 @@ exports[`render Stateless pagination component 1`] = `
       </span>
     </button>
     <button
-      class="c11 c5"
+      class="c8 c5"
       type="button"
     >
       <span
@@ -402,7 +361,7 @@ exports[`render Stateless pagination component 1`] = `
       >
         <svg
           aria-labelledby=":r4:"
-          class="c12"
+          class="c9"
           fill="currentColor"
           height="24"
           stroke="currentColor"

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   width: 2rem;
 }
 
-.c15 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -15,11 +15,6 @@ exports[`offset pagination renders a pagination component 1`] = `
 
 .c1 {
   box-sizing: border-box;
-}
-
-.c11 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c4 {
@@ -164,7 +159,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c14 {
+.c11 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -213,32 +208,32 @@ exports[`offset pagination renders a pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c14:focus {
+.c11:focus {
   outline: none;
 }
 
-.c14[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c14 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c14:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c14:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c14:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c14[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -254,27 +249,6 @@ exports[`offset pagination renders a pagination component 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c12 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c13 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c6 {
@@ -324,14 +298,14 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c14 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c14 {
+  .c11 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -393,28 +367,13 @@ exports[`offset pagination renders a pagination component 1`] = `
               </svg>
             </span>
           </button>
-          <div
-            class="c11"
-            style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
-          >
-            <div
-              class="c12"
-            >
-              <ul
-                aria-labelledby=":r13:-label"
-                class="c13"
-                id=":r13:-menu"
-                role="menu"
-              />
-            </div>
-          </div>
         </div>
       </div>
       <div
         class="c1 c5"
       >
         <button
-          class="c14 c8"
+          class="c11 c8"
           disabled=""
           type="button"
         >
@@ -423,7 +382,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           >
             <svg
               aria-labelledby=":r16:"
-              class="c15"
+              class="c12"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -447,7 +406,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           </span>
         </button>
         <button
-          class="c14 c8"
+          class="c11 c8"
           type="button"
         >
           <span
@@ -455,7 +414,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           >
             <svg
               aria-labelledby=":r17:"
-              class="c15"
+              class="c12"
               fill="currentColor"
               height="24"
               stroke="currentColor"

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   width: 2rem;
 }
 
-.c15 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -15,11 +15,6 @@ exports[`offset pagination renders a pagination component 1`] = `
 
 .c1 {
   box-sizing: border-box;
-}
-
-.c11 {
-  box-sizing: border-box;
-  z-index: 1060;
 }
 
 .c4 {
@@ -164,7 +159,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c14 {
+.c11 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -213,32 +208,32 @@ exports[`offset pagination renders a pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c14:focus {
+.c11:focus {
   outline: none;
 }
 
-.c14[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c14 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c14:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c14:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c14:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c14[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -254,27 +249,6 @@ exports[`offset pagination renders a pagination component 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
-}
-
-.c12 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c13 {
-  border-radius: 0.25rem;
-  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
-  background-color: #FFFFFF;
-  color: #313440;
-  margin: 0;
-  max-height: 15.625rem;
-  outline: none;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-  z-index: 1060;
 }
 
 .c6 {
@@ -324,14 +298,14 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c14 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c14 {
+  .c11 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -393,28 +367,13 @@ exports[`offset pagination renders a pagination component 1`] = `
               </svg>
             </span>
           </button>
-          <div
-            class="c11"
-            style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
-          >
-            <div
-              class="c12"
-            >
-              <ul
-                aria-labelledby=":r13:-label"
-                class="c13"
-                id=":r13:-menu"
-                role="menu"
-              />
-            </div>
-          </div>
         </div>
       </div>
       <div
         class="c1 c5"
       >
         <button
-          class="c14 c8"
+          class="c11 c8"
           disabled=""
           type="button"
         >
@@ -423,7 +382,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           >
             <svg
               aria-labelledby=":r16:"
-              class="c15"
+              class="c12"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -447,7 +406,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           </span>
         </button>
         <button
-          class="c14 c8"
+          class="c11 c8"
           type="button"
         >
           <span
@@ -455,7 +414,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           >
             <svg
               aria-labelledby=":r17:"
-              class="c15"
+              class="c12"
               fill="currentColor"
               height="24"
               stroke="currentColor"


### PR DESCRIPTION
## What?

- updated Dropdown component to render its popover menu inside a React Portal using react-popper
- replaced useRef with setReferenceElement/setPopperElement for stable positioning with Popper


## Why?

Previously, the Dropdown menu was rendered inline, which could cause issues with clipping (overflow: hidden, z-index conflicts, or positioning within scrollable containers). 
By rendering the menu into a portal (document.body or a custom container), we ensure consistent layering and positioning of the dropdown regardless of DOM hierarchy.

## Screenshots/Screen Recordings


https://github.com/user-attachments/assets/84a16c95-7623-49dc-ab0e-b10f956fbf41


Result of suggestions: 
Modal before:
<img width="2104" height="1287" alt="Screenshot 2025-09-08 at 11 50 59" src="https://github.com/user-attachments/assets/6ee9b9d5-9564-44cb-9118-3565814381e2" />


Modal indexed higher after:
<img width="1562" height="1309" alt="Screenshot 2025-09-08 at 12 15 29" src="https://github.com/user-attachments/assets/fdc6f937-3ae3-4781-b1af-75f337ed7fb6" />




## Testing/Proof

- updated and ran unit tests for the Dropdown component
