### PR TITLE
fix(component): adjust left padding for icon presence

### DIFF
--- a/.changeset/crisp-parents-occur.md
+++ b/.changeset/crisp-parents-occur.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design': patch
+---
+
+Chip: use xxSmall left padding when icon is present

--- a/packages/big-design/src/components/Chip/Chip.tsx
+++ b/packages/big-design/src/components/Chip/Chip.tsx
@@ -33,7 +33,7 @@ export const Chip: React.FC<ChipProps> = memo(({ children, icon, label, onDelete
       {...rest}
       backgroundColor="secondary30"
       borderRadius="normal"
-      paddingLeft="xSmall"
+      paddingLeft={icon ? 'xxSmall' : 'xSmall'}
       paddingRight="xxSmall"
     >
       {icon ? <StyledChipIcon>{icon}</StyledChipIcon> : null}

--- a/packages/big-design/src/components/Chip/spec.tsx
+++ b/packages/big-design/src/components/Chip/spec.tsx
@@ -72,3 +72,19 @@ test('icon is always constrained to 16px even if size is set to 40px', () => {
   expect(iconWrapper).toHaveStyleRule('height', '1rem', { modifier: 'svg' });
   expect(iconWrapper).toHaveStyleRule('width', '1rem', { modifier: 'svg' });
 });
+
+test('uses xSmall left padding when there is no icon', () => {
+  render(<Chip label="No icon" />);
+
+  const chip = screen.getByText('No icon').parentElement;
+  expect(chip).toHaveStyle({ paddingLeft: '0.5rem' }); // xSmall
+});
+
+test('uses xxSmall left padding when icon is present', () => {
+  const { container } = render(
+    <Chip icon={<AddIcon size="medium" />} label="With icon" />,
+  );
+
+  const chip = container.firstChild as HTMLElement;
+  expect(chip).toHaveStyle({ paddingLeft: '0.25rem' }); // xxSmall
+});

--- a/packages/big-design/src/components/Chip/spec.tsx
+++ b/packages/big-design/src/components/Chip/spec.tsx
@@ -77,14 +77,14 @@ test('uses xSmall left padding when there is no icon', () => {
   render(<Chip label="No icon" />);
 
   const chip = screen.getByText('No icon').parentElement;
+
   expect(chip).toHaveStyle({ paddingLeft: '0.5rem' }); // xSmall
 });
 
 test('uses xxSmall left padding when icon is present', () => {
-  const { container } = render(
-    <Chip icon={<AddIcon size="medium" />} label="With icon" />,
-  );
+  render(<Chip icon={<AddIcon size="medium" />} label="With icon" />);
 
-  const chip = container.firstChild as HTMLElement;
+  const chip = screen.getByText('With icon').parentElement;
+
   expect(chip).toHaveStyle({ paddingLeft: '0.25rem' }); // xxSmall
 });


### PR DESCRIPTION
# Pull Request

## What?

Adjusts left padding on the Chip component so that when an `icon` is present it uses `xxSmall` instead of `xSmall`; when there is no icon it still uses `xSmall`.

## Why?

Chips with an icon already have the icon’s width and its margin adding to the left side. Keeping `xSmall` in that case made the chip feel too wide. Using `xxSmall` when an icon is present tightens the left padding and keeps the chip visually balanced. Chips without an icon are unchanged.

## Screenshots/Screen Recordings
with Icon
<img width="1014" height="221" alt="image" src="https://github.com/user-attachments/assets/d8fa81b4-f18f-4bee-9ee7-c7e8cafa5321" />

Without Icon 
<img width="743" height="233" alt="image" src="https://github.com/user-attachments/assets/a064b532-ad4a-45c6-a79d-353cda1ab9c8" />
 

## Testing/Proof
- Manually checked a Chip with `icon` and without in the docs or a local app to verify left padding looks correct in both cases.
