### PR TITLE
feat(component): add collapsible feature to checkbox components, collapse component updates

### DIFF
--- a/.changeset/fancy-mice-join.md
+++ b/.changeset/fancy-mice-join.md
@@ -1,0 +1,10 @@
+---
+'@bigcommerce/big-design': minor
+'@bigcommerce/docs': minor
+---
+
+- **Checkbox**: add `collapseOptions` (collapsible content with `disableWhenUnchecked`) and `img` props.
+- **Collapse**: add `disabled`, `portalTarget`, `panelProps`, and `marginVertical` props; `title` now accepts `ReactNode`.
+- **Docs**: document new Checkbox props and add a collapsible usage example.
+
+---

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -7,15 +7,20 @@ import React, {
   Ref,
   useId,
   useMemo,
+  useState,
 } from 'react';
 
 import { typedMemo, warning } from '../../utils';
 import { Badge, BadgeProps } from '../Badge';
+import { Box } from '../Box';
+import { Collapse } from '../Collapse';
 import { FormControlDescription, FormControlDescriptionLinkProps } from '../Form';
 
 import { CheckboxLabel } from './Label';
 import {
   CheckboxContainer,
+  CheckboxContentContainer,
+  CheckboxImgContainer,
   CheckboxLabelContainer,
   HiddenCheckbox,
   StyledCheckbox,
@@ -27,6 +32,8 @@ interface Props {
   label: React.ReactNode;
   description?: CheckboxDescription | string;
   badge?: BadgeProps;
+  collapseOptions?: CheckboxCollapse;
+  img?: CheckboxImg;
 }
 
 interface CheckboxDescription {
@@ -34,11 +41,25 @@ interface CheckboxDescription {
   link?: FormControlDescriptionLinkProps;
 }
 
+interface CheckboxImg {
+  src: string;
+}
+
 interface PrivateProps {
   forwardedRef: Ref<HTMLInputElement>;
 }
 
 export type CheckboxProps = Props & ComponentPropsWithoutRef<'input'>;
+
+interface CheckboxCollapse {
+  children: React.ReactNode;
+  collapsedTitle?: string;
+  expandedTitle?: string;
+  disableWhenUnchecked?: boolean;
+}
+
+const DEFAULT_COLLAPSED_TITLE = 'Show more';
+const DEFAULT_EXPANDED_TITLE = 'Show less';
 
 const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   checked,
@@ -50,10 +71,23 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   label,
   forwardedRef,
   style,
+  collapseOptions,
+  img,
   badge,
   onClick,
   ...props
 }) => {
+  const collapsedTitle = collapseOptions?.collapsedTitle ?? DEFAULT_COLLAPSED_TITLE;
+  const expandedTitle = collapseOptions?.expandedTitle ?? DEFAULT_EXPANDED_TITLE;
+
+  const [currentCollapseTitle, setCurrentCollapseTitle] = useState(collapsedTitle);
+  const [panelRef, setPanelRef] = useState<HTMLDivElement | null>(null);
+
+  const handleCollapseChange = (isOpen: boolean) =>
+    setCurrentCollapseTitle(isOpen ? expandedTitle : collapsedTitle);
+
+  const isVerticalCenterCheckboxContainer = collapseOptions?.children || img?.src;
+
   const uniqueCheckboxId = useId();
   const labelId = useId();
   const id = props.id ? props.id : uniqueCheckboxId;
@@ -101,48 +135,79 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   }, [description]);
 
   return (
-    <CheckboxContainer className={className} onClick={onClick} style={style}>
-      <HiddenCheckbox
-        checked={checked}
-        disabled={disabled}
-        id={id}
-        type="checkbox"
-        {...props}
-        aria-checked={checked}
-        aria-labelledby={labelId}
-        ref={(checkbox) => {
-          if (checkbox && typeof isIndeterminate === 'boolean') {
-            checkbox.indeterminate = !checked && isIndeterminate;
-          }
-
-          if (forwardedRef) {
-            if (typeof forwardedRef === 'function') {
-              forwardedRef(checkbox);
-            } else {
-              // RefObject.current is readonly in DefinitelyTyped
-              // but in practice you can still write to it.
-              // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
-              // @ts-expect-error TODO look into useImperativeHandle
-              forwardedRef.current = checkbox;
-            }
-          }
-        }}
-      />
-
-      <StyledCheckbox
-        aria-hidden={true}
-        checked={checked}
-        disabled={disabled}
-        htmlFor={id}
-        isIndeterminate={isIndeterminate}
+    <Box>
+      <CheckboxContainer
+        className={className}
+        isVerticalCenter={Boolean(isVerticalCenterCheckboxContainer)}
+        onClick={onClick}
+        style={style}
       >
-        {!checked && isIndeterminate ? <RemoveIcon /> : <CheckIcon />}
-      </StyledCheckbox>
-      <CheckboxLabelContainer hasContent={Boolean(label) || Boolean(description)}>
-        {renderedLabel}
-        {renderedDescription}
-      </CheckboxLabelContainer>
-    </CheckboxContainer>
+        <HiddenCheckbox
+          checked={checked}
+          disabled={disabled}
+          id={id}
+          type="checkbox"
+          {...props}
+          aria-checked={checked}
+          aria-labelledby={labelId}
+          ref={(checkbox) => {
+            if (checkbox && typeof isIndeterminate === 'boolean') {
+              checkbox.indeterminate = !checked && isIndeterminate;
+            }
+
+            if (forwardedRef) {
+              if (typeof forwardedRef === 'function') {
+                forwardedRef(checkbox);
+              } else {
+                // RefObject.current is readonly in DefinitelyTyped
+                // but in practice you can still write to it.
+                // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
+                // @ts-expect-error TODO look into useImperativeHandle
+                forwardedRef.current = checkbox;
+              }
+            }
+          }}
+        />
+
+        <StyledCheckbox
+          aria-hidden={true}
+          checked={checked}
+          disabled={disabled}
+          htmlFor={id}
+          isIndeterminate={isIndeterminate}
+        >
+          {!checked && isIndeterminate ? <RemoveIcon /> : <CheckIcon />}
+        </StyledCheckbox>
+        <CheckboxContentContainer
+          hasContent={Boolean(label) || Boolean(description)}
+          isVerticalCenter={Boolean(isVerticalCenterCheckboxContainer)}
+        >
+          <CheckboxLabelContainer>
+            {img && <CheckboxImgContainer src={img.src} />}
+            <Box>
+              {renderedLabel}
+              {renderedDescription}
+            </Box>
+          </CheckboxLabelContainer>
+          {collapseOptions && (
+            <Collapse
+              disabled={collapseOptions.disableWhenUnchecked ? !checked : undefined}
+              marginVertical="none"
+              onCollapseChange={handleCollapseChange}
+              panelProps={{
+                padding: 'medium',
+                backgroundColor: 'secondary20',
+              }}
+              portalTarget={panelRef}
+              title={currentCollapseTitle}
+            >
+              {collapseOptions.children}
+            </Collapse>
+          )}
+        </CheckboxContentContainer>
+      </CheckboxContainer>
+      {collapseOptions ? <Box ref={setPanelRef} /> : null}
+    </Box>
   );
 };
 

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`render Checkbox checked 1`] = `
-.c5 {
+.c6 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -15,19 +15,34 @@ exports[`render Checkbox checked 1`] = `
   line-height: 1.5rem;
 }
 
-.c7:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
+.c10 {
   cursor: pointer;
 }
 
-.c6 {
+.c0 {
+  box-sizing: border-box;
+}
+
+.c7 {
   margin-left: 0.5rem;
 }
 
-.c0 {
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -38,7 +53,7 @@ exports[`render Checkbox checked 1`] = `
   display: flex;
 }
 
-.c2 {
+.c3 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -51,7 +66,7 @@ exports[`render Checkbox checked 1`] = `
   width: 1px;
 }
 
-.c4 {
+.c5 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -85,75 +100,87 @@ exports[`render Checkbox checked 1`] = `
   width: 1.25rem;
 }
 
-.c4:hover {
+.c5:hover {
   border-color: #3C64F4;
 }
 
-.c1:focus + .c3 {
+.c2:focus + .c4 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c5 svg {
   opacity: 1;
 }
 
 <div
   class="c0"
 >
-  <input
-    aria-checked="true"
-    aria-labelledby=":r1:"
-    checked=""
-    class="c1 c2"
-    id=":r0:"
-    type="checkbox"
-  />
-  <label
-    aria-hidden="true"
-    class="c3 c4"
-    for=":r0:"
-  >
-    <svg
-      aria-hidden="true"
-      class="c5"
-      fill="currentColor"
-      height="24"
-      stroke="currentColor"
-      stroke-width="0"
-      viewBox="0 0 24 24"
-      width="24"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-      />
-    </svg>
-  </label>
   <div
-    class="c6"
+    class="c1"
   >
+    <input
+      aria-checked="true"
+      aria-labelledby=":r1:"
+      checked=""
+      class="c2 c3"
+      id=":r0:"
+      type="checkbox"
+    />
     <label
-      class="c7 c8"
+      aria-hidden="true"
+      class="c4 c5"
       for=":r0:"
-      id=":r1:"
     >
-      Checked
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="currentColor"
+        height="24"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+        />
+      </svg>
     </label>
+    <div
+      class="c7"
+    >
+      <div
+        class="c8"
+      >
+        <div
+          class="c0"
+        >
+          <label
+            class="c9 c10"
+            for=":r0:"
+            id=":r1:"
+          >
+            Checked
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`render Checkbox disabled checked 1`] = `
-.c5 {
+.c6 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -161,20 +188,35 @@ exports[`render Checkbox disabled checked 1`] = `
   line-height: 1.5rem;
 }
 
-.c7:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
+.c10 {
   cursor: pointer;
   cursor: not-allowed;
 }
 
-.c6 {
+.c0 {
+  box-sizing: border-box;
+}
+
+.c7 {
   margin-left: 0.5rem;
 }
 
-.c0 {
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -185,7 +227,7 @@ exports[`render Checkbox disabled checked 1`] = `
   display: flex;
 }
 
-.c2 {
+.c3 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -198,7 +240,7 @@ exports[`render Checkbox disabled checked 1`] = `
   width: 1px;
 }
 
-.c4 {
+.c5 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -235,75 +277,87 @@ exports[`render Checkbox disabled checked 1`] = `
   cursor: not-allowed;
 }
 
-.c1:focus + .c3 {
+.c2:focus + .c4 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c5 svg {
   opacity: 1;
 }
 
 <div
   class="c0"
 >
-  <input
-    aria-checked="true"
-    aria-labelledby=":rj:"
-    checked=""
-    class="c1 c2"
-    disabled=""
-    id=":ri:"
-    type="checkbox"
-  />
-  <label
-    aria-hidden="true"
-    class="c3 c4"
-    disabled=""
-    for=":ri:"
-  >
-    <svg
-      aria-hidden="true"
-      class="c5"
-      fill="currentColor"
-      height="24"
-      stroke="currentColor"
-      stroke-width="0"
-      viewBox="0 0 24 24"
-      width="24"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-      />
-    </svg>
-  </label>
   <div
-    class="c6"
+    class="c1"
   >
+    <input
+      aria-checked="true"
+      aria-labelledby=":rp:"
+      checked=""
+      class="c2 c3"
+      disabled=""
+      id=":ro:"
+      type="checkbox"
+    />
     <label
       aria-hidden="true"
-      class="c7 c8"
+      class="c4 c5"
       disabled=""
-      for=":ri:"
-      id=":rj:"
+      for=":ro:"
     >
-      Checked
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="currentColor"
+        height="24"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+        />
+      </svg>
     </label>
+    <div
+      class="c7"
+    >
+      <div
+        class="c8"
+      >
+        <div
+          class="c0"
+        >
+          <label
+            aria-hidden="true"
+            class="c9 c10"
+            disabled=""
+            for=":ro:"
+            id=":rp:"
+          >
+            Checked
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`render Checkbox disabled indeterminate 1`] = `
-.c5 {
+.c6 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -311,20 +365,35 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   line-height: 1.5rem;
 }
 
-.c7:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
+.c10 {
   cursor: pointer;
   cursor: not-allowed;
 }
 
-.c6 {
+.c0 {
+  box-sizing: border-box;
+}
+
+.c7 {
   margin-left: 0.5rem;
 }
 
-.c0 {
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -335,7 +404,7 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   display: flex;
 }
 
-.c2 {
+.c3 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -348,7 +417,7 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   width: 1px;
 }
 
-.c4 {
+.c5 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -385,73 +454,85 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   cursor: not-allowed;
 }
 
-.c1:focus + .c3 {
+.c2:focus + .c4 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c5 svg {
   opacity: 1;
 }
 
 <div
   class="c0"
 >
-  <input
-    aria-labelledby=":rp:"
-    class="c1 c2"
-    disabled=""
-    id=":ro:"
-    type="checkbox"
-  />
-  <label
-    aria-hidden="true"
-    class="c3 c4"
-    disabled=""
-    for=":ro:"
-  >
-    <svg
-      aria-hidden="true"
-      class="c5"
-      fill="currentColor"
-      height="24"
-      stroke="currentColor"
-      stroke-width="0"
-      viewBox="0 0 24 24"
-      width="24"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M18 13H6c-.55 0-1-.45-1-1s.45-1 1-1h12c.55 0 1 .45 1 1s-.45 1-1 1"
-      />
-    </svg>
-  </label>
   <div
-    class="c6"
+    class="c1"
   >
+    <input
+      aria-labelledby=":rv:"
+      class="c2 c3"
+      disabled=""
+      id=":ru:"
+      type="checkbox"
+    />
     <label
       aria-hidden="true"
-      class="c7 c8"
+      class="c4 c5"
       disabled=""
-      for=":ro:"
-      id=":rp:"
+      for=":ru:"
     >
-      Unchecked
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="currentColor"
+        height="24"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M18 13H6c-.55 0-1-.45-1-1s.45-1 1-1h12c.55 0 1 .45 1 1s-.45 1-1 1"
+        />
+      </svg>
     </label>
+    <div
+      class="c7"
+    >
+      <div
+        class="c8"
+      >
+        <div
+          class="c0"
+        >
+          <label
+            aria-hidden="true"
+            class="c9 c10"
+            disabled=""
+            for=":ru:"
+            id=":rv:"
+          >
+            Unchecked
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`render Checkbox disabled unchecked 1`] = `
-.c5 {
+.c6 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -459,20 +540,35 @@ exports[`render Checkbox disabled unchecked 1`] = `
   line-height: 1.5rem;
 }
 
-.c7:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
+.c10 {
   cursor: pointer;
   cursor: not-allowed;
 }
 
-.c6 {
+.c0 {
+  box-sizing: border-box;
+}
+
+.c7 {
   margin-left: 0.5rem;
 }
 
-.c0 {
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -483,7 +579,7 @@ exports[`render Checkbox disabled unchecked 1`] = `
   display: flex;
 }
 
-.c2 {
+.c3 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -496,7 +592,7 @@ exports[`render Checkbox disabled unchecked 1`] = `
   width: 1px;
 }
 
-.c4 {
+.c5 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -533,74 +629,86 @@ exports[`render Checkbox disabled unchecked 1`] = `
   cursor: not-allowed;
 }
 
-.c1:focus + .c3 {
+.c2:focus + .c4 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c5 svg {
   opacity: 0;
 }
 
 <div
   class="c0"
 >
-  <input
-    aria-checked="false"
-    aria-labelledby=":rm:"
-    class="c1 c2"
-    disabled=""
-    id=":rl:"
-    type="checkbox"
-  />
-  <label
-    aria-hidden="true"
-    class="c3 c4"
-    disabled=""
-    for=":rl:"
-  >
-    <svg
-      aria-hidden="true"
-      class="c5"
-      fill="currentColor"
-      height="24"
-      stroke="currentColor"
-      stroke-width="0"
-      viewBox="0 0 24 24"
-      width="24"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-      />
-    </svg>
-  </label>
   <div
-    class="c6"
+    class="c1"
   >
+    <input
+      aria-checked="false"
+      aria-labelledby=":rs:"
+      class="c2 c3"
+      disabled=""
+      id=":rr:"
+      type="checkbox"
+    />
     <label
       aria-hidden="true"
-      class="c7 c8"
+      class="c4 c5"
       disabled=""
-      for=":rl:"
-      id=":rm:"
+      for=":rr:"
     >
-      Checked
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="currentColor"
+        height="24"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+        />
+      </svg>
     </label>
+    <div
+      class="c7"
+    >
+      <div
+        class="c8"
+      >
+        <div
+          class="c0"
+        >
+          <label
+            aria-hidden="true"
+            class="c9 c10"
+            disabled=""
+            for=":rr:"
+            id=":rs:"
+          >
+            Checked
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`render Checkbox indeterminate 1`] = `
-.c5 {
+.c6 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -608,19 +716,34 @@ exports[`render Checkbox indeterminate 1`] = `
   line-height: 1.5rem;
 }
 
-.c7:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
+.c10 {
   cursor: pointer;
 }
 
-.c6 {
+.c0 {
+  box-sizing: border-box;
+}
+
+.c7 {
   margin-left: 0.5rem;
 }
 
-.c0 {
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -631,7 +754,7 @@ exports[`render Checkbox indeterminate 1`] = `
   display: flex;
 }
 
-.c2 {
+.c3 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -644,7 +767,7 @@ exports[`render Checkbox indeterminate 1`] = `
   width: 1px;
 }
 
-.c4 {
+.c5 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -678,73 +801,85 @@ exports[`render Checkbox indeterminate 1`] = `
   width: 1.25rem;
 }
 
-.c4:hover {
+.c5:hover {
   border-color: #3C64F4;
 }
 
-.c1:focus + .c3 {
+.c2:focus + .c4 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c5 svg {
   opacity: 1;
 }
 
 <div
   class="c0"
 >
-  <input
-    aria-labelledby=":rg:"
-    class="c1 c2"
-    id=":rf:"
-    type="checkbox"
-  />
-  <label
-    aria-hidden="true"
-    class="c3 c4"
-    for=":rf:"
-  >
-    <svg
-      aria-hidden="true"
-      class="c5"
-      fill="currentColor"
-      height="24"
-      stroke="currentColor"
-      stroke-width="0"
-      viewBox="0 0 24 24"
-      width="24"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M18 13H6c-.55 0-1-.45-1-1s.45-1 1-1h12c.55 0 1 .45 1 1s-.45 1-1 1"
-      />
-    </svg>
-  </label>
   <div
-    class="c6"
+    class="c1"
   >
+    <input
+      aria-labelledby=":rm:"
+      class="c2 c3"
+      id=":rl:"
+      type="checkbox"
+    />
     <label
-      class="c7 c8"
-      for=":rf:"
-      id=":rg:"
+      aria-hidden="true"
+      class="c4 c5"
+      for=":rl:"
     >
-      Unchecked
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="currentColor"
+        height="24"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M18 13H6c-.55 0-1-.45-1-1s.45-1 1-1h12c.55 0 1 .45 1 1s-.45 1-1 1"
+        />
+      </svg>
     </label>
+    <div
+      class="c7"
+    >
+      <div
+        class="c8"
+      >
+        <div
+          class="c0"
+        >
+          <label
+            class="c9 c10"
+            for=":rl:"
+            id=":rm:"
+          >
+            Unchecked
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`render Checkbox unchecked 1`] = `
-.c5 {
+.c6 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -752,19 +887,34 @@ exports[`render Checkbox unchecked 1`] = `
   line-height: 1.5rem;
 }
 
-.c7:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
+.c10 {
   cursor: pointer;
 }
 
-.c6 {
+.c0 {
+  box-sizing: border-box;
+}
+
+.c7 {
   margin-left: 0.5rem;
 }
 
-.c0 {
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -775,7 +925,7 @@ exports[`render Checkbox unchecked 1`] = `
   display: flex;
 }
 
-.c2 {
+.c3 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -788,7 +938,7 @@ exports[`render Checkbox unchecked 1`] = `
   width: 1px;
 }
 
-.c4 {
+.c5 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -822,74 +972,86 @@ exports[`render Checkbox unchecked 1`] = `
   width: 1.25rem;
 }
 
-.c4:hover {
+.c5:hover {
   border-color: #B4BAD1;
 }
 
-.c1:focus + .c3 {
+.c2:focus + .c4 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c5 svg {
   opacity: 0;
 }
 
 <div
   class="c0"
 >
-  <input
-    aria-checked="false"
-    aria-labelledby=":r4:"
-    class="c1 c2"
-    id=":r3:"
-    type="checkbox"
-  />
-  <label
-    aria-hidden="true"
-    class="c3 c4"
-    for=":r3:"
-  >
-    <svg
-      aria-hidden="true"
-      class="c5"
-      fill="currentColor"
-      height="24"
-      stroke="currentColor"
-      stroke-width="0"
-      viewBox="0 0 24 24"
-      width="24"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-      />
-    </svg>
-  </label>
   <div
-    class="c6"
+    class="c1"
   >
+    <input
+      aria-checked="false"
+      aria-labelledby=":r4:"
+      class="c2 c3"
+      id=":r3:"
+      type="checkbox"
+    />
     <label
-      class="c7 c8"
+      aria-hidden="true"
+      class="c4 c5"
       for=":r3:"
-      id=":r4:"
     >
-      Unchecked
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="currentColor"
+        height="24"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+        />
+      </svg>
     </label>
+    <div
+      class="c7"
+    >
+      <div
+        class="c8"
+      >
+        <div
+          class="c0"
+        >
+          <label
+            class="c9 c10"
+            for=":r3:"
+            id=":r4:"
+          >
+            Unchecked
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
-exports[`render Checkbox with description object 1`] = `
-.c5 {
+exports[`render Checkbox with collapsible component 1`] = `
+.c6 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -897,11 +1059,11 @@ exports[`render Checkbox with description object 1`] = `
   line-height: 1.5rem;
 }
 
-.c7:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
-.c9 {
+.c11 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -911,15 +1073,420 @@ exports[`render Checkbox with description object 1`] = `
   margin: 0 0 0.75rem;
 }
 
+.c11:last-child {
+  margin-bottom: 0;
+}
+
+.c10 {
+  cursor: pointer;
+}
+
+.c0 {
+  box-sizing: border-box;
+}
+
+.c15 {
+  display: none;
+  padding: 1rem;
+  box-sizing: border-box;
+  background-color: #ECEEF5;
+}
+
+.c12 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: background-color,border-color,box-shadow,color;
+  transition-property: background-color,border-color,box-shadow,color;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 1px solid #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  font-size: 1rem;
+  font-weight: 400;
+  height: 2.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 2rem;
+  outline: none;
+  padding: 0 1rem;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  padding-right: 0.5rem;
+  background-color: transparent;
+  border-color: transparent;
+  color: #3C64F4;
+}
+
+.c12.c12 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12[disabled] {
+  border-color: #D9DCE9;
+  pointer-events: none;
+}
+
+.c12 + .bd-button {
+  margin-top: 0.5rem;
+}
+
+.c12:active {
+  background-color: #DBE3FE;
+}
+
+.c12:focus {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c12:hover:not(:active) {
+  background-color: #F0F3FF;
+}
+
+.c12[disabled] {
+  border-color: transparent;
+  color: #D9DCE9;
+}
+
+.c14 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5rem;
+}
+
+.c13 {
+  height: auto;
+  line-height: inherit;
+  margin-left: -0.25rem;
+  padding: 0.25rem;
+  padding-right: 0;
+  width: auto;
+}
+
+.c13:active,
+.c13:hover:not(:active) {
+  background: none;
+  color: #0024A6;
+}
+
+.c13 span {
+  grid-gap: 0;
+}
+
+.c13 svg {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: -webkit-transform;
+  -webkit-transition-property: transform;
+  transition-property: transform;
+}
+
+.c7 {
+  margin-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
+  transition-property: border-color,background,box-shadow,color,opacity;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #FFFFFF;
+  box-sizing: border-box;
+  border: 1px solid #D9DCE9;
+  border-color: #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 1.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-bottom: 0.125rem;
+  margin-top: 0.125rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1.25rem;
+}
+
+.c5:hover {
+  border-color: #B4BAD1;
+}
+
+.c2:focus + .c4 {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c5 svg {
+  opacity: 0;
+}
+
+@media (min-width:720px) {
+  .c12 + .bd-button {
+    margin-top: 0;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:720px) {
+  .c12 {
+    width: auto;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <input
+      aria-checked="false"
+      aria-labelledby=":rg:"
+      class="c2 c3"
+      id=":rf:"
+      name="test-group"
+      type="checkbox"
+    />
+    <label
+      aria-hidden="true"
+      class="c4 c5"
+      for=":rf:"
+    >
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="currentColor"
+        height="24"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+        />
+      </svg>
+    </label>
+    <div
+      class="c7"
+    >
+      <div
+        class="c8"
+      >
+        <div
+          class="c0"
+        >
+          <label
+            class="c9 c10"
+            for=":rf:"
+            id=":rg:"
+          >
+            Unchecked
+          </label>
+          <p
+            class="c11"
+          >
+            description text
+          </p>
+        </div>
+      </div>
+      <button
+        aria-controls=":rj:"
+        aria-expanded="false"
+        class="c12 c13"
+        id=":ri:"
+        type="button"
+      >
+        <span
+          class="c14"
+        >
+          Configure
+          <svg
+            aria-labelledby=":rk:"
+            class="c6"
+            fill="currentColor"
+            height="24"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <title
+              id=":rk:"
+            >
+              Configure
+            </title>
+            <path
+              d="M24 24H0V0h24z"
+              fill="none"
+              opacity="0.87"
+            />
+            <path
+              d="M15.88 9.29 12 13.17 8.12 9.29a.996.996 0 1 0-1.41 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41c-.39-.38-1.03-.39-1.42 0"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    class="c0"
+  >
+    <div
+      aria-labelledby=":ri:"
+      class="c15"
+      display="none"
+      hidden=""
+      id=":rj:"
+      role="region"
+    >
+      CARD
+    </div>
+  </div>
+</div>
+`;
+
+exports[`render Checkbox with description object 1`] = `
+.c6 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c9 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
 .c9:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
-  cursor: pointer;
+.c11 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c11:last-child {
+  margin-bottom: 0;
 }
 
 .c10 {
+  cursor: pointer;
+}
+
+.c0 {
+  box-sizing: border-box;
+}
+
+.c12 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -932,23 +1499,34 @@ exports[`render Checkbox with description object 1`] = `
   text-decoration: none;
 }
 
-.c10:active {
+.c12:active {
   color: #0024A6;
 }
 
-.c10:hover:not(:active) {
+.c12:hover:not(:active) {
   color: #0024A6;
 }
 
-.c11 {
+.c13 {
   font-size: 0.875rem;
 }
 
-.c6 {
+.c7 {
   margin-left: 0.5rem;
 }
 
-.c0 {
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -959,7 +1537,7 @@ exports[`render Checkbox with description object 1`] = `
   display: flex;
 }
 
-.c2 {
+.c3 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -972,7 +1550,7 @@ exports[`render Checkbox with description object 1`] = `
   width: 1px;
 }
 
-.c4 {
+.c5 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -1006,88 +1584,100 @@ exports[`render Checkbox with description object 1`] = `
   width: 1.25rem;
 }
 
-.c4:hover {
+.c5:hover {
   border-color: #B4BAD1;
 }
 
-.c1:focus + .c3 {
+.c2:focus + .c4 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c5 svg {
   opacity: 0;
 }
 
 <div
   class="c0"
 >
-  <input
-    aria-checked="false"
-    aria-labelledby=":r7:"
-    class="c1 c2"
-    id=":r6:"
-    name="test-group"
-    type="checkbox"
-  />
-  <label
-    aria-hidden="true"
-    class="c3 c4"
-    for=":r6:"
-  >
-    <svg
-      aria-hidden="true"
-      class="c5"
-      fill="currentColor"
-      height="24"
-      stroke="currentColor"
-      stroke-width="0"
-      viewBox="0 0 24 24"
-      width="24"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-      />
-    </svg>
-  </label>
   <div
-    class="c6"
+    class="c1"
   >
+    <input
+      aria-checked="false"
+      aria-labelledby=":r7:"
+      class="c2 c3"
+      id=":r6:"
+      name="test-group"
+      type="checkbox"
+    />
     <label
-      class="c7 c8"
+      aria-hidden="true"
+      class="c4 c5"
       for=":r6:"
-      id=":r7:"
     >
-      Unchecked
-    </label>
-    <p
-      class="c9"
-    >
-      description
-       
-      <a
-        class="c10 c11"
-        href="bar"
-        target="foo"
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="currentColor"
+        height="24"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="24"
       >
-        learn more
-      </a>
-    </p>
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+        />
+      </svg>
+    </label>
+    <div
+      class="c7"
+    >
+      <div
+        class="c8"
+      >
+        <div
+          class="c0"
+        >
+          <label
+            class="c9 c10"
+            for=":r6:"
+            id=":r7:"
+          >
+            Unchecked
+          </label>
+          <p
+            class="c11"
+          >
+            description
+             
+            <a
+              class="c12 c13"
+              href="bar"
+              target="foo"
+            >
+              learn more
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`render Checkbox with description string 1`] = `
-.c5 {
+.c6 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c9 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1095,11 +1685,11 @@ exports[`render Checkbox with description string 1`] = `
   line-height: 1.5rem;
 }
 
-.c7:last-child {
+.c9:last-child {
   margin-bottom: 0;
 }
 
-.c9 {
+.c11 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -1109,19 +1699,34 @@ exports[`render Checkbox with description string 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c9:last-child {
+.c11:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
+.c10 {
   cursor: pointer;
 }
 
-.c6 {
+.c0 {
+  box-sizing: border-box;
+}
+
+.c7 {
   margin-left: 0.5rem;
 }
 
-.c0 {
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -1132,7 +1737,7 @@ exports[`render Checkbox with description string 1`] = `
   display: flex;
 }
 
-.c2 {
+.c3 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -1145,7 +1750,7 @@ exports[`render Checkbox with description string 1`] = `
   width: 1px;
 }
 
-.c4 {
+.c5 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -1179,68 +1784,80 @@ exports[`render Checkbox with description string 1`] = `
   width: 1.25rem;
 }
 
-.c4:hover {
+.c5:hover {
   border-color: #B4BAD1;
 }
 
-.c1:focus + .c3 {
+.c2:focus + .c4 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c5 svg {
   opacity: 0;
 }
 
 <div
   class="c0"
 >
-  <input
-    aria-checked="false"
-    aria-labelledby=":rd:"
-    class="c1 c2"
-    id=":rc:"
-    name="test-group"
-    type="checkbox"
-  />
-  <label
-    aria-hidden="true"
-    class="c3 c4"
-    for=":rc:"
-  >
-    <svg
-      aria-hidden="true"
-      class="c5"
-      fill="currentColor"
-      height="24"
-      stroke="currentColor"
-      stroke-width="0"
-      viewBox="0 0 24 24"
-      width="24"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-      />
-    </svg>
-  </label>
   <div
-    class="c6"
+    class="c1"
   >
+    <input
+      aria-checked="false"
+      aria-labelledby=":rd:"
+      class="c2 c3"
+      id=":rc:"
+      name="test-group"
+      type="checkbox"
+    />
     <label
-      class="c7 c8"
+      aria-hidden="true"
+      class="c4 c5"
       for=":rc:"
-      id=":rd:"
     >
-      Unchecked
+      <svg
+        aria-hidden="true"
+        class="c6"
+        fill="currentColor"
+        height="24"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+        />
+      </svg>
     </label>
-    <p
-      class="c9"
+    <div
+      class="c7"
     >
-      description text
-    </p>
+      <div
+        class="c8"
+      >
+        <div
+          class="c0"
+        >
+          <label
+            class="c9 c10"
+            for=":rc:"
+            id=":rd:"
+          >
+            Unchecked
+          </label>
+          <p
+            class="c11"
+          >
+            description text
+          </p>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/packages/big-design/src/components/Checkbox/spec.tsx
+++ b/packages/big-design/src/components/Checkbox/spec.tsx
@@ -76,6 +76,25 @@ describe('render Checkbox', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('with collapsible component', () => {
+    const { container } = render(
+      <Checkbox
+        checked={false}
+        collapseOptions={{
+          collapsedTitle: 'Configure',
+          expandedTitle: 'Close',
+          children: 'CARD',
+        }}
+        description="description text"
+        label="Unchecked"
+        name="test-group"
+        onChange={() => null}
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('indeterminate', () => {
     const { container } = render(
       <Checkbox isIndeterminate={true} label="Unchecked" onChange={() => null} />,
@@ -202,4 +221,68 @@ test('does not forward styles', () => {
 
   expect(container.getElementsByClassName('test')).toHaveLength(0);
   expect(container.firstChild).not.toHaveStyle('background: red');
+});
+
+test('disabled panel controller when checkbox is unchecked', async () => {
+  render(
+    <Checkbox
+      checked={false}
+      collapseOptions={{
+        collapsedTitle: 'Configure',
+        expandedTitle: 'Close',
+        children: 'CARD',
+        disableWhenUnchecked: true,
+      }}
+      data-testid="checkbox"
+      description="description text"
+      label="Unchecked"
+      name="test-group"
+      onChange={() => null}
+    />,
+  );
+
+  const button = screen.getByRole<HTMLInputElement>('button');
+
+  expect(button).toBeDisabled();
+});
+
+test('panel is expanded by clicking on the controller when checkbox is checked', async () => {
+  render(
+    <Checkbox
+      checked={true}
+      collapseOptions={{
+        collapsedTitle: 'Configure',
+        expandedTitle: 'Close',
+        children: 'CARD',
+      }}
+      data-testid="checkbox"
+      description="description text"
+      label="Unchecked"
+      name="test-group"
+      onChange={() => null}
+    />,
+  );
+
+  const button = screen.getByRole<HTMLInputElement>('button');
+
+  await userEvent.click(button);
+
+  const panel = screen.getByRole<HTMLInputElement>('region');
+
+  expect(panel).toBeInTheDocument();
+});
+
+test('with img', () => {
+  render(
+    <Checkbox
+      checked={false}
+      description="description text"
+      img={{ src: 'img/src' }}
+      label="Unchecked"
+      name="test-group"
+      onChange={() => null}
+    />,
+  );
+
+  expect(screen.getByRole('img')).toBeVisible();
 });

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -1,4 +1,4 @@
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { theme as defaultTheme, remCalc } from '@bigcommerce/big-design-theme';
 import { hideVisually } from 'polished';
 import styled, { css } from 'styled-components';
 
@@ -10,17 +10,35 @@ interface StyledCheckboxProps {
   disabled?: boolean;
 }
 
-export interface StyledLabelProps {
-  hidden?: boolean;
-  disabled?: boolean;
-}
-
-export const CheckboxLabelContainer = styled.div<{ hasContent?: boolean }>`
-  margin-left: ${({ hasContent, theme }) => (hasContent ? theme.spacing.xSmall : 0)};
+export const CheckboxImgContainer = styled.img`
+  height: ${remCalc(40)};
+  width: ${remCalc(40)};
+  margin-right: ${({ theme }) => theme.spacing.xSmall};
 `;
 
-export const CheckboxContainer = styled.div`
-  align-items: flex-start;
+export const CheckboxContentContainer = styled.div<{
+  hasContent?: boolean;
+  isVerticalCenter?: boolean;
+}>`
+  margin-left: ${({ hasContent, theme }) => (hasContent ? theme.spacing.xSmall : 0)};
+
+  ${({ isVerticalCenter }) =>
+    isVerticalCenter &&
+    css`
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+    `}
+`;
+
+export const CheckboxLabelContainer = styled.div`
+  align-items: center;
+  display: flex;
+`;
+
+export const CheckboxContainer = styled.div<{ isVerticalCenter?: boolean }>`
+  align-items: ${({ isVerticalCenter }) => (isVerticalCenter ? 'center' : 'flex-start')};
   display: flex;
 `;
 
@@ -78,3 +96,5 @@ StyledCheckbox.defaultProps = { theme: defaultTheme };
 CheckboxLabelContainer.defaultProps = { theme: defaultTheme };
 CheckboxContainer.defaultProps = { theme: defaultTheme };
 HiddenCheckbox.defaultProps = { theme: defaultTheme };
+CheckboxContentContainer.defaultProps = { theme: defaultTheme };
+CheckboxImgContainer.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Collapse/Collapse.tsx
+++ b/packages/big-design/src/components/Collapse/Collapse.tsx
@@ -1,15 +1,25 @@
 import { ExpandMoreIcon } from '@bigcommerce/big-design-icons';
-import React, { useId, useState } from 'react';
+import type { Colors } from '@bigcommerce/big-design-theme';
+import React, { useEffect, useId, useState } from 'react';
+import { createPortal } from 'react-dom';
 
+import { MarginProps, PaddingProps } from '../../helpers';
 import { Box } from '../Box';
 
 import { StyledButton } from './styled';
 
-export interface CollapseProps {
+export interface CollapsePanelProps extends PaddingProps, MarginProps {
+  backgroundColor?: keyof Colors;
+}
+
+export interface CollapseProps extends MarginProps {
   children?: React.ReactNode;
-  title: string;
+  title: string | React.ReactNode;
   initiallyOpen?: boolean;
   onCollapseChange?(isOpen: boolean): void;
+  portalTarget?: Element | null;
+  panelProps?: CollapsePanelProps;
+  disabled?: boolean;
 }
 
 export const Collapse: React.FC<CollapseProps> = ({
@@ -17,10 +27,24 @@ export const Collapse: React.FC<CollapseProps> = ({
   title,
   onCollapseChange,
   initiallyOpen = false,
+  portalTarget = null,
+  marginVertical,
+  panelProps,
+  disabled,
 }) => {
-  const [isOpen, setIsOpen] = useState(initiallyOpen);
+  const [isOpen, setIsOpen] = useState(disabled ? false : initiallyOpen);
   const triggerId = useId();
   const panelId = useId();
+
+  useEffect(() => {
+    if (disabled && isOpen) {
+      setIsOpen(false);
+
+      if (typeof onCollapseChange === 'function') {
+        onCollapseChange(false);
+      }
+    }
+  }, [disabled, isOpen, onCollapseChange]);
 
   const handleTitleClick = () => {
     const nextIsOpen = !isOpen;
@@ -32,30 +56,36 @@ export const Collapse: React.FC<CollapseProps> = ({
     }
   };
 
+  const collapsablePanel = (
+    <Box
+      {...panelProps}
+      aria-labelledby={triggerId}
+      display={isOpen ? 'block' : 'none'}
+      hidden={!isOpen}
+      id={panelId}
+      role="region"
+    >
+      {children}
+    </Box>
+  );
+
   return (
     <>
       <StyledButton
         aria-controls={panelId}
         aria-expanded={isOpen}
+        disabled={disabled}
         iconRight={<ExpandMoreIcon title={title} />}
         id={triggerId}
         isOpen={isOpen}
-        marginVertical="small"
+        marginVertical={marginVertical ?? 'small'}
         onClick={handleTitleClick}
         type="button"
         variant="subtle"
       >
         {title}
       </StyledButton>
-      <Box
-        aria-labelledby={triggerId}
-        display={isOpen ? 'block' : 'none'}
-        hidden={!isOpen}
-        id={panelId}
-        role="region"
-      >
-        {children}
-      </Box>
+      {portalTarget ? createPortal(collapsablePanel, portalTarget) : collapsablePanel}
     </>
   );
 };

--- a/packages/big-design/src/components/Collapse/spec.tsx
+++ b/packages/big-design/src/components/Collapse/spec.tsx
@@ -178,3 +178,92 @@ test('onCollapseChange is called', async () => {
 
   expect(handleChange).toHaveBeenCalled();
 });
+
+test('renders with ReactNode title', () => {
+  render(
+    <Collapse title={<span data-testid="custom-title">Custom Title</span>}>
+      <Text>Content</Text>
+    </Collapse>,
+  );
+
+  expect(screen.getAllByTestId('custom-title').length).toBeGreaterThan(0);
+});
+
+test('title button is disabled when disabled prop is true', () => {
+  render(
+    <Collapse disabled title="title">
+      <Text>Content</Text>
+    </Collapse>,
+  );
+
+  expect(screen.getByRole('button')).toBeDisabled();
+});
+
+test('panel stays hidden when disabled and initiallyOpen', () => {
+  render(
+    <Collapse disabled initiallyOpen title="title">
+      <Text>Content</Text>
+    </Collapse>,
+  );
+
+  expect(screen.getByRole('region', { hidden: true })).not.toBeVisible();
+});
+
+test('open panel closes when disabled becomes true', async () => {
+  const onChange = jest.fn();
+
+  const { rerender } = render(
+    <Collapse initiallyOpen onCollapseChange={onChange} title="title">
+      <Text>Content</Text>
+    </Collapse>,
+  );
+
+  const panel = screen.getByRole('region');
+
+  expect(panel).toBeVisible();
+
+  rerender(
+    <Collapse disabled initiallyOpen onCollapseChange={onChange} title="title">
+      <Text>Content</Text>
+    </Collapse>,
+  );
+
+  expect(screen.getByRole('region', { hidden: true })).not.toBeVisible();
+  expect(onChange).toHaveBeenCalledWith(false);
+});
+
+test('panel renders inside portalTarget when provided', () => {
+  const portalTarget = document.createElement('div');
+
+  portalTarget.setAttribute('data-testid', 'portal-target');
+  document.body.appendChild(portalTarget);
+
+  render(
+    <Collapse initiallyOpen portalTarget={portalTarget} title="title">
+      <Text>Portal Content</Text>
+    </Collapse>,
+  );
+
+  const panel = screen.getByRole('region');
+
+  expect(portalTarget).toContainElement(panel);
+  expect(panel).toHaveTextContent('Portal Content');
+
+  document.body.removeChild(portalTarget);
+});
+
+test('applies panelProps to the panel', () => {
+  render(
+    <Collapse
+      initiallyOpen
+      panelProps={{ backgroundColor: 'secondary20', padding: 'medium' }}
+      title="title"
+    >
+      <Text>Content</Text>
+    </Collapse>,
+  );
+
+  const panel = screen.getByRole('region');
+
+  expect(panel).toHaveStyle('padding: 1rem');
+});

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -759,7 +759,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   box-sizing: border-box;
 }
 
-.c15 {
+.c16 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
@@ -807,7 +807,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   flex-shrink: 0;
 }
 
-.c12 {
+.c13 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -815,11 +815,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   line-height: 1.5rem;
 }
 
-.c12:last-child {
+.c13:last-child {
   margin-bottom: 0;
 }
 
-.c14 {
+.c15 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -828,11 +828,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin-left: 0.75rem;
 }
 
-.c14:last-child {
+.c15:last-child {
   margin-bottom: 0;
 }
 
-.c16 {
+.c17 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -841,11 +841,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0;
 }
 
-.c16:last-child {
+.c17:last-child {
   margin-bottom: 0;
 }
 
-.c13 {
+.c14 {
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -861,6 +861,17 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 
 .c11 {
   margin-left: 0.5rem;
+}
+
+.c12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c5 {
@@ -966,64 +977,76 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       class="c3 c4"
     >
       <div
-        class="c5"
+        class="c3"
       >
-        <input
-          aria-checked="false"
-          aria-labelledby=":r37:"
-          class="c6 c7"
-          id=":r36:"
-          type="checkbox"
-        />
-        <label
-          aria-hidden="true"
-          class="c8 c9"
-          for=":r36:"
-        >
-          <svg
-            aria-hidden="true"
-            class="c10"
-            fill="currentColor"
-            height="24"
-            stroke="currentColor"
-            stroke-width="0"
-            viewBox="0 0 24 24"
-            width="24"
-          >
-            <path
-              d="M0 0h24v24H0z"
-              fill="none"
-            />
-            <path
-              d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-            />
-          </svg>
-        </label>
         <div
-          class="c11"
+          class="c5"
         >
+          <input
+            aria-checked="false"
+            aria-labelledby=":r37:"
+            class="c6 c7"
+            id=":r36:"
+            type="checkbox"
+          />
           <label
-            class="c12 c13"
+            aria-hidden="true"
+            class="c8 c9"
             for=":r36:"
-            hidden=""
-            id=":r37:"
           >
-            Select All
+            <svg
+              aria-hidden="true"
+              class="c10"
+              fill="currentColor"
+              height="24"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+              />
+            </svg>
           </label>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <div
+                class="c3"
+              >
+                <label
+                  class="c13 c14"
+                  for=":r36:"
+                  hidden=""
+                  id=":r37:"
+                >
+                  Select All
+                </label>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <p
-        class="c14"
+        class="c15"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c15 c2"
+    class="c16 c2"
   >
     <p
-      class="c16"
+      class="c17"
     >
       Product
     </p>

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -819,7 +819,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   box-sizing: border-box;
 }
 
-.c15 {
+.c16 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
@@ -867,7 +867,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   flex-shrink: 0;
 }
 
-.c12 {
+.c13 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -875,11 +875,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   line-height: 1.5rem;
 }
 
-.c12:last-child {
+.c13:last-child {
   margin-bottom: 0;
 }
 
-.c14 {
+.c15 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -888,11 +888,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin-left: 0.75rem;
 }
 
-.c14:last-child {
+.c15:last-child {
   margin-bottom: 0;
 }
 
-.c16 {
+.c17 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -901,11 +901,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0;
 }
 
-.c16:last-child {
+.c17:last-child {
   margin-bottom: 0;
 }
 
-.c13 {
+.c14 {
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -921,6 +921,17 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 
 .c11 {
   margin-left: 0.5rem;
+}
+
+.c12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c5 {
@@ -1026,64 +1037,76 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       class="c3 c4"
     >
       <div
-        class="c5"
+        class="c3"
       >
-        <input
-          aria-checked="false"
-          aria-labelledby=":r8l:"
-          class="c6 c7"
-          id=":r8k:"
-          type="checkbox"
-        />
-        <label
-          aria-hidden="true"
-          class="c8 c9"
-          for=":r8k:"
-        >
-          <svg
-            aria-hidden="true"
-            class="c10"
-            fill="currentColor"
-            height="24"
-            stroke="currentColor"
-            stroke-width="0"
-            viewBox="0 0 24 24"
-            width="24"
-          >
-            <path
-              d="M0 0h24v24H0z"
-              fill="none"
-            />
-            <path
-              d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-            />
-          </svg>
-        </label>
         <div
-          class="c11"
+          class="c5"
         >
+          <input
+            aria-checked="false"
+            aria-labelledby=":r8l:"
+            class="c6 c7"
+            id=":r8k:"
+            type="checkbox"
+          />
           <label
-            class="c12 c13"
+            aria-hidden="true"
+            class="c8 c9"
             for=":r8k:"
-            hidden=""
-            id=":r8l:"
           >
-            Select All
+            <svg
+              aria-hidden="true"
+              class="c10"
+              fill="currentColor"
+              height="24"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+              />
+            </svg>
           </label>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <div
+                class="c3"
+              >
+                <label
+                  class="c13 c14"
+                  for=":r8k:"
+                  hidden=""
+                  id=":r8l:"
+                >
+                  Select All
+                </label>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <p
-        class="c14"
+        class="c15"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c15 c2"
+    class="c16 c2"
   >
     <p
-      class="c16"
+      class="c17"
     >
       Product
     </p>
@@ -1107,7 +1130,7 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   box-sizing: border-box;
 }
 
-.c15 {
+.c16 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
@@ -1155,7 +1178,7 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   flex-shrink: 0;
 }
 
-.c12 {
+.c13 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1163,11 +1186,11 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   line-height: 1.5rem;
 }
 
-.c12:last-child {
+.c13:last-child {
   margin-bottom: 0;
 }
 
-.c14 {
+.c15 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1176,11 +1199,11 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   margin-left: 0.75rem;
 }
 
-.c14:last-child {
+.c15:last-child {
   margin-bottom: 0;
 }
 
-.c16 {
+.c17 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1189,11 +1212,11 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   margin: 0;
 }
 
-.c16:last-child {
+.c17:last-child {
   margin-bottom: 0;
 }
 
-.c13 {
+.c14 {
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -1209,6 +1232,17 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
 
 .c11 {
   margin-left: 0.5rem;
+}
+
+.c12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c5 {
@@ -1322,64 +1356,76 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
       class="c3 c4"
     >
       <div
-        class="c5"
+        class="c3"
       >
-        <input
-          aria-checked="false"
-          aria-labelledby=":r9b:"
-          class="c6 c7"
-          id=":r9a:"
-          type="checkbox"
-        />
-        <label
-          aria-hidden="true"
-          class="c8 c9"
-          for=":r9a:"
-        >
-          <svg
-            aria-hidden="true"
-            class="c10"
-            fill="currentColor"
-            height="24"
-            stroke="currentColor"
-            stroke-width="0"
-            viewBox="0 0 24 24"
-            width="24"
-          >
-            <path
-              d="M0 0h24v24H0z"
-              fill="none"
-            />
-            <path
-              d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-            />
-          </svg>
-        </label>
         <div
-          class="c11"
+          class="c5"
         >
+          <input
+            aria-checked="false"
+            aria-labelledby=":r9b:"
+            class="c6 c7"
+            id=":r9a:"
+            type="checkbox"
+          />
           <label
-            class="c12 c13"
+            aria-hidden="true"
+            class="c8 c9"
             for=":r9a:"
-            hidden=""
-            id=":r9b:"
           >
-            Select All
+            <svg
+              aria-hidden="true"
+              class="c10"
+              fill="currentColor"
+              height="24"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+              />
+            </svg>
           </label>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <div
+                class="c3"
+              >
+                <label
+                  class="c13 c14"
+                  for=":r9a:"
+                  hidden=""
+                  id=":r9b:"
+                >
+                  Select All
+                </label>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <p
-        class="c14"
+        class="c15"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c15 c2"
+    class="c16 c2"
   >
     <p
-      class="c16"
+      class="c17"
     >
       Product
     </p>
@@ -1403,7 +1449,7 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   box-sizing: border-box;
 }
 
-.c15 {
+.c16 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
@@ -1451,7 +1497,7 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   flex-shrink: 0;
 }
 
-.c12 {
+.c13 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1459,11 +1505,11 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   line-height: 1.5rem;
 }
 
-.c12:last-child {
+.c13:last-child {
   margin-bottom: 0;
 }
 
-.c14 {
+.c15 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1472,11 +1518,11 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   margin-left: 0.75rem;
 }
 
-.c14:last-child {
+.c15:last-child {
   margin-bottom: 0;
 }
 
-.c16 {
+.c17 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1485,11 +1531,11 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   margin: 0;
 }
 
-.c16:last-child {
+.c17:last-child {
   margin-bottom: 0;
 }
 
-.c13 {
+.c14 {
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -1505,6 +1551,17 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
 
 .c11 {
   margin-left: 0.5rem;
+}
+
+.c12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c5 {
@@ -1618,64 +1675,76 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
       class="c3 c4"
     >
       <div
-        class="c5"
+        class="c3"
       >
-        <input
-          aria-checked="false"
-          aria-labelledby=":rd2:"
-          class="c6 c7"
-          id=":rd1:"
-          type="checkbox"
-        />
-        <label
-          aria-hidden="true"
-          class="c8 c9"
-          for=":rd1:"
-        >
-          <svg
-            aria-hidden="true"
-            class="c10"
-            fill="currentColor"
-            height="24"
-            stroke="currentColor"
-            stroke-width="0"
-            viewBox="0 0 24 24"
-            width="24"
-          >
-            <path
-              d="M0 0h24v24H0z"
-              fill="none"
-            />
-            <path
-              d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-            />
-          </svg>
-        </label>
         <div
-          class="c11"
+          class="c5"
         >
+          <input
+            aria-checked="false"
+            aria-labelledby=":rd2:"
+            class="c6 c7"
+            id=":rd1:"
+            type="checkbox"
+          />
           <label
-            class="c12 c13"
+            aria-hidden="true"
+            class="c8 c9"
             for=":rd1:"
-            hidden=""
-            id=":rd2:"
           >
-            Select All
+            <svg
+              aria-hidden="true"
+              class="c10"
+              fill="currentColor"
+              height="24"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+              />
+            </svg>
           </label>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <div
+                class="c3"
+              >
+                <label
+                  class="c13 c14"
+                  for=":rd1:"
+                  hidden=""
+                  id=":rd2:"
+                >
+                  Select All
+                </label>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <p
-        class="c14"
+        class="c15"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c15 c2"
+    class="c16 c2"
   >
     <p
-      class="c16"
+      class="c17"
     >
       Product
     </p>

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -7,17 +7,28 @@ exports[`renders worksheet 1`] = `
   width: 1rem;
 }
 
-.c18 {
+.c19 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c19 {
+.c20 {
   margin-left: 0.5rem;
 }
 
-.c13 {
+.c21 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c14 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -28,7 +39,7 @@ exports[`renders worksheet 1`] = `
   display: flex;
 }
 
-.c15 {
+.c16 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -41,7 +52,7 @@ exports[`renders worksheet 1`] = `
   width: 1px;
 }
 
-.c17 {
+.c18 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -75,19 +86,19 @@ exports[`renders worksheet 1`] = `
   width: 1.25rem;
 }
 
-.c17:hover {
+.c18:hover {
   border-color: #3C64F4;
 }
 
-.c14:focus + .c16 {
+.c15:focus + .c17 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c17 svg {
+.c18 svg {
   opacity: 1;
 }
 
-.c31 {
+.c32 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -121,15 +132,15 @@ exports[`renders worksheet 1`] = `
   width: 1.25rem;
 }
 
-.c31:hover {
+.c32:hover {
   border-color: #B4BAD1;
 }
 
-.c14:focus + .c16 {
+.c15:focus + .c17 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c31 svg {
+.c32 svg {
   opacity: 0;
 }
 
@@ -138,16 +149,16 @@ exports[`renders worksheet 1`] = `
   box-sizing: border-box;
 }
 
-.c22 {
+.c13 {
   box-sizing: border-box;
 }
 
-.c24 {
+.c25 {
   padding-right: 0.75rem;
   box-sizing: border-box;
 }
 
-.c23 {
+.c24 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
@@ -168,7 +179,7 @@ exports[`renders worksheet 1`] = `
   display: flex;
 }
 
-.c25 {
+.c26 {
   -webkit-align-self: auto;
   -ms-flex-item-align: auto;
   align-self: auto;
@@ -187,7 +198,7 @@ exports[`renders worksheet 1`] = `
   flex-shrink: 1;
 }
 
-.c20 {
+.c22 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -195,7 +206,7 @@ exports[`renders worksheet 1`] = `
   line-height: 1.5rem;
 }
 
-.c20:last-child {
+.c22:last-child {
   margin-bottom: 0;
 }
 
@@ -219,7 +230,7 @@ exports[`renders worksheet 1`] = `
   margin-bottom: 0;
 }
 
-.c27 {
+.c28 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -268,37 +279,37 @@ exports[`renders worksheet 1`] = `
   color: #3C64F4;
 }
 
-.c27:focus {
+.c28:focus {
   outline: none;
 }
 
-.c27[disabled] {
+.c28[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c27 + .bd-button {
+.c28 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c27:active {
+.c28:active {
   background-color: #DBE3FE;
 }
 
-.c27:focus {
+.c28:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c27:hover:not(:active) {
+.c28:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c27[disabled] {
+.c28[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
 
-.c29 {
+.c30 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -311,7 +322,7 @@ exports[`renders worksheet 1`] = `
   grid-gap: 0.5rem;
 }
 
-.c21 {
+.c23 {
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -332,23 +343,23 @@ exports[`renders worksheet 1`] = `
   justify-content: center;
 }
 
-.c28 {
+.c29 {
   font-size: 0.875rem;
   height: auto;
   line-height: 1.25rem;
   padding: 0;
 }
 
-.c28:hover:not(:active) {
+.c29:hover:not(:active) {
   background-color: inherit;
   color: #0024A6;
 }
 
-.c28:active {
+.c29:active {
   background-color: inherit;
 }
 
-.c26 {
+.c27 {
   overflow: hidden;
 }
 
@@ -392,7 +403,7 @@ exports[`renders worksheet 1`] = `
   margin: 0;
 }
 
-.c30 {
+.c31 {
   position: relative;
   background-color: inherit;
   border: 0.03125rem solid #D9DCE9;
@@ -405,14 +416,14 @@ exports[`renders worksheet 1`] = `
   user-select: none;
 }
 
-.c30 p {
+.c31 p {
   display: block;
   white-space: inherit;
   word-break: break-word;
   margin: 0;
 }
 
-.c33 {
+.c34 {
   position: relative;
   background-color: inherit;
   border: 0.03125rem solid #D9DCE9;
@@ -426,14 +437,14 @@ exports[`renders worksheet 1`] = `
   border: 0.03125rem double #DB3643;
 }
 
-.c33 p {
+.c34 p {
   display: block;
   white-space: inherit;
   word-break: break-word;
   margin: 0;
 }
 
-.c34 {
+.c35 {
   position: relative;
   background-color: inherit;
   border: 0.03125rem solid #D9DCE9;
@@ -447,7 +458,7 @@ exports[`renders worksheet 1`] = `
   border: 0.03125rem double #DB3643;
 }
 
-.c34 p {
+.c35 p {
   display: block;
   white-space: inherit;
   word-break: break-word;
@@ -476,7 +487,7 @@ exports[`renders worksheet 1`] = `
   width: 0.25rem;
 }
 
-.c32 {
+.c33 {
   background-color: #D9DCE9;
   border-top: 0.03125rem solid #D9DCE9;
   box-sizing: border-box;
@@ -552,7 +563,7 @@ exports[`renders worksheet 1`] = `
 }
 
 @media (min-width:0px) {
-  .c23 {
+  .c24 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -560,7 +571,7 @@ exports[`renders worksheet 1`] = `
 }
 
 @media (min-width:720px) {
-  .c23 {
+  .c24 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -568,14 +579,14 @@ exports[`renders worksheet 1`] = `
 }
 
 @media (min-width:720px) {
-  .c27 + .bd-button {
+  .c28 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c27 {
+  .c28 {
     width: auto;
   }
 }
@@ -683,50 +694,62 @@ exports[`renders worksheet 1`] = `
             <div
               class="c13"
             >
-              <input
-                aria-checked="true"
-                aria-labelledby=":r5:"
-                checked=""
-                class="c14 c15"
-                id=":r4:"
-                type="checkbox"
-              />
-              <label
-                aria-hidden="true"
-                class="c16 c17"
-                for=":r4:"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c18"
-                  fill="currentColor"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-                  />
-                </svg>
-              </label>
               <div
-                class="c19"
+                class="c14"
               >
+                <input
+                  aria-checked="true"
+                  aria-labelledby=":r5:"
+                  checked=""
+                  class="c15 c16"
+                  id=":r4:"
+                  type="checkbox"
+                />
                 <label
-                  aria-hidden="false"
-                  class="c20 c21"
+                  aria-hidden="true"
+                  class="c17 c18"
                   for=":r4:"
-                  hidden=""
-                  id=":r5:"
                 >
-                  Checked
+                  <svg
+                    aria-hidden="true"
+                    class="c19"
+                    fill="currentColor"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+                    />
+                  </svg>
                 </label>
+                <div
+                  class="c20"
+                >
+                  <div
+                    class="c21"
+                  >
+                    <div
+                      class="c13"
+                    >
+                      <label
+                        aria-hidden="false"
+                        class="c22 c23"
+                        for=":r4:"
+                        hidden=""
+                        id=":r5:"
+                      >
+                        Checked
+                      </label>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -756,10 +779,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c13 c24"
           >
             <div
-              class="c24 c25 c26"
+              class="c25 c26 c27"
             >
               <p
                 class="c9"
@@ -770,10 +793,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c28 c29"
             >
               <span
-                class="c29"
+                class="c30"
               >
                 Edit
               </span>
@@ -785,7 +808,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c31"
           type="number"
         >
           <p
@@ -831,50 +854,62 @@ exports[`renders worksheet 1`] = `
             <div
               class="c13"
             >
-              <input
-                aria-checked="true"
-                aria-labelledby=":rd:"
-                checked=""
-                class="c14 c15"
-                id=":rc:"
-                type="checkbox"
-              />
-              <label
-                aria-hidden="true"
-                class="c16 c17"
-                for=":rc:"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c18"
-                  fill="currentColor"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-                  />
-                </svg>
-              </label>
               <div
-                class="c19"
+                class="c14"
               >
+                <input
+                  aria-checked="true"
+                  aria-labelledby=":rd:"
+                  checked=""
+                  class="c15 c16"
+                  id=":rc:"
+                  type="checkbox"
+                />
                 <label
-                  aria-hidden="false"
-                  class="c20 c21"
+                  aria-hidden="true"
+                  class="c17 c18"
                   for=":rc:"
-                  hidden=""
-                  id=":rd:"
                 >
-                  Checked
+                  <svg
+                    aria-hidden="true"
+                    class="c19"
+                    fill="currentColor"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+                    />
+                  </svg>
                 </label>
+                <div
+                  class="c20"
+                >
+                  <div
+                    class="c21"
+                  >
+                    <div
+                      class="c13"
+                    >
+                      <label
+                        aria-hidden="false"
+                        class="c22 c23"
+                        for=":rc:"
+                        hidden=""
+                        id=":rd:"
+                      >
+                        Checked
+                      </label>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -904,10 +939,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c13 c24"
           >
             <div
-              class="c24 c25 c26"
+              class="c25 c26 c27"
             >
               <p
                 class="c9"
@@ -918,10 +953,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c28 c29"
             >
               <span
-                class="c29"
+                class="c30"
               >
                 Edit
               </span>
@@ -933,7 +968,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c31"
           type="number"
         >
           <p
@@ -979,49 +1014,61 @@ exports[`renders worksheet 1`] = `
             <div
               class="c13"
             >
-              <input
-                aria-checked="false"
-                aria-labelledby=":rl:"
-                class="c14 c15"
-                id=":rk:"
-                type="checkbox"
-              />
-              <label
-                aria-hidden="true"
-                class="c16 c31"
-                for=":rk:"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c18"
-                  fill="currentColor"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-                  />
-                </svg>
-              </label>
               <div
-                class="c19"
+                class="c14"
               >
+                <input
+                  aria-checked="false"
+                  aria-labelledby=":rl:"
+                  class="c15 c16"
+                  id=":rk:"
+                  type="checkbox"
+                />
                 <label
-                  aria-hidden="false"
-                  class="c20 c21"
+                  aria-hidden="true"
+                  class="c17 c32"
                   for=":rk:"
-                  hidden=""
-                  id=":rl:"
                 >
-                  Unchecked
+                  <svg
+                    aria-hidden="true"
+                    class="c19"
+                    fill="currentColor"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+                    />
+                  </svg>
                 </label>
+                <div
+                  class="c20"
+                >
+                  <div
+                    class="c21"
+                  >
+                    <div
+                      class="c13"
+                    >
+                      <label
+                        aria-hidden="false"
+                        class="c22 c23"
+                        for=":rk:"
+                        hidden=""
+                        id=":rl:"
+                      >
+                        Unchecked
+                      </label>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1049,10 +1096,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c13 c24"
           >
             <div
-              class="c24 c25 c26"
+              class="c25 c26 c27"
             >
               <p
                 class="c9"
@@ -1063,10 +1110,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c28 c29"
             >
               <span
-                class="c29"
+                class="c30"
               >
                 Edit
               </span>
@@ -1078,7 +1125,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c31"
           type="number"
         >
           <p
@@ -1124,50 +1171,62 @@ exports[`renders worksheet 1`] = `
             <div
               class="c13"
             >
-              <input
-                aria-checked="true"
-                aria-labelledby=":rt:"
-                checked=""
-                class="c14 c15"
-                id=":rs:"
-                type="checkbox"
-              />
-              <label
-                aria-hidden="true"
-                class="c16 c17"
-                for=":rs:"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c18"
-                  fill="currentColor"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-                  />
-                </svg>
-              </label>
               <div
-                class="c19"
+                class="c14"
               >
+                <input
+                  aria-checked="true"
+                  aria-labelledby=":rt:"
+                  checked=""
+                  class="c15 c16"
+                  id=":rs:"
+                  type="checkbox"
+                />
                 <label
-                  aria-hidden="false"
-                  class="c20 c21"
+                  aria-hidden="true"
+                  class="c17 c18"
                   for=":rs:"
-                  hidden=""
-                  id=":rt:"
                 >
-                  Checked
+                  <svg
+                    aria-hidden="true"
+                    class="c19"
+                    fill="currentColor"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+                    />
+                  </svg>
                 </label>
+                <div
+                  class="c20"
+                >
+                  <div
+                    class="c21"
+                  >
+                    <div
+                      class="c13"
+                    >
+                      <label
+                        aria-hidden="false"
+                        class="c22 c23"
+                        for=":rs:"
+                        hidden=""
+                        id=":rt:"
+                      >
+                        Checked
+                      </label>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1197,10 +1256,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c13 c24"
           >
             <div
-              class="c24 c25 c26"
+              class="c25 c26 c27"
             >
               <p
                 class="c9"
@@ -1211,10 +1270,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c28 c29"
             >
               <span
-                class="c29"
+                class="c30"
               >
                 Edit
               </span>
@@ -1226,7 +1285,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c31"
           type="number"
         >
           <p
@@ -1244,10 +1303,10 @@ exports[`renders worksheet 1`] = `
       </tr>
       <tr>
         <td
-          class="c32"
+          class="c33"
         />
         <td
-          class="c33"
+          class="c34"
           type="text"
         >
           <p
@@ -1270,48 +1329,60 @@ exports[`renders worksheet 1`] = `
             <div
               class="c13"
             >
-              <input
-                aria-labelledby=":r15:"
-                class="c14 c15"
-                id=":r14:"
-                type="checkbox"
-              />
-              <label
-                aria-hidden="true"
-                class="c16 c31"
-                for=":r14:"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c18"
-                  fill="currentColor"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-                  />
-                </svg>
-              </label>
               <div
-                class="c19"
+                class="c14"
               >
+                <input
+                  aria-labelledby=":r15:"
+                  class="c15 c16"
+                  id=":r14:"
+                  type="checkbox"
+                />
                 <label
-                  aria-hidden="false"
-                  class="c20 c21"
+                  aria-hidden="true"
+                  class="c17 c32"
                   for=":r14:"
-                  hidden=""
-                  id=":r15:"
                 >
-                  Unchecked
+                  <svg
+                    aria-hidden="true"
+                    class="c19"
+                    fill="currentColor"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+                    />
+                  </svg>
                 </label>
+                <div
+                  class="c20"
+                >
+                  <div
+                    class="c21"
+                  >
+                    <div
+                      class="c13"
+                    >
+                      <label
+                        aria-hidden="false"
+                        class="c22 c23"
+                        for=":r14:"
+                        hidden=""
+                        id=":r15:"
+                      >
+                        Unchecked
+                      </label>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1339,10 +1410,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c13 c24"
           >
             <div
-              class="c24 c25 c26"
+              class="c25 c26 c27"
             >
               <p
                 class="c9"
@@ -1351,10 +1422,10 @@ exports[`renders worksheet 1`] = `
               />
             </div>
             <button
-              class="c27 c28"
+              class="c28 c29"
             >
               <span
-                class="c29"
+                class="c30"
               >
                 Edit
               </span>
@@ -1366,7 +1437,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c34"
+          class="c35"
           type="number"
         >
           <p
@@ -1410,50 +1481,62 @@ exports[`renders worksheet 1`] = `
             <div
               class="c13"
             >
-              <input
-                aria-checked="true"
-                aria-labelledby=":r1d:"
-                checked=""
-                class="c14 c15"
-                id=":r1c:"
-                type="checkbox"
-              />
-              <label
-                aria-hidden="true"
-                class="c16 c17"
-                for=":r1c:"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c18"
-                  fill="currentColor"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-                  />
-                </svg>
-              </label>
               <div
-                class="c19"
+                class="c14"
               >
+                <input
+                  aria-checked="true"
+                  aria-labelledby=":r1d:"
+                  checked=""
+                  class="c15 c16"
+                  id=":r1c:"
+                  type="checkbox"
+                />
                 <label
-                  aria-hidden="false"
-                  class="c20 c21"
+                  aria-hidden="true"
+                  class="c17 c18"
                   for=":r1c:"
-                  hidden=""
-                  id=":r1d:"
                 >
-                  Checked
+                  <svg
+                    aria-hidden="true"
+                    class="c19"
+                    fill="currentColor"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+                    />
+                  </svg>
                 </label>
+                <div
+                  class="c20"
+                >
+                  <div
+                    class="c21"
+                  >
+                    <div
+                      class="c13"
+                    >
+                      <label
+                        aria-hidden="false"
+                        class="c22 c23"
+                        for=":r1c:"
+                        hidden=""
+                        id=":r1d:"
+                      >
+                        Checked
+                      </label>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1483,10 +1566,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c13 c24"
           >
             <div
-              class="c24 c25 c26"
+              class="c25 c26 c27"
             >
               <p
                 class="c9"
@@ -1497,10 +1580,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c28 c29"
             >
               <span
-                class="c29"
+                class="c30"
               >
                 Edit
               </span>
@@ -1512,7 +1595,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c31"
           type="number"
         >
           <p
@@ -1530,7 +1613,7 @@ exports[`renders worksheet 1`] = `
       </tr>
       <tr>
         <td
-          class="c32"
+          class="c33"
         />
         <td
           class="c8"
@@ -1558,49 +1641,61 @@ exports[`renders worksheet 1`] = `
             <div
               class="c13"
             >
-              <input
-                aria-checked="false"
-                aria-labelledby=":r1l:"
-                class="c14 c15"
-                id=":r1k:"
-                type="checkbox"
-              />
-              <label
-                aria-hidden="true"
-                class="c16 c31"
-                for=":r1k:"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c18"
-                  fill="currentColor"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-                  />
-                </svg>
-              </label>
               <div
-                class="c19"
+                class="c14"
               >
+                <input
+                  aria-checked="false"
+                  aria-labelledby=":r1l:"
+                  class="c15 c16"
+                  id=":r1k:"
+                  type="checkbox"
+                />
                 <label
-                  aria-hidden="false"
-                  class="c20 c21"
+                  aria-hidden="true"
+                  class="c17 c32"
                   for=":r1k:"
-                  hidden=""
-                  id=":r1l:"
                 >
-                  Unchecked
+                  <svg
+                    aria-hidden="true"
+                    class="c19"
+                    fill="currentColor"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+                    />
+                  </svg>
                 </label>
+                <div
+                  class="c20"
+                >
+                  <div
+                    class="c21"
+                  >
+                    <div
+                      class="c13"
+                    >
+                      <label
+                        aria-hidden="false"
+                        class="c22 c23"
+                        for=":r1k:"
+                        hidden=""
+                        id=":r1l:"
+                      >
+                        Unchecked
+                      </label>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1630,10 +1725,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c13 c24"
           >
             <div
-              class="c24 c25 c26"
+              class="c25 c26 c27"
             >
               <p
                 class="c9"
@@ -1644,10 +1739,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c28 c29"
             >
               <span
-                class="c29"
+                class="c30"
               >
                 Edit
               </span>
@@ -1659,7 +1754,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c34"
+          class="c35"
           type="number"
         >
           <p
@@ -1705,50 +1800,62 @@ exports[`renders worksheet 1`] = `
             <div
               class="c13"
             >
-              <input
-                aria-checked="true"
-                aria-labelledby=":r1t:"
-                checked=""
-                class="c14 c15"
-                id=":r1s:"
-                type="checkbox"
-              />
-              <label
-                aria-hidden="true"
-                class="c16 c17"
-                for=":r1s:"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c18"
-                  fill="currentColor"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-                  />
-                </svg>
-              </label>
               <div
-                class="c19"
+                class="c14"
               >
+                <input
+                  aria-checked="true"
+                  aria-labelledby=":r1t:"
+                  checked=""
+                  class="c15 c16"
+                  id=":r1s:"
+                  type="checkbox"
+                />
                 <label
-                  aria-hidden="false"
-                  class="c20 c21"
+                  aria-hidden="true"
+                  class="c17 c18"
                   for=":r1s:"
-                  hidden=""
-                  id=":r1t:"
                 >
-                  Checked
+                  <svg
+                    aria-hidden="true"
+                    class="c19"
+                    fill="currentColor"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+                    />
+                  </svg>
                 </label>
+                <div
+                  class="c20"
+                >
+                  <div
+                    class="c21"
+                  >
+                    <div
+                      class="c13"
+                    >
+                      <label
+                        aria-hidden="false"
+                        class="c22 c23"
+                        for=":r1s:"
+                        hidden=""
+                        id=":r1t:"
+                      >
+                        Checked
+                      </label>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1778,10 +1885,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c13 c24"
           >
             <div
-              class="c24 c25 c26"
+              class="c25 c26 c27"
             >
               <p
                 class="c9"
@@ -1792,10 +1899,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c28 c29"
             >
               <span
-                class="c29"
+                class="c30"
               >
                 Edit
               </span>
@@ -1807,7 +1914,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c31"
           type="number"
         >
           <p
@@ -1853,50 +1960,62 @@ exports[`renders worksheet 1`] = `
             <div
               class="c13"
             >
-              <input
-                aria-checked="true"
-                aria-labelledby=":r25:"
-                checked=""
-                class="c14 c15"
-                id=":r24:"
-                type="checkbox"
-              />
-              <label
-                aria-hidden="true"
-                class="c16 c17"
-                for=":r24:"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c18"
-                  fill="currentColor"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="24"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-                  />
-                </svg>
-              </label>
               <div
-                class="c19"
+                class="c14"
               >
+                <input
+                  aria-checked="true"
+                  aria-labelledby=":r25:"
+                  checked=""
+                  class="c15 c16"
+                  id=":r24:"
+                  type="checkbox"
+                />
                 <label
-                  aria-hidden="false"
-                  class="c20 c21"
+                  aria-hidden="true"
+                  class="c17 c18"
                   for=":r24:"
-                  hidden=""
-                  id=":r25:"
                 >
-                  Checked
+                  <svg
+                    aria-hidden="true"
+                    class="c19"
+                    fill="currentColor"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+                    />
+                  </svg>
                 </label>
+                <div
+                  class="c20"
+                >
+                  <div
+                    class="c21"
+                  >
+                    <div
+                      class="c13"
+                    >
+                      <label
+                        aria-hidden="false"
+                        class="c22 c23"
+                        for=":r24:"
+                        hidden=""
+                        id=":r25:"
+                      >
+                        Checked
+                      </label>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1926,10 +2045,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c13 c24"
           >
             <div
-              class="c24 c25 c26"
+              class="c25 c26 c27"
             >
               <p
                 class="c9"
@@ -1940,10 +2059,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c28 c29"
             >
               <span
-                class="c29"
+                class="c30"
               >
                 Edit
               </span>
@@ -1955,7 +2074,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c31"
           type="number"
         >
           <p

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -1024,7 +1024,7 @@ describe('keyboard navigation', () => {
         numberField: 50,
       },
     ]);
-    expect(cells[1].parentElement?.parentElement?.parentElement).toHaveStyle(
+    expect(cells[1].parentElement?.parentElement?.parentElement?.parentElement).toHaveStyle(
       `border-color: ${theme.colors.primary};`,
     );
 
@@ -1825,7 +1825,7 @@ describe('useKeyEvents coverage improvements', () => {
 
     // Should navigate to previous column (visibleOnStorefront checkbox) after finishing edit
     const checkboxes = getAllByLabelText('Checked');
-    const prevCell = checkboxes[0].parentElement?.parentElement?.parentElement;
+    const prevCell = checkboxes[0].parentElement?.parentElement?.parentElement?.parentElement;
 
     expect(prevCell).toHaveStyle(`border-color: ${theme.colors.primary}`);
   });

--- a/packages/docs/PropTables/CheckboxPropTable.tsx
+++ b/packages/docs/PropTables/CheckboxPropTable.tsx
@@ -75,6 +75,36 @@ const checkboxProps: Prop[] = [
       </>
     ),
   },
+  {
+    name: 'collapseOptions',
+    types: [
+      <NextLink
+        href={{
+          hash: 'checkbox-collapse-prop-table',
+          query: { props: 'checkbox-collapse' },
+        }}
+        key="checkbox-collapse"
+      >
+        CheckboxCollapse
+      </NextLink>,
+    ],
+    description: <>Adds a collapsible section beneath the checkbox row.</>,
+  },
+  {
+    name: 'img',
+    types: [
+      <NextLink
+        href={{
+          hash: 'checkbox-img-prop-table',
+          query: { props: 'checkbox-img' },
+        }}
+        key="checkbox-img"
+      >
+        CheckboxImg
+      </NextLink>,
+    ],
+    description: <>Renders an image next to the label.</>,
+  },
 ];
 
 const checkboxDescriptionProps: Prop[] = [
@@ -117,6 +147,49 @@ const checkboxDescriptionProps: Prop[] = [
   },
 ];
 
+const checkboxCollapseProps: Prop[] = [
+  {
+    name: 'children',
+    types: ['React.ReactNode'],
+    required: true,
+    description: <>Collapsible content.</>,
+  },
+  {
+    name: 'collapsedTitle',
+    types: ['string'],
+    required: false,
+    defaultValue: 'Show more',
+    description: <>Title for the collapsed content.</>,
+  },
+  {
+    name: 'expandedTitle',
+    types: ['string'],
+    required: false,
+    defaultValue: 'Show less',
+    description: <>Title for the expanded content.</>,
+  },
+  {
+    name: 'disableWhenUnchecked',
+    types: ['boolean'],
+    required: false,
+    description: (
+      <>
+        When true, the collapse trigger is disabled and the panel is forced closed while the
+        checkbox is unchecked.
+      </>
+    ),
+  },
+];
+
+const checkboxImgProps: Prop[] = [
+  {
+    name: 'src',
+    types: ['string'],
+    required: true,
+    description: <>Image URL.</>,
+  },
+];
+
 export const CheckboxPropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable
     nativeElement={['input', 'all']}
@@ -141,5 +214,23 @@ export const CheckboxDescriptionLinkPropTable: React.FC<PropTableWrapper> = (pro
     title="Checkbox[CheckboxDescriptionLink]"
     {...props}
     id="checkbox-description-link-prop-table"
+  />
+);
+
+export const CheckboxCollapsePropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable
+    propList={checkboxCollapseProps}
+    title="Checkbox[CheckboxCollapse]"
+    {...props}
+    id="checkbox-collapse-prop-table"
+  />
+);
+
+export const CheckboxImgPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable
+    propList={checkboxImgProps}
+    title="Checkbox[CheckboxImg]"
+    {...props}
+    id="checkbox-img-prop-table"
   />
 );

--- a/packages/docs/PropTables/CollapsePropTable.tsx
+++ b/packages/docs/PropTables/CollapsePropTable.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 
-import { Prop, PropTable, PropTableWrapper } from '../components';
+import { NextLink, Prop, PropTable, PropTableWrapper } from '../components';
 
 const collapseProps: Prop[] = [
   {
     name: 'title',
-    types: 'string',
+    types: ['string', 'React.ReactNode'],
     description: 'Collapse title.',
     required: true,
   },
   {
     name: 'initiallyOpen',
     types: 'boolean',
+    defaultValue: 'false',
     description: 'Defines if panel with content is visible by default.',
   },
   {
@@ -19,8 +20,58 @@ const collapseProps: Prop[] = [
     types: '(isOpen: boolean) => void',
     description: 'Function that will be called when a title is clicked.',
   },
+  {
+    name: 'portalTarget',
+    types: ['Element', 'null'],
+    defaultValue: 'null',
+    description:
+      'The panel is mounted at that node instead of inline next to the trigger. When omitted, the panel renders in place.',
+  },
+  {
+    name: 'disabled',
+    types: 'boolean',
+    description: "Disables the title button so it can't be toggled.",
+  },
+  {
+    name: 'panelProps',
+    types: (
+      <NextLink
+        href={{
+          hash: 'collapse-panel-prop-table',
+          query: { props: 'collapse-panel' },
+        }}
+      >
+        CollapsePanelProps
+      </NextLink>
+    ),
+    description:
+      'Accepts padding, margin, and backgroundColor for styling the collapsible region without wrapping it externally.',
+  },
+];
+
+const collapsePanelProps: Prop[] = [
+  {
+    name: 'backgroundColor',
+    types: (
+      <NextLink href="/colors" key="colors-type">
+        Colors
+      </NextLink>
+    ),
+    defaultValue: 'unset',
+    description: 'Panel background color.',
+    required: false,
+  },
 ];
 
 export const CollapsePropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable propList={collapseProps} title="Collapse" {...props} />
+);
+
+export const CollapsePanelPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable
+    id="collapse-panel-prop-table"
+    propList={collapsePanelProps}
+    title="Collapse[CollapsePannel]"
+    {...props}
+  />
 );

--- a/packages/docs/pages/checkbox.tsx
+++ b/packages/docs/pages/checkbox.tsx
@@ -3,8 +3,10 @@ import React, { Fragment, useState } from 'react';
 
 import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
 import {
+  CheckboxCollapsePropTable,
   CheckboxDescriptionLinkPropTable,
   CheckboxDescriptionPropTable,
+  CheckboxImgPropTable,
   CheckboxPropTable,
 } from '../PropTables';
 
@@ -179,6 +181,67 @@ const CheckboxPage = () => {
                 </Fragment>
               ),
             },
+            {
+              id: 'collapse',
+              title: 'Collapse',
+              render: () => (
+                <Fragment key="collapse">
+                  <Text>
+                    <Code primary>Checkboxes</Code> support <Code primary>Collapse</Code> that
+                    allows additional information to be displayed below{' '}
+                    <Code primary>Checkboxes</Code>.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    {function Example() {
+                      const [checkedA, setChangeA] = useState(false);
+                      const [checkedB, setChangeB] = useState(false);
+
+                      const handleChangeA = () => setChangeA(!checkedA);
+                      const handleChangeB = () => setChangeB(!checkedB);
+
+                      return (
+                        <Form>
+                          <FormGroup>
+                            <Checkbox
+                              badge={{
+                                label: 'warning',
+                                variant: 'warning',
+                              }}
+                              checked={checkedB}
+                              collapseOptions={{
+                                collapsedTitle: 'Configure',
+                                expandedTitle: 'Close',
+                                children: <Text>I am a CheckboxCollapse</Text>,
+                              }}
+                              description={{
+                                text: 'I am a CheckboxDescription.',
+                              }}
+                              label="Checkbox with collapseOptions, description and badge"
+                              onChange={handleChangeB}
+                            />
+                            <Checkbox
+                              checked={checkedA}
+                              collapseOptions={{
+                                collapsedTitle: 'Configure',
+                                expandedTitle: 'Close',
+                                children: <Text>I am a CheckboxCollapse</Text>,
+                                disableWhenUnchecked: true,
+                              }}
+                              img={{ src: '/logo.svg' }}
+                              label="Checkbox with collapseOptions and img"
+                              onChange={handleChangeA}
+                            />
+                          </FormGroup>
+                        </Form>
+                      );
+                    }}
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
           ]}
         />
       </Panel>
@@ -203,6 +266,16 @@ const CheckboxPage = () => {
               render: () => (
                 <CheckboxDescriptionLinkPropTable id="checkbox-description-link-prop-table" />
               ),
+            },
+            {
+              id: 'checkbox-collapse',
+              title: 'CheckboxCollapse',
+              render: () => <CheckboxCollapsePropTable id="checkbox-collapse" />,
+            },
+            {
+              id: 'checkbox-img',
+              title: 'CheckboxImg',
+              render: () => <CheckboxImgPropTable id="checkbox-img" />,
             },
           ]}
         />

--- a/packages/docs/pages/collapse.tsx
+++ b/packages/docs/pages/collapse.tsx
@@ -1,8 +1,8 @@
 import { Collapse, H1, Panel, Text } from '@bigcommerce/big-design';
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 
-import { Code, CodePreview, GuidelinesTable, List } from '../components';
-import { CollapsePropTable } from '../PropTables';
+import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
+import { CollapsePanelPropTable, CollapsePropTable } from '../PropTables';
 
 const CollapsePage = () => {
   return (
@@ -32,7 +32,11 @@ const CollapsePage = () => {
             const handleChange = (isOpen: boolean) => setTitle(isOpen ? 'Show less' : 'Show more');
 
             return (
-              <Collapse onCollapseChange={handleChange} title={title}>
+              <Collapse
+                onCollapseChange={handleChange}
+                panelProps={{ backgroundColor: 'secondary30' }}
+                title={title}
+              >
                 <Text>
                   Ea tempor sunt amet labore proident dolor proident commodo in exercitation ea
                   nulla sunt pariatur. Nulla sunt ipsum do eu consectetur exercitation occaecat
@@ -47,7 +51,21 @@ const CollapsePage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <CollapsePropTable />
+        <ContentRoutingTabs
+          id="props"
+          routes={[
+            {
+              id: 'collapse',
+              title: 'Collapse',
+              render: () => <CollapsePropTable />,
+            },
+            {
+              id: 'collapse-panel',
+              title: 'CollapsePanel',
+              render: () => <CollapsePanelPropTable id="collapse-panel-prop-table" />,
+            },
+          ]}
+        />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">


### PR DESCRIPTION
## What?

Adds a collapsible content feature to `Checkbox` and a supporting image (avatar) slot, with corresponding API extensions to `Collapse` to make this composition possible

## Why?

There a new design which requires a new functionality extensions for `Checkbox` and `Collapse` components

## Screenshots/Screen Recordings

Checkbox

https://github.com/user-attachments/assets/6d3da4ae-0130-4f61-ad33-14ead7901f89

Collaps

https://github.com/user-attachments/assets/a76b7c35-10d8-4b01-8822-c7cb1eaf118b


## Testing/Proof

- [x] New unit tests in Checkbox/spec.tsx: image render, collapsible render, disableWhenUnchecked disables the trigger, panel expands on trigger click when checked.
- [x] New unit tests in Collapse/spec.tsx: ReactNode title, disabled state, ignored clicks while disabled, auto-close on disabled toggle, portalTarget, panelProps forwarding, custom marginVertical.
- [x] Snapshot updates for new Checkbox variants.
- [x] Verify in local docs site
