### PR TITLE
fix(component): dropdown causing infinite loop

### DIFF
--- a/.changeset/fix-dropdown-infinite-render.md
+++ b/.changeset/fix-dropdown-infinite-render.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Fix infinite re-render loop in Dropdown component when using portal. Ensures List component is always mounted (hidden when closed) to satisfy downshift requirements.

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -114,11 +114,6 @@ export const Dropdown = memo(
         toggleButtonId: toggle.props.id,
       });
 
-    // downshift throws a ref error if getMenuProps is called with no args and the menu is closed
-    if (!isOpen) {
-      getMenuProps({}, { suppressRefError: true });
-    }
-
     const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null);
     const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 
@@ -155,28 +150,51 @@ export const Dropdown = memo(
         }),
       });
 
-    const popperContent = (
-      <Box ref={setPopperElement} style={styles.popper} {...attributes.popper} zIndex="popover">
-        <List
-          {...props}
-          autoWidth={autoWidth}
-          getItemProps={getItemProps}
-          getMenuProps={getMenuProps}
-          highlightedIndex={highlightedIndex}
-          isDropdown={true}
-          isOpen={isOpen}
-          items={items}
-          maxHeight={maxHeight}
-          role="menu"
-          update={update}
-        />
-      </Box>
-    );
-
     return (
       <StyledBox>
         {clonedToggle}
-        {isOpen ? createPortal(popperContent, document.body) : null}
+        {isOpen ? (
+          createPortal(
+            <Box
+              ref={setPopperElement}
+              style={styles.popper}
+              {...attributes.popper}
+              zIndex="popover"
+            >
+              <List
+                {...props}
+                autoWidth={autoWidth}
+                getItemProps={getItemProps}
+                getMenuProps={getMenuProps}
+                highlightedIndex={highlightedIndex}
+                isDropdown={true}
+                isOpen={isOpen}
+                items={items}
+                maxHeight={maxHeight}
+                role="menu"
+                update={update}
+              />
+            </Box>,
+            document.body,
+          )
+        ) : (
+          // We need to render the menu hidden to ensure it has a reference for popper
+          <Box style={styles.popper} {...attributes.popper} display="none" zIndex="popover">
+            <List
+              {...props}
+              autoWidth={autoWidth}
+              getItemProps={getItemProps}
+              getMenuProps={getMenuProps}
+              highlightedIndex={highlightedIndex}
+              isDropdown={true}
+              isOpen={isOpen}
+              items={items}
+              maxHeight={maxHeight}
+              role="menu"
+              update={update}
+            />
+          </Box>
+        )}
       </StyledBox>
     );
   },

--- a/packages/big-design/src/components/GlobalStyles/spec.tsx
+++ b/packages/big-design/src/components/GlobalStyles/spec.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ServerStyleSheet } from 'styled-components';
+
+import 'jest-styled-components';
+
+import { GlobalStyles } from './GlobalStyles';
+
+test('renders global styles', () => {
+  const sheet = new ServerStyleSheet();
+
+  try {
+    const html = sheet.collectStyles(<GlobalStyles />);
+
+    render(html);
+
+    const styles = sheet.getStyleTags();
+
+    expect(styles).toContain('body');
+    expect(styles).toContain('Source Sans Pro');
+  } finally {
+    sheet.seal();
+  }
+});

--- a/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`render offset pagination component 1`] = `
   width: 2rem;
 }
 
-.c9 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -15,6 +15,12 @@ exports[`render offset pagination component 1`] = `
 
 .c0 {
   box-sizing: border-box;
+}
+
+.c8 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c1 {
@@ -140,7 +146,7 @@ exports[`render offset pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c8 {
+.c11 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -189,32 +195,32 @@ exports[`render offset pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c8:focus {
+.c11:focus {
   outline: none;
 }
 
-.c8[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c8 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c8:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c8:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c8:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c8[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -230,6 +236,27 @@ exports[`render offset pagination component 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c9 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c3 {
@@ -255,14 +282,14 @@ exports[`render offset pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c8 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c8 {
+  .c11 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -315,13 +342,29 @@ exports[`render offset pagination component 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c8"
+        display="none"
+        style="position: fixed; left: 0px; top: 0px;"
+      >
+        <div
+          class="c9"
+        >
+          <ul
+            aria-labelledby=":r0:-label"
+            class="c10"
+            id=":r0:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
   <div
     class="c0 c2"
   >
     <button
-      class="c8 c5"
+      class="c11 c5"
       disabled=""
       type="button"
     >
@@ -330,7 +373,7 @@ exports[`render offset pagination component 1`] = `
       >
         <svg
           aria-labelledby=":r3:"
-          class="c9"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -354,7 +397,7 @@ exports[`render offset pagination component 1`] = `
       </span>
     </button>
     <button
-      class="c8 c5"
+      class="c11 c5"
       type="button"
     >
       <span
@@ -362,7 +405,7 @@ exports[`render offset pagination component 1`] = `
       >
         <svg
           aria-labelledby=":r4:"
-          class="c9"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -396,7 +439,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
   width: 2rem;
 }
 
-.c9 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -404,6 +447,12 @@ exports[`render offset pagination component with invalid page info 1`] = `
 
 .c0 {
   box-sizing: border-box;
+}
+
+.c8 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c1 {
@@ -529,7 +578,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
   color: #D9DCE9;
 }
 
-.c8 {
+.c11 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -578,32 +627,32 @@ exports[`render offset pagination component with invalid page info 1`] = `
   color: #3C64F4;
 }
 
-.c8:focus {
+.c11:focus {
   outline: none;
 }
 
-.c8[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c8 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c8:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c8:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c8:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c8[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -619,6 +668,27 @@ exports[`render offset pagination component with invalid page info 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c9 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c3 {
@@ -644,14 +714,14 @@ exports[`render offset pagination component with invalid page info 1`] = `
 }
 
 @media (min-width:720px) {
-  .c8 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c8 {
+  .c11 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -704,13 +774,29 @@ exports[`render offset pagination component with invalid page info 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c8"
+        display="none"
+        style="position: fixed; left: 0px; top: 0px;"
+      >
+        <div
+          class="c9"
+        >
+          <ul
+            aria-labelledby=":r5:-label"
+            class="c10"
+            id=":r5:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
   <div
     class="c0 c2"
   >
     <button
-      class="c8 c5"
+      class="c11 c5"
       disabled=""
       type="button"
     >
@@ -719,7 +805,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
       >
         <svg
           aria-labelledby=":r8:"
-          class="c9"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -743,7 +829,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
       </span>
     </button>
     <button
-      class="c8 c5"
+      class="c11 c5"
       type="button"
     >
       <span
@@ -751,7 +837,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
       >
         <svg
           aria-labelledby=":r9:"
-          class="c9"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -785,7 +871,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
   width: 2rem;
 }
 
-.c9 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -793,6 +879,12 @@ exports[`render offset pagination component with invalid range info 1`] = `
 
 .c0 {
   box-sizing: border-box;
+}
+
+.c8 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c1 {
@@ -918,7 +1010,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
   color: #D9DCE9;
 }
 
-.c8 {
+.c11 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -967,32 +1059,32 @@ exports[`render offset pagination component with invalid range info 1`] = `
   color: #3C64F4;
 }
 
-.c8:focus {
+.c11:focus {
   outline: none;
 }
 
-.c8[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c8 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c8:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c8:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c8:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c8[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -1008,6 +1100,27 @@ exports[`render offset pagination component with invalid range info 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c9 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c3 {
@@ -1033,14 +1146,14 @@ exports[`render offset pagination component with invalid range info 1`] = `
 }
 
 @media (min-width:720px) {
-  .c8 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c8 {
+  .c11 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -1093,13 +1206,29 @@ exports[`render offset pagination component with invalid range info 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c8"
+        display="none"
+        style="position: fixed; left: 0px; top: 0px;"
+      >
+        <div
+          class="c9"
+        >
+          <ul
+            aria-labelledby=":ra:-label"
+            class="c10"
+            id=":ra:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
   <div
     class="c0 c2"
   >
     <button
-      class="c8 c5"
+      class="c11 c5"
       disabled=""
       type="button"
     >
@@ -1108,7 +1237,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
       >
         <svg
           aria-labelledby=":rd:"
-          class="c9"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1132,7 +1261,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
       </span>
     </button>
     <button
-      class="c8 c5"
+      class="c11 c5"
       disabled=""
       type="button"
     >
@@ -1141,7 +1270,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
       >
         <svg
           aria-labelledby=":re:"
-          class="c9"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1175,7 +1304,7 @@ exports[`render offset pagination component with no items 1`] = `
   width: 2rem;
 }
 
-.c9 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -1183,6 +1312,12 @@ exports[`render offset pagination component with no items 1`] = `
 
 .c0 {
   box-sizing: border-box;
+}
+
+.c8 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c1 {
@@ -1308,7 +1443,7 @@ exports[`render offset pagination component with no items 1`] = `
   color: #D9DCE9;
 }
 
-.c8 {
+.c11 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -1357,32 +1492,32 @@ exports[`render offset pagination component with no items 1`] = `
   color: #3C64F4;
 }
 
-.c8:focus {
+.c11:focus {
   outline: none;
 }
 
-.c8[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c8 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c8:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c8:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c8:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c8[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -1398,6 +1533,27 @@ exports[`render offset pagination component with no items 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c9 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c3 {
@@ -1423,14 +1579,14 @@ exports[`render offset pagination component with no items 1`] = `
 }
 
 @media (min-width:720px) {
-  .c8 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c8 {
+  .c11 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -1483,13 +1639,29 @@ exports[`render offset pagination component with no items 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c8"
+        display="none"
+        style="position: fixed; left: 0px; top: 0px;"
+      >
+        <div
+          class="c9"
+        >
+          <ul
+            aria-labelledby=":rf:-label"
+            class="c10"
+            id=":rf:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
   <div
     class="c0 c2"
   >
     <button
-      class="c8 c5"
+      class="c11 c5"
       disabled=""
       type="button"
     >
@@ -1498,7 +1670,7 @@ exports[`render offset pagination component with no items 1`] = `
       >
         <svg
           aria-labelledby=":ri:"
-          class="c9"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -1522,7 +1694,7 @@ exports[`render offset pagination component with no items 1`] = `
       </span>
     </button>
     <button
-      class="c8 c5"
+      class="c11 c5"
       disabled=""
       type="button"
     >
@@ -1531,7 +1703,7 @@ exports[`render offset pagination component with no items 1`] = `
       >
         <svg
           aria-labelledby=":rj:"
-          class="c9"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -11,6 +11,12 @@ exports[`dropdown is not visible if items fit 1`] = `
   box-sizing: border-box;
 }
 
+.c9 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
+}
+
 .c1 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
@@ -227,6 +233,27 @@ exports[`dropdown is not visible if items fit 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c6 {
@@ -335,6 +362,22 @@ exports[`dropdown is not visible if items fit 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c9"
+        display="none"
+        style="position: absolute; left: 0px; top: 0px;"
+      >
+        <div
+          class="c10"
+        >
+          <ul
+            aria-labelledby=":r3:-label"
+            class="c11"
+            id=":r3:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -349,6 +392,12 @@ exports[`it renders the given tabs 1`] = `
 
 .c0 {
   box-sizing: border-box;
+}
+
+.c9 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c1 {
@@ -567,6 +616,27 @@ exports[`it renders the given tabs 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c6 {
@@ -675,6 +745,22 @@ exports[`it renders the given tabs 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c9"
+        display="none"
+        style="position: absolute; left: 0px; top: 0px;"
+      >
+        <div
+          class="c10"
+        >
+          <ul
+            aria-labelledby=":r0:-label"
+            class="c11"
+            id=":r0:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -689,6 +775,12 @@ exports[`only the pills that fit are visible 1`] = `
 
 .c0 {
   box-sizing: border-box;
+}
+
+.c9 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c1 {
@@ -907,6 +999,27 @@ exports[`only the pills that fit are visible 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c6 {
@@ -1049,6 +1162,22 @@ exports[`only the pills that fit are visible 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c9"
+        display="none"
+        style="position: absolute; left: 0px; top: 0px;"
+      >
+        <div
+          class="c10"
+        >
+          <ul
+            aria-labelledby=":rc:-label"
+            class="c11"
+            id=":rc:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -1063,6 +1192,12 @@ exports[`only the pills that fit are visible 2 1`] = `
 
 .c0 {
   box-sizing: border-box;
+}
+
+.c9 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c1 {
@@ -1281,6 +1416,27 @@ exports[`only the pills that fit are visible 2 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c6 {
@@ -1422,6 +1578,22 @@ exports[`only the pills that fit are visible 2 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c9"
+        display="none"
+        style="position: absolute; left: 0px; top: 0px;"
+      >
+        <div
+          class="c10"
+        >
+          <ul
+            aria-labelledby=":rf:-label"
+            class="c11"
+            id=":rf:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -1436,6 +1608,12 @@ exports[`renders all the filters if they fit 1`] = `
 
 .c0 {
   box-sizing: border-box;
+}
+
+.c9 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c1 {
@@ -1656,6 +1834,27 @@ exports[`renders all the filters if they fit 1`] = `
   grid-gap: 0.5rem;
 }
 
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
 .c6 {
   position: relative;
 }
@@ -1794,6 +1993,22 @@ exports[`renders all the filters if they fit 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c9"
+        display="none"
+        style="position: absolute; left: 0px; top: 0px;"
+      >
+        <div
+          class="c10"
+        >
+          <ul
+            aria-labelledby=":r9:-label"
+            class="c11"
+            id=":r9:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -1808,6 +2023,12 @@ exports[`renders dropdown if items do not fit 1`] = `
 
 .c0 {
   box-sizing: border-box;
+}
+
+.c9 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c1 {
@@ -2028,6 +2249,27 @@ exports[`renders dropdown if items do not fit 1`] = `
   grid-gap: 0.5rem;
 }
 
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c11 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
+}
+
 .c6 {
   position: relative;
 }
@@ -2152,6 +2394,22 @@ exports[`renders dropdown if items do not fit 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c9"
+        display="none"
+        style="position: absolute; left: 0px; top: 0px;"
+      >
+        <div
+          class="c10"
+        >
+          <ul
+            aria-labelledby=":r6:-label"
+            class="c11"
+            id=":r6:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`render Stateless pagination component 1`] = `
   width: 2rem;
 }
 
-.c9 {
+.c12 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -15,6 +15,12 @@ exports[`render Stateless pagination component 1`] = `
 
 .c0 {
   box-sizing: border-box;
+}
+
+.c8 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c1 {
@@ -140,7 +146,7 @@ exports[`render Stateless pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c8 {
+.c11 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -189,32 +195,32 @@ exports[`render Stateless pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c8:focus {
+.c11:focus {
   outline: none;
 }
 
-.c8[disabled] {
+.c11[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c8 + .bd-button {
+.c11 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c8:active {
+.c11:active {
   background-color: #DBE3FE;
 }
 
-.c8:focus {
+.c11:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c8:hover:not(:active) {
+.c11:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c8[disabled] {
+.c11[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -230,6 +236,27 @@ exports[`render Stateless pagination component 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c9 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c3 {
@@ -255,14 +282,14 @@ exports[`render Stateless pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c8 + .bd-button {
+  .c11 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c8 {
+  .c11 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -315,13 +342,29 @@ exports[`render Stateless pagination component 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="c8"
+        display="none"
+        style="position: fixed; left: 0px; top: 0px;"
+      >
+        <div
+          class="c9"
+        >
+          <ul
+            aria-labelledby=":r0:-label"
+            class="c10"
+            id=":r0:-menu"
+            role="menu"
+          />
+        </div>
+      </div>
     </div>
   </div>
   <div
     class="c0 c2"
   >
     <button
-      class="c8 c5"
+      class="c11 c5"
       type="button"
     >
       <span
@@ -329,7 +372,7 @@ exports[`render Stateless pagination component 1`] = `
       >
         <svg
           aria-labelledby=":r3:"
-          class="c9"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -353,7 +396,7 @@ exports[`render Stateless pagination component 1`] = `
       </span>
     </button>
     <button
-      class="c8 c5"
+      class="c11 c5"
       type="button"
     >
       <span
@@ -361,7 +404,7 @@ exports[`render Stateless pagination component 1`] = `
       >
         <svg
           aria-labelledby=":r4:"
-          class="c9"
+          class="c12"
           fill="currentColor"
           height="24"
           stroke="currentColor"

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c15 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -15,6 +15,12 @@ exports[`offset pagination renders a pagination component 1`] = `
 
 .c1 {
   box-sizing: border-box;
+}
+
+.c11 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c4 {
@@ -159,7 +165,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c14 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -208,32 +214,32 @@ exports[`offset pagination renders a pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c14:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c14[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c14 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c14:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c14:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c14:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c14[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -249,6 +255,27 @@ exports[`offset pagination renders a pagination component 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c12 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c13 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c6 {
@@ -298,14 +325,14 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c14 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c14 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -367,13 +394,29 @@ exports[`offset pagination renders a pagination component 1`] = `
               </svg>
             </span>
           </button>
+          <div
+            class="c11"
+            display="none"
+            style="position: fixed; left: 0px; top: 0px;"
+          >
+            <div
+              class="c12"
+            >
+              <ul
+                aria-labelledby=":r13:-label"
+                class="c13"
+                id=":r13:-menu"
+                role="menu"
+              />
+            </div>
+          </div>
         </div>
       </div>
       <div
         class="c1 c5"
       >
         <button
-          class="c11 c8"
+          class="c14 c8"
           disabled=""
           type="button"
         >
@@ -382,7 +425,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           >
             <svg
               aria-labelledby=":r16:"
-              class="c12"
+              class="c15"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -406,7 +449,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           </span>
         </button>
         <button
-          class="c11 c8"
+          class="c14 c8"
           type="button"
         >
           <span
@@ -414,7 +457,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           >
             <svg
               aria-labelledby=":r17:"
-              class="c12"
+              class="c15"
               fill="currentColor"
               height="24"
               stroke="currentColor"

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   width: 2rem;
 }
 
-.c12 {
+.c15 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -15,6 +15,12 @@ exports[`offset pagination renders a pagination component 1`] = `
 
 .c1 {
   box-sizing: border-box;
+}
+
+.c11 {
+  display: none;
+  box-sizing: border-box;
+  z-index: 1060;
 }
 
 .c4 {
@@ -159,7 +165,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   color: #D9DCE9;
 }
 
-.c11 {
+.c14 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -208,32 +214,32 @@ exports[`offset pagination renders a pagination component 1`] = `
   color: #3C64F4;
 }
 
-.c11:focus {
+.c14:focus {
   outline: none;
 }
 
-.c11[disabled] {
+.c14[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c14 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c11:active {
+.c14:active {
   background-color: #DBE3FE;
 }
 
-.c11:focus {
+.c14:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c11:hover:not(:active) {
+.c14:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c11[disabled] {
+.c14[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
@@ -249,6 +255,27 @@ exports[`offset pagination renders a pagination component 1`] = `
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.c12 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c13 {
+  border-radius: 0.25rem;
+  box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
+  background-color: #FFFFFF;
+  color: #313440;
+  margin: 0;
+  max-height: 15.625rem;
+  outline: none;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  z-index: 1060;
 }
 
 .c6 {
@@ -298,14 +325,14 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 @media (min-width:720px) {
-  .c11 + .bd-button {
+  .c14 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c11 {
+  .c14 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
@@ -367,13 +394,29 @@ exports[`offset pagination renders a pagination component 1`] = `
               </svg>
             </span>
           </button>
+          <div
+            class="c11"
+            display="none"
+            style="position: fixed; left: 0px; top: 0px;"
+          >
+            <div
+              class="c12"
+            >
+              <ul
+                aria-labelledby=":r13:-label"
+                class="c13"
+                id=":r13:-menu"
+                role="menu"
+              />
+            </div>
+          </div>
         </div>
       </div>
       <div
         class="c1 c5"
       >
         <button
-          class="c11 c8"
+          class="c14 c8"
           disabled=""
           type="button"
         >
@@ -382,7 +425,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           >
             <svg
               aria-labelledby=":r16:"
-              class="c12"
+              class="c15"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -406,7 +449,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           </span>
         </button>
         <button
-          class="c11 c8"
+          class="c14 c8"
           type="button"
         >
           <span
@@ -414,7 +457,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           >
             <svg
               aria-labelledby=":r17:"
-              class="c12"
+              class="c15"
               fill="currentColor"
               height="24"
               stroke="currentColor"


### PR DESCRIPTION
## What?

Fixes a "Maximum update depth exceeded" infinite re-render loop in the Dropdown component introduced by commit `8b48238a6756bc2cf52f204ca5557adf7defdc6f` which added portal support.

> [!TIP]
> Reviewing by commit will be helpful. Main changes: https://github.com/bigcommerce/big-design/pull/1766/commits/afbac854b1329597f7d659dda65725bf687924b3

## Why?

The portal implementation introduced a critical bug where calling `getMenuProps({}, { suppressRefError: true })` on every render when the menu was closed caused an infinite loop:

1. When menu is closed, `getMenuProps()` is called on every render
2. `getMenuProps()` triggers downshift's internal `setState`
3. `setState` causes a re-render, which calls `getMenuProps()` again
4. This loop continues infinitely, crashing React applications using the Dropdown component

The previous portal implementation conditionally rendered the List component only when open (`{isOpen ? createPortal(...) : null}`), which meant `getMenuProps()` was never called during the component lifecycle when closed. The workaround of manually calling `getMenuProps()` in the component body was the source of the infinite loop.

The fix ensures the List component is **always mounted** to satisfy downshift's requirements, but only **visible via portal** when the menu is open:
- When `isOpen=true`: List is rendered in a portal to `document.body` (preserving intended portal functionality)
- When `isOpen=false`: List is rendered in a hidden container (`display: none`) to ensure `getMenuProps()` is called without triggering infinite re-renders

```bash
Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
    at checkForNestedUpdates (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:19207:15)
    at scheduleUpdateOnFiber (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:18081:7)
    at dispatchSetState (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:11953:11)
    at eval (webpack-internal:///./node_modules/downshift/dist/downshift.esm.js:95:9)
    at Array.forEach (<anonymous>)
    at eval (webpack-internal:///./node_modules/downshift/dist/downshift.esm.js:93:10)
    at safelyDetachRef (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:16279:24)
    at commitMutationEffectsOnFiber (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:17289:15)
    at recursivelyTraverseMutationEffects (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:17233:11)
    at commitMutationEffectsOnFiber (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:17247:11)
```

## Screenshots/Screen Recordings

https://github.com/user-attachments/assets/7ee98ef1-9797-46b1-9648-0b2e295856e9

## Testing/Proof

- ✅ All 36 Dropdown component tests pass (`pnpm -F @bigcommerce/big-design run test -- Dropdown`)
- ✅ Full test suite passes
- ✅ Lint and typecheck pass with no errors
- ✅ Verified no "Maximum update depth exceeded" error occurs when using Dropdown component
- ✅ Dropdown continues to render in portal when open (preserving intended functionality from original portal PR)
- ✅ Dropdown correctly hides when closed without triggering infinite re-renders

---

This pull request description was generated with the assistance of AI. Portions of the code and/or implementation ideas in this PR may also have been created or influenced by AI tools.

**Initial Prompt:**
> Based on the conversation history from the previous session (summarized at the start of this conversation), the issue was identified while investigating commit `8b48238a6756bc2cf52f204ca5557adf7defdc6f` which added portal support to the Dropdown component. The root cause was the conditional call to `getMenuProps({}, { suppressRefError: true })` when the menu was closed, which caused infinite React re-renders. The solution implemented ensures the List component is always mounted (hidden when closed, portaled when open) to satisfy downshift requirements without triggering infinite loops.
