### PR TITLE
feat(component): add the new InfoCard component

### DIFF
--- a/.changeset/curvy-trams-attack.md
+++ b/.changeset/curvy-trams-attack.md
@@ -1,0 +1,6 @@
+---
+'@bigcommerce/big-design': minor
+'@bigcommerce/docs': minor
+---
+
+feat(component): add the new `InfoCard` component for displaying a title with an optional thumbnail, description, and status badge.

--- a/.changeset/curvy-trams-attack.md
+++ b/.changeset/curvy-trams-attack.md
@@ -4,3 +4,5 @@
 ---
 
 feat(component): add the new `InfoCard` component for displaying a title with an optional thumbnail, description, and status badge.
+
+The `img` prop accepts all native `<img />` element attributes (`ComponentPropsWithoutRef<'img'>`). The thumbnail renders at 40&times;40 by default, and the size can be overridden via the native `width`/`height` attributes. `alt` defaults to an empty string (decorative) per WCAG 1.1.1.

--- a/packages/big-design/src/components/InfoCard/InfoCard.tsx
+++ b/packages/big-design/src/components/InfoCard/InfoCard.tsx
@@ -1,24 +1,22 @@
-import React from 'react';
+import React, { ComponentPropsWithoutRef } from 'react';
 
 import { Badge, BadgeProps } from '../Badge';
 import { Box } from '../Box';
+import { Flex } from '../Flex';
 import { Small, StyleableText } from '../Typography/Typography';
 
-import { InfoCardImgContainer, InfoCardTitleContainer } from './styled';
+import { InfoCardImgContainer } from './styled';
 
 export interface InfoCardProps {
   title: string;
   description?: string;
   badge?: BadgeProps;
-  img?: {
-    src: string;
-    alt?: string;
-  };
+  img?: ComponentPropsWithoutRef<'img'>;
 }
 
 export const InfoCard: React.FC<InfoCardProps> = ({ img, title, badge, description }) => (
-  <InfoCardTitleContainer>
-    {img && <InfoCardImgContainer alt={img.alt ?? ''} src={img.src} />}
+  <Flex alignItems="center">
+    {img && <InfoCardImgContainer height={40} width={40} {...img} alt={img.alt ?? ''} />}
     <Box>
       <StyleableText margin="none">
         {title}
@@ -26,5 +24,5 @@ export const InfoCard: React.FC<InfoCardProps> = ({ img, title, badge, descripti
       </StyleableText>
       {description ? <Small>{description}</Small> : null}
     </Box>
-  </InfoCardTitleContainer>
+  </Flex>
 );

--- a/packages/big-design/src/components/InfoCard/InfoCard.tsx
+++ b/packages/big-design/src/components/InfoCard/InfoCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { Badge, BadgeProps } from '../Badge';
+import { Box } from '../Box';
+import { Small, StyleableText } from '../Typography/Typography';
+
+import { InfoCardImgContainer, InfoCardTitleContainer } from './styled';
+
+export interface InfoCardProps {
+  title: string;
+  description?: string;
+  badge?: BadgeProps;
+  img?: {
+    src: string;
+    alt?: string;
+  };
+}
+
+export const InfoCard: React.FC<InfoCardProps> = ({ img, title, badge, description }) => (
+  <InfoCardTitleContainer>
+    {img && <InfoCardImgContainer alt={img.alt ?? ''} src={img.src} />}
+    <Box>
+      <StyleableText margin="none">
+        {title}
+        {badge ? <Badge marginLeft="xSmall" {...badge} /> : null}
+      </StyleableText>
+      {description ? <Small>{description}</Small> : null}
+    </Box>
+  </InfoCardTitleContainer>
+);

--- a/packages/big-design/src/components/InfoCard/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InfoCard/__snapshots__/spec.tsx.snap
@@ -16,8 +16,29 @@ exports[`matches snapshot 1`] = `
   background-color: #5E637A;
 }
 
-.c2 {
+.c0 {
   box-sizing: border-box;
+}
+
+.c1 {
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c3 {
@@ -47,29 +68,38 @@ exports[`matches snapshot 1`] = `
   margin-bottom: 0;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.c2 {
+  margin-inline-end: 0.5rem;
 }
 
-.c1 {
-  height: 2.5rem;
-  width: 2.5rem;
-  margin-right: 0.5rem;
+@media (min-width:0px) {
+  .c1 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:720px) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <img
     alt="Logo"
-    class="c1"
+    class="c2"
+    height="40"
     src="logo.png"
+    width="40"
   />
   <div
-    class="c2"
+    class="c0"
   >
     <p
       class="c3"

--- a/packages/big-design/src/components/InfoCard/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InfoCard/__snapshots__/spec.tsx.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`matches snapshot 1`] = `
+.c4 {
+  margin-left: 0.5rem;
+  color: #FFFFFF;
+  border-radius: 0.25rem;
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.25rem;
+  text-align: center;
+  text-transform: uppercase;
+  vertical-align: middle;
+  padding: 0 0.5rem;
+  background-color: #5E637A;
+}
+
+.c2 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  color: #313440;
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0;
+}
+
+.c3:last-child {
+  margin-bottom: 0;
+}
+
+.c5 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c5:last-child {
+  margin-bottom: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  height: 2.5rem;
+  width: 2.5rem;
+  margin-right: 0.5rem;
+}
+
+<div
+  class="c0"
+>
+  <img
+    alt="Logo"
+    class="c1"
+    src="logo.png"
+  />
+  <div
+    class="c2"
+  >
+    <p
+      class="c3"
+    >
+      Card title
+      <span
+        class="c4"
+      >
+        New
+      </span>
+    </p>
+    <p
+      class="c5"
+    >
+      Card description
+    </p>
+  </div>
+</div>
+`;

--- a/packages/big-design/src/components/InfoCard/index.ts
+++ b/packages/big-design/src/components/InfoCard/index.ts
@@ -1,0 +1,1 @@
+export { InfoCard, type InfoCardProps } from './InfoCard';

--- a/packages/big-design/src/components/InfoCard/spec.tsx
+++ b/packages/big-design/src/components/InfoCard/spec.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import 'jest-styled-components';
+
+import { InfoCard } from './index';
+
+test('renders the title', () => {
+  render(<InfoCard title="Card title" />);
+
+  expect(screen.getByText('Card title')).toBeInTheDocument();
+});
+
+test('renders the description when provided', () => {
+  render(<InfoCard description="Card description" title="Card title" />);
+
+  expect(screen.getByText('Card description')).toBeInTheDocument();
+});
+
+test('does not render a description when not provided', () => {
+  render(<InfoCard title="Card title" />);
+
+  expect(screen.queryByText('Card description')).not.toBeInTheDocument();
+});
+
+test('renders the badge when provided', () => {
+  render(<InfoCard badge={{ label: 'New' }} title="Card title" />);
+
+  expect(screen.getByText('New')).toBeInTheDocument();
+});
+
+test('does not render a badge when not provided', () => {
+  render(<InfoCard title="Card title" />);
+
+  expect(screen.queryByText('New')).not.toBeInTheDocument();
+});
+
+test('renders the image with src and alt', () => {
+  render(<InfoCard img={{ alt: 'Logo', src: 'logo.png' }} title="Card title" />);
+
+  const img = screen.getByRole('img', { name: 'Logo' });
+
+  expect(img).toHaveAttribute('src', 'logo.png');
+});
+
+test('image alt defaults to an empty string', () => {
+  const { container } = render(<InfoCard img={{ src: '/logo.png' }} title="Card title" />);
+
+  expect(container.querySelector('img')).toHaveAttribute('alt', '');
+});
+
+test('does not render an image when not provided', () => {
+  render(<InfoCard title="Card title" />);
+
+  expect(screen.queryByRole('img')).not.toBeInTheDocument();
+});
+
+test('matches snapshot', () => {
+  const { container } = render(
+    <InfoCard
+      badge={{ label: 'New' }}
+      description="Card description"
+      img={{ alt: 'Logo', src: 'logo.png' }}
+      title="Card title"
+    />,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/packages/big-design/src/components/InfoCard/spec.tsx
+++ b/packages/big-design/src/components/InfoCard/spec.tsx
@@ -48,6 +48,32 @@ test('image alt defaults to an empty string', () => {
   expect(container.querySelector('img')).toHaveAttribute('alt', '');
 });
 
+test('image width and height default to 40', () => {
+  render(<InfoCard img={{ alt: 'Logo', src: 'logo.png' }} title="Card title" />);
+
+  const img = screen.getByRole('img', { name: 'Logo' });
+
+  expect(img).toHaveAttribute('width', '40');
+  expect(img).toHaveAttribute('height', '40');
+});
+
+test('image width and height can be overridden', () => {
+  render(
+    <InfoCard img={{ alt: 'Logo', height: 64, src: 'logo.png', width: 64 }} title="Card title" />,
+  );
+
+  const img = screen.getByRole('img', { name: 'Logo' });
+
+  expect(img).toHaveAttribute('width', '64');
+  expect(img).toHaveAttribute('height', '64');
+});
+
+test('forwards native img attributes', () => {
+  render(<InfoCard img={{ alt: 'Logo', loading: 'lazy', src: 'logo.png' }} title="Card title" />);
+
+  expect(screen.getByRole('img', { name: 'Logo' })).toHaveAttribute('loading', 'lazy');
+});
+
 test('does not render an image when not provided', () => {
   render(<InfoCard title="Card title" />);
 

--- a/packages/big-design/src/components/InfoCard/styled.tsx
+++ b/packages/big-design/src/components/InfoCard/styled.tsx
@@ -1,0 +1,14 @@
+import { theme as defaultTheme, remCalc } from '@bigcommerce/big-design-theme';
+import styled from 'styled-components';
+
+export const InfoCardTitleContainer = styled.div`
+  display: flex;
+`;
+
+export const InfoCardImgContainer = styled.img`
+  height: ${remCalc(40)};
+  width: ${remCalc(40)};
+  margin-right: ${({ theme }) => theme.spacing.xSmall};
+`;
+
+InfoCardImgContainer.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/InfoCard/styled.tsx
+++ b/packages/big-design/src/components/InfoCard/styled.tsx
@@ -1,14 +1,8 @@
-import { theme as defaultTheme, remCalc } from '@bigcommerce/big-design-theme';
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
-export const InfoCardTitleContainer = styled.div`
-  display: flex;
-`;
-
 export const InfoCardImgContainer = styled.img`
-  height: ${remCalc(40)};
-  width: ${remCalc(40)};
-  margin-right: ${({ theme }) => theme.spacing.xSmall};
+  margin-inline-end: ${({ theme }) => theme.spacing.xSmall};
 `;
 
 InfoCardImgContainer.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/index.ts
+++ b/packages/big-design/src/components/index.ts
@@ -18,6 +18,7 @@ export * from './FileUploader';
 export * from './Form';
 export * from './GlobalStyles';
 export * from './Grid';
+export * from './InfoCard';
 export * from './InlineMessage';
 export * from './Input';
 export * from './Link';

--- a/packages/docs/PropTables/InfoCardPropTable.tsx
+++ b/packages/docs/PropTables/InfoCardPropTable.tsx
@@ -37,12 +37,13 @@ const infoCardProps: Prop[] = [
   },
   {
     name: 'img',
-    types: '{ src: string; alt?: string }',
+    types: <NextLink href={{ hash: 'img-prop-table', query: { props: 'img' } }}>ImgProps</NextLink>,
     description: (
       <>
-        Renders a thumbnail to the left of the <Code primary>title</Code>. Set <Code>alt</Code> when
-        the image conveys meaning the title doesn&apos;t; when omitted it defaults to an empty
-        string (decorative) per WCAG 1.1.1.
+        Renders a thumbnail to the left of the <Code primary>title</Code>, sized 40&times;40 by
+        default. See{' '}
+        <NextLink href={{ hash: 'img-prop-table', query: { props: 'img' } }}>ImgProps</NextLink> for
+        usage.
       </>
     ),
   },
@@ -50,4 +51,50 @@ const infoCardProps: Prop[] = [
 
 export const InfoCardPropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable propList={infoCardProps} title="InfoCard" {...props} />
+);
+
+const imgProps: Prop[] = [
+  {
+    name: 'src',
+    types: 'string',
+    required: true,
+    description: <>Source of the thumbnail image.</>,
+  },
+  {
+    name: 'alt',
+    types: 'string',
+    defaultValue: "''",
+    description: (
+      <>
+        Set <Code>alt</Code> when the image conveys meaning the <Code primary>title</Code>{' '}
+        doesn&apos;t; when omitted it defaults to an empty string (decorative) per WCAG 1.1.1.
+      </>
+    ),
+  },
+  {
+    name: 'width',
+    types: ['number', 'string'],
+    defaultValue: '40',
+    description: (
+      <>
+        Rendered width of the thumbnail. Override to size the image differently from the 40px
+        default.
+      </>
+    ),
+  },
+  {
+    name: 'height',
+    types: ['number', 'string'],
+    defaultValue: '40',
+    description: (
+      <>
+        Rendered height of the thumbnail. Override to size the image differently from the 40px
+        default.
+      </>
+    ),
+  },
+];
+
+export const ImgPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable nativeElement={['img', 'all']} propList={imgProps} title="Img" {...props} />
 );

--- a/packages/docs/PropTables/InfoCardPropTable.tsx
+++ b/packages/docs/PropTables/InfoCardPropTable.tsx
@@ -53,48 +53,6 @@ export const InfoCardPropTable: React.FC<PropTableWrapper> = (props) => (
   <PropTable propList={infoCardProps} title="InfoCard" {...props} />
 );
 
-const imgProps: Prop[] = [
-  {
-    name: 'src',
-    types: 'string',
-    required: true,
-    description: <>Source of the thumbnail image.</>,
-  },
-  {
-    name: 'alt',
-    types: 'string',
-    defaultValue: "''",
-    description: (
-      <>
-        Set <Code>alt</Code> when the image conveys meaning the <Code primary>title</Code>{' '}
-        doesn&apos;t; when omitted it defaults to an empty string (decorative) per WCAG 1.1.1.
-      </>
-    ),
-  },
-  {
-    name: 'width',
-    types: ['number', 'string'],
-    defaultValue: '40',
-    description: (
-      <>
-        Rendered width of the thumbnail. Override to size the image differently from the 40px
-        default.
-      </>
-    ),
-  },
-  {
-    name: 'height',
-    types: ['number', 'string'],
-    defaultValue: '40',
-    description: (
-      <>
-        Rendered height of the thumbnail. Override to size the image differently from the 40px
-        default.
-      </>
-    ),
-  },
-];
-
 export const ImgPropTable: React.FC<PropTableWrapper> = (props) => (
-  <PropTable nativeElement={['img', 'all']} propList={imgProps} title="Img" {...props} />
+  <PropTable nativeElement={['img', 'all']} propList={[]} title="Img" {...props} />
 );

--- a/packages/docs/PropTables/InfoCardPropTable.tsx
+++ b/packages/docs/PropTables/InfoCardPropTable.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { Code, NextLink, Prop, PropTable, PropTableWrapper } from '../components';
+
+const infoCardProps: Prop[] = [
+  {
+    name: 'title',
+    types: 'string',
+    required: true,
+    description: (
+      <>
+        Primary text displayed by the <Code primary>InfoCard</Code>.
+      </>
+    ),
+  },
+  {
+    name: 'description',
+    types: 'string',
+    description: (
+      <>
+        Secondary text rendered below the <Code primary>title</Code>.
+      </>
+    ),
+  },
+  {
+    name: 'badge',
+    types: [
+      <NextLink href="/badge" key="badge-type">
+        BadgeProps
+      </NextLink>,
+    ],
+    description: (
+      <>
+        Renders a <NextLink href="/badge">Badge</NextLink> next to the <Code primary>title</Code>.
+      </>
+    ),
+  },
+  {
+    name: 'img',
+    types: '{ src: string; alt?: string }',
+    description: (
+      <>
+        Renders a thumbnail to the left of the <Code primary>title</Code>. Set <Code>alt</Code> when
+        the image conveys meaning the title doesn&apos;t; when omitted it defaults to an empty
+        string (decorative) per WCAG 1.1.1.
+      </>
+    ),
+  },
+];
+
+export const InfoCardPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable propList={infoCardProps} title="InfoCard" {...props} />
+);

--- a/packages/docs/PropTables/index.ts
+++ b/packages/docs/PropTables/index.ts
@@ -15,6 +15,7 @@ export * from './FlexPropTable';
 export * from './FormPropTable';
 export * from './GridPropTable';
 export * from './IconPropTable';
+export * from './InfoCardPropTable';
 export * from './InlineMessagePropTable';
 export * from './InputPropTable';
 export * from './LinkPropTable';

--- a/packages/docs/components/SideNav/SideNav.tsx
+++ b/packages/docs/components/SideNav/SideNav.tsx
@@ -97,6 +97,7 @@ export const SideNav: React.FC = () => {
                 <SideNavLink href="/alert">Alert</SideNavLink>
                 <SideNavLink href="/badge">Badge</SideNavLink>
                 <SideNavLink href="/feature-set">FeatureSet</SideNavLink>
+                <SideNavLink href="/info-card">InfoCard</SideNavLink>
                 <SideNavLink href="/inline-message">InlineMessage</SideNavLink>
                 <SideNavLink href="/lozenge">Lozenge</SideNavLink>
                 <SideNavLink href="/message">Message</SideNavLink>

--- a/packages/docs/pages/info-card.tsx
+++ b/packages/docs/pages/info-card.tsx
@@ -3,7 +3,7 @@ import React, { Fragment } from 'react';
 
 import { Code, CodePreview, ContentRoutingTabs, List } from '../components';
 import { GuidelinesTable } from '../components/GuidelinesTable';
-import { InfoCardPropTable } from '../PropTables';
+import { ImgPropTable, InfoCardPropTable } from '../PropTables';
 
 const InfoCardPage = () => {
   return (
@@ -115,7 +115,21 @@ const InfoCardPage = () => {
       </Panel>
 
       <Panel header="Props" headerId="props">
-        <InfoCardPropTable />
+        <ContentRoutingTabs
+          id="props"
+          routes={[
+            {
+              id: 'info-card',
+              title: 'InfoCard',
+              render: () => <InfoCardPropTable />,
+            },
+            {
+              id: 'img',
+              title: 'ImgProps',
+              render: () => <ImgPropTable id="img-prop-table" />,
+            },
+          ]}
+        />
       </Panel>
 
       <Panel header="Do's and Don'ts" headerId="guidelines">

--- a/packages/docs/pages/info-card.tsx
+++ b/packages/docs/pages/info-card.tsx
@@ -1,0 +1,138 @@
+import { H1, InfoCard, Panel, Text } from '@bigcommerce/big-design';
+import React, { Fragment } from 'react';
+
+import { Code, CodePreview, ContentRoutingTabs, List } from '../components';
+import { GuidelinesTable } from '../components/GuidelinesTable';
+import { InfoCardPropTable } from '../PropTables';
+
+const InfoCardPage = () => {
+  return (
+    <>
+      <H1>InfoCard</H1>
+
+      <Panel header="Overview" headerId="overview">
+        <Text>
+          <Code primary>InfoCards</Code> display a compact summary of an object — a title with an
+          optional thumbnail, description, and status badge.
+        </Text>
+        <Text bold>When to use:</Text>
+        <List>
+          <List.Item>
+            Use <Code primary>InfoCards</Code> to represent a 3rd party integration (e.g. a payment
+            provider or channel) alongside its connection status.
+          </List.Item>
+          <List.Item>
+            Pair the <Code primary>img</Code> thumbnail with a <Code primary>badge</Code> to convey
+            both identity and state at a glance.
+          </List.Item>
+        </List>
+      </Panel>
+
+      <Panel header="Implementation" headerId="implementation">
+        <ContentRoutingTabs
+          id="implementation"
+          routes={[
+            {
+              id: 'basic',
+              title: 'Basic',
+              render: () => (
+                <CodePreview key="basic">
+                  {/* jsx-to-string:start */}
+                  <InfoCard title="Payment provider" />
+                  {/* jsx-to-string:end */}
+                </CodePreview>
+              ),
+            },
+            {
+              id: 'description',
+              title: 'Description',
+              render: () => (
+                <Fragment key="description">
+                  <Text>
+                    Add supporting copy below the title with the <Code primary>description</Code>{' '}
+                    prop.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <InfoCard
+                      description="Accept credit cards and digital wallets."
+                      title="Payment provider"
+                    />
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'badge',
+              title: 'Badge',
+              render: () => (
+                <Fragment key="badge">
+                  <Text>
+                    Surface a status next to the title with the <Code primary>badge</Code> prop. See{' '}
+                    <Code primary>Badge</Code> for available props.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <InfoCard
+                      badge={{ label: 'connected', variant: 'success' }}
+                      description="Accept credit cards and digital wallets."
+                      title="Payment provider"
+                    />
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+            {
+              id: 'image',
+              title: 'Image',
+              render: () => (
+                <Fragment key="image">
+                  <Text>
+                    Render a thumbnail to the left of the title with the <Code primary>img</Code>{' '}
+                    prop. Set <Code primary>alt</Code> when the image conveys meaning the title
+                    doesn&apos;t; when omitted it is treated as decorative.
+                  </Text>
+
+                  <CodePreview>
+                    {/* jsx-to-string:start */}
+                    <InfoCard
+                      badge={{ label: 'connected', variant: 'success' }}
+                      description="Accept credit cards and digital wallets."
+                      img={{ src: '/logo.svg', alt: 'Payment provider' }}
+                      title="Payment provider"
+                    />
+                    {/* jsx-to-string:end */}
+                  </CodePreview>
+                </Fragment>
+              ),
+            },
+          ]}
+        />
+      </Panel>
+
+      <Panel header="Props" headerId="props">
+        <InfoCardPropTable />
+      </Panel>
+
+      <Panel header="Do's and Don'ts" headerId="guidelines">
+        <GuidelinesTable
+          discouraged={[
+            <>
+              Don’t use long <Code primary>title</Code> or <Code primary>description</Code> text;
+              keep it concise so the card stays scannable.
+            </>,
+          ]}
+          recommended={[
+            'Provide a meaningful alt value when the thumbnail carries information the title does not.',
+          ]}
+        />
+      </Panel>
+    </>
+  );
+};
+
+export default InfoCardPage;


### PR DESCRIPTION
## What?

**Changes**

- New component: `InfoCard.tsx`, `styled.tsx`, `index.ts`.
- Exported `InfoCard` from `packages/big-design/src/components/index.ts`.
- Docs: new `pages/info-card.tsx` (Overview, Implementation tabs — Basic/Description/Badge/Image, Props, Do's & Don'ts), `InfoCardPropTable.tsx`, and a SideNav link under "Status & Feedback".
- Changeset: `minor` bump for `@bigcommerce/big-design` and `@bigcommerce/docs`.

## Why?

We need a reusable card to represent integrations (e.g. payment providers, channels) showing identity and connection status together. This pattern was being rebuilt ad hoc; promoting it to a shared component gives consistent layout, spacing, and accessible image handling.


## Screenshots/Screen Recordings

https://github.com/user-attachments/assets/7a419c2b-f610-45e0-87e5-9f0a0a8c11d8


## Testing/Proof

Manual
