### PR TITLE
chore: hoist @bigcommerce/eslint-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "turbo typecheck"
   },
   "devDependencies": {
+    "@bigcommerce/eslint-config": "^2.12.0",
     "@changesets/assemble-release-plan": "^6.0.9",
     "@changesets/changelog-git": "^0.2.1",
     "@changesets/cli": "^2.29.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     devDependencies:
+      '@bigcommerce/eslint-config':
+        specifier: ^2.12.0
+        version: 2.12.0(@testing-library/dom@10.4.1)(@types/eslint@8.56.10)(eslint@8.57.0)(jest@30.2.0(@types/node@25.0.3))(typescript@5.9.3)
       '@changesets/assemble-release-plan':
         specifier: ^6.0.9
         version: 6.0.9(patch_hash=e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553)
@@ -8007,9 +8010,9 @@ snapshots:
       '@typescript-eslint/parser': 8.46.2(eslint@8.57.0)(typescript@5.9.3)
       eslint: 8.57.0
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-gettext: 1.2.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(jest@30.2.0(@types/node@25.0.3))(typescript@5.9.3)
       eslint-plugin-jest-dom: 5.5.0(@testing-library/dom@10.4.1)(eslint@8.57.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.0)
@@ -10863,6 +10866,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 8.57.0
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -10905,6 +10923,17 @@ snapshots:
       '@typescript-eslint/parser': 8.46.2(eslint@8.57.0)(typescript@5.9.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.46.2(eslint@8.57.0)(typescript@5.9.3)
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
@@ -10912,6 +10941,35 @@ snapshots:
   eslint-plugin-gettext@1.2.0:
     dependencies:
       gettext-parser: 4.2.0
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.46.2(eslint@8.57.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
     dependencies:
@@ -10924,7 +10982,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## What/Why?

When trying to version the changesets we are running into an issue where the `@bigcommerce/eslint-config` dependency is not being hoisted which is causing `changeset version` to not properly run:
```
Error: Cannot find module '@bigcommerce/eslint-config/prettier'
2026-02-04T19:10:38.3093296Z Require stack:
2026-02-04T19:10:38.3094260Z - /home/runner/work/big-design/big-design/node_modules/.pnpm/prettier@2.8.8/node_modules/prettier/index.js
2026-02-04T19:10:38.3095921Z - /home/runner/work/big-design/big-design/node_modules/.pnpm/@changesets+write@0.4.0/node_modules/@changesets/write/dist/changesets-write.cjs.js
2026-02-04T19:10:38.3097155Z - /home/runner/work/big-design/big-design/node_modules/.pnpm/@changesets+cli@2.29.7_@types+node@25.0.3/node_modules/@changesets/cli/dist/changesets-cli.cjs.js
2026-02-04T19:10:38.3098298Z - /home/runner/work/big-design/big-design/node_modules/.pnpm/@changesets+cli@2.29.7_@types+node@25.0.3/node_modules/@changesets/cli/bin.js
2026-02-04T19:10:38.3099322Z     at Module._resolveFilename (node:internal/modules/cjs/loader:1421:15)
2026-02-04T19:10:38.3099907Z     at resolve (node:internal/modules/helpers:163:19)
2026-02-04T19:10:38.3100641Z     at Object.transform (/home/runner/work/big-design/big-design/node_modules/.pnpm/prettier@2.8.8/node_modules/prettier/index.js:18425:34)
2026-02-04T19:10:38.3101648Z     at run (/home/runner/work/big-design/big-design/node_modules/.pnpm/prettier@2.8.8/node_modules/prettier/third-party.js:8418:53)
2026-02-04T19:10:38.3103209Z     at async cacheWrapper (/home/runner/work/big-design/big-design/node_modules/.pnpm/prettier@2.8.8/node_modules/prettier/third-party.js:8294:22)
2026-02-04T19:10:38.3105529Z     at async Explorer.search (/home/runner/work/big-design/big-design/node_modules/.pnpm/prettier@2.8.8/node_modules/prettier/third-party.js:8407:24)
2026-02-04T19:10:38.3106608Z     at async Promise.all (index 0)
2026-02-04T19:10:38.3107712Z     at async writeFormattedMarkdownFile (/home/runner/work/big-design/big-design/node_modules/.pnpm/@changesets+apply-release-plan@7.0.13/node_modules/@changesets/apply-release-plan/dist/changesets-apply-release-plan.cjs.js:463:76)
2026-02-04T19:10:38.3109686Z     at async prependFile (/home/runner/work/big-design/big-design/node_modules/.pnpm/@changesets+apply-release-plan@7.0.13/node_modules/@changesets/apply-release-plan/dist/changesets-apply-release-plan.cjs.js:458:3)
2026-02-04T19:10:38.3111354Z     at async updateChangelog (/home/runner/work/big-design/big-design/node_modules/.pnpm/@changesets+apply-release-plan@7.0.13/node_modules/@changesets/apply-release-plan/dist/changesets-apply-release-plan.cjs.js:433:7) {
2026-02-04T19:10:38.3112288Z   code: 'MODULE_NOT_FOUND',
2026-02-04T19:10:38.3112520Z   requireStack: [
2026-02-04T19:10:38.3113019Z     '/home/runner/work/big-design/big-design/node_modules/.pnpm/prettier@2.8.8/node_modules/prettier/index.js',
2026-02-04T19:10:38.3113942Z     '/home/runner/work/big-design/big-design/node_modules/.pnpm/@changesets+write@0.4.0/node_modules/@changesets/write/dist/changesets-write.cjs.js',
2026-02-04T19:10:38.3115281Z     '/home/runner/work/big-design/big-design/node_modules/.pnpm/@changesets+cli@2.29.7_@types+node@25.0.3/node_modules/@changesets/cli/dist/changesets-cli.cjs.js',
2026-02-04T19:10:38.3116383Z     '/home/runner/work/big-design/big-design/node_modules/.pnpm/@changesets+cli@2.29.7_@types+node@25.0.3/node_modules/@changesets/cli/bin.js'
2026-02-04T19:10:38.3116962Z   ]
2026-02-04T19:10:38.3117132Z }
```

## Screenshots/Screen Recordings

N/A

## Testing/Proof

Can only tell when running in CI. Locally it hoists fine, but CI it doesn't
