### PR TITLE
feat: add Source Sans 3 support

### DIFF
--- a/.changeset/true-cougars-notice.md
+++ b/.changeset/true-cougars-notice.md
@@ -1,0 +1,8 @@
+---
+'@bigcommerce/big-design-theme': minor
+'@bigcommerce/big-design': minor
+'@bigcommerce/examples': minor
+'@bigcommerce/docs': minor
+---
+
+Change the documentation and code to use Source Sans 3 instead of Source Sans Pro. Source Sans Pro is licensed by Adobe now which means we need to the utilize the open license with Source Sans 3.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,23 @@ Add the font as a `<link>` in your `index.html`/`<head>` element.
 <head>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
-  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@200;300;400;600&display=swap" rel="stylesheet" />
 </head>
 ```
+
+If using Next.js, utilize the `next/fonts/google` import:
+
+```tsx
+import { Source_Sans_3 } from 'next/font/google';
+
+const sourceSans3 = Source_Sans_3({
+  display: 'swap',
+  weight: ["200", "300", "400", "600"],
+  subsets: ['latin'],
+});
+```
+
+See https://nextjs.org/docs/app/api-reference/components/font for more details on how to apply the font.
 
 Import the `GlobalStyles` component and use it once in your app. This will set a few styles globally
 and add [normalize.css](https://github.com/necolas/normalize.css/). We recommend placing it close to

--- a/packages/big-design-theme/src/system/typography.ts
+++ b/packages/big-design-theme/src/system/typography.ts
@@ -25,7 +25,7 @@ export interface Typography {
 }
 
 export const createTypography = (): Typography => ({
-  fontFamily: '"Source Sans Pro", "Helvetica Neue", Arial, sans-serif',
+  fontFamily: '"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Arial, sans-serif',
   fontSize: {
     small: remCalc(14),
     medium: remCalc(16),

--- a/packages/big-design/README.md
+++ b/packages/big-design/README.md
@@ -26,9 +26,23 @@ Add the font as a `<link>` in your `index.html`/`<head>` element.
 <head>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
-  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@200;300;400;600&display=swap" rel="stylesheet" />
 </head>
 ```
+
+If using Next.js, utilize the `next/fonts/google` import:
+
+```tsx
+import { Source_Sans_3 } from 'next/font/google';
+
+const sourceSans3 = Source_Sans_3({
+  display: 'swap',
+  weight: ["200", "300", "400", "600"],
+  subsets: ['latin'],
+});
+```
+
+See https://nextjs.org/docs/app/api-reference/components/font for more details on how to apply the font.
 
 Import the `GlobalStyles` component and use it once in your app. This will set a few styles globally
 and add [normalize.css](https://github.com/necolas/normalize.css/). We recommend placing it close to

--- a/packages/docs/pages/_app.tsx
+++ b/packages/docs/pages/_app.tsx
@@ -57,7 +57,7 @@ const App = ({ Component, pageProps }) => {
         <link href="https://fonts.googleapis.com" rel="preconnect" />
         <link crossOrigin="" href="https://fonts.gstatic.com" rel="preconnect" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@200;300;400;600&display=swap"
           rel="stylesheet"
         />
       </Head>

--- a/packages/docs/pages/index.tsx
+++ b/packages/docs/pages/index.tsx
@@ -98,7 +98,7 @@ const GettingStartedPage = () => {
           <head>
             <link rel="preconnect" href="https://fonts.googleapis.com" />
             <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600&display=swap" rel="stylesheet" />
+            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@200;300;400;600&display=swap" rel="stylesheet" />
           </head>
           `}
         </CodeSnippet>

--- a/packages/examples/index.html
+++ b/packages/examples/index.html
@@ -6,7 +6,7 @@
     <title>BigDesign Example</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@200;300;400;600&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## What?

Update the BigDesign library to use Source Sans 3 instead of Source Sans Pro across all documentation, examples, and font configurations.

## Why?

Source Sans Pro is now licensed by Adobe, requiring us to migrate to Source Sans 3 which maintains an open license. This change ensures the BigDesign library continues to use freely available fonts without licensing restrictions. The font family configuration has been updated to include Source Sans 3 as the primary font while maintaining Source Sans Pro as a fallback to ensure backward compatibility.

## Screenshots/Screen Recordings

No visual changes are expected as Source Sans 3 is visually identical to Source Sans Pro - this is purely a licensing and configuration update.

## Testing/Proof

Updated font references across:
- Root README.md and package-specific README.md files
- Documentation site (`packages/docs/pages/_app.tsx` and `packages/docs/pages/index.tsx`)
- Examples HTML template (`packages/examples/index.html`)
- Theme typography configuration (`packages/big-design-theme/src/system/typography.ts`)

Added Next.js font import examples to README files for developers using Next.js applications. Verified all Google Fonts URLs point to the correct Source Sans 3 font family with appropriate font weights (200, 300, 400, 600).

<img width="1174" height="488" alt="Screenshot 2025-10-15 at 11 40 48" src="https://github.com/user-attachments/assets/221fdbf6-3a13-4144-b263-66064e513acf" />
<img width="1158" height="262" alt="Screenshot 2025-10-15 at 11 40 35" src="https://github.com/user-attachments/assets/13dddf53-20f2-4d93-9280-e18c9bfe6070" />
<img width="2416" height="1404" alt="Screenshot 2025-10-15 at 11 40 39" src="https://github.com/user-attachments/assets/6ead931c-164b-4e30-9c37-9dd4321604c6" />


This pull request description was generated with the assistance of AI. Portions of the code and/or implementation ideas in this PR may also have been created or influenced by AI tools.