### PR TITLE
chore(configs): update codeowners to @bigcommerce/frontend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bigcommerce/big-design-stewards @bigcommerce/team-platform-design
+* @bigcommerce/frontend


### PR DESCRIPTION
## What?

Replaces the wildcard CODEOWNERS rule's owners (`@bigcommerce/big-design-stewards`, `@bigcommerce/team-platform-design`) with `@bigcommerce/frontend`.

## Why?

Consolidating big-design review ownership under `@bigcommerce/frontend`.

## Screenshots/Screen Recordings

N/A — CODEOWNERS-only change, no UI impact.

## Testing/Proof

N/A — single-line ownership change in `.github/CODEOWNERS`, no code path affected.