### PR TITLE
feat(component): [worksheet] add row virtualisation via @tanstack/react-virtual

### DIFF
--- a/.changeset/worksheet-virtualization.md
+++ b/.changeset/worksheet-virtualization.md
@@ -1,0 +1,10 @@
+---
+"@bigcommerce/big-design": minor
+---
+
+Add opt-in row virtualization to the Worksheet component via `@tanstack/react-virtual`.
+
+- New `height` prop enables virtualization — when provided, only visible rows are rendered in the DOM, significantly improving performance for large datasets.
+- Virtualization-aware scroll sync keeps the selected cell in view automatically (`VirtualScrollSync`).
+- Collapsed expandable child rows are excluded from the virtual list so the virtualizer doesn't allocate space for hidden rows.
+- Fix formatting function to correctly handle non-numeric values when copying (`Number(value)` guard).

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -46,6 +46,7 @@
     "react-datepicker": "^7.3.0",
     "react-intersection-observer": "^10.0.0",
     "react-popper": "^2.3.0",
+    "@tanstack/react-virtual": "^3.13.0",
     "zustand": "^5.0.11"
   },
   "peerDependencies": {

--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -185,7 +185,7 @@ const InternalCell = <T extends WorksheetItem>({
   }, [cell, isShiftPressed, rowIndex, selectedCells, setSelectedCells, setSelectedRows]);
 
   const renderedValue = useMemo(() => {
-    if (typeof formatting === 'function' && value !== '' && !Number.isNaN(value)) {
+    if (typeof formatting === 'function' && value !== '' && !Number.isNaN(Number(value))) {
       return formatting(value);
     }
 

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -159,11 +159,7 @@ const InternalWorksheet = typedMemo(
       estimateSize: () => 44,
       getScrollElement: () => scrollContainerRef.current,
       observeElementRect: (instance, cb) => {
-        const el = instance.scrollElement;
-
-        if (!el) {
-          return;
-        }
+        const el = instance.scrollElement!;
 
         const measure = () => {
           const rect = el.getBoundingClientRect();

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -1,4 +1,5 @@
 import { BaselineHelpIcon } from '@bigcommerce/big-design-icons';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import React, {
   createContext,
   createRef,
@@ -65,12 +66,14 @@ const InternalWorksheet = typedMemo(
     expandableRows,
     defaultExpandedRows,
     disabledRows,
+    height = 600,
     items,
     minWidth,
     onChange,
     onErrors,
   }: WorksheetProps<T>): React.ReactElement<WorksheetProps<T>> => {
     const tableRef = createRef<HTMLTableElement>();
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
     const shouldBeTriggeredOnChange = useRef(false);
     const { store, useStore } = useWorksheetStore();
     const tooltipId = useId();
@@ -112,6 +115,14 @@ const InternalWorksheet = typedMemo(
       store,
       useShallow((state) => state.invalidCells),
     );
+    const hiddenRows = useStore(
+      store,
+      useShallow((state) => state.hiddenRows),
+    );
+    const selectedCells = useStore(
+      store,
+      useShallow((state) => state.selectedCells),
+    );
 
     const { handleKeyDown, handleKeyUp } = useKeyEvents();
 
@@ -121,6 +132,71 @@ const InternalWorksheet = typedMemo(
         ? [{ hash: '', header: '', type: 'toggle', width: 32 }, ...columns]
         : columns;
     }, [columns, expandableRows]);
+
+    // Compute which rows are children (for virtualization filtering)
+    const childIds = useMemo(
+      () => new Set(Object.values(expandableRows || {}).flat()),
+      [expandableRows],
+    );
+
+    // Only virtualise rows that are visible (non-hidden child rows are excluded)
+    const visibleRowIndices = useMemo(
+      () =>
+        rows.reduce<number[]>((acc, row, index) => {
+          if (!(childIds.has(row.id) && hiddenRows.includes(row.id))) {
+            acc.push(index);
+          }
+
+          return acc;
+        }, []),
+      [rows, childIds, hiddenRows],
+    );
+
+    const fallbackHeight = typeof height === 'number' ? height : 600;
+
+    const virtualizer = useVirtualizer({
+      count: visibleRowIndices.length,
+      estimateSize: () => 44,
+      getScrollElement: () => scrollContainerRef.current,
+      observeElementRect: (instance, cb) => {
+        const el = instance.scrollElement;
+
+        if (!el) {
+          return;
+        }
+
+        const measure = () => {
+          const rect = el.getBoundingClientRect();
+
+          cb({ height: rect.height || fallbackHeight, width: rect.width });
+        };
+
+        measure();
+
+        if (typeof ResizeObserver !== 'undefined') {
+          const ro = new ResizeObserver(measure);
+
+          ro.observe(el);
+
+          return () => ro.disconnect();
+        }
+      },
+      overscan: 5,
+    });
+
+    const virtualItems = virtualizer.getVirtualItems();
+
+    // Scroll the virtualised list to keep the keyboard-selected row in view
+    useEffect(() => {
+      if (selectedCells.length > 0) {
+        const rowIndex = selectedCells[0].rowIndex;
+        const virtualIndex = visibleRowIndices.indexOf(rowIndex);
+
+        if (virtualIndex !== -1) {
+          virtualizer.scrollToIndex(virtualIndex, { behavior: 'auto' });
+        }
+      }
+    }, [selectedCells, visibleRowIndices, virtualizer]);
 
     useEffect(() => {
       shouldBeTriggeredOnChange.current = editedCells.length > 0;
@@ -201,15 +277,39 @@ const InternalWorksheet = typedMemo(
       [expandedColumns],
     );
 
+    const paddingTop = virtualItems.length > 0 ? virtualItems[0].start : 0;
+    const paddingBottom =
+      virtualItems.length > 0
+        ? virtualizer.getTotalSize() - virtualItems[virtualItems.length - 1].end
+        : 0;
+
     const renderedRows = useMemo(
       () => (
         <tbody>
-          {rows.map((_row, rowIndex) => (
-            <Row columns={expandedColumns} key={rowIndex} rowIndex={rowIndex} />
-          ))}
+          {paddingTop > 0 && (
+            <tr aria-hidden="true">
+              <td
+                colSpan={expandedColumns.length + 1}
+                style={{ border: 'none', height: paddingTop, padding: 0 }}
+              />
+            </tr>
+          )}
+          {virtualItems.map((virtualItem) => {
+            const rowIndex = visibleRowIndices[virtualItem.index];
+
+            return <Row columns={expandedColumns} key={rowIndex} rowIndex={rowIndex} />;
+          })}
+          {paddingBottom > 0 && (
+            <tr aria-hidden="true">
+              <td
+                colSpan={expandedColumns.length + 1}
+                style={{ border: 'none', height: paddingBottom, padding: 0 }}
+              />
+            </tr>
+          )}
         </tbody>
       ),
-      [expandedColumns, rows],
+      [expandedColumns, virtualItems, visibleRowIndices, paddingTop, paddingBottom],
     );
 
     const renderedModals = useMemo(
@@ -222,7 +322,7 @@ const InternalWorksheet = typedMemo(
 
     return (
       <UpdateItemsProvider items={rows}>
-        <StyledBox>
+        <StyledBox containerHeight={height} ref={scrollContainerRef}>
           <InternalTable
             hasExpandableRows={Boolean(expandableRows)}
             hasStaticWidth={tableHasStaticWidth}

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -34,6 +34,35 @@ import {
 } from './types';
 import { editedRows, invalidRows } from './utils';
 
+// Syncs the virtualizer scroll position to the selected cell.
+// Isolated in its own component so selectedCells changes don't re-render InternalWorksheet.
+const VirtualScrollSync = ({
+  scrollToIndex,
+  visibleRowIndices,
+}: {
+  scrollToIndex: (index: number) => void;
+  visibleRowIndices: number[];
+}) => {
+  const { store, useStore } = useWorksheetStore();
+  const selectedCells = useStore(
+    store,
+    useShallow((state) => state.selectedCells),
+  );
+
+  useEffect(() => {
+    if (selectedCells.length > 0) {
+      const rowIndex = selectedCells[0].rowIndex;
+      const virtualIndex = visibleRowIndices.indexOf(rowIndex);
+
+      if (virtualIndex !== -1) {
+        scrollToIndex(virtualIndex);
+      }
+    }
+  }, [scrollToIndex, selectedCells, visibleRowIndices]);
+
+  return null;
+};
+
 const InternalTable = ({
   hasExpandableRows,
   hasStaticWidth,
@@ -66,7 +95,7 @@ const InternalWorksheet = typedMemo(
     expandableRows,
     defaultExpandedRows,
     disabledRows,
-    height = 600,
+    height,
     items,
     minWidth,
     onChange,
@@ -119,12 +148,11 @@ const InternalWorksheet = typedMemo(
       store,
       useShallow((state) => state.hiddenRows),
     );
-    const selectedCells = useStore(
-      store,
-      useShallow((state) => state.selectedCells),
-    );
 
     const { handleKeyDown, handleKeyUp } = useKeyEvents();
+
+    // Virtualization is opt-in: only active when `height` is explicitly provided.
+    const isVirtualized = height !== undefined;
 
     // Add a column for the toggle components
     const expandedColumns: Array<InternalWorksheetColumn<T>> = useMemo(() => {
@@ -139,23 +167,26 @@ const InternalWorksheet = typedMemo(
       [expandableRows],
     );
 
+    const hiddenRowsSet = useMemo(() => new Set(hiddenRows), [hiddenRows]);
+
     // Only virtualise rows that are visible (non-hidden child rows are excluded)
     const visibleRowIndices = useMemo(
       () =>
         rows.reduce<number[]>((acc, row, index) => {
-          if (!(childIds.has(row.id) && hiddenRows.includes(row.id))) {
+          if (!(childIds.has(row.id) && hiddenRowsSet.has(row.id))) {
             acc.push(index);
           }
 
           return acc;
         }, []),
-      [rows, childIds, hiddenRows],
+      [rows, childIds, hiddenRowsSet],
     );
 
-    const fallbackHeight = typeof height === 'number' ? height : 600;
+    // When height is a number use it as a JSDOM fallback (getBoundingClientRect returns 0 in tests).
+    const fallbackHeight = typeof height === 'number' ? height : 0;
 
     const virtualizer = useVirtualizer({
-      count: visibleRowIndices.length,
+      count: isVirtualized ? visibleRowIndices.length : 0,
       estimateSize: () => 44,
       getScrollElement: () => scrollContainerRef.current,
       observeElementRect: (instance, cb) => {
@@ -176,23 +207,19 @@ const InternalWorksheet = typedMemo(
 
           return () => ro.disconnect();
         }
+
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        return () => {};
       },
       overscan: 5,
     });
 
+    const scrollToIndex = useCallback(
+      (index: number) => virtualizer.scrollToIndex(index, { behavior: 'auto' }),
+      [virtualizer],
+    );
+
     const virtualItems = virtualizer.getVirtualItems();
-
-    // Scroll the virtualised list to keep the keyboard-selected row in view
-    useEffect(() => {
-      if (selectedCells.length > 0) {
-        const rowIndex = selectedCells[0].rowIndex;
-        const virtualIndex = visibleRowIndices.indexOf(rowIndex);
-
-        if (virtualIndex !== -1) {
-          virtualizer.scrollToIndex(virtualIndex, { behavior: 'auto' });
-        }
-      }
-    }, [selectedCells, visibleRowIndices, virtualizer]);
 
     useEffect(() => {
       shouldBeTriggeredOnChange.current = editedCells.length > 0;
@@ -279,33 +306,38 @@ const InternalWorksheet = typedMemo(
         ? virtualizer.getTotalSize() - virtualItems[virtualItems.length - 1].end
         : 0;
 
-    const renderedRows = useMemo(
-      () => (
-        <tbody>
-          {paddingTop > 0 && (
-            <tr aria-hidden="true">
-              <td
-                colSpan={expandedColumns.length + 1}
-                style={{ border: 'none', height: paddingTop, padding: 0 }}
-              />
-            </tr>
-          )}
-          {virtualItems.map((virtualItem) => {
-            const rowIndex = visibleRowIndices[virtualItem.index];
+    const renderedRows = (
+      <tbody>
+        {isVirtualized ? (
+          <>
+            {paddingTop > 0 && (
+              <tr aria-hidden="true">
+                <td
+                  colSpan={expandedColumns.length + 1}
+                  style={{ border: 'none', height: paddingTop, padding: 0 }}
+                />
+              </tr>
+            )}
+            {virtualItems.map((virtualItem) => {
+              const rowIndex = visibleRowIndices[virtualItem.index];
 
-            return <Row columns={expandedColumns} key={rowIndex} rowIndex={rowIndex} />;
-          })}
-          {paddingBottom > 0 && (
-            <tr aria-hidden="true">
-              <td
-                colSpan={expandedColumns.length + 1}
-                style={{ border: 'none', height: paddingBottom, padding: 0 }}
-              />
-            </tr>
-          )}
-        </tbody>
-      ),
-      [expandedColumns, virtualItems, visibleRowIndices, paddingTop, paddingBottom],
+              return <Row columns={expandedColumns} key={rowIndex} rowIndex={rowIndex} />;
+            })}
+            {paddingBottom > 0 && (
+              <tr aria-hidden="true">
+                <td
+                  colSpan={expandedColumns.length + 1}
+                  style={{ border: 'none', height: paddingBottom, padding: 0 }}
+                />
+              </tr>
+            )}
+          </>
+        ) : (
+          rows.map((_, rowIndex) => (
+            <Row columns={expandedColumns} key={rowIndex} rowIndex={rowIndex} />
+          ))
+        )}
+      </tbody>
     );
 
     const renderedModals = useMemo(
@@ -318,7 +350,7 @@ const InternalWorksheet = typedMemo(
 
     return (
       <UpdateItemsProvider items={rows}>
-        <StyledBox containerHeight={height} ref={scrollContainerRef}>
+        <StyledBox containerHeight={isVirtualized ? height : undefined} ref={scrollContainerRef}>
           <InternalTable
             hasExpandableRows={Boolean(expandableRows)}
             hasStaticWidth={tableHasStaticWidth}
@@ -331,6 +363,9 @@ const InternalWorksheet = typedMemo(
             {renderedRows}
           </InternalTable>
         </StyledBox>
+        {isVirtualized && (
+          <VirtualScrollSync scrollToIndex={scrollToIndex} visibleRowIndices={visibleRowIndices} />
+        )}
         {renderedModals}
       </UpdateItemsProvider>
     );

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders worksheet 1`] = `
-.c8 {
+.c7 {
   vertical-align: middle;
   height: 1rem;
   width: 1rem;
 }
 
-.c19 {
+.c18 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c20 {
+.c19 {
   margin-left: 0.5rem;
 }
 
-.c14 {
+.c13 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -28,7 +28,7 @@ exports[`renders worksheet 1`] = `
   display: flex;
 }
 
-.c16 {
+.c15 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -41,7 +41,7 @@ exports[`renders worksheet 1`] = `
   width: 1px;
 }
 
-.c18 {
+.c17 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -75,15 +75,15 @@ exports[`renders worksheet 1`] = `
   width: 1.25rem;
 }
 
-.c18:hover {
+.c17:hover {
   border-color: #3C64F4;
 }
 
-.c15:focus + .c17 {
+.c14:focus + .c16 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c18 svg {
+.c17 svg {
   opacity: 1;
 }
 
@@ -125,7 +125,7 @@ exports[`renders worksheet 1`] = `
   border-color: #B4BAD1;
 }
 
-.c15:focus + .c17 {
+.c14:focus + .c16 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
@@ -133,12 +133,12 @@ exports[`renders worksheet 1`] = `
   opacity: 0;
 }
 
-.c0 {
+.c6 {
+  margin-left: 0.25rem;
   box-sizing: border-box;
 }
 
-.c7 {
-  margin-left: 0.25rem;
+.c22 {
   box-sizing: border-box;
 }
 
@@ -187,7 +187,7 @@ exports[`renders worksheet 1`] = `
   flex-shrink: 1;
 }
 
-.c21 {
+.c20 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -195,11 +195,11 @@ exports[`renders worksheet 1`] = `
   line-height: 1.5rem;
 }
 
-.c21:last-child {
+.c20:last-child {
   margin-bottom: 0;
 }
 
-.c10 {
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   display: inline-block;
@@ -215,7 +215,7 @@ exports[`renders worksheet 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c10:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
@@ -311,7 +311,7 @@ exports[`renders worksheet 1`] = `
   grid-gap: 0.5rem;
 }
 
-.c22 {
+.c21 {
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -325,7 +325,7 @@ exports[`renders worksheet 1`] = `
   width: 1px;
 }
 
-.c13 > div {
+.c12 > div {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -352,7 +352,7 @@ exports[`renders worksheet 1`] = `
   overflow: hidden;
 }
 
-.c9 {
+.c8 {
   position: relative;
   background-color: inherit;
   border: 0.03125rem solid #D9DCE9;
@@ -365,14 +365,14 @@ exports[`renders worksheet 1`] = `
   user-select: none;
 }
 
-.c9 p {
+.c8 p {
   display: block;
   white-space: inherit;
   word-break: break-word;
   margin: 0;
 }
 
-.c12 {
+.c11 {
   position: relative;
   background-color: inherit;
   border: 0.03125rem solid #D9DCE9;
@@ -385,7 +385,7 @@ exports[`renders worksheet 1`] = `
   user-select: none;
 }
 
-.c12 p {
+.c11 p {
   display: block;
   white-space: inherit;
   word-break: break-word;
@@ -454,7 +454,7 @@ exports[`renders worksheet 1`] = `
   margin: 0;
 }
 
-.c11 {
+.c10 {
   position: absolute;
   border: 0.0625rem solid #FFFFFF;
   height: 0.375rem;
@@ -467,7 +467,7 @@ exports[`renders worksheet 1`] = `
   display: none;
 }
 
-.c3 {
+.c2 {
   background-color: #D9DCE9;
   border-top: 0.03125rem solid #D9DCE9;
   box-sizing: border-box;
@@ -487,7 +487,7 @@ exports[`renders worksheet 1`] = `
   border: 0.03125rem solid #DB3643;
 }
 
-.c2 {
+.c1 {
   border-collapse: collapse;
   border-spacing: 0;
   min-width: auto;
@@ -495,11 +495,19 @@ exports[`renders worksheet 1`] = `
   width: 100%;
 }
 
-.c2:focus {
+.c1:focus {
   outline: none;
 }
 
-.c4 {
+.c1 > thead {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: #FFFFFF;
+}
+
+.c3 {
   border: 0.03125rem solid #D9DCE9;
   border-right-color: #D9DCE9;
   box-sizing: border-box;
@@ -512,7 +520,7 @@ exports[`renders worksheet 1`] = `
   width: auto;
 }
 
-.c5 {
+.c4 {
   border: 0.03125rem solid #D9DCE9;
   border-right-color: #D9DCE9;
   box-sizing: border-box;
@@ -525,7 +533,7 @@ exports[`renders worksheet 1`] = `
   width: 80px;
 }
 
-.c6 {
+.c5 {
   border: 0.03125rem solid #D9DCE9;
   border-right-color: #D9DCE9;
   box-sizing: border-box;
@@ -538,8 +546,10 @@ exports[`renders worksheet 1`] = `
   width: 90px;
 }
 
-.c1 {
-  overflow-x: scroll;
+.c0 {
+  overflow-x: auto;
+  overflow-y: auto;
+  height: 600px;
 }
 
 @media (min-width:0px) {
@@ -572,53 +582,53 @@ exports[`renders worksheet 1`] = `
 }
 
 <div
-  class="c0 c1"
+  class="c0"
 >
   <table
-    class="c2"
+    class="c1"
     tabindex="0"
   >
     <thead>
       <tr>
         <td
-          class="c3"
+          class="c2"
         />
         <th
-          class="c4"
+          class="c3"
         >
           Product name
            
         </th>
         <th
-          class="c5"
+          class="c4"
         >
           Visible on storefront
            
         </th>
         <th
-          class="c4"
+          class="c3"
         >
           Other field
            
         </th>
         <th
-          class="c4"
+          class="c3"
         >
           Other field
            
         </th>
         <th
-          class="c6"
+          class="c5"
         >
           Number field
            
           <span
-            class="c7"
+            class="c6"
           >
             <svg
               aria-describedby=":r0:"
               aria-labelledby=":r1:"
-              class="c8"
+              class="c7"
               fill="currentColor"
               height="24"
               stroke="currentColor"
@@ -646,14 +656,14 @@ exports[`renders worksheet 1`] = `
     <tbody>
       <tr>
         <td
-          class="c3"
+          class="c2"
         />
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Shoes Name Three"
           >
@@ -661,35 +671,35 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c12"
+          class="c11"
           type="checkbox"
         >
           <div
-            class="c13"
+            class="c12"
           >
             <div
-              class="c14"
+              class="c13"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":r5:"
                 checked=""
-                class="c15 c16"
+                class="c14 c15"
                 id=":r4:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="c17 c18"
+                class="c16 c17"
                 for=":r4:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c19"
+                  class="c18"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -707,11 +717,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c20"
+                class="c19"
               >
                 <label
                   aria-hidden="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   for=":r4:"
                   hidden=""
                   id=":r5:"
@@ -723,15 +733,15 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Text"
           >
@@ -739,21 +749,21 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="modal"
         >
           <div
-            class="c0 c23"
+            class="c22 c23"
           >
             <div
               class="c24 c25 c26"
             >
               <p
-                class="c10"
+                class="c9"
                 color="secondary70"
                 title="1"
               >
@@ -772,7 +782,7 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
@@ -780,7 +790,7 @@ exports[`renders worksheet 1`] = `
           type="number"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="$50.00"
           >
@@ -788,20 +798,20 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
       </tr>
       <tr>
         <td
-          class="c3"
+          class="c2"
         />
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Shoes Name Two"
           >
@@ -809,35 +819,35 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c12"
+          class="c11"
           type="checkbox"
         >
           <div
-            class="c13"
+            class="c12"
           >
             <div
-              class="c14"
+              class="c13"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":rd:"
                 checked=""
-                class="c15 c16"
+                class="c14 c15"
                 id=":rc:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="c17 c18"
+                class="c16 c17"
                 for=":rc:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c19"
+                  class="c18"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -855,11 +865,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c20"
+                class="c19"
               >
                 <label
                   aria-hidden="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   for=":rc:"
                   hidden=""
                   id=":rd:"
@@ -871,15 +881,15 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Text"
           >
@@ -887,21 +897,21 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="modal"
         >
           <div
-            class="c0 c23"
+            class="c22 c23"
           >
             <div
               class="c24 c25 c26"
             >
               <p
-                class="c10"
+                class="c9"
                 color="secondary70"
                 title="2"
               >
@@ -920,7 +930,7 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
@@ -928,7 +938,7 @@ exports[`renders worksheet 1`] = `
           type="number"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="$50.00"
           >
@@ -936,20 +946,20 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
       </tr>
       <tr>
         <td
-          class="c3"
+          class="c2"
         />
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Shoes Name One"
           >
@@ -957,34 +967,34 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c12"
+          class="c11"
           type="checkbox"
         >
           <div
-            class="c13"
+            class="c12"
           >
             <div
-              class="c14"
+              class="c13"
             >
               <input
                 aria-checked="false"
                 aria-labelledby=":rl:"
-                class="c15 c16"
+                class="c14 c15"
                 id=":rk:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="c17 c31"
+                class="c16 c31"
                 for=":rk:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c19"
+                  class="c18"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1002,11 +1012,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c20"
+                class="c19"
               >
                 <label
                   aria-hidden="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   for=":rk:"
                   hidden=""
                   id=":rl:"
@@ -1018,35 +1028,35 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title=""
           />
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="modal"
         >
           <div
-            class="c0 c23"
+            class="c22 c23"
           >
             <div
               class="c24 c25 c26"
             >
               <p
-                class="c10"
+                class="c9"
                 color="secondary70"
                 title="3"
               >
@@ -1065,7 +1075,7 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
@@ -1073,7 +1083,7 @@ exports[`renders worksheet 1`] = `
           type="number"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="$50.00"
           >
@@ -1081,20 +1091,20 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
       </tr>
       <tr>
         <td
-          class="c3"
+          class="c2"
         />
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Variant 1"
           >
@@ -1102,35 +1112,35 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c12"
+          class="c11"
           type="checkbox"
         >
           <div
-            class="c13"
+            class="c12"
           >
             <div
-              class="c14"
+              class="c13"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":rt:"
                 checked=""
-                class="c15 c16"
+                class="c14 c15"
                 id=":rs:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="c17 c18"
+                class="c16 c17"
                 for=":rs:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c19"
+                  class="c18"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1148,11 +1158,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c20"
+                class="c19"
               >
                 <label
                   aria-hidden="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   for=":rs:"
                   hidden=""
                   id=":rt:"
@@ -1164,15 +1174,15 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Text"
           >
@@ -1180,21 +1190,21 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="modal"
         >
           <div
-            class="c0 c23"
+            class="c22 c23"
           >
             <div
               class="c24 c25 c26"
             >
               <p
-                class="c10"
+                class="c9"
                 color="secondary70"
                 title="4"
               >
@@ -1213,7 +1223,7 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
@@ -1221,7 +1231,7 @@ exports[`renders worksheet 1`] = `
           type="number"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="$50.00"
           >
@@ -1229,7 +1239,7 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
       </tr>
@@ -1242,39 +1252,39 @@ exports[`renders worksheet 1`] = `
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title=""
           />
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c12"
+          class="c11"
           type="checkbox"
         >
           <div
-            class="c13"
+            class="c12"
           >
             <div
-              class="c14"
+              class="c13"
             >
               <input
                 aria-labelledby=":r15:"
-                class="c15 c16"
+                class="c14 c15"
                 id=":r14:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="c17 c31"
+                class="c16 c31"
                 for=":r14:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c19"
+                  class="c18"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1292,11 +1302,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c20"
+                class="c19"
               >
                 <label
                   aria-hidden="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   for=":r14:"
                   hidden=""
                   id=":r15:"
@@ -1308,35 +1318,35 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title=""
           />
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="modal"
         >
           <div
-            class="c0 c23"
+            class="c22 c23"
           >
             <div
               class="c24 c25 c26"
             >
               <p
-                class="c10"
+                class="c9"
                 color="secondary70"
                 title=""
               />
@@ -1353,7 +1363,7 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
@@ -1361,26 +1371,26 @@ exports[`renders worksheet 1`] = `
           type="number"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title=""
           />
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
       </tr>
       <tr>
         <td
-          class="c3"
+          class="c2"
         />
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Variant 2"
           >
@@ -1388,35 +1398,35 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c12"
+          class="c11"
           type="checkbox"
         >
           <div
-            class="c13"
+            class="c12"
           >
             <div
-              class="c14"
+              class="c13"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":r1d:"
                 checked=""
-                class="c15 c16"
+                class="c14 c15"
                 id=":r1c:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="c17 c18"
+                class="c16 c17"
                 for=":r1c:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c19"
+                  class="c18"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1434,11 +1444,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c20"
+                class="c19"
               >
                 <label
                   aria-hidden="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   for=":r1c:"
                   hidden=""
                   id=":r1d:"
@@ -1450,15 +1460,15 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Text"
           >
@@ -1466,21 +1476,21 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="modal"
         >
           <div
-            class="c0 c23"
+            class="c22 c23"
           >
             <div
               class="c24 c25 c26"
             >
               <p
-                class="c10"
+                class="c9"
                 color="secondary70"
                 title="6"
               >
@@ -1499,7 +1509,7 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
@@ -1507,7 +1517,7 @@ exports[`renders worksheet 1`] = `
           type="number"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="$50.00"
           >
@@ -1515,7 +1525,7 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
       </tr>
@@ -1524,11 +1534,11 @@ exports[`renders worksheet 1`] = `
           class="c32"
         />
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Variant 3"
           >
@@ -1536,34 +1546,34 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c12"
+          class="c11"
           type="checkbox"
         >
           <div
-            class="c13"
+            class="c12"
           >
             <div
-              class="c14"
+              class="c13"
             >
               <input
                 aria-checked="false"
                 aria-labelledby=":r1l:"
-                class="c15 c16"
+                class="c14 c15"
                 id=":r1k:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="c17 c31"
+                class="c16 c31"
                 for=":r1k:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c19"
+                  class="c18"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1581,11 +1591,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c20"
+                class="c19"
               >
                 <label
                   aria-hidden="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   for=":r1k:"
                   hidden=""
                   id=":r1l:"
@@ -1597,15 +1607,15 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Text"
           >
@@ -1613,21 +1623,21 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="modal"
         >
           <div
-            class="c0 c23"
+            class="c22 c23"
           >
             <div
               class="c24 c25 c26"
             >
               <p
-                class="c10"
+                class="c9"
                 color="secondary70"
                 title="7"
               >
@@ -1646,7 +1656,7 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
@@ -1654,7 +1664,7 @@ exports[`renders worksheet 1`] = `
           type="number"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="$49.00"
           >
@@ -1662,20 +1672,20 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
       </tr>
       <tr>
         <td
-          class="c3"
+          class="c2"
         />
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Dress Name One"
           >
@@ -1683,35 +1693,35 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c12"
+          class="c11"
           type="checkbox"
         >
           <div
-            class="c13"
+            class="c12"
           >
             <div
-              class="c14"
+              class="c13"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":r1t:"
                 checked=""
-                class="c15 c16"
+                class="c14 c15"
                 id=":r1s:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="c17 c18"
+                class="c16 c17"
                 for=":r1s:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c19"
+                  class="c18"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1729,11 +1739,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c20"
+                class="c19"
               >
                 <label
                   aria-hidden="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   for=":r1s:"
                   hidden=""
                   id=":r1t:"
@@ -1745,15 +1755,15 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Text"
           >
@@ -1761,21 +1771,21 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="modal"
         >
           <div
-            class="c0 c23"
+            class="c22 c23"
           >
             <div
               class="c24 c25 c26"
             >
               <p
-                class="c10"
+                class="c9"
                 color="secondary70"
                 title="8"
               >
@@ -1794,7 +1804,7 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
@@ -1802,7 +1812,7 @@ exports[`renders worksheet 1`] = `
           type="number"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="$50.00"
           >
@@ -1810,20 +1820,20 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
       </tr>
       <tr>
         <td
-          class="c3"
+          class="c2"
         />
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Fans Name One"
           >
@@ -1831,35 +1841,35 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c12"
+          class="c11"
           type="checkbox"
         >
           <div
-            class="c13"
+            class="c12"
           >
             <div
-              class="c14"
+              class="c13"
             >
               <input
                 aria-checked="true"
                 aria-labelledby=":r25:"
                 checked=""
-                class="c15 c16"
+                class="c14 c15"
                 id=":r24:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
-                class="c17 c18"
+                class="c16 c17"
                 for=":r24:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c19"
+                  class="c18"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1877,11 +1887,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c20"
+                class="c19"
               >
                 <label
                   aria-hidden="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   for=":r24:"
                   hidden=""
                   id=":r25:"
@@ -1893,15 +1903,15 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="text"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="Text"
           >
@@ -1909,21 +1919,21 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
-          class="c9"
+          class="c8"
           type="modal"
         >
           <div
-            class="c0 c23"
+            class="c22 c23"
           >
             <div
               class="c24 c25 c26"
             >
               <p
-                class="c10"
+                class="c9"
                 color="secondary70"
                 title="9"
               >
@@ -1942,7 +1952,7 @@ exports[`renders worksheet 1`] = `
           </div>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
         <td
@@ -1950,7 +1960,7 @@ exports[`renders worksheet 1`] = `
           type="number"
         >
           <p
-            class="c10"
+            class="c9"
             color="secondary70"
             title="$50.00"
           >
@@ -1958,7 +1968,7 @@ exports[`renders worksheet 1`] = `
           </p>
           <div
             aria-label="Autofill handler"
-            class="c11"
+            class="c10"
           />
         </td>
       </tr>

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -549,7 +549,6 @@ exports[`renders worksheet 1`] = `
 .c0 {
   overflow-x: auto;
   overflow-y: auto;
-  height: 600px;
 }
 
 @media (min-width:0px) {

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -1944,4 +1944,18 @@ describe('virtualization', () => {
       writable: true,
     });
   });
+
+  test('scrolls the virtual list when a cell is selected', async () => {
+    render(
+      <Worksheet columns={columns} height={400} items={items} onChange={handleChange} />,
+    );
+
+    const cell = await screen.findByText('Shoes Name One');
+
+    if (cell.parentElement) {
+      fireEvent.click(cell.parentElement);
+    }
+
+    expect(cell.parentElement).toHaveStyle(`border-color: ${theme.colors.primary}`);
+  });
 });

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -1905,42 +1905,24 @@ describe('virtualization', () => {
     expect(paddingRows.length).toBeGreaterThan(0);
   });
 
-  test('handles null scroll element gracefully in observeElementRect', () => {
-    const useVirtualizer = require('@tanstack/react-virtual').useVirtualizer;
-
-    jest.spyOn(require('@tanstack/react-virtual'), 'useVirtualizer').mockImplementation((opts) => {
-      if (opts.observeElementRect) {
-        opts.observeElementRect({ scrollElement: null } as any, jest.fn());
-      }
-
-      return useVirtualizer(opts);
-    });
-
-    const { getByText } = render(
-      <Worksheet columns={columns} items={items} onChange={handleChange} />,
-    );
-
-    expect(getByText('Shoes Name One')).toBeInTheDocument();
-
-    jest.restoreAllMocks();
-  });
-
   test('uses ResizeObserver when available', () => {
     const observe = jest.fn();
     const disconnect = jest.fn();
 
     const MockResizeObserver = jest.fn().mockImplementation((cb) => ({
+      disconnect,
       observe: () => {
         observe();
         cb([]);
       },
-      disconnect,
       unobserve: jest.fn(),
     }));
 
-    const original = (global as any).ResizeObserver;
-
-    (global as any).ResizeObserver = MockResizeObserver;
+    Object.defineProperty(global, 'ResizeObserver', {
+      configurable: true,
+      value: MockResizeObserver,
+      writable: true,
+    });
 
     const { unmount } = render(
       <Worksheet columns={columns} height={400} items={items} onChange={handleChange} />,
@@ -1952,6 +1934,10 @@ describe('virtualization', () => {
 
     expect(disconnect).toHaveBeenCalled();
 
-    (global as any).ResizeObserver = original;
+    Object.defineProperty(global, 'ResizeObserver', {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
   });
 });

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -1946,9 +1946,7 @@ describe('virtualization', () => {
   });
 
   test('scrolls the virtual list when a cell is selected', async () => {
-    render(
-      <Worksheet columns={columns} height={400} items={items} onChange={handleChange} />,
-    );
+    render(<Worksheet columns={columns} height={400} items={items} onChange={handleChange} />);
 
     const cell = await screen.findByText('Shoes Name One');
 

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -1867,3 +1867,91 @@ describe('useKeyEvents coverage improvements', () => {
     expect(queryByDisplayValue('Shoes Name Three')).not.toBeInTheDocument();
   });
 });
+
+describe('virtualization', () => {
+  test('renders rows inside a scroll container', () => {
+    const { getByText } = render(
+      <Worksheet columns={columns} height={400} items={items} onChange={handleChange} />,
+    );
+
+    expect(getByText('Shoes Name One')).toBeInTheDocument();
+  });
+
+  test('accepts height as a string', () => {
+    const { getByText } = render(
+      <Worksheet columns={columns} height="300px" items={items} onChange={handleChange} />,
+    );
+
+    expect(getByText('Shoes Name One')).toBeInTheDocument();
+  });
+
+  test('renders padding rows when items overflow the virtual window', () => {
+    const manyItems = Array.from({ length: 20 }, (_, i) => ({
+      id: i + 1,
+      productName: `Product ${i + 1}`,
+      visibleOnStorefront: true,
+      otherField: 'Text',
+      otherField2: i + 1,
+      numberField: 50,
+    }));
+
+    const { container } = render(
+      <Worksheet columns={columns} height={200} items={manyItems} onChange={handleChange} />,
+    );
+
+    // padding <tr> rows have aria-hidden="true"
+    const paddingRows = container.querySelectorAll('tr[aria-hidden="true"]');
+
+    expect(paddingRows.length).toBeGreaterThan(0);
+  });
+
+  test('handles null scroll element gracefully in observeElementRect', () => {
+    const useVirtualizer = require('@tanstack/react-virtual').useVirtualizer;
+
+    jest.spyOn(require('@tanstack/react-virtual'), 'useVirtualizer').mockImplementation((opts) => {
+      if (opts.observeElementRect) {
+        opts.observeElementRect({ scrollElement: null } as any, jest.fn());
+      }
+
+      return useVirtualizer(opts);
+    });
+
+    const { getByText } = render(
+      <Worksheet columns={columns} items={items} onChange={handleChange} />,
+    );
+
+    expect(getByText('Shoes Name One')).toBeInTheDocument();
+
+    jest.restoreAllMocks();
+  });
+
+  test('uses ResizeObserver when available', () => {
+    const observe = jest.fn();
+    const disconnect = jest.fn();
+
+    const MockResizeObserver = jest.fn().mockImplementation((cb) => ({
+      observe: () => {
+        observe();
+        cb([]);
+      },
+      disconnect,
+      unobserve: jest.fn(),
+    }));
+
+    const original = (global as any).ResizeObserver;
+
+    (global as any).ResizeObserver = MockResizeObserver;
+
+    const { unmount } = render(
+      <Worksheet columns={columns} height={400} items={items} onChange={handleChange} />,
+    );
+
+    expect(observe).toHaveBeenCalled();
+
+    unmount();
+
+    expect(disconnect).toHaveBeenCalled();
+
+    (global as any).ResizeObserver = original;
+  });
+});

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -1878,11 +1878,12 @@ describe('virtualization', () => {
   });
 
   test('accepts height as a string', () => {
-    const { getByText } = render(
+    const { container } = render(
       <Worksheet columns={columns} height="300px" items={items} onChange={handleChange} />,
     );
 
-    expect(getByText('Shoes Name One')).toBeInTheDocument();
+    // The scroll container should have the string height applied as a CSS style.
+    expect(container.firstChild).toHaveStyle({ height: '300px' });
   });
 
   test('renders padding rows when items overflow the virtual window', () => {
@@ -1903,6 +1904,9 @@ describe('virtualization', () => {
     const paddingRows = container.querySelectorAll('tr[aria-hidden="true"]');
 
     expect(paddingRows.length).toBeGreaterThan(0);
+
+    // virtualization keeps only a window of rows in the DOM
+    expect(container.querySelectorAll('tbody tr').length).toBeLessThan(manyItems.length);
   });
 
   test('uses ResizeObserver when available', () => {

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -1886,7 +1886,7 @@ describe('virtualization', () => {
   });
 
   test('renders padding rows when items overflow the virtual window', () => {
-    const manyItems = Array.from({ length: 20 }, (_, i) => ({
+    const manyItems: Array<Partial<Product>> = Array.from({ length: 20 }, (_, i) => ({
       id: i + 1,
       productName: `Product ${i + 1}`,
       visibleOnStorefront: true,

--- a/packages/big-design/src/components/Worksheet/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/styled.tsx
@@ -1,8 +1,6 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { Box } from '../Box';
-
 import { InternalWorksheetColumn } from './types';
 
 export const Table = styled.table<{
@@ -19,6 +17,13 @@ export const Table = styled.table<{
 
   &:focus {
     outline: none;
+  }
+
+  & > thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: ${({ theme }) => theme.colors.white};
   }
 
   ${({ hasExpandableRows }) =>
@@ -68,9 +73,14 @@ export const Header = styled.th<{
     typeof columnWidth === 'string' ? columnWidth : `${columnWidth}px`};
 `;
 
-export const StyledBox = styled(Box)`
-  overflow-x: scroll;
+export const StyledBox = styled.div<{ containerHeight?: number | string }>`
+  overflow-x: auto;
+  overflow-y: auto;
+  ${({ containerHeight }) =>
+    containerHeight &&
+    css`
+      height: ${typeof containerHeight === 'number' ? `${containerHeight}px` : containerHeight};
+    `}
 `;
 
 Header.defaultProps = { theme: defaultTheme };
-StyledBox.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -17,6 +17,7 @@ export interface WorksheetProps<Item extends WorksheetItem> {
   expandableRows?: ExpandableRows;
   defaultExpandedRows?: Array<string | number>;
   disabledRows?: DisabledRows;
+  height?: number | string;
   localization?: WorksheetLocalization;
   minWidth?: number;
   onChange(items: Item[]): void;

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -713,6 +713,83 @@ const WorksheetPage = () => {
               ),
             },
             {
+              id: 'virtualization',
+              title: 'Virtualization (1k rows)',
+              render: () => (
+                <CodePreview key="virtualization">
+                  {/* jsx-to-string:start */}
+                  {function Example() {
+                    const columns: Array<WorksheetColumn<Partial<Product>>> = [
+                      {
+                        hash: 'productName',
+                        header: 'Product name',
+                        validation: (value) => !!value,
+                        width: 200,
+                      },
+                      { hash: 'isVisible', header: 'Visible', type: 'checkbox', width: 80 },
+                      { hash: 'otherField', header: 'SKU', width: 160 },
+                      {
+                        hash: 'numberField',
+                        header: 'Price',
+                        type: 'number',
+                        formatting: (value: number) => `$${(value ?? 0).toFixed(2)}`,
+                        width: 100,
+                      },
+                    ];
+
+                    const { items, expandableRows } = React.useMemo(() => {
+                      const VARIANT_COUNT = 1000;
+                      const builtItems: Array<Partial<Product>> = [];
+                      const childIds: number[] = [];
+
+                      builtItems.push({
+                        id: 1,
+                        productName: 'Product 1',
+                        isVisible: true,
+                        otherField: 'SKU-P0001',
+                        numberField: 99.99,
+                      });
+
+                      for (let c = 0; c < VARIANT_COUNT; c++) {
+                        const childId = c + 2;
+
+                        builtItems.push({
+                          id: childId,
+                          productName: `Variant ${c + 1}`,
+                          isVisible: c % 2 === 0,
+                          otherField: `SKU-V${String(childId).padStart(4, '0')}`,
+                          numberField: Math.round((c + 1) * 4.99 * 10) / 10,
+                        });
+                        childIds.push(childId);
+                      }
+
+                      return { expandableRows: { 1: childIds }, items: builtItems };
+                    }, []);
+
+                    const [currentItems, setCurrentItems] = React.useState(items);
+
+                    const handleChange = (changedItems: Array<Partial<Product>>) => {
+                      const byId = new Map(changedItems.map((item) => [item.id, item]));
+
+                      setCurrentItems((prev) => prev.map((item) => byId.get(item.id) ?? item));
+                    };
+
+                    return (
+                      <Worksheet
+                        columns={columns}
+                        defaultExpandedRows={[1]}
+                        expandableRows={expandableRows}
+                        height={500}
+                        items={currentItems}
+                        onChange={handleChange}
+                      />
+                    );
+                  }}
+                  {/* jsx-to-string:end */}
+                </CodePreview>
+              ),
+            },
+            {
               id: 'disabled-rows',
               title: 'Disabled rows',
               render: () => (

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -1,6 +1,6 @@
 import { H1, Panel, StatefulTree, Text, Worksheet, WorksheetColumn } from '@bigcommerce/big-design';
 import { AllInclusiveIcon } from '@bigcommerce/big-design-icons';
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 
 import {
   Code,
@@ -737,7 +737,7 @@ const WorksheetPage = () => {
                       },
                     ];
 
-                    const { items, expandableRows } = React.useMemo(() => {
+                    const { items, expandableRows } = useMemo(() => {
                       const VARIANT_COUNT = 1000;
                       const builtItems: Array<Partial<Product>> = [];
                       const childIds: number[] = [];
@@ -766,7 +766,7 @@ const WorksheetPage = () => {
                       return { expandableRows: { 1: childIds }, items: builtItems };
                     }, []);
 
-                    const [currentItems, setCurrentItems] = React.useState(items);
+                    const [currentItems, setCurrentItems] = useState(items);
 
                     const handleChange = (changedItems: Array<Partial<Product>>) => {
                       const byId = new Map(changedItems.map((item) => [item.id, item]));

--- a/packages/docs/pages/worksheet.tsx
+++ b/packages/docs/pages/worksheet.tsx
@@ -716,7 +716,7 @@ const WorksheetPage = () => {
               id: 'virtualization',
               title: 'Virtualization (1k rows)',
               render: () => (
-                <CodePreview key="virtualization">
+                <CodePreview key="virtualization" scope={{ useMemo, useState }}>
                   {/* jsx-to-string:start */}
                   {function Example() {
                     const columns: Array<WorksheetColumn<Partial<Product>>> = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@changesets/assemble-release-plan@6.0.9':
-    hash: e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553
+    hash: nupakrv7g6a3umbjsd542h3ave
     path: patches/@changesets__assemble-release-plan@6.0.9.patch
 
 importers:
@@ -18,7 +18,7 @@ importers:
         version: 2.12.0(@testing-library/dom@10.4.1)(@types/eslint@8.56.10)(eslint@8.57.0)(jest@30.2.0(@types/node@25.0.3))(typescript@5.9.3)
       '@changesets/assemble-release-plan':
         specifier: ^6.0.9
-        version: 6.0.9(patch_hash=e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553)
+        version: 6.0.9(patch_hash=nupakrv7g6a3umbjsd542h3ave)
       '@changesets/changelog-git':
         specifier: ^0.2.1
         version: 0.2.1
@@ -58,6 +58,9 @@ importers:
       '@popperjs/core':
         specifier: ^2.11.6
         version: 2.11.8
+      '@tanstack/react-virtual':
+        specifier: ^3.13.0
+        version: 3.13.23(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react-datepicker':
         specifier: ^7.0.0
         version: 7.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2739,6 +2742,15 @@ packages:
 
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
+
+  '@tanstack/react-virtual@3.13.23':
+    resolution: {integrity: sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.13.23':
+    resolution: {integrity: sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -8055,7 +8067,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.3
 
-  '@changesets/assemble-release-plan@6.0.9(patch_hash=e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553)':
+  '@changesets/assemble-release-plan@6.0.9(patch_hash=nupakrv7g6a3umbjsd542h3ave)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -8071,7 +8083,7 @@ snapshots:
   '@changesets/cli@2.29.7(@types/node@25.0.3)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.13
-      '@changesets/assemble-release-plan': 6.0.9(patch_hash=e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553)
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=nupakrv7g6a3umbjsd542h3ave)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.1
       '@changesets/errors': 0.2.0
@@ -8124,7 +8136,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9(patch_hash=e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553)
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=nupakrv7g6a3umbjsd542h3ave)
       '@changesets/config': 3.1.1
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.5
@@ -9352,6 +9364,14 @@ snapshots:
   '@swc/types@0.1.25':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@tanstack/react-virtual@3.13.23(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.23
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@tanstack/virtual-core@3.13.23': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10893,7 +10913,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -10919,7 +10939,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@changesets/assemble-release-plan@6.0.9':
-    hash: nupakrv7g6a3umbjsd542h3ave
+    hash: e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553
     path: patches/@changesets__assemble-release-plan@6.0.9.patch
 
 importers:
@@ -18,7 +18,7 @@ importers:
         version: 2.12.0(@testing-library/dom@10.4.1)(@types/eslint@8.56.10)(eslint@8.57.0)(jest@30.2.0(@types/node@25.0.3))(typescript@5.9.3)
       '@changesets/assemble-release-plan':
         specifier: ^6.0.9
-        version: 6.0.9(patch_hash=nupakrv7g6a3umbjsd542h3ave)
+        version: 6.0.9(patch_hash=e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553)
       '@changesets/changelog-git':
         specifier: ^0.2.1
         version: 0.2.1
@@ -8067,7 +8067,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.3
 
-  '@changesets/assemble-release-plan@6.0.9(patch_hash=nupakrv7g6a3umbjsd542h3ave)':
+  '@changesets/assemble-release-plan@6.0.9(patch_hash=e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -8083,7 +8083,7 @@ snapshots:
   '@changesets/cli@2.29.7(@types/node@25.0.3)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.13
-      '@changesets/assemble-release-plan': 6.0.9(patch_hash=nupakrv7g6a3umbjsd542h3ave)
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.1
       '@changesets/errors': 0.2.0
@@ -8136,7 +8136,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9(patch_hash=nupakrv7g6a3umbjsd542h3ave)
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=e7d33fb22d985ad82567035a33aa7efd18243f05e9d67fc84900cc8c48609553)
       '@changesets/config': 3.1.1
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.5
@@ -10913,7 +10913,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -10939,7 +10939,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## What?

Adds row virtualisation to the `Worksheet` component using `@tanstack/react-virtual`. Only the rows currently visible in the scroll viewport are rendered, keeping DOM size constant regardless of total row count. A new optional `height` prop controls the scroll container height (default `600`).


https://github.com/user-attachments/assets/4ec0dc67-c5a0-4fb8-803c-23c4035fa018



## Why?

The `Worksheet` component renders every row as a `<tr>` in the DOM. With 500+ sub-rows (e.g. products with many variants) this causes significant layout/paint overhead and makes the table sluggish to interact with. Virtualisation keeps the rendered row count proportional to the visible area (~15–20 rows at a time) rather than the total data size, eliminating the jank.

## Screenshots/Screen Recordings

A "Virtualization (1k rows)" tab was added to the Worksheet docs page. It renders 1 parent product with 1 000 child variants expanded by default. Scrolling, keyboard navigation, cell editing, and expand/collapse all work correctly with the virtual list.

## Testing/Proof

- All 73 existing `Worksheet` unit tests pass without modification (snapshot updated for a CSS class rename caused by removing the unused `Box` base from `StyledBox`).
- Manual testing on the new docs demo:
  - Scrolling through 1 000 child rows is smooth; only ~15 rows are in the DOM at any time.
  - Keyboard navigation (arrow keys, Tab, Enter) auto-scrolls the virtualiser to keep the selected cell visible.
  - Expand/collapse of the parent row correctly adds/removes child rows from the virtual list.
  - Editing a cell and confirming the change persists the value correctly.
  - `height` prop accepts both `number` (px) and `string` (`'50vh'`, `'400px'`, etc.).