### PR TITLE
chore: add pages permission

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -12,6 +12,7 @@ permissions:
   contents: write
   packages: write
   pull-requests: write
+  pages: write
   issues: read
 
 jobs:


### PR DESCRIPTION
## What/why?

Adds the pages permission to deploy the updated docs site.

## Screenshots/Screen Recordings

N/A

## Testing/Proof

N/A