### PR TITLE
refactor: TRAC-1296 Remove defaultProps from function components, fix act imports

### DIFF
--- a/.changeset/tame-buses-jump.md
+++ b/.changeset/tame-buses-jump.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Move `defaultProps` on `Button`, `Alert`, `Message`, and `InlineMessage` into destructuring defaults ahead of the React 19 upgrade, which silently ignores `defaultProps` on function components. Swap `act` imports in `AlertsManager` and `AnchorNav` specs from the removed `react-dom/test-utils` to `@testing-library/react`. No behavior change on React 18.

--- a/packages/big-design/src/components/Alert/Alert.tsx
+++ b/packages/big-design/src/components/Alert/Alert.tsx
@@ -13,44 +13,47 @@ export interface AlertProps extends Omit<SharedMessagingProps, 'actions'> {
   key?: string;
 }
 
-export const Alert: React.FC<AlertProps> = memo(({ className, style, header, ...props }) => {
-  const headerId = useId();
-  const filteredProps = excludePaddingProps(props);
-  const icon = useMemo(() => props.type && getMessagingIcon(props.type), [props.type]);
+export const Alert: React.FC<AlertProps> = memo(
+  ({ className, style, header, messages = [], type = 'success', ...props }) => {
+    const headerId = useId();
+    const filteredProps = excludePaddingProps(props);
+    const icon = useMemo(() => type && getMessagingIcon(type), [type]);
 
-  const renderedMessages = useMemo(
-    () =>
-      props.messages.map(({ text, link }, index) => (
-        <Box key={index}>
-          <StyledMessageItem>{text}</StyledMessageItem>{' '}
-          {link && <StyledLink {...link}>{link.text}</StyledLink>}
-        </Box>
-      )),
-    [props.messages],
-  );
+    const renderedMessages = useMemo(
+      () =>
+        messages.map(({ text, link }, index) => (
+          <Box key={index}>
+            <StyledMessageItem>{text}</StyledMessageItem>{' '}
+            {link && <StyledLink {...link}>{link.text}</StyledLink>}
+          </Box>
+        )),
+      [messages],
+    );
 
-  const renderedHeader = useMemo(
-    () => header && <StyledHeader id={headerId}>{header}</StyledHeader>,
-    [header, headerId],
-  );
+    const renderedHeader = useMemo(
+      () => header && <StyledHeader id={headerId}>{header}</StyledHeader>,
+      [header, headerId],
+    );
 
-  return (
-    <StyledAlert {...filteredProps} aria-labelledby={header && headerId} role="alert">
-      <GridItem gridArea="icon">{icon}</GridItem>
-      <GridItem gridArea="messages">
-        {renderedHeader}
-        {renderedMessages}
-      </GridItem>
-      {props.onClose && (
-        <GridItem>
-          <MessagingButton iconOnly={<CloseIcon size="large" />} onClick={props.onClose} />
+    return (
+      <StyledAlert
+        {...filteredProps}
+        aria-labelledby={header && headerId}
+        messages={messages}
+        role="alert"
+        type={type}
+      >
+        <GridItem gridArea="icon">{icon}</GridItem>
+        <GridItem gridArea="messages">
+          {renderedHeader}
+          {renderedMessages}
         </GridItem>
-      )}
-    </StyledAlert>
-  );
-});
-
-Alert.defaultProps = {
-  messages: [],
-  type: 'success',
-};
+        {props.onClose && (
+          <GridItem>
+            <MessagingButton iconOnly={<CloseIcon size="large" />} onClick={props.onClose} />
+          </GridItem>
+        )}
+      </StyledAlert>
+    );
+  },
+);

--- a/packages/big-design/src/components/AnchorNav/spec.tsx
+++ b/packages/big-design/src/components/AnchorNav/spec.tsx
@@ -1,6 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { useInView } from 'react-intersection-observer';
 
 import 'jest-styled-components';

--- a/packages/big-design/src/components/Button/Button.tsx
+++ b/packages/big-design/src/components/Button/Button.tsx
@@ -27,13 +27,24 @@ const LoadingSpinner = () => (
 );
 
 const RawButton: React.FC<ButtonProps & PrivateProps> = memo(
-  ({ forwardedRef, isLoading, disabled, ...props }) => {
+  ({
+    forwardedRef,
+    actionType = 'normal',
+    isLoading = false,
+    mobileWidth = '100%',
+    variant = 'primary',
+    disabled,
+    ...props
+  }) => {
     return (
       <StyledButton
         className="bd-button"
         {...props}
+        actionType={actionType}
         disabled={isLoading || disabled}
+        mobileWidth={mobileWidth}
         ref={forwardedRef}
+        variant={variant}
       >
         {isLoading ? <LoadingSpinner /> : null}
         <ContentWrapper isLoading={isLoading}>
@@ -55,15 +66,5 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, style, ...props }, ref) => <RawButton {...props} forwardedRef={ref} />,
 );
 
-const defaultProps = {
-  actionType: 'normal' as const,
-  isLoading: false,
-  mobileWidth: '100%' as const,
-  variant: 'primary' as const,
-};
-
 Button.displayName = 'Button';
-Button.defaultProps = { ...defaultProps };
-
 StyleableButton.displayName = 'StyleableButton';
-StyleableButton.defaultProps = { ...defaultProps };

--- a/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
+++ b/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
@@ -28,19 +28,27 @@ export type InlineMessageProps = SharedMessagingProps &
   MarginProps & { localization?: InlineMessageLocalization };
 
 export const InlineMessage: React.FC<InlineMessageProps> = memo(
-  ({ className, style, header, localization = defaultLocalization, ...props }) => {
+  ({
+    className,
+    style,
+    header,
+    localization = defaultLocalization,
+    messages = [],
+    type = 'success',
+    ...props
+  }) => {
     const filteredProps = excludePaddingProps(props);
-    const icon = useMemo(() => props.type && getMessagingIcon(props.type, true), [props.type]);
+    const icon = useMemo(() => type && getMessagingIcon(type, true), [type]);
 
     const renderedMessages = useMemo(
       () =>
-        props.messages.map(({ text, link }, index) => (
+        messages.map(({ text, link }, index) => (
           <Box key={index}>
             <StyledMessageItem>{text}</StyledMessageItem>{' '}
             {link && <StyledLink {...link}>{link.text}</StyledLink>}
           </Box>
         )),
-      [props.messages],
+      [messages],
     );
 
     const renderedHeader = useMemo(() => header && <StyledHeader>{header}</StyledHeader>, [header]);
@@ -67,7 +75,13 @@ export const InlineMessage: React.FC<InlineMessageProps> = memo(
     );
 
     return (
-      <StyledInlineMessage {...filteredProps} backgroundColor="white" role="alert">
+      <StyledInlineMessage
+        {...filteredProps}
+        backgroundColor="white"
+        messages={messages}
+        role="alert"
+        type={type}
+      >
         <GridItem gridArea="icon">{icon}</GridItem>
         <GridItem gridArea="messages">
           {renderedHeader}
@@ -86,8 +100,3 @@ export const InlineMessage: React.FC<InlineMessageProps> = memo(
     );
   },
 );
-
-InlineMessage.defaultProps = {
-  messages: [],
-  type: 'success',
-};

--- a/packages/big-design/src/components/Message/Message.tsx
+++ b/packages/big-design/src/components/Message/Message.tsx
@@ -28,19 +28,27 @@ export type MessageProps = SharedMessagingProps &
   MarginProps & { localization?: MessageLocalization };
 
 export const Message: React.FC<MessageProps> = memo(
-  ({ className, localization = defaultLocalization, style, header, ...props }) => {
+  ({
+    className,
+    localization = defaultLocalization,
+    style,
+    header,
+    messages = [],
+    type = 'success',
+    ...props
+  }) => {
     const filteredProps = excludePaddingProps(props);
-    const icon = useMemo(() => props.type && getMessagingIcon(props.type), [props.type]);
+    const icon = useMemo(() => type && getMessagingIcon(type), [type]);
 
     const renderedMessages = useMemo(
       () =>
-        props.messages.map(({ text, link }, index) => (
+        messages.map(({ text, link }, index) => (
           <Box key={index}>
             <StyledMessageItem>{text}</StyledMessageItem>{' '}
             {link && <StyledLink {...link}>{link.text}</StyledLink>}
           </Box>
         )),
-      [props.messages],
+      [messages],
     );
 
     const renderedHeader = useMemo(() => header && <StyledHeader>{header}</StyledHeader>, [header]);
@@ -67,7 +75,13 @@ export const Message: React.FC<MessageProps> = memo(
     );
 
     return (
-      <StyledMessage {...filteredProps} backgroundColor="white" role="alert">
+      <StyledMessage
+        {...filteredProps}
+        backgroundColor="white"
+        messages={messages}
+        role="alert"
+        type={type}
+      >
         <GridItem gridArea="icon">{icon}</GridItem>
         <GridItem gridArea="messages">
           {renderedHeader}
@@ -86,8 +100,3 @@ export const Message: React.FC<MessageProps> = memo(
     );
   },
 );
-
-Message.defaultProps = {
-  messages: [],
-  type: 'success',
-};

--- a/packages/big-design/src/managers/alerts/spec.tsx
+++ b/packages/big-design/src/managers/alerts/spec.tsx
@@ -1,7 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import 'jest-styled-components';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import { AlertProps } from '../../components/Alert';
 


### PR DESCRIPTION
Jira: [TRAC-1296](https://bigcommercecloud.atlassian.net/browse/TRAC-1296)

## What?

Moves `defaultProps` into destructuring defaults on `Button`, `Alert`, `Message`, and `InlineMessage`, and swaps the `act` import in the `AlertsManager` and `AnchorNav` specs away from `react-dom/test-utils`.

## Why?

React 19 silently ignores `defaultProps` on function components and removes `react-dom/test-utils`. Fixing both ahead of the upgrade; this is a no-op on React 18.

`Button`'s defaults move inside `RawButton` so both `Button` and `StyleableButton` keep them and the variant/actionType-keyed CSS in `Button/styled.tsx` still resolves. `Alert`/`Message`/`InlineMessage` now pass `messages`/`type` through explicitly to their styled components since those props are no longer part of the spread props object once destructured with defaults.

`Button/private.ts` and `GlobalStyles.tsx` are untouched — those `defaultProps` are on styled-components internals (styled components / `createGlobalStyle`), which styled-components handles itself.

For the spec files, `act` now comes from `@testing-library/react` rather than `react` directly. The ticket assumed importing `act` from `react` would be a no-op on React 18, but this repo pins React 18.2.0, which only exports `unstable_act` (`act` was added to the `react` package in 18.3.0). Bumping react/react-dom to 18.3.1 surfaced new "defaultProps on memo components" warnings from `GlobalStyles` and `react-beautiful-dnd`, which broke 4 unrelated test suites under `jest-fail-on-console`. `@testing-library/react` ships the same version-compat `act` shim, so this avoids the dependency bump entirely while still moving off the removed `react-dom/test-utils`.

## Screenshots/Screen Recordings

No visual changes — this is a behind-the-scenes refactor with no rendering differences on React 18.

## Testing/Proof

`pnpm run lint`, `pnpm run typecheck`, and `pnpm run test` all pass (70 suites / 1115 tests / 182 snapshots, no new console warnings under `jest-fail-on-console`). Added a `patch` changeset for `@bigcommerce/big-design`.

[TRAC-1296]: https://bigcommercecloud.atlassian.net/browse/TRAC-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ