### PR TITLE
chore: eslint ignore next-env.d.ts

### DIFF
--- a/packages/docs/.eslintrc.js
+++ b/packages/docs/.eslintrc.js
@@ -2,7 +2,7 @@
 module.exports = {
   root: true,
   extends: [require.resolve('@bigcommerce/configs/eslint/base.js')],
-  ignorePatterns: ['.next', 'out', 'node_modules'],
+  ignorePatterns: ['.next', 'out', 'node_modules', 'next-env.d.ts'],
   overrides: [
     {
       files: ['design-docs/**/*.mdx'],


### PR DESCRIPTION
## What/Why?

ESLint ignore the `next-env.d.ts` file as it's autogenerated.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

<img width="1193" height="287" alt="Screenshot 2025-09-03 at 15 40 05" src="https://github.com/user-attachments/assets/0ad757e5-2692-4d3f-a471-9997847292b2" />

