### PR TITLE
chore: .gitignore next-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 coverage
 .vscode
 packages/docs/.next
+packages/docs/next-env.d.ts
 packages/docs/out
 packages/docs/pages/Dev
 packages/docs/pages/dev.tsx

--- a/packages/docs/next-env.d.ts
+++ b/packages/docs/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="./.next/types/routes.d.ts" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,8 +13,7 @@
   "scripts": {
     "build": "next build",
     "lint": "eslint . --max-warnings 0",
-    "start": "next",
-    "typecheck": "tsc --noEmit"
+    "start": "next"
   },
   "prettier": "@bigcommerce/eslint-config/prettier",
   "dependencies": {


### PR DESCRIPTION
## What/Why?

Adds the `next-env.d.ts` file to `.gitingore`. This is the recommended approach from Next.js as the file is autogenerated on each build/dev script run.

This also removes the typecheck script as typechecking happens during `next build` which generates the `next-env.d.ts` file needed to typecheck. I looked into running the docs build before we typechecked but because the docs requires all the other packages to be built, it increases the typechecking script time.


## Screenshots/Screen Recordings

N/A

## Testing/Proof

CI should build like normal.