### PR TITLE
feat(component): CATALOG-12827 dropdown max width, pilltabs minor improvements

### DIFF
--- a/.changeset/pill-tabs-separator-and-dropdown-wrap.md
+++ b/.changeset/pill-tabs-separator-and-dropdown-wrap.md
@@ -1,0 +1,10 @@
+---
+'@bigcommerce/big-design': minor
+'@bigcommerce/docs': minor
+---
+
+Fix PillTabs group separator padding and add `maxWidth` support to Dropdown.
+
+- `PillTabs`: the group separator used symmetric horizontal margins which — combined with the preceding pill's `marginRight="xSmall"` — produced a larger gap on the left than on the right. The separator's left margin is now `0`, so spacing is symmetric on both sides.
+- `Dropdown`: new optional `maxWidth` prop. When set, dropdown items are capped at that width (in px) and long content wraps via `overflow-wrap: break-word` / `word-break: break-word` / `white-space: normal`, preventing the overflow menu from breaking the layout on very long item labels.
+- `PillTabs`: new optional `dropdownMaxWidth` prop that is forwarded to the overflow `Dropdown` as `maxWidth`, so consumers can opt in to wrapping long pill titles inside the "more" menu.

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -28,6 +28,7 @@ export const Dropdown = memo(
     className,
     disabled = false,
     maxHeight,
+    maxWidth,
     id,
     items,
     placement = 'bottom-start' as const,
@@ -171,6 +172,7 @@ export const Dropdown = memo(
                 isOpen={isOpen}
                 items={items}
                 maxHeight={maxHeight}
+                maxWidth={maxWidth}
                 role="menu"
                 update={update}
               />
@@ -196,6 +198,7 @@ export const Dropdown = memo(
               isOpen={isOpen}
               items={items}
               maxHeight={maxHeight}
+              maxWidth={maxWidth}
               role="menu"
               update={update}
             />

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -190,6 +190,35 @@ test('should accept a maxHeight prop', async () => {
   expect(list).toHaveStyleRule('max-height', remCalc(350));
 });
 
+test('should accept a maxWidth prop and enable word wrapping on items', async () => {
+  render(
+    <Dropdown
+      items={[{ content: 'A very long content that should wrap inside the dropdown', onItemClick }]}
+      maxWidth={280}
+      toggle={<Button>Button</Button>}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole('button'));
+
+  const [item] = await screen.findAllByRole('option');
+
+  expect(item).toHaveStyleRule('max-width', remCalc(280));
+  expect(item).toHaveStyleRule('overflow-wrap', 'break-word');
+  expect(item).toHaveStyleRule('white-space', 'normal');
+  expect(item).toHaveStyleRule('word-break', 'break-word');
+});
+
+test('should not apply max-width when prop is omitted', async () => {
+  render(DropdownMock);
+
+  fireEvent.click(screen.getByRole('button'));
+
+  const [item] = await screen.findAllByRole('option');
+
+  expect(item).not.toHaveStyleRule('max-width');
+});
+
 test('should default max-height to 250', async () => {
   render(DropdownMock);
 

--- a/packages/big-design/src/components/Dropdown/types.ts
+++ b/packages/big-design/src/components/Dropdown/types.ts
@@ -7,6 +7,7 @@ export interface DropdownProps extends Omit<ComponentPropsWithoutRef<'ul'>, 'chi
   items: Array<DropdownItem | DropdownLinkItem> | DropdownItemGroup[];
   selectedItem?: DropdownItem;
   maxHeight?: number;
+  maxWidth?: number;
   placement?: Placement;
   positionFixed?: boolean;
   toggle: ReactElement<{ id?: string }>;

--- a/packages/big-design/src/components/List/Item/Content.tsx
+++ b/packages/big-design/src/components/List/Item/Content.tsx
@@ -12,9 +12,10 @@ import { StyledLink } from './styled';
 interface ContentProps {
   item: DropdownItem | DropdownLinkItem | SelectOption<any> | SelectAction;
   isHighlighted: boolean;
+  wrapText?: boolean;
 }
 
-export const Content = memo(({ item, isHighlighted }: ContentProps) => {
+export const Content = memo(({ item, isHighlighted, wrapText = false }: ContentProps) => {
   const iconColor = useMemo(() => {
     if (item.disabled) {
       return 'secondary40';
@@ -67,13 +68,17 @@ export const Content = memo(({ item, isHighlighted }: ContentProps) => {
   const getContent = useMemo(() => {
     const { content, disabled, description, icon } = item;
 
+    // When text can wrap (maxWidth set) or a description is present, anchor the
+    // icon to the first line instead of vertically centering against all lines.
+    const alignIconToTop = Boolean(description) || wrapText;
+
     const baseContent = (
       <Flex alignItems="center" flexDirection="row">
         {icon && (
           <FlexItem
-            alignSelf={description ? 'flex-start' : undefined}
+            alignSelf={alignIconToTop ? 'flex-start' : undefined}
             paddingRight="xSmall"
-            paddingTop={description ? 'xSmall' : undefined}
+            paddingTop={alignIconToTop ? 'xSmall' : undefined}
           >
             {renderIcon}
           </FlexItem>
@@ -97,7 +102,7 @@ export const Content = memo(({ item, isHighlighted }: ContentProps) => {
     return disabled && 'tooltip' in item && item.tooltip
       ? wrapInTooltip(item.tooltip, finalContent)
       : finalContent;
-  }, [descriptionColor, item, renderIcon, wrapInLink, wrapInTooltip]);
+  }, [descriptionColor, item, renderIcon, wrapInLink, wrapInTooltip, wrapText]);
 
   return getContent;
 });

--- a/packages/big-design/src/components/List/Item/Item.tsx
+++ b/packages/big-design/src/components/List/Item/Item.tsx
@@ -21,6 +21,7 @@ export interface ListItemProps<T> extends ComponentPropsWithoutRef<'li'> {
   isIndeterminate?: boolean;
   isSelected?: boolean;
   item: DropdownItem | DropdownLinkItem | SelectOption<T> | SelectAction;
+  maxWidth?: number;
   getItemProps:
     | UseSelectPropGetters<any>['getItemProps']
     | UseComboboxPropGetters<any>['getItemProps'];
@@ -44,6 +45,7 @@ const StyleableListItem = typedMemo(
     isSelected = false,
     isIndeterminate = false,
     item,
+    maxWidth,
     getItemProps,
     addItem,
     removeItem,
@@ -74,6 +76,7 @@ const StyleableListItem = typedMemo(
         autoWidth={autoWidth}
         isAction={isAction}
         isHighlighted={isHighlighted}
+        maxWidth={maxWidth}
       >
         <Checkbox
           checked={isChecked}
@@ -100,6 +103,7 @@ const StyleableListItem = typedMemo(
         isAction={isAction}
         isHighlighted={isHighlighted}
         isSelected={isSelected}
+        maxWidth={maxWidth}
       >
         <Content isHighlighted={isHighlighted} item={item} />
         {isSelected && <CheckIcon color="primary" size="large" />}

--- a/packages/big-design/src/components/List/Item/Item.tsx
+++ b/packages/big-design/src/components/List/Item/Item.tsx
@@ -105,7 +105,7 @@ const StyleableListItem = typedMemo(
         isSelected={isSelected}
         maxWidth={maxWidth}
       >
-        <Content isHighlighted={isHighlighted} item={item} />
+        <Content isHighlighted={isHighlighted} item={item} wrapText={maxWidth !== undefined} />
         {isSelected && <CheckIcon color="primary" size="large" />}
       </StyledListItem>
     ),

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -21,6 +21,14 @@ export const StyledListItem = styled.li<
   min-width: ${({ autoWidth, theme }) => (autoWidth ? 'auto' : theme.helpers.remCalc(256))};
   outline: none;
   padding: ${({ theme }) => `${theme.spacing.xxSmall} ${theme.spacing.medium}`};
+  ${({ maxWidth, theme }) =>
+    maxWidth !== undefined &&
+    css`
+      max-width: ${theme.helpers.remCalc(maxWidth)};
+      overflow-wrap: break-word;
+      white-space: normal;
+      word-break: break-word;
+    `}
 
   a {
     align-items: center;

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -32,6 +32,7 @@ export interface ListProps<T> extends ComponentPropsWithoutRef<'ul'> {
   items: DropdownProps['items'] | SelectProps<T>['options'];
   isDropdown?: boolean;
   maxHeight?: number;
+  maxWidth?: number;
   selectedItem?: SelectOption<T> | null;
   selectedItems?: Array<SelectOption<T>> | null;
   selectAll?: boolean;
@@ -67,6 +68,7 @@ const StyleableList = typedMemo(
     isOpen,
     items,
     maxHeight = 250,
+    maxWidth,
     selectedItem,
     selectedItems,
     selectAll,
@@ -132,6 +134,7 @@ const StyleableList = typedMemo(
               isIndeterminate={isSomeSelected && !isAllSelected}
               item={{ content: localization?.selectAll, value: 'select-all' }}
               key="select-all"
+              maxWidth={maxWidth}
               removeItem={handleUnselectAll}
             />
             <Box borderTop="box" marginHorizontal="medium" marginTop="xSmall" paddingTop="xSmall" />
@@ -142,6 +145,7 @@ const StyleableList = typedMemo(
         getItemProps,
         highlightedIndex,
         autoWidth,
+        maxWidth,
         selectedItems,
         handleSelectAll,
         handleUnselectAll,
@@ -165,11 +169,12 @@ const StyleableList = typedMemo(
               isSelected={false}
               item={action}
               key="action"
+              maxWidth={maxWidth}
             />
           </Box>
         );
       },
-      [getItemProps, autoWidth, highlightedIndex],
+      [getItemProps, autoWidth, highlightedIndex, maxWidth],
     );
 
     const renderItems = useCallback(
@@ -214,6 +219,7 @@ const StyleableList = typedMemo(
                 isSelected={!isDropdown && isOption(item) && selectedItem?.value === item.value}
                 item={item}
                 key={`${key}-${item.content}`}
+                maxWidth={maxWidth}
                 removeItem={removeItem}
               />
             );
@@ -227,6 +233,7 @@ const StyleableList = typedMemo(
         getItemProps,
         highlightedIndex,
         isDropdown,
+        maxWidth,
         removeItem,
         selectedItem,
         selectedItems,

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -16,14 +16,14 @@ import { useAvailableWidth } from './useAvailableWidth';
 // - PILL_MARGIN_RIGHT is intentionally tied to the design-system's xSmall horizontal spacing token.
 //   At the time of writing, theme.spacing.xSmall resolves to 8px, which is what we hard-code here.
 // - SEPARATOR_WIDTH is the total horizontal space taken by the group separator:
-//   1px border + left margin (8px) + right margin (8px) = 17px.
+//   1px border + left margin (0px, pill's marginRight provides the gap) + right margin (8px) = 9px.
 //
 // These values are hard-coded to avoid pulling theme values at module load time and to keep the
 // width calculations referentially transparent. If the theme's xSmall spacing or the separator's
 // border/margin specs change, these constants MUST be updated to match the new design tokens to
 // prevent layout regressions in PillTabs.
 const PILL_MARGIN_RIGHT = 8;
-const SEPARATOR_WIDTH = 17;
+const SEPARATOR_WIDTH = 9;
 
 export interface PillTabItem {
   id: string;
@@ -52,6 +52,7 @@ export interface PillTabsProps {
   activePills: string[];
   onPillClick: (itemId: string) => void;
   dropdownItems?: DropdownProps['items'];
+  dropdownMaxWidth?: DropdownProps['maxWidth'];
 }
 
 // Type guard to determine if the provided items are PillTabItemGroup[]
@@ -65,6 +66,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({
   items,
   onPillClick,
   dropdownItems: customDropdownItems = [],
+  dropdownMaxWidth,
 }) => {
   // Stable refs for parent and dropdown
   const parentRef = useRef<HTMLDivElement>(null);
@@ -221,6 +223,7 @@ export const PillTabs: React.FC<PillTabsProps> = ({
       <StyledFlexItem isVisible={dropdownItemGroups.length > 0} ref={refs.dropdown} role="listitem">
         <Dropdown
           items={dropdownItemGroups}
+          maxWidth={dropdownMaxWidth}
           toggle={
             <Button iconOnly={<MoreHorizIcon title="add" />} type="button" variant="subtle" />
           }

--- a/packages/big-design/src/components/PillTabs/spec.tsx
+++ b/packages/big-design/src/components/PillTabs/spec.tsx
@@ -803,6 +803,34 @@ describe('when using item groups', () => {
     expect(separator).not.toBeInTheDocument();
   });
 
+  test('separator has symmetric horizontal spacing', async () => {
+    const groups = [
+      {
+        items: [
+          { title: 'All', id: 'all' },
+          { title: 'Out of stock', id: 'out-of-stock' },
+        ],
+      },
+      {
+        items: [
+          { title: 'Millennials', id: 'millennials' },
+          { title: 'Elders', id: 'elders' },
+        ],
+      },
+    ];
+
+    render(<TestComponent activePills={[]} items={groups} onPillClick={jest.fn()} />);
+
+    // Preceding pill provides marginRight="xSmall"; separator must not also add
+    // left margin or the spacing becomes asymmetric.
+    const separator = await screen.findByRole('separator');
+
+    expect(separator).toHaveStyleRule(
+      'margin',
+      `${defaultTheme.spacing.xxSmall} ${defaultTheme.spacing.xSmall} ${defaultTheme.spacing.xxSmall} 0`,
+    );
+  });
+
   test('hides separator when group boundary pills are hidden', async () => {
     Object.defineProperties(window.HTMLElement.prototype, {
       offsetWidth: {

--- a/packages/big-design/src/components/PillTabs/styled.tsx
+++ b/packages/big-design/src/components/PillTabs/styled.tsx
@@ -33,7 +33,10 @@ export const StyledFlexItem = styled(FlexItem)<StyledFlexItemProps>`
 export const StyledGroupSeparator = styled.div<StyledFlexItemProps>`
   align-self: stretch;
   border-left: ${({ theme }) => theme.border.box};
-  margin: ${({ theme }) => `${theme.spacing.xxSmall} ${theme.spacing.xSmall}`};
+  // Left margin is 0 because the preceding pill already has marginRight="xSmall",
+  // which keeps the spacing on both sides of the separator symmetric.
+  margin: ${({ theme }) =>
+    `${theme.spacing.xxSmall} ${theme.spacing.xSmall} ${theme.spacing.xxSmall} 0`};
 
   ${(props) =>
     !props.isVisible &&

--- a/packages/docs/PropTables/DropdownPropTable.tsx
+++ b/packages/docs/PropTables/DropdownPropTable.tsx
@@ -16,6 +16,12 @@ const dropdownProps: Prop[] = [
     description: 'Sets the max-height of the dropdown.',
   },
   {
+    name: 'maxWidth',
+    types: 'number',
+    description:
+      'Sets the max-width (in px) of each dropdown item and enables word wrapping. Useful when item content may be long.',
+  },
+  {
     name: 'placement',
     types: [
       'auto',

--- a/packages/docs/PropTables/PillTabsPropTable.tsx
+++ b/packages/docs/PropTables/PillTabsPropTable.tsx
@@ -61,6 +61,17 @@ const pillTabsPropTable: Prop[] = [
       </>
     ),
   },
+  {
+    name: 'dropdownMaxWidth',
+    types: 'number',
+    description: (
+      <>
+        Forwarded to the overflow <NextLink href="/dropdown">Dropdown</NextLink> as{' '}
+        <code>maxWidth</code>. Caps the overflow menu width (in px) and wraps long pill titles
+        instead of letting them overflow.
+      </>
+    ),
+  },
 ];
 
 export const PillTabsPropTable: React.FC<PropTableWrapper> = (props) => (


### PR DESCRIPTION
## What?

- Added max width prop to dropdown to avoid excessive width layout e.g.
<img width="3372" height="1384" alt="6d2bd72c-18cc-4deb-ac4d-0e1164a2b939" src="https://github.com/user-attachments/assets/b5f5d9ca-ae7e-41d0-ac77-81ab4d1fe312" />
- Fixed separator uneven gap in PillTab component

## Why?

Long names in PillTabs dropdown making layout look broken, so ability to set maxWidth with overflowing text can handle that

## Screenshots/Screen Recordings

UPDATED screen recording for Icon alignment discussion:

https://github.com/user-attachments/assets/f09b1c45-5816-464a-a7eb-4b2f5e23eb91

-----------
https://github.com/user-attachments/assets/8f9bb2ea-6568-48f1-9155-f3e3af8816d1



## Testing/Proof

Tests for checking maxwidth and separator were added
