### PR TITLE
chore: utilize OIDC for publishing

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -51,7 +52,6 @@ jobs:
           commit: "chore(release): publish"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Setup Pages
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## What/why?

Utilizes OIDC for publishing instead of a NPM_TOKEN.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

We'll see when this is merged onto main.