### PR TITLE
fix(component): dropdown items click not firing inside modal

### DIFF
--- a/.changeset/heavy-llamas-join.md
+++ b/.changeset/heavy-llamas-join.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+fix(component): dropdown items click not firing inside modal

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import 'jest-styled-components';
 
 import { Button } from '../Button';
+import { Modal } from '../Modal';
 
 import { Dropdown } from './';
 
@@ -683,4 +684,21 @@ test("dropdown toggle doesn't trigger onItemClick", async () => {
   await userEvent.click(document.body);
 
   expect(onItemClick).not.toHaveBeenCalled();
+});
+
+test('dropdown onItemClick triggers inside a modal', async () => {
+  onItemClick.mockClear();
+
+  render(<Modal isOpen={true}>{DropdownMock}</Modal>);
+
+  const toggle = await screen.findByRole('button', { name: 'Button' });
+
+  await userEvent.click(toggle);
+
+  const options = await screen.findAllByRole('option');
+
+  await userEvent.click(options[1]);
+
+  expect(onItemClick).toHaveBeenCalledTimes(1);
+  expect(onItemClick).toHaveBeenCalledWith({ content: 'Option 2', onItemClick });
 });

--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -96,7 +96,23 @@ const InternalModal: React.FC<ModalProps> = ({
   // Setup focus-trap
   useEffect(() => {
     if (modalRef && internalTrap.current === null) {
-      internalTrap.current = createFocusTrap(modalRef, { fallbackFocus: modalRef });
+      internalTrap.current = createFocusTrap(modalRef, {
+        allowOutsideClick: (event) => {
+          const target = event.target;
+
+          // Allow clicks on portaled menu/listbox elements (e.g., Dropdown, Select)
+          /* istanbul ignore next */
+          if (target instanceof Element) {
+            return (
+              target.closest('[role="menu"]') !== null ||
+              target.closest('[role="listbox"]') !== null
+            );
+          }
+
+          return false;
+        },
+        fallbackFocus: modalRef,
+      });
       internalTrap.current.activate();
     }
 


### PR DESCRIPTION
## What?/Why?

This PR fixes an issue where interactive components rendered via portals (e.g., Dropdown, Select) inside a Modal could not be clicked or interacted with.
The problem occurred because the modal's focus-trap considered these portaled elements to be outside the modal, blocking all pointer events and preventing handlers such as onItemClick from firing.

The fix introduces a focused change to the modal’s focus trap configuration to safely allow pointer events on menus and listboxes without breaking accessibility or modal isolation.

**Changes:**
- Updated the createFocusTrap configuration to include a custom `allowOutsideClick` predicate.
- This predicate now allows clicks on elements (or their descendants) with `role="menu"` or `role="listbox"`.
- Retains full focus trap functionality:
  - Focus is still restricted within the modal for keyboard navigation.
  - Backdrop clicks and Escape key continue to close the modal when enabled.
- No API or behavioral changes for other components.

## Screenshots/Screen Recordings

**Before:**

https://github.com/user-attachments/assets/02c86a62-0dda-42ff-86fc-9871902250fe

**After:**


https://github.com/user-attachments/assets/32f00a8e-59ba-4dcf-8f1b-3de9c1dcce66


## Testing/Proof

- Local testing (see video)
- Additional unit tests
