### PR TITLE
fix(component): [checkbox] prevent rendering empty label container

### DIFF
--- a/.changeset/long-sites-trade.md
+++ b/.changeset/long-sites-trade.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design': patch
+---
+
+Fix alignment issue in Checkbox component when no label is provided.

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -138,7 +138,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
       >
         {!checked && isIndeterminate ? <RemoveIcon /> : <CheckIcon />}
       </StyledCheckbox>
-      <CheckboxLabelContainer>
+      <CheckboxLabelContainer hasContent={Boolean(label) || Boolean(description)}>
         {renderedLabel}
         {renderedDescription}
       </CheckboxLabelContainer>

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -15,8 +15,8 @@ export interface StyledLabelProps {
   disabled?: boolean;
 }
 
-export const CheckboxLabelContainer = styled.div`
-  margin-left: ${({ theme }) => theme.spacing.xSmall};
+export const CheckboxLabelContainer = styled.div<{ hasContent?: boolean }>`
+  margin-left: ${({ hasContent, theme }) => (hasContent ? theme.spacing.xSmall : 0)};
 `;
 
 export const CheckboxContainer = styled.div`


### PR DESCRIPTION
## What?

Remove label container when no description or label is provided.

## Why?

When the checkbox component is rendered without a label or description the container with a small margin is still included causing the checkbox to be slightly mis-aligned when centered.

## Screenshots/Screen Recordings

Before change:
<img width="1000" height="635" alt="Screenshot 2026-03-04 at 5 03 13 pm" src="https://github.com/user-attachments/assets/53eae39b-a00d-49d1-8bcf-4658f451e60a" />

After change:
<img width="998" height="639" alt="Screenshot 2026-03-04 at 5 03 48 pm" src="https://github.com/user-attachments/assets/630da7d9-9c21-48b0-89bf-493bd38b6a72" />


## Testing/Proof
See screenshot above. 
