### PR TITLE
fix(component): restore useeffect in the buttongroup

### DIFF
--- a/.changeset/tired-taxis-give.md
+++ b/.changeset/tired-taxis-give.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design': patch
+---
+
+restore useeffect in the buttongroup

--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -4,6 +4,7 @@ import React, {
   createRef,
   memo,
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useState,
@@ -54,13 +55,17 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
     const parentRef = createRef<HTMLDivElement>();
     const dropdownRef = createRef<HTMLDivElement>();
     const [isMenuVisible, setIsMenuVisible] = useState(false);
-    const [actionsState, setActionsState] = useState<ActionsState[]>(() => {
-      return actions.map((action) => ({
-        isVisible: true,
-        action: excludeIconProps(action),
-        ref: createRef<HTMLDivElement>(),
-      }));
-    });
+    const [actionsState, setActionsState] = useState<ActionsState[]>([]);
+
+    useEffect(() => {
+      setActionsState(
+        actions.map((action) => ({
+          isVisible: true,
+          action: excludeIconProps(action),
+          ref: createRef<HTMLDivElement>(),
+        })),
+      );
+    }, [actions]);
 
     const hideOverflowedActions = useCallback(() => {
       const parentWidth = parentRef.current?.offsetWidth ?? 0;


### PR DESCRIPTION
## What?

Restore the  useEffect hook in the ButtonGroup component

## Why?

In a prior change, per code review, we replaced the useEffect initializer with lazy state and moved measurements to useLayoutEffect. Under real usage (frequent actions reference changes), this led to stale refs and visible flicker/layout shift. This PR restores the useEffect wrapper to re-sync actionsState when actions change, while leaving size measurements in useLayoutEffect.

## Screenshots/Screen Recordings

before the restoration



https://github.com/user-attachments/assets/39a037f4-4105-409f-aefb-95bff65b6215




after the restoration


https://github.com/user-attachments/assets/b7abb6b5-6fe3-40d8-945b-a1b03d0f214d


## Testing/Proof

manually tested on Safari 18.3


https://github.com/user-attachments/assets/9c0e6d04-07ea-4623-87d4-b11c47e816b0

