### PR TITLE
feat(component): update collapse component with a new API

### DIFF
--- a/.changeset/moody-roses-sleep.md
+++ b/.changeset/moody-roses-sleep.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design': major
+'@bigcommerce/docs': minor
+---
+
+BREAKING: rewrite Collapse to a headless compound component (Collapse.Trigger + Collapse.Panel).

--- a/packages/big-design/src/components/Collapse/Collapse.tsx
+++ b/packages/big-design/src/components/Collapse/Collapse.tsx
@@ -27,7 +27,7 @@ export const Collapse: CollapseComponent = ({
   const wasDisabled = useRef(disabled);
 
   const isControlled = isOpen !== undefined;
-  const [uncontrolledOpen, setUncontrolledOpen] = useState(initiallyOpen);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(disabled ? false : initiallyOpen);
   const isCollapseOpen = isControlled ? isOpen : uncontrolledOpen;
 
   const triggerId = useId();
@@ -38,15 +38,14 @@ export const Collapse: CollapseComponent = ({
 
     wasDisabled.current = disabled;
 
-    if (isControlled) {
-      return;
-    }
+    if (justDisabled && isCollapseOpen) {
+      if (!isControlled) {
+        setUncontrolledOpen(false);
+      }
 
-    if (justDisabled && uncontrolledOpen) {
-      setUncontrolledOpen(false);
       onCollapseChange?.(false);
     }
-  }, [disabled, isControlled, uncontrolledOpen, onCollapseChange]);
+  }, [disabled, isControlled, isCollapseOpen, onCollapseChange]);
 
   const toggle = useCallback(() => {
     if (disabled) {

--- a/packages/big-design/src/components/Collapse/Collapse.tsx
+++ b/packages/big-design/src/components/Collapse/Collapse.tsx
@@ -1,61 +1,68 @@
-import { ExpandMoreIcon } from '@bigcommerce/big-design-icons';
-import React, { useId, useState } from 'react';
+import React, { useCallback, useEffect, useId, useState } from 'react';
 
-import { Box } from '../Box';
-
-import { StyledButton } from './styled';
+import { CollapsePanel, CollapsePanelProps } from './CollapsePanel';
+import { CollapseTrigger, CollapseTriggerProps } from './CollapseTrigger';
+import { CollapseContext } from './useCollapseContext';
 
 export interface CollapseProps {
   children?: React.ReactNode;
-  title: string;
-  initiallyOpen?: boolean;
+  isCollapseOpen?: boolean;
+  defaultOpen?: boolean;
   onCollapseChange?(isOpen: boolean): void;
+  disabled?: boolean;
+  triggerProps?: Omit<CollapseTriggerProps, 'title'>;
+  panelProps?: Omit<CollapsePanelProps, 'children'>;
 }
 
-export const Collapse: React.FC<CollapseProps> = ({
+type CollapseComponent = React.FC<CollapseProps> & {
+  Trigger: typeof CollapseTrigger;
+  Panel: typeof CollapsePanel;
+};
+
+export const Collapse: CollapseComponent = ({
   children,
-  title,
+  isCollapseOpen,
+  defaultOpen = false,
   onCollapseChange,
-  initiallyOpen = false,
+  disabled,
 }) => {
-  const [isOpen, setIsOpen] = useState(initiallyOpen);
+  const isControlled = isCollapseOpen !== undefined;
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(disabled ? false : defaultOpen);
+  const isOpen = isControlled ? isCollapseOpen : uncontrolledOpen;
+
   const triggerId = useId();
   const panelId = useId();
 
-  const handleTitleClick = () => {
-    const nextIsOpen = !isOpen;
+  useEffect(() => {
+    if (disabled && isOpen) {
+      if (!isControlled) {
+        setUncontrolledOpen(false);
+      }
 
-    setIsOpen(nextIsOpen);
-
-    if (typeof onCollapseChange === 'function') {
-      onCollapseChange(nextIsOpen);
+      onCollapseChange?.(false);
     }
-  };
+  }, [disabled, isOpen, isControlled, onCollapseChange]);
+
+  const toggle = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+
+    const next = !isOpen;
+
+    if (!isControlled) {
+      setUncontrolledOpen(next);
+    }
+
+    onCollapseChange?.(next);
+  }, [disabled, isControlled, isOpen, onCollapseChange]);
 
   return (
-    <>
-      <StyledButton
-        aria-controls={panelId}
-        aria-expanded={isOpen}
-        iconRight={<ExpandMoreIcon title={title} />}
-        id={triggerId}
-        isOpen={isOpen}
-        marginVertical="small"
-        onClick={handleTitleClick}
-        type="button"
-        variant="subtle"
-      >
-        {title}
-      </StyledButton>
-      <Box
-        aria-labelledby={triggerId}
-        display={isOpen ? 'block' : 'none'}
-        hidden={!isOpen}
-        id={panelId}
-        role="region"
-      >
-        {children}
-      </Box>
-    </>
+    <CollapseContext.Provider value={{ isOpen, toggle, disabled, triggerId, panelId }}>
+      {children}
+    </CollapseContext.Provider>
   );
 };
+
+Collapse.Trigger = CollapseTrigger;
+Collapse.Panel = CollapsePanel;

--- a/packages/big-design/src/components/Collapse/Collapse.tsx
+++ b/packages/big-design/src/components/Collapse/Collapse.tsx
@@ -1,17 +1,15 @@
-import React, { useCallback, useEffect, useId, useState } from 'react';
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 
-import { CollapsePanel, CollapsePanelProps } from './CollapsePanel';
-import { CollapseTrigger, CollapseTriggerProps } from './CollapseTrigger';
+import { CollapsePanel } from './CollapsePanel';
+import { CollapseTrigger } from './CollapseTrigger';
 import { CollapseContext } from './useCollapseContext';
 
 export interface CollapseProps {
   children?: React.ReactNode;
-  isCollapseOpen?: boolean;
-  defaultOpen?: boolean;
+  isOpen?: boolean;
+  initiallyOpen?: boolean;
   onCollapseChange?(isOpen: boolean): void;
   disabled?: boolean;
-  triggerProps?: Omit<CollapseTriggerProps, 'title'>;
-  panelProps?: Omit<CollapsePanelProps, 'children'>;
 }
 
 type CollapseComponent = React.FC<CollapseProps> & {
@@ -21,44 +19,53 @@ type CollapseComponent = React.FC<CollapseProps> & {
 
 export const Collapse: CollapseComponent = ({
   children,
-  isCollapseOpen,
-  defaultOpen = false,
+  isOpen,
+  initiallyOpen = false,
   onCollapseChange,
   disabled,
 }) => {
-  const isControlled = isCollapseOpen !== undefined;
-  const [uncontrolledOpen, setUncontrolledOpen] = useState(disabled ? false : defaultOpen);
-  const isOpen = isControlled ? isCollapseOpen : uncontrolledOpen;
+  const wasDisabled = useRef(disabled);
+
+  const isControlled = isOpen !== undefined;
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(initiallyOpen);
+  const isCollapseOpen = isControlled ? isOpen : uncontrolledOpen;
 
   const triggerId = useId();
   const panelId = useId();
 
   useEffect(() => {
-    if (disabled && isOpen) {
-      if (!isControlled) {
-        setUncontrolledOpen(false);
-      }
+    const justDisabled = disabled && !wasDisabled.current;
 
+    wasDisabled.current = disabled;
+
+    if (isControlled) {
+      return;
+    }
+
+    if (justDisabled && uncontrolledOpen) {
+      setUncontrolledOpen(false);
       onCollapseChange?.(false);
     }
-  }, [disabled, isOpen, isControlled, onCollapseChange]);
+  }, [disabled, isControlled, uncontrolledOpen, onCollapseChange]);
 
   const toggle = useCallback(() => {
     if (disabled) {
       return;
     }
 
-    const next = !isOpen;
+    const next = !isCollapseOpen;
 
     if (!isControlled) {
       setUncontrolledOpen(next);
     }
 
     onCollapseChange?.(next);
-  }, [disabled, isControlled, isOpen, onCollapseChange]);
+  }, [disabled, isControlled, isCollapseOpen, onCollapseChange]);
 
   return (
-    <CollapseContext.Provider value={{ isOpen, toggle, disabled, triggerId, panelId }}>
+    <CollapseContext.Provider
+      value={{ isOpen: isCollapseOpen, toggle, disabled, triggerId, panelId }}
+    >
       {children}
     </CollapseContext.Provider>
   );

--- a/packages/big-design/src/components/Collapse/CollapsePanel/CollapsePanel.tsx
+++ b/packages/big-design/src/components/Collapse/CollapsePanel/CollapsePanel.tsx
@@ -1,0 +1,28 @@
+import type { Colors } from '@bigcommerce/big-design-theme';
+import React from 'react';
+
+import { MarginProps, PaddingProps } from '../../../helpers';
+import { Box } from '../../Box';
+import { useCollapseContext } from '../useCollapseContext';
+
+export interface CollapsePanelProps extends PaddingProps, MarginProps {
+  children?: React.ReactNode;
+  backgroundColor?: keyof Colors;
+}
+
+export const CollapsePanel: React.FC<CollapsePanelProps> = ({ children, ...boxProps }) => {
+  const { isOpen, triggerId, panelId } = useCollapseContext('Collapse.Panel');
+
+  return (
+    <Box
+      {...boxProps}
+      aria-labelledby={triggerId}
+      display={isOpen ? 'block' : 'none'}
+      hidden={!isOpen}
+      id={panelId}
+      role="region"
+    >
+      {children}
+    </Box>
+  );
+};

--- a/packages/big-design/src/components/Collapse/CollapsePanel/index.ts
+++ b/packages/big-design/src/components/Collapse/CollapsePanel/index.ts
@@ -1,0 +1,1 @@
+export { CollapsePanel, type CollapsePanelProps } from './CollapsePanel';

--- a/packages/big-design/src/components/Collapse/CollapseTrigger/CollapseTrigger.tsx
+++ b/packages/big-design/src/components/Collapse/CollapseTrigger/CollapseTrigger.tsx
@@ -1,0 +1,37 @@
+import { ExpandMoreIcon } from '@bigcommerce/big-design-icons';
+import React from 'react';
+
+import { MarginProps } from '../../../helpers';
+import { useCollapseContext } from '../useCollapseContext';
+
+import { StyledButton } from './styled';
+
+export interface CollapseTriggerProps extends MarginProps {
+  title: string | React.ReactNode;
+}
+
+export const CollapseTrigger: React.FC<CollapseTriggerProps> = ({
+  title,
+  marginVertical = 'small',
+  ...marginProps
+}) => {
+  const { isOpen, toggle, disabled, triggerId, panelId } = useCollapseContext('Collapse.Trigger');
+
+  return (
+    <StyledButton
+      aria-controls={panelId}
+      aria-expanded={isOpen}
+      disabled={disabled}
+      iconRight={<ExpandMoreIcon title={typeof title === 'string' ? title : undefined} />}
+      id={triggerId}
+      isOpen={isOpen}
+      marginVertical={marginVertical}
+      onClick={toggle}
+      type="button"
+      variant="subtle"
+      {...marginProps}
+    >
+      {title}
+    </StyledButton>
+  );
+};

--- a/packages/big-design/src/components/Collapse/CollapseTrigger/CollapseTrigger.tsx
+++ b/packages/big-design/src/components/Collapse/CollapseTrigger/CollapseTrigger.tsx
@@ -7,7 +7,7 @@ import { useCollapseContext } from '../useCollapseContext';
 import { StyledButton } from './styled';
 
 export interface CollapseTriggerProps extends MarginProps {
-  title: string | React.ReactNode;
+  title: string;
 }
 
 export const CollapseTrigger: React.FC<CollapseTriggerProps> = ({
@@ -22,7 +22,7 @@ export const CollapseTrigger: React.FC<CollapseTriggerProps> = ({
       aria-controls={panelId}
       aria-expanded={isOpen}
       disabled={disabled}
-      iconRight={<ExpandMoreIcon title={typeof title === 'string' ? title : undefined} />}
+      iconRight={<ExpandMoreIcon title={title} />}
       id={triggerId}
       isOpen={isOpen}
       marginVertical={marginVertical}

--- a/packages/big-design/src/components/Collapse/CollapseTrigger/index.ts
+++ b/packages/big-design/src/components/Collapse/CollapseTrigger/index.ts
@@ -1,0 +1,1 @@
+export { CollapseTrigger, type CollapseTriggerProps } from './CollapseTrigger';

--- a/packages/big-design/src/components/Collapse/CollapseTrigger/styled.tsx
+++ b/packages/big-design/src/components/Collapse/CollapseTrigger/styled.tsx
@@ -1,9 +1,9 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { withTransition } from '../../helpers/transitions';
-import { ButtonProps } from '../Button';
-import { StyleableButton } from '../Button/private';
+import { withTransition } from '../../../helpers/transitions';
+import { ButtonProps } from '../../Button';
+import { StyleableButton } from '../../Button/private';
 
 interface StyledButtonProps extends ButtonProps {
   isOpen?: boolean;

--- a/packages/big-design/src/components/Collapse/index.ts
+++ b/packages/big-design/src/components/Collapse/index.ts
@@ -1,1 +1,4 @@
 export { Collapse, type CollapseProps } from './Collapse';
+
+export { CollapsePanel, type CollapsePanelProps } from './CollapsePanel';
+export { CollapseTrigger, type CollapseTriggerProps } from './CollapseTrigger';

--- a/packages/big-design/src/components/Collapse/spec.tsx
+++ b/packages/big-design/src/components/Collapse/spec.tsx
@@ -264,6 +264,19 @@ test('open panel closes when disabled becomes true', () => {
   expect(onChange).toHaveBeenCalledWith(false);
 });
 
+test('panel stays hidden when disabled and initiallyOpen', () => {
+  render(
+    <Collapse disabled initiallyOpen>
+      <Collapse.Trigger title="title" />
+      <Collapse.Panel>
+        <Text>Content</Text>
+      </Collapse.Panel>
+    </Collapse>,
+  );
+
+  expect(screen.getByRole('region', { hidden: true })).not.toBeVisible();
+});
+
 test('panel applies backgroundColor and padding', () => {
   render(
     <Collapse initiallyOpen>
@@ -277,6 +290,7 @@ test('panel applies backgroundColor and padding', () => {
   const panel = screen.getByRole('region');
 
   expect(panel).toHaveStyle('padding: 1rem');
+  expect(panel).toHaveStyle('background-color: rgb(236, 238, 245)');
 });
 
 test('panel renders provided children', () => {
@@ -309,7 +323,7 @@ test('Trigger applies custom marginVertical', () => {
   expect(screen.getByRole('button')).toHaveStyle('margin-top: 1.25rem');
 });
 
-test('controlled mode: isCollapseOpen drives the open state', async () => {
+test('controlled mode: isOpen drives the open state', async () => {
   const ControlledExample = () => {
     const [isOpen, setIsOpen] = useState(false);
 

--- a/packages/big-design/src/components/Collapse/spec.tsx
+++ b/packages/big-design/src/components/Collapse/spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import React from 'react';
+import React, { useState } from 'react';
 import 'jest-styled-components';
 
 import { Text } from '../Typography';
@@ -9,14 +9,25 @@ import { Collapse } from './Collapse';
 
 const handleChange = jest.fn();
 
+beforeEach(() => {
+  handleChange.mockClear();
+});
+
 const CollapseWithStaticTitleMock = (
-  <Collapse onCollapseChange={handleChange} title="title">
-    <Text>Content</Text>
+  <Collapse onCollapseChange={handleChange}>
+    <Collapse.Trigger title="title" />
+    <Collapse.Panel>
+      <Text>Content</Text>
+    </Collapse.Panel>
   </Collapse>
 );
+
 const CollapseWithVisiblePanelMock = (
-  <Collapse initiallyOpen title="show more">
-    <Text>Content</Text>
+  <Collapse defaultOpen>
+    <Collapse.Trigger title="show more" />
+    <Collapse.Panel>
+      <Text>Content</Text>
+    </Collapse.Panel>
   </Collapse>
 );
 
@@ -176,5 +187,193 @@ test('onCollapseChange is called', async () => {
 
   await userEvent.click(trigger);
 
-  expect(handleChange).toHaveBeenCalled();
+  expect(handleChange).toHaveBeenCalledWith(true);
+});
+
+test('renders with ReactNode title', () => {
+  render(
+    <Collapse>
+      <Collapse.Trigger title={<span data-testid="custom-title">Custom Title</span>} />
+      <Collapse.Panel>
+        <Text>Content</Text>
+      </Collapse.Panel>
+    </Collapse>,
+  );
+
+  expect(screen.getAllByTestId('custom-title').length).toBeGreaterThan(0);
+});
+
+test('title button is disabled when disabled prop is true', () => {
+  render(
+    <Collapse disabled>
+      <Collapse.Trigger title="title" />
+      <Collapse.Panel>
+        <Text>Content</Text>
+      </Collapse.Panel>
+    </Collapse>,
+  );
+
+  expect(screen.getByRole('button')).toBeDisabled();
+});
+
+test('panel stays hidden when disabled and defaultOpen', () => {
+  render(
+    <Collapse defaultOpen disabled>
+      <Collapse.Trigger title="title" />
+      <Collapse.Panel>
+        <Text>Content</Text>
+      </Collapse.Panel>
+    </Collapse>,
+  );
+
+  expect(screen.getByRole('region', { hidden: true })).not.toBeVisible();
+});
+
+test('click on disabled title does not toggle panel', async () => {
+  const onChange = jest.fn();
+
+  render(
+    <Collapse disabled onCollapseChange={onChange}>
+      <Collapse.Trigger title="title" />
+      <Collapse.Panel>
+        <Text>Content</Text>
+      </Collapse.Panel>
+    </Collapse>,
+  );
+
+  const trigger = screen.getByRole<HTMLButtonElement>('button');
+  const panel = screen.getByRole('region', { hidden: true });
+
+  await userEvent.click(trigger, { pointerEventsCheck: 0 });
+
+  expect(panel).not.toBeVisible();
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test('open panel closes when disabled becomes true', () => {
+  const onChange = jest.fn();
+
+  const { rerender } = render(
+    <Collapse defaultOpen onCollapseChange={onChange}>
+      <Collapse.Trigger title="title" />
+      <Collapse.Panel>
+        <Text>Content</Text>
+      </Collapse.Panel>
+    </Collapse>,
+  );
+
+  expect(screen.getByRole('region')).toBeVisible();
+
+  rerender(
+    <Collapse defaultOpen disabled onCollapseChange={onChange}>
+      <Collapse.Trigger title="title" />
+      <Collapse.Panel>
+        <Text>Content</Text>
+      </Collapse.Panel>
+    </Collapse>,
+  );
+
+  expect(screen.getByRole('region', { hidden: true })).not.toBeVisible();
+  expect(onChange).toHaveBeenCalledWith(false);
+});
+
+test('panel applies backgroundColor and padding', () => {
+  render(
+    <Collapse defaultOpen>
+      <Collapse.Trigger title="title" />
+      <Collapse.Panel backgroundColor="secondary20" padding="medium">
+        <Text>Content</Text>
+      </Collapse.Panel>
+    </Collapse>,
+  );
+
+  const panel = screen.getByRole('region');
+
+  expect(panel).toHaveStyle('padding: 1rem');
+});
+
+test('Trigger applies custom marginVertical', () => {
+  render(
+    <Collapse>
+      <Collapse.Trigger marginVertical="large" title="title" />
+      <Collapse.Panel>
+        <Text>Content</Text>
+      </Collapse.Panel>
+    </Collapse>,
+  );
+
+  expect(screen.getByRole('button')).toHaveStyle('margin-top: 1.25rem');
+});
+
+test('controlled mode: isCollapseOpen drives the open state', async () => {
+  const ControlledExample = () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <Collapse isCollapseOpen={isOpen} onCollapseChange={setIsOpen}>
+        <Collapse.Trigger title="title" />
+        <Collapse.Panel>
+          <Text>Content</Text>
+        </Collapse.Panel>
+      </Collapse>
+    );
+  };
+
+  render(<ControlledExample />);
+
+  const trigger = screen.getByRole<HTMLButtonElement>('button');
+
+  expect(screen.getByRole('region', { hidden: true })).not.toBeVisible();
+
+  await userEvent.click(trigger);
+
+  expect(screen.getByRole('region')).toBeVisible();
+});
+
+test('Trigger and Panel can be placed in separate parts of the subtree', async () => {
+  render(
+    <Collapse>
+      <header>
+        <Collapse.Trigger title="title" />
+      </header>
+      <section>
+        <Collapse.Panel>
+          <Text>Content</Text>
+        </Collapse.Panel>
+      </section>
+    </Collapse>,
+  );
+
+  const trigger = screen.getByRole<HTMLButtonElement>('button');
+  const panel = screen.getByRole('region', { hidden: true });
+
+  expect(panel).not.toBeVisible();
+
+  await userEvent.click(trigger);
+
+  expect(panel).toBeVisible();
+});
+
+test('Collapse.Trigger throws when used outside Collapse', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  expect(() => render(<Collapse.Trigger title="title" />)).toThrow(
+    /Collapse\.Trigger must be used inside a <Collapse> component\./,
+  );
+
+  errorSpy.mockRestore();
+});
+
+test('Collapse.Panel throws when used outside Collapse', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  expect(() =>
+    render(
+      <Collapse.Panel>
+        <Text>Content</Text>
+      </Collapse.Panel>,
+    ),
+  ).toThrow(/Collapse\.Panel must be used inside a <Collapse> component\./);
+
+  errorSpy.mockRestore();
 });

--- a/packages/big-design/src/components/Collapse/spec.tsx
+++ b/packages/big-design/src/components/Collapse/spec.tsx
@@ -23,7 +23,7 @@ const CollapseWithStaticTitleMock = (
 );
 
 const CollapseWithVisiblePanelMock = (
-  <Collapse defaultOpen>
+  <Collapse initiallyOpen>
     <Collapse.Trigger title="show more" />
     <Collapse.Panel>
       <Text>Content</Text>
@@ -190,17 +190,17 @@ test('onCollapseChange is called', async () => {
   expect(handleChange).toHaveBeenCalledWith(true);
 });
 
-test('renders with ReactNode title', () => {
+test('renders with string title', () => {
   render(
     <Collapse>
-      <Collapse.Trigger title={<span data-testid="custom-title">Custom Title</span>} />
+      <Collapse.Trigger title="Custom Title" />
       <Collapse.Panel>
         <Text>Content</Text>
       </Collapse.Panel>
     </Collapse>,
   );
 
-  expect(screen.getAllByTestId('custom-title').length).toBeGreaterThan(0);
+  expect(screen.getByRole('button')).toHaveTextContent('Custom Title');
 });
 
 test('title button is disabled when disabled prop is true', () => {
@@ -214,19 +214,6 @@ test('title button is disabled when disabled prop is true', () => {
   );
 
   expect(screen.getByRole('button')).toBeDisabled();
-});
-
-test('panel stays hidden when disabled and defaultOpen', () => {
-  render(
-    <Collapse defaultOpen disabled>
-      <Collapse.Trigger title="title" />
-      <Collapse.Panel>
-        <Text>Content</Text>
-      </Collapse.Panel>
-    </Collapse>,
-  );
-
-  expect(screen.getByRole('region', { hidden: true })).not.toBeVisible();
 });
 
 test('click on disabled title does not toggle panel', async () => {
@@ -254,7 +241,7 @@ test('open panel closes when disabled becomes true', () => {
   const onChange = jest.fn();
 
   const { rerender } = render(
-    <Collapse defaultOpen onCollapseChange={onChange}>
+    <Collapse initiallyOpen onCollapseChange={onChange}>
       <Collapse.Trigger title="title" />
       <Collapse.Panel>
         <Text>Content</Text>
@@ -265,7 +252,7 @@ test('open panel closes when disabled becomes true', () => {
   expect(screen.getByRole('region')).toBeVisible();
 
   rerender(
-    <Collapse defaultOpen disabled onCollapseChange={onChange}>
+    <Collapse disabled initiallyOpen onCollapseChange={onChange}>
       <Collapse.Trigger title="title" />
       <Collapse.Panel>
         <Text>Content</Text>
@@ -279,7 +266,7 @@ test('open panel closes when disabled becomes true', () => {
 
 test('panel applies backgroundColor and padding', () => {
   render(
-    <Collapse defaultOpen>
+    <Collapse initiallyOpen>
       <Collapse.Trigger title="title" />
       <Collapse.Panel backgroundColor="secondary20" padding="medium">
         <Text>Content</Text>
@@ -290,6 +277,23 @@ test('panel applies backgroundColor and padding', () => {
   const panel = screen.getByRole('region');
 
   expect(panel).toHaveStyle('padding: 1rem');
+});
+
+test('panel renders provided children', () => {
+  render(
+    <Collapse initiallyOpen>
+      <Collapse.Trigger title="title" />
+      <Collapse.Panel>
+        <Text data-testid="panel-child">Panel content</Text>
+      </Collapse.Panel>
+    </Collapse>,
+  );
+
+  const panel = screen.getByRole('region');
+  const child = screen.getByTestId('panel-child');
+
+  expect(panel).toContainElement(child);
+  expect(child).toHaveTextContent('Panel content');
 });
 
 test('Trigger applies custom marginVertical', () => {
@@ -310,7 +314,7 @@ test('controlled mode: isCollapseOpen drives the open state', async () => {
     const [isOpen, setIsOpen] = useState(false);
 
     return (
-      <Collapse isCollapseOpen={isOpen} onCollapseChange={setIsOpen}>
+      <Collapse isOpen={isOpen} onCollapseChange={setIsOpen}>
         <Collapse.Trigger title="title" />
         <Collapse.Panel>
           <Text>Content</Text>

--- a/packages/big-design/src/components/Collapse/useCollapseContext.tsx
+++ b/packages/big-design/src/components/Collapse/useCollapseContext.tsx
@@ -1,0 +1,21 @@
+import { createContext, useContext } from 'react';
+
+interface CollapseContextValue {
+  isOpen: boolean;
+  toggle: () => void;
+  disabled?: boolean;
+  triggerId: string;
+  panelId: string;
+}
+
+export const CollapseContext = createContext<CollapseContextValue | null>(null);
+
+export const useCollapseContext = (componentName: string): CollapseContextValue => {
+  const context = useContext(CollapseContext);
+
+  if (!context) {
+    throw new Error(`${componentName} must be used inside a <Collapse> component.`);
+  }
+
+  return context;
+};

--- a/packages/docs/PropTables/CollapsePropTable.tsx
+++ b/packages/docs/PropTables/CollapsePropTable.tsx
@@ -24,7 +24,7 @@ const collapseProps: Prop[] = [
     name: 'isOpen',
     types: 'boolean',
     description:
-      'Controlled open state. When provided, the component is controlled and ignores isOpen.',
+      'Controlled open state. When provided, the component is controlled and ignores initiallyOpen.',
   },
   {
     name: 'onCollapseChange',

--- a/packages/docs/PropTables/CollapsePropTable.tsx
+++ b/packages/docs/PropTables/CollapsePropTable.tsx
@@ -15,16 +15,16 @@ const collapseProps: Prop[] = [
     required: true,
   },
   {
-    name: 'defaultOpen',
+    name: 'initiallyOpen',
     types: 'boolean',
     defaultValue: 'false',
     description: 'Initial open state when uncontrolled.',
   },
   {
-    name: 'isCollapseOpen',
+    name: 'isOpen',
     types: 'boolean',
     description:
-      'Controlled open state. When provided, the component is controlled and ignores defaultOpen.',
+      'Controlled open state. When provided, the component is controlled and ignores isOpen.',
   },
   {
     name: 'onCollapseChange',
@@ -43,7 +43,7 @@ const collapseProps: Prop[] = [
 const collapseTriggerProps: Prop[] = [
   {
     name: 'title',
-    types: ['string', 'React.ReactNode'],
+    types: 'string',
     description: 'Trigger label rendered alongside the chevron icon.',
     required: true,
   },

--- a/packages/docs/PropTables/CollapsePropTable.tsx
+++ b/packages/docs/PropTables/CollapsePropTable.tsx
@@ -4,23 +4,73 @@ import { Prop, PropTable, PropTableWrapper } from '../components';
 
 const collapseProps: Prop[] = [
   {
-    name: 'title',
-    types: 'string',
-    description: 'Collapse title.',
+    name: 'children',
+    types: 'React.ReactNode',
+    description: (
+      <>
+        Should include a <code>Collapse.Trigger</code> and a <code>Collapse.Panel</code>. Placement
+        within the subtree is up to the consumer.
+      </>
+    ),
     required: true,
   },
   {
-    name: 'initiallyOpen',
+    name: 'defaultOpen',
     types: 'boolean',
-    description: 'Defines if panel with content is visible by default.',
+    defaultValue: 'false',
+    description: 'Initial open state when uncontrolled.',
+  },
+  {
+    name: 'isCollapseOpen',
+    types: 'boolean',
+    description:
+      'Controlled open state. When provided, the component is controlled and ignores defaultOpen.',
   },
   {
     name: 'onCollapseChange',
     types: '(isOpen: boolean) => void',
-    description: 'Function that will be called when a title is clicked.',
+    description:
+      'Fires when the trigger toggles, and when an open panel is auto-closed because disabled became true.',
+  },
+  {
+    name: 'disabled',
+    types: 'boolean',
+    description:
+      "Disables the trigger so it can't be toggled. If the panel is open when disabled becomes true, it auto-collapses and fires onCollapseChange(false).",
+  },
+];
+
+const collapseTriggerProps: Prop[] = [
+  {
+    name: 'title',
+    types: ['string', 'React.ReactNode'],
+    description: 'Trigger label rendered alongside the chevron icon.',
+    required: true,
+  },
+];
+
+const collapsePanelProps: Prop[] = [
+  {
+    name: 'children',
+    types: 'React.ReactNode',
+    description: 'Collapsible content rendered when the panel is open.',
+  },
+  {
+    name: 'backgroundColor',
+    types: 'keyof Colors',
+    defaultValue: 'unset',
+    description: 'Panel background color.',
   },
 ];
 
 export const CollapsePropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable propList={collapseProps} title="Collapse" {...props} />
+);
+
+export const CollapseTriggerPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable propList={collapseTriggerProps} title="Collapse.Trigger" {...props} />
+);
+
+export const CollapsePanelPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable propList={collapsePanelProps} title="Collapse.Panel" {...props} />
 );

--- a/packages/docs/pages/collapse.tsx
+++ b/packages/docs/pages/collapse.tsx
@@ -41,7 +41,7 @@ const CollapsePage = () => {
                     <Code primary>Collapse</Code> is a headless compound component. The root
                     provides state via context; place <Code primary>Collapse.Trigger</Code> and{' '}
                     <Code primary>Collapse.Panel</Code> anywhere inside. State can be uncontrolled (
-                    <Code primary>defaultOpen</Code>) — no extra wiring required.
+                    <Code primary>initiallyOpen</Code>) — no extra wiring required.
                   </Text>
 
                   <CodePreview>
@@ -67,7 +67,7 @@ const CollapsePage = () => {
               render: () => (
                 <Fragment key="controlled">
                   <Text>
-                    Lift state up by passing <Code primary>isCollapseOpen</Code> +{' '}
+                    Lift state up by passing <Code primary>isOpen</Code> +{' '}
                     <Code primary>onCollapseChange</Code>. Useful when the open/closed state should
                     drive other UI — for example, swapping the trigger label.
                   </Text>
@@ -78,7 +78,7 @@ const CollapsePage = () => {
                       const [isOpen, setIsOpen] = useState(false);
 
                       return (
-                        <Collapse isCollapseOpen={isOpen} onCollapseChange={setIsOpen}>
+                        <Collapse isOpen={isOpen} onCollapseChange={setIsOpen}>
                           <Collapse.Trigger title={isOpen ? 'Show less' : 'Show more'} />
                           <Collapse.Panel backgroundColor="secondary20" padding="medium">
                             <Text>

--- a/packages/docs/pages/collapse.tsx
+++ b/packages/docs/pages/collapse.tsx
@@ -1,8 +1,14 @@
 import { Collapse, H1, Panel, Text } from '@bigcommerce/big-design';
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 
-import { Code, CodePreview, GuidelinesTable, List } from '../components';
-import { CollapsePropTable } from '../PropTables';
+import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '../components';
+import {
+  CollapsePanelPropTable,
+  CollapsePropTable,
+  CollapseTriggerPropTable,
+  MarginPropTable,
+  PaddingPropTable,
+} from '../PropTables';
 
 const CollapsePage = () => {
   return (
@@ -23,31 +29,131 @@ const CollapsePage = () => {
       </Panel>
 
       <Panel header="Implementation" headerId="implementation">
-        <Text>Allows for showing/hiding content.</Text>
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <Fragment key="basic">
+                  <Text>
+                    <Code primary>Collapse</Code> is a headless compound component. The root
+                    provides state via context; place <Code primary>Collapse.Trigger</Code> and{' '}
+                    <Code primary>Collapse.Panel</Code> anywhere inside. State can be uncontrolled (
+                    <Code primary>defaultOpen</Code>) — no extra wiring required.
+                  </Text>
 
-        <CodePreview>
-          {/* jsx-to-string:start */}
-          {function Example() {
-            const [title, setTitle] = useState('Show more');
-            const handleChange = (isOpen: boolean) => setTitle(isOpen ? 'Show less' : 'Show more');
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Collapse>
+                      <Collapse.Trigger title="Show more" />
+                      <Collapse.Panel backgroundColor="secondary20" padding="medium">
+                        <Text>
+                          Ea tempor sunt amet labore proident dolor proident commodo in exercitation
+                          ea nulla sunt pariatur. Nulla sunt ipsum do eu consectetur exercitation
+                          occaecat labore aliqua.
+                        </Text>
+                      </Collapse.Panel>
+                    </Collapse>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'controlled',
+              title: 'Controlled',
+              render: () => (
+                <Fragment key="controlled">
+                  <Text>
+                    Lift state up by passing <Code primary>isCollapseOpen</Code> +{' '}
+                    <Code primary>onCollapseChange</Code>. Useful when the open/closed state should
+                    drive other UI — for example, swapping the trigger label.
+                  </Text>
 
-            return (
-              <Collapse onCollapseChange={handleChange} title={title}>
-                <Text>
-                  Ea tempor sunt amet labore proident dolor proident commodo in exercitation ea
-                  nulla sunt pariatur. Nulla sunt ipsum do eu consectetur exercitation occaecat
-                  labore aliqua. Aute elit occaecat esse ea fugiat esse. Reprehenderit sunt ea ea
-                  mollit commodo tempor amet fugiat.
-                </Text>
-              </Collapse>
-            );
-          }}
-          {/* jsx-to-string:end */}
-        </CodePreview>
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    {function Example() {
+                      const [isOpen, setIsOpen] = useState(false);
+
+                      return (
+                        <Collapse isCollapseOpen={isOpen} onCollapseChange={setIsOpen}>
+                          <Collapse.Trigger title={isOpen ? 'Show less' : 'Show more'} />
+                          <Collapse.Panel backgroundColor="secondary20" padding="medium">
+                            <Text>
+                              Ea tempor sunt amet labore proident dolor proident commodo in
+                              exercitation ea nulla sunt pariatur.
+                            </Text>
+                          </Collapse.Panel>
+                        </Collapse>
+                      );
+                    }}
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'disabled',
+              title: 'Disabled',
+              render: () => (
+                <Fragment key="disabled">
+                  <Text>
+                    The <Code primary>disabled</Code> prop disables the trigger. If the panel is
+                    open when <Code primary>disabled</Code> becomes <Code>true</Code>, it
+                    auto-collapses and fires <Code primary>onCollapseChange(false)</Code>.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <Collapse disabled>
+                      <Collapse.Trigger title="Show more" />
+                      <Collapse.Panel backgroundColor="secondary20" padding="medium">
+                        <Text>Hidden content.</Text>
+                      </Collapse.Panel>
+                    </Collapse>
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+          ]}
+        />
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <CollapsePropTable />
+        <ContentRoutingTabs
+          id="props"
+          routes={[
+            {
+              id: 'collapse',
+              title: 'Collapse',
+              render: () => <CollapsePropTable />,
+            },
+            {
+              id: 'collapse-trigger',
+              title: 'Collapse.Trigger',
+              render: () => (
+                <CollapseTriggerPropTable inheritedProps={<MarginPropTable collapsible />} />
+              ),
+            },
+            {
+              id: 'collapse-panel',
+              title: 'Collapse.Panel',
+              render: () => (
+                <CollapsePanelPropTable
+                  inheritedProps={
+                    <>
+                      <MarginPropTable collapsible />
+                      <PaddingPropTable collapsible />
+                    </>
+                  }
+                />
+              ),
+            },
+          ]}
+        />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">


### PR DESCRIPTION
## What?

Update `Collapse` component with a new API

## Why?

Rewrites `Collapse` as a headless compound component. The root provides state via Context; consumers compose `Collapse.Trigger `and `Collapse.Panel` anywhere in the subtree.

## Screenshots/Screen Recordings

https://github.com/user-attachments/assets/9df539c2-bcde-4fea-bc76-5d724cbb63b9

## Testing/Proof

Manual testing
