### PR TITLE
feat(component): adds a new CollapsibleCheckbox pattern to big-design-patterns and extends the base Checkbox with image support to power it

### DIFF
--- a/.changeset/collapsible-checkbox.md
+++ b/.changeset/collapsible-checkbox.md
@@ -1,0 +1,9 @@
+---
+'@bigcommerce/big-design-patterns': minor
+'@bigcommerce/big-design': minor
+'@bigcommerce/docs': minor
+---
+
+Add `CollapsibleCheckbox` pattern: a controlled checkbox paired with a `Collapse` trigger and panel, where the panel is disabled while unchecked by default (overridable via `collapseProps`).
+
+Add `img` and `isVerticalCenter` props to `Checkbox`: `img` renders a thumbnail between the checkbox and its label, and the row centers vertically when an image is present.

--- a/packages/big-design-patterns/src/components/CollapsibleCheckbox/CollapsibleCheckbox.tsx
+++ b/packages/big-design-patterns/src/components/CollapsibleCheckbox/CollapsibleCheckbox.tsx
@@ -6,13 +6,15 @@ import {
   CollapseProps,
   CollapseTriggerProps,
 } from '@bigcommerce/big-design';
-import React, { ReactNode } from 'react';
+import React, { ChangeEventHandler, ReactNode } from 'react';
 
 import { StyledCheckboxRow } from './styled';
 
 export interface CollapsibleCheckboxProps extends CheckboxProps {
   /** Controls the checked state. The component is controlled — pair it with `onChange`. */
   checked: boolean;
+  /** Change handler for the checkbox. Required because the component is controlled. */
+  onChange: ChangeEventHandler<HTMLInputElement>;
   /** Title shown on the collapse trigger button. */
   triggerTitle: string;
   /** Content revealed inside the collapse panel. */

--- a/packages/big-design-patterns/src/components/CollapsibleCheckbox/CollapsibleCheckbox.tsx
+++ b/packages/big-design-patterns/src/components/CollapsibleCheckbox/CollapsibleCheckbox.tsx
@@ -1,0 +1,49 @@
+import {
+  Checkbox,
+  CheckboxProps,
+  Collapse,
+  CollapsePanelProps,
+  CollapseProps,
+  CollapseTriggerProps,
+} from '@bigcommerce/big-design';
+import React, { ReactNode } from 'react';
+
+import { StyledCheckboxRow } from './styled';
+
+export interface CollapsibleCheckboxProps extends CheckboxProps {
+  /** Controls the checked state. The component is controlled — pair it with `onChange`. */
+  checked: boolean;
+  /** Title shown on the collapse trigger button. */
+  triggerTitle: string;
+  /** Content revealed inside the collapse panel. */
+  children: ReactNode;
+  /**
+   * Props forwarded to the underlying `Collapse`. By default the panel is disabled while the
+   * checkbox is unchecked; pass `disabled` here to override that behavior.
+   */
+  collapseProps?: Omit<CollapseProps, 'children'>;
+  /** Props forwarded to the underlying `Collapse.Trigger`. */
+  triggerProps?: Omit<CollapseTriggerProps, 'title'>;
+  /** Props forwarded to the underlying `Collapse.Panel`. */
+  panelProps?: Omit<CollapsePanelProps, 'children'>;
+}
+
+export const CollapsibleCheckbox = ({
+  checked,
+  triggerTitle,
+  children,
+  collapseProps,
+  triggerProps,
+  panelProps,
+  ...checkboxProps
+}: CollapsibleCheckboxProps) => (
+  <Collapse disabled={!checked} {...collapseProps}>
+    <StyledCheckboxRow alignItems="center" justifyContent="space-between">
+      <Checkbox {...checkboxProps} checked={checked} />
+      <Collapse.Trigger marginVertical="none" {...triggerProps} title={triggerTitle} />
+    </StyledCheckboxRow>
+    <Collapse.Panel backgroundColor="secondary20" padding="medium" {...panelProps}>
+      {children}
+    </Collapse.Panel>
+  </Collapse>
+);

--- a/packages/big-design-patterns/src/components/CollapsibleCheckbox/index.ts
+++ b/packages/big-design-patterns/src/components/CollapsibleCheckbox/index.ts
@@ -1,0 +1,1 @@
+export { CollapsibleCheckbox, type CollapsibleCheckboxProps } from './CollapsibleCheckbox';

--- a/packages/big-design-patterns/src/components/CollapsibleCheckbox/spec.tsx
+++ b/packages/big-design-patterns/src/components/CollapsibleCheckbox/spec.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { CollapsibleCheckbox } from './CollapsibleCheckbox';
+
+test('renders the checkbox, trigger and (hidden) panel', () => {
+  render(
+    <CollapsibleCheckbox
+      checked={false}
+      label="Enable feature"
+      onChange={jest.fn()}
+      triggerTitle="Configure"
+    >
+      Panel content
+    </CollapsibleCheckbox>,
+  );
+
+  expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  expect(screen.getByRole('button')).toHaveTextContent('Configure');
+  expect(screen.getByText('Panel content')).not.toBeVisible();
+});
+
+test('disables the trigger by default while unchecked', () => {
+  render(
+    <CollapsibleCheckbox
+      checked={false}
+      label="Enable feature"
+      onChange={jest.fn()}
+      triggerTitle="Configure"
+    >
+      Panel content
+    </CollapsibleCheckbox>,
+  );
+
+  expect(screen.getByRole('button')).toBeDisabled();
+});
+
+test('collapseProps.disabled overrides the default gating', () => {
+  render(
+    <CollapsibleCheckbox
+      checked={true}
+      collapseProps={{ disabled: true }}
+      label="Enable feature"
+      onChange={jest.fn()}
+      triggerTitle="Configure"
+    >
+      Panel content
+    </CollapsibleCheckbox>,
+  );
+
+  expect(screen.getByRole('button')).toBeDisabled();
+});
+
+test('trigger is enabled and the panel can open while checked', () => {
+  render(
+    <CollapsibleCheckbox
+      checked={true}
+      label="Enable feature"
+      onChange={jest.fn()}
+      triggerTitle="Configure"
+    >
+      Panel content
+    </CollapsibleCheckbox>,
+  );
+
+  const trigger = screen.getByRole('button');
+
+  expect(trigger).toBeEnabled();
+
+  fireEvent.click(trigger);
+
+  expect(screen.getByText('Panel content')).toBeVisible();
+});
+
+test('forwards checked and onChange to the underlying checkbox', () => {
+  const onChange = jest.fn();
+
+  render(
+    <CollapsibleCheckbox
+      checked={true}
+      label="Enable feature"
+      onChange={onChange}
+      triggerTitle="Configure"
+    >
+      Panel content
+    </CollapsibleCheckbox>,
+  );
+
+  const checkbox = screen.getByRole('checkbox');
+
+  expect(checkbox).toBeChecked();
+
+  fireEvent.click(checkbox);
+
+  expect(onChange).toHaveBeenCalledTimes(1);
+});

--- a/packages/big-design-patterns/src/components/CollapsibleCheckbox/spec.tsx
+++ b/packages/big-design-patterns/src/components/CollapsibleCheckbox/spec.tsx
@@ -35,11 +35,13 @@ test('disables the trigger by default while unchecked', () => {
   expect(screen.getByRole('button')).toBeDisabled();
 });
 
-test('collapseProps.disabled overrides the default gating', () => {
+test('collapseProps.disabled can re-enable the panel while unchecked', () => {
+  // The spread order `<Collapse disabled={!checked} {...collapseProps}>` must let a caller
+  // re-enable the panel while unchecked — the direction the default gating would otherwise block.
   render(
     <CollapsibleCheckbox
-      checked={true}
-      collapseProps={{ disabled: true }}
+      checked={false}
+      collapseProps={{ disabled: false }}
       label="Enable feature"
       onChange={jest.fn()}
       triggerTitle="Configure"
@@ -48,7 +50,7 @@ test('collapseProps.disabled overrides the default gating', () => {
     </CollapsibleCheckbox>,
   );
 
-  expect(screen.getByRole('button')).toBeDisabled();
+  expect(screen.getByRole('button')).toBeEnabled();
 });
 
 test('trigger is enabled and the panel can open while checked', () => {

--- a/packages/big-design-patterns/src/components/CollapsibleCheckbox/spec.tsx
+++ b/packages/big-design-patterns/src/components/CollapsibleCheckbox/spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { CollapsibleCheckbox } from './CollapsibleCheckbox';
 
@@ -93,4 +93,33 @@ test('forwards checked and onChange to the underlying checkbox', () => {
   fireEvent.click(checkbox);
 
   expect(onChange).toHaveBeenCalledTimes(1);
+});
+
+test('collapses an open panel when the checkbox is unchecked', () => {
+  const Wrapper = () => {
+    const [checked, setChecked] = useState(true);
+
+    return (
+      <CollapsibleCheckbox
+        checked={checked}
+        label="Enable feature"
+        onChange={(event) => setChecked(event.target.checked)}
+        triggerTitle="Configure"
+      >
+        Panel content
+      </CollapsibleCheckbox>
+    );
+  };
+
+  render(<Wrapper />);
+
+  // Open the panel while checked.
+  fireEvent.click(screen.getByRole('button'));
+
+  expect(screen.getByText('Panel content')).toBeVisible();
+
+  // Unchecking disables the Collapse, which auto-collapses the open panel.
+  fireEvent.click(screen.getByRole('checkbox'));
+
+  expect(screen.getByText('Panel content')).not.toBeVisible();
 });

--- a/packages/big-design-patterns/src/components/CollapsibleCheckbox/styled.tsx
+++ b/packages/big-design-patterns/src/components/CollapsibleCheckbox/styled.tsx
@@ -1,0 +1,7 @@
+import { Flex } from '@bigcommerce/big-design';
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import styled from 'styled-components';
+
+export const StyledCheckboxRow = styled(Flex).attrs({ theme: defaultTheme })`
+  width: 100%;
+`;

--- a/packages/big-design-patterns/src/components/index.ts
+++ b/packages/big-design-patterns/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './Header';
 export * from './Page';
 export * from './ActionBar';
+export * from './CollapsibleCheckbox';

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -113,12 +113,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   }, [description]);
 
   return (
-    <CheckboxContainer
-      className={className}
-      isVerticalCenter={Boolean(img)}
-      onClick={onClick}
-      style={style}
-    >
+    <CheckboxContainer className={className} hasImg={Boolean(img)} onClick={onClick} style={style}>
       <HiddenCheckbox
         checked={checked}
         disabled={disabled}

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -38,6 +38,10 @@ interface CheckboxDescription {
 
 export interface CheckboxImg {
   src: string;
+  /**
+   * Accessible name for the thumbnail. Defaults to an empty string (decorative) when omitted —
+   * set it whenever the image carries meaning the label doesn't already convey.
+   */
   alt?: string;
 }
 

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -16,6 +16,7 @@ import { FormControlDescription, FormControlDescriptionLinkProps } from '../Form
 import { CheckboxLabel } from './Label';
 import {
   CheckboxContainer,
+  CheckboxImgContainer,
   CheckboxLabelContainer,
   HiddenCheckbox,
   StyledCheckbox,
@@ -27,11 +28,17 @@ interface Props {
   label: React.ReactNode;
   description?: CheckboxDescription | string;
   badge?: BadgeProps;
+  img?: CheckboxImg;
 }
 
 interface CheckboxDescription {
   text: string;
   link?: FormControlDescriptionLinkProps;
+}
+
+export interface CheckboxImg {
+  src: string;
+  alt?: string;
 }
 
 interface PrivateProps {
@@ -51,6 +58,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   forwardedRef,
   style,
   badge,
+  img,
   onClick,
   ...props
 }) => {
@@ -101,7 +109,12 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   }, [description]);
 
   return (
-    <CheckboxContainer className={className} onClick={onClick} style={style}>
+    <CheckboxContainer
+      className={className}
+      isVerticalCenter={Boolean(img)}
+      onClick={onClick}
+      style={style}
+    >
       <HiddenCheckbox
         checked={checked}
         disabled={disabled}
@@ -138,6 +151,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
       >
         {!checked && isIndeterminate ? <RemoveIcon /> : <CheckIcon />}
       </StyledCheckbox>
+      {img ? <CheckboxImgContainer alt={img.alt ?? ''} src={img.src} /> : null}
       <CheckboxLabelContainer hasContent={Boolean(label) || Boolean(description)}>
         {renderedLabel}
         {renderedDescription}

--- a/packages/big-design/src/components/Checkbox/spec.tsx
+++ b/packages/big-design/src/components/Checkbox/spec.tsx
@@ -107,6 +107,44 @@ describe('render Checkbox', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('with img props', () => {
+    render(
+      <Checkbox
+        checked={false}
+        img={{ src: 'https://example.com/logo.png', alt: 'Logo' }}
+        label="Unchecked"
+        onChange={() => null}
+      />,
+    );
+
+    const image = screen.getByRole('img', { name: 'Logo' });
+
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute('src', 'https://example.com/logo.png');
+  });
+
+  test('defaults img alt to an empty string when omitted', () => {
+    const { container } = render(
+      <Checkbox
+        checked={false}
+        img={{ src: 'https://example.com/logo.png' }}
+        label="Unchecked"
+        onChange={() => null}
+      />,
+    );
+
+    const image = container.querySelector('img');
+
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute('alt', '');
+  });
+
+  test('does not render an img when img is not provided', () => {
+    render(<Checkbox checked={false} label="Unchecked" onChange={() => null} />);
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
 });
 
 test('has correct value for checked', async () => {

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -1,4 +1,4 @@
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { theme as defaultTheme, remCalc } from '@bigcommerce/big-design-theme';
 import { hideVisually } from 'polished';
 import styled, { css } from 'styled-components';
 
@@ -19,8 +19,16 @@ export const CheckboxLabelContainer = styled.div<{ hasContent?: boolean }>`
   margin-left: ${({ hasContent, theme }) => (hasContent ? theme.spacing.xSmall : 0)};
 `;
 
-export const CheckboxContainer = styled.div`
-  align-items: flex-start;
+export const CheckboxImgContainer = styled.img`
+  flex-shrink: 0;
+  height: ${remCalc(40)};
+  object-fit: cover;
+  width: ${remCalc(40)};
+  margin: 0 ${({ theme }) => theme.spacing.xxSmall};
+`;
+
+export const CheckboxContainer = styled.div<{ isVerticalCenter?: boolean }>`
+  align-items: ${({ isVerticalCenter }) => (isVerticalCenter ? 'center' : 'flex-start')};
   display: flex;
 `;
 
@@ -78,3 +86,4 @@ StyledCheckbox.defaultProps = { theme: defaultTheme };
 CheckboxLabelContainer.defaultProps = { theme: defaultTheme };
 CheckboxContainer.defaultProps = { theme: defaultTheme };
 HiddenCheckbox.defaultProps = { theme: defaultTheme };
+CheckboxImgContainer.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -27,8 +27,8 @@ export const CheckboxImgContainer = styled.img`
   margin: 0 ${({ theme }) => theme.spacing.xxSmall};
 `;
 
-export const CheckboxContainer = styled.div<{ isVerticalCenter?: boolean }>`
-  align-items: ${({ isVerticalCenter }) => (isVerticalCenter ? 'center' : 'flex-start')};
+export const CheckboxContainer = styled.div<{ hasImg?: boolean }>`
+  align-items: ${({ hasImg }) => (hasImg ? 'center' : 'flex-start')};
   display: flex;
 `;
 

--- a/packages/docs/PropTables/CheckboxPropTable.tsx
+++ b/packages/docs/PropTables/CheckboxPropTable.tsx
@@ -80,18 +80,9 @@ const checkboxProps: Prop[] = [
     types: '{ src: string; alt?: string }',
     description: (
       <>
-        Renders a thumbnail between the <Code primary>Checkbox</Code> and its label. When provided,
-        the row is vertically centered.
-      </>
-    ),
-  },
-  {
-    name: 'isVerticalCenter',
-    types: 'boolean',
-    description: (
-      <>
-        Vertically centers the <Code primary>Checkbox</Code> with its label and description. Enabled
-        automatically when <Code primary>img</Code> is set.
+        Renders a thumbnail between the <Code primary>Checkbox</Code> and its label, and vertically
+        centers the row. Set <Code>alt</Code> when the image conveys meaning the label doesn&apos;t;
+        when omitted it defaults to an empty string (decorative) per WCAG 1.1.1.
       </>
     ),
   },

--- a/packages/docs/PropTables/CheckboxPropTable.tsx
+++ b/packages/docs/PropTables/CheckboxPropTable.tsx
@@ -75,6 +75,26 @@ const checkboxProps: Prop[] = [
       </>
     ),
   },
+  {
+    name: 'img',
+    types: '{ src: string; alt?: string }',
+    description: (
+      <>
+        Renders a thumbnail between the <Code primary>Checkbox</Code> and its label. When provided,
+        the row is vertically centered.
+      </>
+    ),
+  },
+  {
+    name: 'isVerticalCenter',
+    types: 'boolean',
+    description: (
+      <>
+        Vertically centers the <Code primary>Checkbox</Code> with its label and description. Enabled
+        automatically when <Code primary>img</Code> is set.
+      </>
+    ),
+  },
 ];
 
 const checkboxDescriptionProps: Prop[] = [

--- a/packages/docs/PropTables/CollapsibleCheckboxPropTable.tsx
+++ b/packages/docs/PropTables/CollapsibleCheckboxPropTable.tsx
@@ -1,0 +1,85 @@
+import { Text } from '@bigcommerce/big-design';
+import React from 'react';
+
+import { Code, NextLink, Prop, PropTable, PropTableWrapper } from '../components';
+
+import { CheckboxPropTable } from './CheckboxPropTable';
+
+const collapsibleCheckboxProps: Prop[] = [
+  {
+    name: 'checked',
+    types: 'boolean',
+    description: (
+      <>
+        Controls the checked state. The component is controlled — pair it with <Code>onChange</Code>
+        . The panel can only be expanded while <Code>checked</Code> is <Code>true</Code>.
+      </>
+    ),
+    required: true,
+  },
+  {
+    name: 'triggerTitle',
+    types: 'string',
+    description: 'Title shown on the collapse trigger button.',
+    required: true,
+  },
+  {
+    name: 'children',
+    types: 'React.ReactNode',
+    description: 'Content revealed inside the collapse panel.',
+    required: true,
+  },
+  {
+    name: 'collapseProps',
+    types: (
+      <NextLink href={{ pathname: '/collapse', hash: 'props', query: { props: 'collapse' } }}>
+        Omit&lt;CollapseProps, &apos;children&apos;&gt;
+      </NextLink>
+    ),
+    description: (
+      <>
+        Props forwarded to the underlying Collapse. By default the panel is disabled while the
+        checkbox is unchecked; pass <Code>disabled</Code> here to override that.
+      </>
+    ),
+  },
+  {
+    name: 'triggerProps',
+    types: (
+      <NextLink
+        href={{ pathname: '/collapse', hash: 'props', query: { props: 'collapse-trigger' } }}
+      >
+        Omit&lt;CollapseTriggerProps, &apos;title&apos;&gt;
+      </NextLink>
+    ),
+    description: 'Props forwarded to the underlying Collapse.Trigger.',
+  },
+  {
+    name: 'panelProps',
+    types: (
+      <NextLink href={{ pathname: '/collapse', hash: 'props', query: { props: 'collapse-panel' } }}>
+        Omit&lt;CollapsePanelProps, &apos;children&apos;&gt;
+      </NextLink>
+    ),
+    description: 'Props forwarded to the underlying Collapse.Panel.',
+  },
+];
+
+export const CollapsibleCheckboxPropsTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable
+    inheritedProps={
+      <>
+        <Text>
+          Extends <NextLink href="/checkbox">Checkbox</NextLink>, so it accepts every{' '}
+          <Code>Checkbox</Code> prop (<Code>label</Code>, <Code>description</Code>, <Code>img</Code>
+          , <Code>badge</Code>, <Code>onChange</Code>, …) as well as the native <Code>input</Code>{' '}
+          attributes.
+        </Text>
+        <CheckboxPropTable collapsible />
+      </>
+    }
+    propList={collapsibleCheckboxProps}
+    title="CollapsibleCheckbox"
+    {...props}
+  />
+);

--- a/packages/docs/PropTables/CollapsibleCheckboxPropTable.tsx
+++ b/packages/docs/PropTables/CollapsibleCheckboxPropTable.tsx
@@ -18,6 +18,12 @@ const collapsibleCheckboxProps: Prop[] = [
     required: true,
   },
   {
+    name: 'onChange',
+    types: 'ChangeEventHandler<HTMLInputElement>',
+    description: 'Change handler for the checkbox. Required because the component is controlled.',
+    required: true,
+  },
+  {
     name: 'triggerTitle',
     types: 'string',
     description: 'Title shown on the collapse trigger button.',
@@ -72,8 +78,7 @@ export const CollapsibleCheckboxPropsTable: React.FC<PropTableWrapper> = (props)
         <Text>
           Extends <NextLink href="/checkbox">Checkbox</NextLink>, so it accepts every{' '}
           <Code>Checkbox</Code> prop (<Code>label</Code>, <Code>description</Code>, <Code>img</Code>
-          , <Code>badge</Code>, <Code>onChange</Code>, …) as well as the native <Code>input</Code>{' '}
-          attributes.
+          , <Code>badge</Code>, …) as well as the native <Code>input</Code> attributes.
         </Text>
         <CheckboxPropTable collapsible />
       </>

--- a/packages/docs/PropTables/index.ts
+++ b/packages/docs/PropTables/index.ts
@@ -5,6 +5,7 @@ export * from './ButtonPropTable';
 export * from './ButtonGroupPropTable';
 export * from './CheckboxPropTable';
 export * from './CollapsePropTable';
+export * from './CollapsibleCheckboxPropTable';
 export * from './CounterPropTable';
 export * from './DatepickerPropsTable';
 export * from './DisplayPropTable';

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -109,6 +109,7 @@ export const SideNav: React.FC = () => {
 
               <SideNavGroup title="Patterns">
                 <SideNavLink href="/action-bar">Action Bar</SideNavLink>
+                <SideNavLink href="/collapsible-checkbox">Collapsible Checkbox</SideNavLink>
                 <SideNavLink href="/header">Header</SideNavLink>
                 <SideNavLink href="/page">Page</SideNavLink>
               </SideNavGroup>

--- a/packages/docs/pages/collapsible-checkbox.tsx
+++ b/packages/docs/pages/collapsible-checkbox.tsx
@@ -1,0 +1,160 @@
+import { H1, Panel, Text } from '@bigcommerce/big-design';
+import { CollapsibleCheckbox } from '@bigcommerce/big-design-patterns';
+import React, { Fragment, useState } from 'react';
+
+import { Code, CodePreview, CodeSnippet, ContentRoutingTabs, GuidelinesTable } from '../components';
+import { CollapsibleCheckboxPropsTable } from '../PropTables';
+
+const CollapsibleCheckboxPage = () => {
+  return (
+    <>
+      <H1>CollapsibleCheckbox</H1>
+
+      <Panel header="Overview" headerId="overview">
+        <Text>
+          The <Code primary>CollapsibleCheckbox</Code> component pairs a checkbox with a collapsible
+          panel. The panel can only be expanded while the checkbox is checked, making it a
+          convenient way to reveal optional settings that depend on a feature being enabled.
+        </Text>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <Fragment key="import">
+          <Text>
+            To use <Code primary>CollapsibleCheckbox</Code> import the component from the package:
+          </Text>
+          <CodeSnippet>{`import { CollapsibleCheckbox } from '@bigcommerce/big-design-patterns';`}</CodeSnippet>
+        </Fragment>
+
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <Fragment key="basic">
+                  <Text>
+                    The component is controlled. Pass <Code primary>checked</Code> and{' '}
+                    <Code primary>onChange</Code> to drive it — the panel is disabled automatically
+                    while the checkbox is unchecked, so it can only be expanded once checked.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    {function Example() {
+                      const [checked, setChecked] = useState(false);
+
+                      return (
+                        <CollapsibleCheckbox
+                          checked={checked}
+                          label="Enable advanced settings"
+                          onChange={(event) => setChecked(event.target.checked)}
+                          triggerTitle="Advanced settings"
+                        >
+                          <Text marginBottom="none">
+                            These settings are only available while the option above is enabled.
+                          </Text>
+                        </CollapsibleCheckbox>
+                      );
+                    }}
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'with-image',
+              title: 'With image',
+              render: () => (
+                <Fragment key="with-image">
+                  <Text>
+                    Pass an <Code primary>img</Code> to display a thumbnail between the checkbox and
+                    the label. The row is vertically centered automatically when an image is
+                    present.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    {function Example() {
+                      const [checked, setChecked] = useState(false);
+
+                      return (
+                        <CollapsibleCheckbox
+                          checked={checked}
+                          description="Accept credit cards and digital wallets."
+                          img={{ src: '/logo.svg', alt: 'Payment provider' }}
+                          label="Enable payment provider"
+                          onChange={(event) => setChecked(event.target.checked)}
+                          triggerTitle="Provider settings"
+                        >
+                          <Text marginBottom="none">
+                            Configure the provider once it has been enabled.
+                          </Text>
+                        </CollapsibleCheckbox>
+                      );
+                    }}
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'initially-open',
+              title: 'Initially open',
+              render: () => (
+                <Fragment key="initially-open">
+                  <Text>
+                    Forward props to the underlying primitives with{' '}
+                    <Code primary>collapseProps</Code>, <Code primary>triggerProps</Code>, and{' '}
+                    <Code primary>panelProps</Code> — for example, start with the panel expanded, or
+                    pass <Code primary>collapseProps.disabled</Code> to override the default gating.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    {function Example() {
+                      const [checked, setChecked] = useState(true);
+
+                      return (
+                        <CollapsibleCheckbox
+                          checked={checked}
+                          collapseProps={{ initiallyOpen: true }}
+                          label="Subscribe to the newsletter"
+                          onChange={(event) => setChecked(event.target.checked)}
+                          panelProps={{ backgroundColor: 'secondary20', padding: 'medium' }}
+                          triggerTitle="Email preferences"
+                        >
+                          <Text marginBottom="none">
+                            Choose how often you want to hear from us.
+                          </Text>
+                        </CollapsibleCheckbox>
+                      );
+                    }}
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <CollapsibleCheckboxPropsTable />
+      </Panel>
+
+      <Panel header="Do's and Don'ts" headerId="guidelines">
+        <GuidelinesTable
+          discouraged={["Don't hide critical information inside the collapsible panel."]}
+          recommended={[
+            'Use to reveal optional settings that depend on a checkbox being enabled.',
+            'Keep the trigger title short and descriptive of the revealed content.',
+          ]}
+        />
+      </Panel>
+    </>
+  );
+};
+
+export default CollapsibleCheckboxPage;


### PR DESCRIPTION
## What?

Adds a new CollapsibleCheckbox pattern to big-design-patterns and extends the base Checkbox with image support to power it.

## Why?

  `big-design` — Checkbox

  - Added an optional img prop ({ src: string; alt?: string }) that renders a 40×40 thumbnail between the checkbox and its label.
  - Added an isVerticalCenter prop on CheckboxContainer; the row is vertically centered automatically when an image is present, and can be toggled externally otherwise.
  - New CheckboxImgContainer styled <img> uses object-fit: cover (no distortion for non-square images) and flex-shrink: 0 (holds its size next to long labels).

  `big-design-patterns` — new CollapsibleCheckbox

  - Pairs a Checkbox with a Collapse trigger + panel: the checkbox and trigger sit on one centered, full-width row (space-between), with the panel below.
  - Controlled component — checked is required and paired with onChange. The panel is disabled while unchecked by default, overridable via collapseProps.disabled.
  - Extends CheckboxProps (so label, description, img, badge, etc. pass through) and exposes triggerTitle, children, collapseProps, triggerProps, panelProps.

  `docs`

  - New CollapsibleCheckbox page with Basic, With image, and Initially open examples, plus a props table (and a "CollapsibleCheckbox" entry in the Patterns nav).
  - Documented the new Checkbox img / isVerticalCenter props in the Checkbox prop table.

## Screenshots/Screen Recordings

This is a component library so we love visually looking at changes! If this applies to your pull request, show us your hard work in action.

## Testing/Proof

  - big-design and big-design-patterns typecheck clean; CollapsibleCheckbox tests pass (5/5).
  - docs typechecks clean.
  - manual testing

https://github.com/user-attachments/assets/177cec61-ad8d-49a5-8c11-25dc87efd544




