### PR TITLE
feat(component): add optional img prop to Checkbox

### DIFF
--- a/.changeset/curvy-trams-attack.md
+++ b/.changeset/curvy-trams-attack.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design': minor
+'@bigcommerce/docs': minor
+---
+
+feat(component): add optional `img` prop to Checkbox for rendering a thumbnail alongside the label.

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -16,6 +16,7 @@ import { FormControlDescription, FormControlDescriptionLinkProps } from '../Form
 import { CheckboxLabel } from './Label';
 import {
   CheckboxContainer,
+  CheckboxImgContainer,
   CheckboxLabelContainer,
   HiddenCheckbox,
   StyledCheckbox,
@@ -27,11 +28,21 @@ interface Props {
   label: React.ReactNode;
   description?: CheckboxDescription | string;
   badge?: BadgeProps;
+  img?: CheckboxImg;
 }
 
 interface CheckboxDescription {
   text: string;
   link?: FormControlDescriptionLinkProps;
+}
+
+export interface CheckboxImg {
+  src: string;
+  /**
+   * Accessible name for the thumbnail. Defaults to an empty string (decorative) when omitted —
+   * set it whenever the image carries meaning the label doesn't already convey.
+   */
+  alt?: string;
 }
 
 interface PrivateProps {
@@ -51,6 +62,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   forwardedRef,
   style,
   badge,
+  img,
   onClick,
   ...props
 }) => {
@@ -101,7 +113,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   }, [description]);
 
   return (
-    <CheckboxContainer className={className} onClick={onClick} style={style}>
+    <CheckboxContainer className={className} hasImg={Boolean(img)} onClick={onClick} style={style}>
       <HiddenCheckbox
         checked={checked}
         disabled={disabled}
@@ -138,6 +150,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
       >
         {!checked && isIndeterminate ? <RemoveIcon /> : <CheckIcon />}
       </StyledCheckbox>
+      {img ? <CheckboxImgContainer alt={img.alt ?? ''} src={img.src} /> : null}
       <CheckboxLabelContainer hasContent={Boolean(label) || Boolean(description)}>
         {renderedLabel}
         {renderedDescription}

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -248,18 +248,18 @@ exports[`render Checkbox disabled checked 1`] = `
 >
   <input
     aria-checked="true"
-    aria-labelledby=":rj:"
+    aria-labelledby=":rm:"
     checked=""
     class="c1 c2"
     disabled=""
-    id=":ri:"
+    id=":rl:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
     disabled=""
-    for=":ri:"
+    for=":rl:"
   >
     <svg
       aria-hidden="true"
@@ -287,8 +287,8 @@ exports[`render Checkbox disabled checked 1`] = `
       aria-hidden="true"
       class="c7 c8"
       disabled=""
-      for=":ri:"
-      id=":rj:"
+      for=":rl:"
+      id=":rm:"
     >
       Checked
     </label>
@@ -397,17 +397,17 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby=":rp:"
+    aria-labelledby=":rs:"
     class="c1 c2"
     disabled=""
-    id=":ro:"
+    id=":rr:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
     disabled=""
-    for=":ro:"
+    for=":rr:"
   >
     <svg
       aria-hidden="true"
@@ -435,8 +435,8 @@ exports[`render Checkbox disabled indeterminate 1`] = `
       aria-hidden="true"
       class="c7 c8"
       disabled=""
-      for=":ro:"
-      id=":rp:"
+      for=":rr:"
+      id=":rs:"
     >
       Unchecked
     </label>
@@ -546,17 +546,17 @@ exports[`render Checkbox disabled unchecked 1`] = `
 >
   <input
     aria-checked="false"
-    aria-labelledby=":rm:"
+    aria-labelledby=":rp:"
     class="c1 c2"
     disabled=""
-    id=":rl:"
+    id=":ro:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
     disabled=""
-    for=":rl:"
+    for=":ro:"
   >
     <svg
       aria-hidden="true"
@@ -584,8 +584,8 @@ exports[`render Checkbox disabled unchecked 1`] = `
       aria-hidden="true"
       class="c7 c8"
       disabled=""
-      for=":rl:"
-      id=":rm:"
+      for=":ro:"
+      id=":rp:"
     >
       Checked
     </label>
@@ -694,15 +694,15 @@ exports[`render Checkbox indeterminate 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby=":rg:"
+    aria-labelledby=":rj:"
     class="c1 c2"
-    id=":rf:"
+    id=":ri:"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3 c4"
-    for=":rf:"
+    for=":ri:"
   >
     <svg
       aria-hidden="true"
@@ -728,8 +728,8 @@ exports[`render Checkbox indeterminate 1`] = `
   >
     <label
       class="c7 c8"
-      for=":rf:"
-      id=":rg:"
+      for=":ri:"
+      id=":rj:"
     >
       Unchecked
     </label>
@@ -1196,6 +1196,167 @@ exports[`render Checkbox with description string 1`] = `
 >
   <input
     aria-checked="false"
+    aria-labelledby=":rg:"
+    class="c1 c2"
+    id=":rf:"
+    name="test-group"
+    type="checkbox"
+  />
+  <label
+    aria-hidden="true"
+    class="c3 c4"
+    for=":rf:"
+  >
+    <svg
+      aria-hidden="true"
+      class="c5"
+      fill="currentColor"
+      height="24"
+      stroke="currentColor"
+      stroke-width="0"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M0 0h24v24H0z"
+        fill="none"
+      />
+      <path
+        d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+      />
+    </svg>
+  </label>
+  <div
+    class="c6"
+  >
+    <label
+      class="c7 c8"
+      for=":rf:"
+      id=":rg:"
+    >
+      Unchecked
+    </label>
+    <p
+      class="c9"
+    >
+      description text
+    </p>
+  </div>
+</div>
+`;
+
+exports[`render Checkbox with img props 1`] = `
+.c5 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c8 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+}
+
+.c8:last-child {
+  margin-bottom: 0;
+}
+
+.c9 {
+  cursor: pointer;
+}
+
+.c7 {
+  margin-left: 0.5rem;
+}
+
+.c6 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  height: 2.5rem;
+  object-fit: cover;
+  width: 2.5rem;
+  margin: 0 0.25rem;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
+  transition-property: border-color,background,box-shadow,color,opacity;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #FFFFFF;
+  box-sizing: border-box;
+  border: 1px solid #D9DCE9;
+  border-color: #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 1.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-bottom: 0.125rem;
+  margin-top: 0.125rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1.25rem;
+}
+
+.c4:hover {
+  border-color: #B4BAD1;
+}
+
+.c1:focus + .c3 {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c4 svg {
+  opacity: 0;
+}
+
+<div
+  class="c0"
+>
+  <input
+    aria-checked="false"
     aria-labelledby=":rd:"
     class="c1 c2"
     id=":rc:"
@@ -1226,21 +1387,21 @@ exports[`render Checkbox with description string 1`] = `
       />
     </svg>
   </label>
-  <div
+  <img
+    alt="Thumbnail"
     class="c6"
+    src="https://example.com/thumbnail.png"
+  />
+  <div
+    class="c7"
   >
     <label
-      class="c7 c8"
+      class="c8 c9"
       for=":rc:"
       id=":rd:"
     >
       Unchecked
     </label>
-    <p
-      class="c9"
-    >
-      description text
-    </p>
   </div>
 </div>
 `;

--- a/packages/big-design/src/components/Checkbox/spec.tsx
+++ b/packages/big-design/src/components/Checkbox/spec.tsx
@@ -62,6 +62,20 @@ describe('render Checkbox', () => {
     expect(container.firstChild).toBeInTheDocument();
   });
 
+  test('with img props', () => {
+    const { container } = render(
+      <Checkbox
+        checked={false}
+        img={{ src: 'https://example.com/thumbnail.png', alt: 'Thumbnail' }}
+        label="Unchecked"
+        name="test-group"
+        onChange={() => null}
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('with description string', () => {
     const { container } = render(
       <Checkbox
@@ -184,6 +198,42 @@ test('does not accept invalid label component', () => {
 
   expect(warning).toHaveBeenCalledTimes(1);
   expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
+});
+
+test('renders img with provided alt text', () => {
+  render(
+    <Checkbox
+      img={{ src: 'https://example.com/thumbnail.png', alt: 'Thumbnail' }}
+      label="Checked"
+      onChange={() => null}
+    />,
+  );
+
+  const img = screen.getByAltText<HTMLImageElement>('Thumbnail');
+
+  expect(img).toBeInTheDocument();
+  expect(img).toHaveAttribute('src', 'https://example.com/thumbnail.png');
+});
+
+test('renders img with empty alt text when alt is omitted', () => {
+  const { container } = render(
+    <Checkbox
+      img={{ src: 'https://example.com/thumbnail.png' }}
+      label="Checked"
+      onChange={() => null}
+    />,
+  );
+
+  const img = container.querySelector('img');
+
+  expect(img).toBeInTheDocument();
+  expect(img).toHaveAttribute('alt', '');
+});
+
+test('does not render img when img prop is omitted', () => {
+  const { container } = render(<Checkbox label="Checked" onChange={() => null} />);
+
+  expect(container.querySelector('img')).not.toBeInTheDocument();
 });
 
 test('forwards ref', () => {

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -1,4 +1,4 @@
-import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import { theme as defaultTheme, remCalc } from '@bigcommerce/big-design-theme';
 import { hideVisually } from 'polished';
 import styled, { css } from 'styled-components';
 
@@ -19,8 +19,16 @@ export const CheckboxLabelContainer = styled.div<{ hasContent?: boolean }>`
   margin-left: ${({ hasContent, theme }) => (hasContent ? theme.spacing.xSmall : 0)};
 `;
 
-export const CheckboxContainer = styled.div`
-  align-items: flex-start;
+export const CheckboxImgContainer = styled.img`
+  flex-shrink: 0;
+  height: ${remCalc(40)};
+  object-fit: cover;
+  width: ${remCalc(40)};
+  margin: 0 ${({ theme }) => theme.spacing.xxSmall};
+`;
+
+export const CheckboxContainer = styled.div<{ hasImg?: boolean }>`
+  align-items: ${({ hasImg }) => (hasImg ? 'center' : 'flex-start')};
   display: flex;
 `;
 
@@ -78,3 +86,4 @@ StyledCheckbox.defaultProps = { theme: defaultTheme };
 CheckboxLabelContainer.defaultProps = { theme: defaultTheme };
 CheckboxContainer.defaultProps = { theme: defaultTheme };
 HiddenCheckbox.defaultProps = { theme: defaultTheme };
+CheckboxImgContainer.defaultProps = { theme: defaultTheme };

--- a/packages/docs/PropTables/CheckboxPropTable.tsx
+++ b/packages/docs/PropTables/CheckboxPropTable.tsx
@@ -75,6 +75,17 @@ const checkboxProps: Prop[] = [
       </>
     ),
   },
+  {
+    name: 'img',
+    types: '{ src: string; alt?: string }',
+    description: (
+      <>
+        Renders a thumbnail between the <Code primary>Checkbox</Code> and its label, and vertically
+        centers the row. Set <Code>alt</Code> when the image conveys meaning the label doesn&apos;t;
+        when omitted it defaults to an empty string (decorative) per WCAG 1.1.1.
+      </>
+    ),
+  },
 ];
 
 const checkboxDescriptionProps: Prop[] = [

--- a/packages/docs/pages/checkbox.tsx
+++ b/packages/docs/pages/checkbox.tsx
@@ -179,6 +179,43 @@ const CheckboxPage = () => {
                 </Fragment>
               ),
             },
+            {
+              id: 'image',
+              title: 'Image',
+              render: () => (
+                <Fragment key="image">
+                  <Text>
+                    <Code primary>Checkboxes</Code> support an <Code primary>img</Code> thumbnail
+                    shown between the checkbox and its label. Set <Code primary>alt</Code> when the
+                    image conveys meaning the label doesn&apos;t; when omitted it is treated as
+                    decorative.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    {function Example() {
+                      const [checked, setChecked] = useState(false);
+                      const handleChange = () => setChecked(!checked);
+
+                      return (
+                        <Form>
+                          <FormGroup>
+                            <Checkbox
+                              checked={checked}
+                              description="Accept credit cards and digital wallets."
+                              img={{ src: '/logo.svg', alt: 'Payment provider' }}
+                              label="Enable payment provider"
+                              onChange={handleChange}
+                            />
+                          </FormGroup>
+                        </Form>
+                      );
+                    }}
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
           ]}
         />
       </Panel>


### PR DESCRIPTION
## What?

Adds an optional `img` prop to the `Checkbox` component, allowing a thumbnail image to be rendered between the checkbox control and its label. When an image is present, the row is vertically centered for alignment.

## Why?

Changes

  - Checkbox.tsx — New optional img prop ({ src: string; alt?: string }) exported as the CheckboxImg interface. Renders a CheckboxImgContainer after the control. Passes hasImg to the container to
  switch alignment from flex-start to center.
  - styled.tsx — New CheckboxImgContainer styled img (40×40, object-fit: cover, flex-shrink: 0, horizontal xxSmall margin). CheckboxContainer now accepts hasImg to control vertical alignment.
  - Accessibility — alt defaults to an empty string (decorative) per WCAG 1.1.1 when omitted; consumers set it when the image conveys meaning the label doesn't.
  - Docs — New "Image" example section on the checkbox page and an img row in the prop table.
  - Tests — Added snapshot + behavioral tests covering: render with img, provided alt, empty-alt default, and absence of img.

## Screenshots/Screen Recordings

<img width="1035" height="612" alt="Screenshot 2026-06-18 at 13 40 15" src="https://github.com/user-attachments/assets/1731a614-5bcb-4057-818d-56ce65f6834f" />

<img width="1037" height="632" alt="Screenshot 2026-06-18 at 13 40 29" src="https://github.com/user-attachments/assets/81e67540-937c-4d15-9cdd-ec616bbca8b1" />

<img width="1032" height="689" alt="Screenshot 2026-06-18 at 13 40 44" src="https://github.com/user-attachments/assets/f801effc-7982-41e2-bfc0-043daa1c8dd0" />

## Testing/Proof

Manual
