### PR TITLE
fix(component): pilltabs component restored data-test-id attributes

### DIFF
--- a/.changeset/goofy-eagles-wait.md
+++ b/.changeset/goofy-eagles-wait.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design': patch
+---
+
+fix(component): added back data-test-id to pilltab component

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -186,7 +186,13 @@ export const PillTabs: React.FC<PillTabsProps> = ({
   }
 
   return (
-    <Flex flexDirection="row" flexWrap="nowrap" ref={refs.parent} role="list">
+    <Flex
+      data-testid="pilltabs-wrapper"
+      flexDirection="row"
+      flexWrap="nowrap"
+      ref={refs.parent}
+      role="list"
+    >
       {pills.map(({ id, isVisible, title, isActive, onClick, groupIndex }, index) => {
         const previousPill = pills[index - 1];
         const isFirstInGroup = previousPill && previousPill.groupIndex !== groupIndex;
@@ -203,7 +209,12 @@ export const PillTabs: React.FC<PillTabsProps> = ({
                 role="separator"
               />
             )}
-            <StyledFlexItem isVisible={isVisible} ref={setPillRef(index)} role="listitem">
+            <StyledFlexItem
+              data-testid={`pilltabs-pill-${index}`}
+              isVisible={isVisible}
+              ref={setPillRef(index)}
+              role="listitem"
+            >
               <StyledPillTab
                 disabled={!isVisible}
                 isActive={isActive}
@@ -218,7 +229,12 @@ export const PillTabs: React.FC<PillTabsProps> = ({
           </Fragment>
         );
       })}
-      <StyledFlexItem isVisible={dropdownItemGroups.length > 0} ref={refs.dropdown} role="listitem">
+      <StyledFlexItem
+        data-testid="pilltabs-dropdown-toggle"
+        isVisible={dropdownItemGroups.length > 0}
+        ref={refs.dropdown}
+        role="listitem"
+      >
         <Dropdown
           items={dropdownItemGroups}
           toggle={

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -296,10 +296,12 @@ exports[`dropdown is not visible if items fit 1`] = `
 
 <div
   class="c0 c1"
+  data-testid="pilltabs-wrapper"
   role="list"
 >
   <div
     class="c0 c2 "
+    data-testid="pilltabs-pill-0"
     role="listitem"
   >
     <button
@@ -315,6 +317,7 @@ exports[`dropdown is not visible if items fit 1`] = `
   </div>
   <div
     class="c0 c2 c5"
+    data-testid="pilltabs-dropdown-toggle"
     role="listitem"
   >
     <div
@@ -679,10 +682,12 @@ exports[`it renders the given tabs 1`] = `
 
 <div
   class="c0 c1"
+  data-testid="pilltabs-wrapper"
   role="list"
 >
   <div
     class="c0 c2 "
+    data-testid="pilltabs-pill-0"
     role="listitem"
   >
     <button
@@ -698,6 +703,7 @@ exports[`it renders the given tabs 1`] = `
   </div>
   <div
     class="c0 c2 c5"
+    data-testid="pilltabs-dropdown-toggle"
     role="listitem"
   >
     <div
@@ -1062,10 +1068,12 @@ exports[`only the pills that fit are visible 1`] = `
 
 <div
   class="c0 c1"
+  data-testid="pilltabs-wrapper"
   role="list"
 >
   <div
     class="c0 c2 "
+    data-testid="pilltabs-pill-0"
     role="listitem"
   >
     <button
@@ -1081,6 +1089,7 @@ exports[`only the pills that fit are visible 1`] = `
   </div>
   <div
     class="c0 c2 c5"
+    data-testid="pilltabs-pill-1"
     role="listitem"
   >
     <button
@@ -1097,6 +1106,7 @@ exports[`only the pills that fit are visible 1`] = `
   </div>
   <div
     class="c0 c2 c5"
+    data-testid="pilltabs-pill-2"
     role="listitem"
   >
     <button
@@ -1113,6 +1123,7 @@ exports[`only the pills that fit are visible 1`] = `
   </div>
   <div
     class="c0 c2 "
+    data-testid="pilltabs-dropdown-toggle"
     role="listitem"
   >
     <div
@@ -1477,10 +1488,12 @@ exports[`only the pills that fit are visible 2 1`] = `
 
 <div
   class="c0 c1"
+  data-testid="pilltabs-wrapper"
   role="list"
 >
   <div
     class="c0 c2 "
+    data-testid="pilltabs-pill-0"
     role="listitem"
   >
     <button
@@ -1496,6 +1509,7 @@ exports[`only the pills that fit are visible 2 1`] = `
   </div>
   <div
     class="c0 c2 "
+    data-testid="pilltabs-pill-1"
     role="listitem"
   >
     <button
@@ -1511,6 +1525,7 @@ exports[`only the pills that fit are visible 2 1`] = `
   </div>
   <div
     class="c0 c2 c5"
+    data-testid="pilltabs-pill-2"
     role="listitem"
   >
     <button
@@ -1527,6 +1542,7 @@ exports[`only the pills that fit are visible 2 1`] = `
   </div>
   <div
     class="c0 c2 "
+    data-testid="pilltabs-dropdown-toggle"
     role="listitem"
   >
     <div
@@ -1891,10 +1907,12 @@ exports[`renders all the filters if they fit 1`] = `
 
 <div
   class="c0 c1"
+  data-testid="pilltabs-wrapper"
   role="list"
 >
   <div
     class="c0 c2 "
+    data-testid="pilltabs-pill-0"
     role="listitem"
   >
     <button
@@ -1910,6 +1928,7 @@ exports[`renders all the filters if they fit 1`] = `
   </div>
   <div
     class="c0 c2 "
+    data-testid="pilltabs-pill-1"
     role="listitem"
   >
     <button
@@ -1925,6 +1944,7 @@ exports[`renders all the filters if they fit 1`] = `
   </div>
   <div
     class="c0 c2 "
+    data-testid="pilltabs-pill-2"
     role="listitem"
   >
     <button
@@ -1940,6 +1960,7 @@ exports[`renders all the filters if they fit 1`] = `
   </div>
   <div
     class="c0 c2 c5"
+    data-testid="pilltabs-dropdown-toggle"
     role="listitem"
   >
     <div
@@ -2304,10 +2325,12 @@ exports[`renders dropdown if items do not fit 1`] = `
 
 <div
   class="c0 c1"
+  data-testid="pilltabs-wrapper"
   role="list"
 >
   <div
     class="c0 c2 "
+    data-testid="pilltabs-pill-0"
     role="listitem"
   >
     <button
@@ -2323,6 +2346,7 @@ exports[`renders dropdown if items do not fit 1`] = `
   </div>
   <div
     class="c0 c2 c5"
+    data-testid="pilltabs-pill-1"
     role="listitem"
   >
     <button
@@ -2339,6 +2363,7 @@ exports[`renders dropdown if items do not fit 1`] = `
   </div>
   <div
     class="c0 c2 "
+    data-testid="pilltabs-dropdown-toggle"
     role="listitem"
   >
     <div


### PR DESCRIPTION
## What?

Reverted `data-test-id` attribute for PillTabs component deleted in [this PR](https://github.com/bigcommerce/big-design/pull/1818)

## Why?

Functional tests are relying on these attributes. UPL related tests started to fail.

## Screenshots/Screen Recordings

https://github.com/user-attachments/assets/6d9611ba-18d4-4d1c-800a-c8baaffc2bfb


## Testing/Proof
Tested locally with checking attributes in react dev tools. + updated snapshots
