### PR TITLE
feat(component): img prop updates

### DIFF
--- a/.changeset/witty-facts-bathe.md
+++ b/.changeset/witty-facts-bathe.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/big-design': minor
+---
+
+feat(component): expand the Checkbox `img` prop to accept native `img` attributes (width/height default to 40)

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -28,7 +28,7 @@ interface Props {
   label: React.ReactNode;
   description?: CheckboxDescription | string;
   badge?: BadgeProps;
-  img?: ComponentPropsWithoutRef<'img'>;
+  img?: Omit<ComponentPropsWithoutRef<'img'>, 'style' | 'className'>;
 }
 
 interface CheckboxDescription {

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -28,21 +28,12 @@ interface Props {
   label: React.ReactNode;
   description?: CheckboxDescription | string;
   badge?: BadgeProps;
-  img?: CheckboxImg;
+  img?: ComponentPropsWithoutRef<'img'>;
 }
 
 interface CheckboxDescription {
   text: string;
   link?: FormControlDescriptionLinkProps;
-}
-
-export interface CheckboxImg {
-  src: string;
-  /**
-   * Accessible name for the thumbnail. Defaults to an empty string (decorative) when omitted —
-   * set it whenever the image carries meaning the label doesn't already convey.
-   */
-  alt?: string;
 }
 
 interface PrivateProps {
@@ -150,7 +141,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
       >
         {!checked && isIndeterminate ? <RemoveIcon /> : <CheckIcon />}
       </StyledCheckbox>
-      {img ? <CheckboxImgContainer alt={img.alt ?? ''} src={img.src} /> : null}
+      {img ? <CheckboxImgContainer height={40} width={40} {...img} alt={img.alt ?? ''} /> : null}
       <CheckboxLabelContainer hasContent={Boolean(label) || Boolean(description)}>
         {renderedLabel}
         {renderedDescription}

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -28,7 +28,7 @@ interface Props {
   label: React.ReactNode;
   description?: CheckboxDescription | string;
   badge?: BadgeProps;
-  img?: Omit<ComponentPropsWithoutRef<'img'>, 'style' | 'className'>;
+  img?: ComponentPropsWithoutRef<'img'>;
 }
 
 interface CheckboxDescription {
@@ -60,6 +60,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   const uniqueCheckboxId = useId();
   const labelId = useId();
   const id = props.id ? props.id : uniqueCheckboxId;
+  const { className: imgClassName, style: imgStyle, ...imgProps } = img ?? {};
 
   const renderedLabel = useMemo(() => {
     if (!label) {
@@ -141,7 +142,9 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
       >
         {!checked && isIndeterminate ? <RemoveIcon /> : <CheckIcon />}
       </StyledCheckbox>
-      {img ? <CheckboxImgContainer height={40} width={40} {...img} alt={img.alt ?? ''} /> : null}
+      {img ? (
+        <CheckboxImgContainer height={40} width={40} {...imgProps} alt={img.alt ?? ''} />
+      ) : null}
       <CheckboxLabelContainer hasContent={Boolean(label) || Boolean(description)}>
         {renderedLabel}
         {renderedDescription}

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -1274,6 +1274,10 @@ exports[`render Checkbox with img props 1`] = `
 
 .c6 {
   margin-inline-start: 0.5rem;
+  object-fit: contain;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 .c0 {

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -1273,13 +1273,7 @@ exports[`render Checkbox with img props 1`] = `
 }
 
 .c6 {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  height: 2.5rem;
-  object-fit: cover;
-  width: 2.5rem;
-  margin: 0 0.25rem;
+  margin-inline-start: 0.5rem;
 }
 
 .c0 {
@@ -1390,7 +1384,9 @@ exports[`render Checkbox with img props 1`] = `
   <img
     alt="Thumbnail"
     class="c6"
+    height="100"
     src="https://example.com/thumbnail.png"
+    width="100"
   />
   <div
     class="c7"

--- a/packages/big-design/src/components/Checkbox/spec.tsx
+++ b/packages/big-design/src/components/Checkbox/spec.tsx
@@ -66,7 +66,12 @@ describe('render Checkbox', () => {
     const { container } = render(
       <Checkbox
         checked={false}
-        img={{ src: 'https://example.com/thumbnail.png', alt: 'Thumbnail' }}
+        img={{
+          src: 'https://example.com/thumbnail.png',
+          alt: 'Thumbnail',
+          width: 100,
+          height: 100,
+        }}
         label="Unchecked"
         name="test-group"
         onChange={() => null}

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -21,6 +21,8 @@ export const CheckboxLabelContainer = styled.div<{ hasContent?: boolean }>`
 
 export const CheckboxImgContainer = styled.img`
   margin-inline-start: ${({ theme }) => theme.spacing.xSmall};
+  object-fit: contain;
+  flex-shrink: 0;
 `;
 
 export const CheckboxContainer = styled.div<{ hasImg?: boolean }>`

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -1,4 +1,4 @@
-import { theme as defaultTheme, remCalc } from '@bigcommerce/big-design-theme';
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { hideVisually } from 'polished';
 import styled, { css } from 'styled-components';
 
@@ -20,11 +20,7 @@ export const CheckboxLabelContainer = styled.div<{ hasContent?: boolean }>`
 `;
 
 export const CheckboxImgContainer = styled.img`
-  flex-shrink: 0;
-  height: ${remCalc(40)};
-  object-fit: cover;
-  width: ${remCalc(40)};
-  margin: 0 ${({ theme }) => theme.spacing.xxSmall};
+  margin-inline-start: ${({ theme }) => theme.spacing.xSmall};
 `;
 
 export const CheckboxContainer = styled.div<{ hasImg?: boolean }>`

--- a/packages/big-design/src/components/InfoCard/InfoCard.tsx
+++ b/packages/big-design/src/components/InfoCard/InfoCard.tsx
@@ -11,7 +11,7 @@ export interface InfoCardProps {
   title: string;
   description?: string;
   badge?: BadgeProps;
-  img?: ComponentPropsWithoutRef<'img'>;
+  img?: Omit<ComponentPropsWithoutRef<'img'>, 'style' | 'className'>;
 }
 
 export const InfoCard: React.FC<InfoCardProps> = ({ img, title, badge, description }) => (

--- a/packages/big-design/src/components/InfoCard/InfoCard.tsx
+++ b/packages/big-design/src/components/InfoCard/InfoCard.tsx
@@ -11,18 +11,22 @@ export interface InfoCardProps {
   title: string;
   description?: string;
   badge?: BadgeProps;
-  img?: Omit<ComponentPropsWithoutRef<'img'>, 'style' | 'className'>;
+  img?: ComponentPropsWithoutRef<'img'>;
 }
 
-export const InfoCard: React.FC<InfoCardProps> = ({ img, title, badge, description }) => (
-  <Flex alignItems="center">
-    {img && <InfoCardImgContainer height={40} width={40} {...img} alt={img.alt ?? ''} />}
-    <Box>
-      <StyleableText margin="none">
-        {title}
-        {badge ? <Badge marginLeft="xSmall" {...badge} /> : null}
-      </StyleableText>
-      {description ? <Small>{description}</Small> : null}
-    </Box>
-  </Flex>
-);
+export const InfoCard: React.FC<InfoCardProps> = ({ img, title, badge, description }) => {
+  const { className: imgClassName, style: imgStyle, ...imgProps } = img ?? {};
+
+  return (
+    <Flex alignItems="center">
+      {img && <InfoCardImgContainer height={40} width={40} {...imgProps} alt={img.alt ?? ''} />}
+      <Box>
+        <StyleableText margin="none">
+          {title}
+          {badge ? <Badge marginLeft="xSmall" {...badge} /> : null}
+        </StyleableText>
+        {description ? <Small>{description}</Small> : null}
+      </Box>
+    </Flex>
+  );
+};

--- a/packages/big-design/src/components/InfoCard/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InfoCard/__snapshots__/spec.tsx.snap
@@ -70,6 +70,10 @@ exports[`matches snapshot 1`] = `
 
 .c2 {
   margin-inline-end: 0.5rem;
+  object-fit: contain;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 @media (min-width:0px) {

--- a/packages/big-design/src/components/InfoCard/styled.tsx
+++ b/packages/big-design/src/components/InfoCard/styled.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 
 export const InfoCardImgContainer = styled.img`
   margin-inline-end: ${({ theme }) => theme.spacing.xSmall};
+  object-fit: contain;
+  flex-shrink: 0;
 `;
 
 InfoCardImgContainer.defaultProps = { theme: defaultTheme };

--- a/packages/docs/PropTables/CheckboxPropTable.tsx
+++ b/packages/docs/PropTables/CheckboxPropTable.tsx
@@ -77,12 +77,14 @@ const checkboxProps: Prop[] = [
   },
   {
     name: 'img',
-    types: '{ src: string; alt?: string }',
+    types: "ComponentPropsWithoutRef<'img'>",
     description: (
       <>
         Renders a thumbnail between the <Code primary>Checkbox</Code> and its label, and vertically
-        centers the row. Set <Code>alt</Code> when the image conveys meaning the label doesn&apos;t;
-        when omitted it defaults to an empty string (decorative) per WCAG 1.1.1.
+        centers the row. Accepts any native <Code>img</Code> attributes and defaults{' '}
+        <Code>width</Code> and <Code>height</Code> to <Code>40</Code>. Set <Code>alt</Code> when the
+        image conveys meaning the label doesn&apos;t; when omitted it defaults to an empty string
+        (decorative) per WCAG 1.1.1.
       </>
     ),
   },

--- a/packages/docs/PropTables/CheckboxPropTable.tsx
+++ b/packages/docs/PropTables/CheckboxPropTable.tsx
@@ -77,14 +77,13 @@ const checkboxProps: Prop[] = [
   },
   {
     name: 'img',
-    types: "ComponentPropsWithoutRef<'img'>",
+    types: <NextLink href={{ hash: 'img-prop-table', query: { props: 'img' } }}>ImgProps</NextLink>,
     description: (
       <>
-        Renders a thumbnail between the <Code primary>Checkbox</Code> and its label, and vertically
-        centers the row. Accepts any native <Code>img</Code> attributes and defaults{' '}
-        <Code>width</Code> and <Code>height</Code> to <Code>40</Code>. Set <Code>alt</Code> when the
-        image conveys meaning the label doesn&apos;t; when omitted it defaults to an empty string
-        (decorative) per WCAG 1.1.1.
+        Renders a thumbnail between the <Code primary>Checkbox</Code> and its label, sized
+        40&times;40 by default, and vertically centers the row. See{' '}
+        <NextLink href={{ hash: 'img-prop-table', query: { props: 'img' } }}>ImgProps</NextLink> for
+        usage.
       </>
     ),
   },
@@ -155,4 +154,8 @@ export const CheckboxDescriptionLinkPropTable: React.FC<PropTableWrapper> = (pro
     {...props}
     id="checkbox-description-link-prop-table"
   />
+);
+
+export const CheckboxImgPropTable: React.FC<PropTableWrapper> = (props) => (
+  <PropTable nativeElement={['img', 'all']} propList={[]} title="Img" {...props} />
 );

--- a/packages/docs/pages/checkbox.tsx
+++ b/packages/docs/pages/checkbox.tsx
@@ -5,6 +5,7 @@ import { Code, CodePreview, ContentRoutingTabs, GuidelinesTable, List } from '..
 import {
   CheckboxDescriptionLinkPropTable,
   CheckboxDescriptionPropTable,
+  CheckboxImgPropTable,
   CheckboxPropTable,
 } from '../PropTables';
 
@@ -240,6 +241,11 @@ const CheckboxPage = () => {
               render: () => (
                 <CheckboxDescriptionLinkPropTable id="checkbox-description-link-prop-table" />
               ),
+            },
+            {
+              id: 'img',
+              title: 'ImgProps',
+              render: () => <CheckboxImgPropTable id="img-prop-table" />,
             },
           ]}
         />


### PR DESCRIPTION
## What?

Allow the Checkbox `img` prop to accept native `img` attributes

## Why?

It is better approach. I did the similar thing for `InfoCard`.

## Screenshots/Screen Recordings

This is a component library so we love visually looking at changes! If this applies to your pull request, show us your hard work in action.

## Testing/Proof

<img width="1034" height="615" alt="Screenshot 2026-07-02 at 13 18 39" src="https://github.com/user-attachments/assets/df8a2c62-855d-4b44-bed6-509a9864cf06" />
