### PR TITLE
ref: TRAC-1302 Replace v5-only styled-components type names in published types

### DIFF
--- a/.changeset/replace-v5-only-styled-components-types.md
+++ b/.changeset/replace-v5-only-styled-components-types.md
@@ -1,0 +1,6 @@
+---
+"@bigcommerce/big-design": patch
+"@bigcommerce/big-design-theme": patch
+---
+
+Replace `FlattenSimpleInterpolation` with a version-agnostic `CSSRules` alias (`ReturnType<typeof css>`) and drop the explicit `styled<StyledComponent<...>>(...)` generics in favor of inferred typing, so published `.d.ts` files no longer reference type names that only exist in styled-components v5's types. No runtime change; public prop shapes are unchanged for v5 consumers.

--- a/packages/big-design-theme/src/helpers/helpers.ts
+++ b/packages/big-design-theme/src/helpers/helpers.ts
@@ -1,14 +1,19 @@
 import { em, hideVisually, math, rem, transparentize } from 'polished';
-import { css, FlattenSimpleInterpolation } from 'styled-components';
+import { css } from 'styled-components';
 
 import { themeOptions } from '../options';
+
+// Derived from `css` rather than referencing styled-components' own type name directly, so
+// it resolves against either v5 or v6 types and doesn't leak a version-specific name into
+// our published `.d.ts` files.
+export type CSSRules = ReturnType<typeof css>;
 
 export interface Helpers {
   addValues(first: string, second: string): string;
   createRGBA(color: string, alpha: number): string;
   remCalc(value: string | number): string;
   emCalc(value: string | number): string;
-  listReset: FlattenSimpleInterpolation;
+  listReset: CSSRules;
   hideVisually: typeof hideVisually;
 }
 

--- a/packages/big-design/src/components/Alert/styled.ts
+++ b/packages/big-design/src/components/Alert/styled.ts
@@ -1,5 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { getBorderStyle } from '../../utils';
 import { Grid } from '../Grid';
@@ -42,9 +42,7 @@ export const StyledHeader = styled(StyleableH4)`
   margin-bottom: ${({ theme }) => theme.spacing.xxSmall};
 `;
 
-export const StyledMessageItem = styled<StyledComponent<'span', DefaultTheme, Partial<TextProps>>>(
-  StyleableSmall,
-).attrs({ as: 'span' })`
+export const StyledMessageItem = styled(StyleableSmall).attrs({ as: 'span' })<Partial<TextProps>>`
   color: ${({ theme }) => theme.colors.secondary70};
   vertical-align: middle;
 `;

--- a/packages/big-design/src/components/Fieldset/Legend/styled.tsx
+++ b/packages/big-design/src/components/Fieldset/Legend/styled.tsx
@@ -1,12 +1,12 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled, { DefaultTheme, StyledComponent } from 'styled-components';
+import styled from 'styled-components';
 
 import { StyleableH4 } from '../../Typography/private';
 import { HeadingProps } from '../../Typography/types';
 
-export const StyledFieldsetLegend = styled<
-  StyledComponent<'legend' | 'h4', DefaultTheme, Partial<HeadingProps>>
->(StyleableH4).attrs({ as: 'legend' })`
+export const StyledFieldsetLegend = styled(StyleableH4).attrs({ as: 'legend' })<
+  Partial<HeadingProps>
+>`
   &:not(:last-child) {
     margin-bottom: ${({ theme }) => theme.spacing.xxSmall};
   }

--- a/packages/big-design/src/components/Flex/types.ts
+++ b/packages/big-design/src/components/Flex/types.ts
@@ -1,5 +1,4 @@
-import { ThemeInterface } from '@bigcommerce/big-design-theme';
-import { FlattenSimpleInterpolation } from 'styled-components';
+import { CSSRules, ThemeInterface } from '@bigcommerce/big-design-theme';
 
 import { ResponsiveProp } from '../../types';
 
@@ -99,41 +98,17 @@ export type FlexedItemProps = Partial<{
 }>;
 
 export interface FlexedOverload {
-  (
-    flexedProp: AlignContent,
-    theme: ThemeInterface,
-    cssKey: 'align-content',
-  ): FlattenSimpleInterpolation;
-  (
-    flexedProp: AlignItems,
-    theme: ThemeInterface,
-    cssKey: 'align-items',
-  ): FlattenSimpleInterpolation;
-  (
-    flexedProp: FlexColumnGap,
-    theme: ThemeInterface,
-    cssKey: 'column-gap',
-  ): FlattenSimpleInterpolation;
-  (
-    flexedProp: FlexDirection,
-    theme: ThemeInterface,
-    cssKey: 'flex-direction',
-  ): FlattenSimpleInterpolation;
-  (flexedProp: FlexGap, theme: ThemeInterface, cssKey: 'gap'): FlattenSimpleInterpolation;
-  (flexedProp: FlexRowGap, theme: ThemeInterface, cssKey: 'row-gap'): FlattenSimpleInterpolation;
-  (flexedProp: FlexWrap, theme: ThemeInterface, cssKey: 'flex-wrap'): FlattenSimpleInterpolation;
-  (
-    flexedProp: JustifyContent,
-    theme: ThemeInterface,
-    cssKey: 'justify-content',
-  ): FlattenSimpleInterpolation;
-  (flexedProp: AlignSelf, theme: ThemeInterface, cssKey: 'align-self'): FlattenSimpleInterpolation;
-  (flexedProp: FlexBasis, theme: ThemeInterface, cssKey: 'flex-basis'): FlattenSimpleInterpolation;
-  (flexedProp: FlexGrow, theme: ThemeInterface, cssKey: 'flex-grow'): FlattenSimpleInterpolation;
-  (flexedProp: FlexOrder, theme: ThemeInterface, cssKey: 'order'): FlattenSimpleInterpolation;
-  (
-    flexedProp: FlexShrink,
-    theme: ThemeInterface,
-    cssKey: 'flex-shrink',
-  ): FlattenSimpleInterpolation;
+  (flexedProp: AlignContent, theme: ThemeInterface, cssKey: 'align-content'): CSSRules;
+  (flexedProp: AlignItems, theme: ThemeInterface, cssKey: 'align-items'): CSSRules;
+  (flexedProp: FlexColumnGap, theme: ThemeInterface, cssKey: 'column-gap'): CSSRules;
+  (flexedProp: FlexDirection, theme: ThemeInterface, cssKey: 'flex-direction'): CSSRules;
+  (flexedProp: FlexGap, theme: ThemeInterface, cssKey: 'gap'): CSSRules;
+  (flexedProp: FlexRowGap, theme: ThemeInterface, cssKey: 'row-gap'): CSSRules;
+  (flexedProp: FlexWrap, theme: ThemeInterface, cssKey: 'flex-wrap'): CSSRules;
+  (flexedProp: JustifyContent, theme: ThemeInterface, cssKey: 'justify-content'): CSSRules;
+  (flexedProp: AlignSelf, theme: ThemeInterface, cssKey: 'align-self'): CSSRules;
+  (flexedProp: FlexBasis, theme: ThemeInterface, cssKey: 'flex-basis'): CSSRules;
+  (flexedProp: FlexGrow, theme: ThemeInterface, cssKey: 'flex-grow'): CSSRules;
+  (flexedProp: FlexOrder, theme: ThemeInterface, cssKey: 'order'): CSSRules;
+  (flexedProp: FlexShrink, theme: ThemeInterface, cssKey: 'flex-shrink'): CSSRules;
 }

--- a/packages/big-design/src/components/Flex/withFlex.ts
+++ b/packages/big-design/src/components/Flex/withFlex.ts
@@ -1,5 +1,10 @@
-import { Breakpoints, breakpointsOrder, ThemeInterface } from '@bigcommerce/big-design-theme';
-import { css, FlattenSimpleInterpolation } from 'styled-components';
+import {
+  Breakpoints,
+  breakpointsOrder,
+  CSSRules,
+  ThemeInterface,
+} from '@bigcommerce/big-design-theme';
+import { css } from 'styled-components';
 
 import { FlexedItemProps, FlexedOverload, FlexedProps } from './types';
 
@@ -33,7 +38,7 @@ const getFlexedStyles: FlexedOverload = (
   flexedProp: any,
   theme: ThemeInterface,
   cssKey: any,
-): FlattenSimpleInterpolation => {
+): CSSRules => {
   if (typeof flexedProp === 'object') {
     return getResponsiveFlex(flexedProp, theme, cssKey);
   }
@@ -45,18 +50,11 @@ const getFlexedStyles: FlexedOverload = (
   return [];
 };
 
-const getSimpleFlex = (
-  flexedProp: string | number,
-  cssKey: string,
-): FlattenSimpleInterpolation => css`
+const getSimpleFlex = (flexedProp: string | number, cssKey: string): CSSRules => css`
   ${cssKey}: ${flexedProp}
 `;
 
-const getResponsiveFlex = (
-  flexedProp: any,
-  theme: ThemeInterface,
-  cssKey: string,
-): FlattenSimpleInterpolation[] => {
+const getResponsiveFlex = (flexedProp: any, theme: ThemeInterface, cssKey: string): CSSRules[] => {
   const breakpointKeys = Object.keys(flexedProp).sort(
     (firstBreakpoint, secondBreakpoint) =>
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/big-design/src/components/Grid/types.ts
+++ b/packages/big-design/src/components/Grid/types.ts
@@ -1,5 +1,4 @@
-import { ThemeInterface } from '@bigcommerce/big-design-theme';
-import { FlattenSimpleInterpolation } from 'styled-components';
+import { CSSRules, ThemeInterface } from '@bigcommerce/big-design-theme';
 
 import { ResponsiveProp } from '../../types';
 
@@ -63,73 +62,21 @@ export type GridedItemProps = Partial<{
 }>;
 
 export interface GridedOverload {
-  (
-    gridedProp: GridAreas,
-    theme: ThemeInterface,
-    cssKey: 'grid-template-areas',
-  ): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridAutoColumns,
-    theme: ThemeInterface,
-    cssKey: 'grid-auto-columns',
-  ): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridAutoFlow,
-    theme: ThemeInterface,
-    cssKey: 'grid-auto-flow',
-  ): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridAutoRows,
-    theme: ThemeInterface,
-    cssKey: 'grid-auto-rows',
-  ): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridColumns,
-    theme: ThemeInterface,
-    cssKey: 'grid-template-columns',
-  ): FlattenSimpleInterpolation;
-  (
-    gridedPopr: GridColumnGap,
-    theme: ThemeInterface,
-    cssKey: 'column-gap',
-  ): FlattenSimpleInterpolation;
-  (gridedProp: GridGap, theme: ThemeInterface, cssKey: 'gap'): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridRows,
-    theme: ThemeInterface,
-    cssKey: 'grid-template-rows',
-  ): FlattenSimpleInterpolation;
-  (gridedProp: GridRowGap, theme: ThemeInterface, cssKey: 'row-gap'): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridTemplate,
-    theme: ThemeInterface,
-    cssKey: 'grid-template',
-  ): FlattenSimpleInterpolation;
-  (gridedProp: GridArea, theme: ThemeInterface, cssKey: 'grid-area'): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridColumn,
-    theme: ThemeInterface,
-    cssKey: 'grid-column',
-  ): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridColumnEnd,
-    theme: ThemeInterface,
-    cssKey: 'grid-column-end',
-  ): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridColumnStart,
-    theme: ThemeInterface,
-    cssKey: 'grid-column-start',
-  ): FlattenSimpleInterpolation;
-  (gridedProp: GridRow, theme: ThemeInterface, cssKey: 'grid-row'): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridRowEnd,
-    theme: ThemeInterface,
-    cssKey: 'grid-row-end',
-  ): FlattenSimpleInterpolation;
-  (
-    gridedProp: GridRowStart,
-    theme: ThemeInterface,
-    cssKey: 'grid-row-start',
-  ): FlattenSimpleInterpolation;
+  (gridedProp: GridAreas, theme: ThemeInterface, cssKey: 'grid-template-areas'): CSSRules;
+  (gridedProp: GridAutoColumns, theme: ThemeInterface, cssKey: 'grid-auto-columns'): CSSRules;
+  (gridedProp: GridAutoFlow, theme: ThemeInterface, cssKey: 'grid-auto-flow'): CSSRules;
+  (gridedProp: GridAutoRows, theme: ThemeInterface, cssKey: 'grid-auto-rows'): CSSRules;
+  (gridedProp: GridColumns, theme: ThemeInterface, cssKey: 'grid-template-columns'): CSSRules;
+  (gridedPopr: GridColumnGap, theme: ThemeInterface, cssKey: 'column-gap'): CSSRules;
+  (gridedProp: GridGap, theme: ThemeInterface, cssKey: 'gap'): CSSRules;
+  (gridedProp: GridRows, theme: ThemeInterface, cssKey: 'grid-template-rows'): CSSRules;
+  (gridedProp: GridRowGap, theme: ThemeInterface, cssKey: 'row-gap'): CSSRules;
+  (gridedProp: GridTemplate, theme: ThemeInterface, cssKey: 'grid-template'): CSSRules;
+  (gridedProp: GridArea, theme: ThemeInterface, cssKey: 'grid-area'): CSSRules;
+  (gridedProp: GridColumn, theme: ThemeInterface, cssKey: 'grid-column'): CSSRules;
+  (gridedProp: GridColumnEnd, theme: ThemeInterface, cssKey: 'grid-column-end'): CSSRules;
+  (gridedProp: GridColumnStart, theme: ThemeInterface, cssKey: 'grid-column-start'): CSSRules;
+  (gridedProp: GridRow, theme: ThemeInterface, cssKey: 'grid-row'): CSSRules;
+  (gridedProp: GridRowEnd, theme: ThemeInterface, cssKey: 'grid-row-end'): CSSRules;
+  (gridedProp: GridRowStart, theme: ThemeInterface, cssKey: 'grid-row-start'): CSSRules;
 }

--- a/packages/big-design/src/components/Grid/withGrid.ts
+++ b/packages/big-design/src/components/Grid/withGrid.ts
@@ -1,5 +1,10 @@
-import { Breakpoints, breakpointsOrder, ThemeInterface } from '@bigcommerce/big-design-theme';
-import { css, FlattenSimpleInterpolation } from 'styled-components';
+import {
+  Breakpoints,
+  breakpointsOrder,
+  CSSRules,
+  ThemeInterface,
+} from '@bigcommerce/big-design-theme';
+import { css } from 'styled-components';
 
 import { GridedItemProps, GridedOverload, GridedProps } from './types';
 
@@ -40,7 +45,7 @@ const getGridedStyles: GridedOverload = (
   gridedProp: any,
   theme: ThemeInterface,
   cssKey: any,
-): FlattenSimpleInterpolation => {
+): CSSRules => {
   if (typeof gridedProp === 'object') {
     return getResponsiveGrid(gridedProp, theme, cssKey);
   }
@@ -52,18 +57,11 @@ const getGridedStyles: GridedOverload = (
   return [];
 };
 
-const getSimpleGrid = (
-  gridedProp: string | number,
-  cssKey: string,
-): FlattenSimpleInterpolation => css`
+const getSimpleGrid = (gridedProp: string | number, cssKey: string): CSSRules => css`
   ${cssKey}: ${gridedProp}
 `;
 
-const getResponsiveGrid = (
-  gridedProp: any,
-  theme: ThemeInterface,
-  cssKey: string,
-): FlattenSimpleInterpolation[] => {
+const getResponsiveGrid = (gridedProp: any, theme: ThemeInterface, cssKey: string): CSSRules[] => {
   const breakpointKeys = Object.keys(gridedProp).sort(
     (firstBreakpoint, secondBreakpoint) =>
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/big-design/src/components/InlineMessage/styled.ts
+++ b/packages/big-design/src/components/InlineMessage/styled.ts
@@ -1,5 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { getBorderStyle } from '../../utils';
 import { Flex } from '../Flex';
@@ -38,9 +38,7 @@ export const StyledHeader = styled(StyleableH4)`
   margin-bottom: ${({ theme }) => theme.spacing.none};
 `;
 
-export const StyledMessageItem = styled<StyledComponent<'span', DefaultTheme, Partial<TextProps>>>(
-  StyleableSmall,
-).attrs({ as: 'span' })`
+export const StyledMessageItem = styled(StyleableSmall).attrs({ as: 'span' })<Partial<TextProps>>`
   color: ${({ theme }) => theme.colors.secondary70};
   vertical-align: middle;
 `;

--- a/packages/big-design/src/components/Message/styled.ts
+++ b/packages/big-design/src/components/Message/styled.ts
@@ -1,5 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { getBorderStyle } from '../../utils';
 import { Flex } from '../Flex';
@@ -36,9 +36,7 @@ export const StyledHeader = styled(StyleableH4)`
   margin-bottom: ${({ theme }) => theme.spacing.none};
 `;
 
-export const StyledMessageItem = styled<StyledComponent<'span', DefaultTheme, Partial<TextProps>>>(
-  StyleableSmall,
-).attrs({ as: 'span' })`
+export const StyledMessageItem = styled(StyleableSmall).attrs({ as: 'span' })<Partial<TextProps>>`
   color: ${({ theme }) => theme.colors.secondary70};
   vertical-align: middle;
 `;

--- a/packages/big-design/src/components/Table/helpers/display/display.tsx
+++ b/packages/big-design/src/components/Table/helpers/display/display.tsx
@@ -1,5 +1,10 @@
-import { Breakpoints, breakpointsOrder, ThemeInterface } from '@bigcommerce/big-design-theme';
-import { css, FlattenSimpleInterpolation } from 'styled-components';
+import {
+  Breakpoints,
+  breakpointsOrder,
+  CSSRules,
+  ThemeInterface,
+} from '@bigcommerce/big-design-theme';
+import { css } from 'styled-components';
 
 import { TableColumnDisplayOverload, TableColumnDisplayProps } from './types';
 
@@ -11,7 +16,7 @@ const getDisplayStyles: TableColumnDisplayOverload = (
   displayProp: any,
   theme: ThemeInterface,
   cssKey: any,
-): FlattenSimpleInterpolation => {
+): CSSRules => {
   if (typeof displayProp === 'object') {
     return getResponsiveDisplay(displayProp, theme, cssKey);
   }
@@ -23,10 +28,7 @@ const getDisplayStyles: TableColumnDisplayOverload = (
   return [];
 };
 
-const getSimpleDisplay = (
-  displayProp: string | number,
-  cssKey: string,
-): FlattenSimpleInterpolation => css`
+const getSimpleDisplay = (displayProp: string | number, cssKey: string): CSSRules => css`
   ${cssKey}: ${displayProp}
 `;
 
@@ -34,7 +36,7 @@ const getResponsiveDisplay: TableColumnDisplayOverload = (
   displayProp: any,
   theme: ThemeInterface,
   cssKey: string,
-): FlattenSimpleInterpolation[] => {
+): CSSRules[] => {
   const breakpointKeys = Object.keys(displayProp).sort(
     (firstBreakpoint, secondBreakpoint) =>
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/big-design/src/components/Table/helpers/display/types.ts
+++ b/packages/big-design/src/components/Table/helpers/display/types.ts
@@ -1,5 +1,4 @@
-import { ThemeInterface } from '@bigcommerce/big-design-theme';
-import { FlattenSimpleInterpolation } from 'styled-components';
+import { CSSRules, ThemeInterface } from '@bigcommerce/big-design-theme';
 
 import { ResponsiveProp } from '../../../../types';
 
@@ -13,4 +12,4 @@ export type TableColumnDisplayOverload = (
   displayProp: TableColumnDisplayProp,
   theme: ThemeInterface,
   cssKey: 'display',
-) => FlattenSimpleInterpolation;
+) => CSSRules;

--- a/packages/big-design/src/components/TableNext/helpers/display/display.tsx
+++ b/packages/big-design/src/components/TableNext/helpers/display/display.tsx
@@ -1,5 +1,10 @@
-import { Breakpoints, breakpointsOrder, ThemeInterface } from '@bigcommerce/big-design-theme';
-import { css, FlattenSimpleInterpolation } from 'styled-components';
+import {
+  Breakpoints,
+  breakpointsOrder,
+  CSSRules,
+  ThemeInterface,
+} from '@bigcommerce/big-design-theme';
+import { css } from 'styled-components';
 
 import { TableColumnDisplayOverload, TableColumnDisplayProps } from './types';
 
@@ -11,7 +16,7 @@ const getDisplayStyles: TableColumnDisplayOverload = (
   displayProp: any,
   theme: ThemeInterface,
   cssKey: any,
-): FlattenSimpleInterpolation => {
+): CSSRules => {
   if (typeof displayProp === 'object') {
     return getResponsiveDisplay(displayProp, theme, cssKey);
   }
@@ -23,10 +28,7 @@ const getDisplayStyles: TableColumnDisplayOverload = (
   return [];
 };
 
-const getSimpleDisplay = (
-  displayProp: string | number,
-  cssKey: string,
-): FlattenSimpleInterpolation => css`
+const getSimpleDisplay = (displayProp: string | number, cssKey: string): CSSRules => css`
   ${cssKey}: ${displayProp}
 `;
 
@@ -34,7 +36,7 @@ const getResponsiveDisplay: TableColumnDisplayOverload = (
   displayProp: any,
   theme: ThemeInterface,
   cssKey: string,
-): FlattenSimpleInterpolation[] => {
+): CSSRules[] => {
   const breakpointKeys = Object.keys(displayProp).sort(
     (firstBreakpoint, secondBreakpoint) =>
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/big-design/src/components/TableNext/helpers/display/types.ts
+++ b/packages/big-design/src/components/TableNext/helpers/display/types.ts
@@ -1,5 +1,4 @@
-import { ThemeInterface } from '@bigcommerce/big-design-theme';
-import { FlattenSimpleInterpolation } from 'styled-components';
+import { CSSRules, ThemeInterface } from '@bigcommerce/big-design-theme';
 
 import { ResponsiveProp } from '../../../../types';
 
@@ -13,4 +12,4 @@ export type TableColumnDisplayOverload = (
   displayProp: TableColumnDisplayProp,
   theme: ThemeInterface,
   cssKey: 'display',
-) => FlattenSimpleInterpolation;
+) => CSSRules;

--- a/packages/big-design/src/helpers/display/display.tsx
+++ b/packages/big-design/src/helpers/display/display.tsx
@@ -1,5 +1,10 @@
-import { Breakpoints, breakpointsOrder, ThemeInterface } from '@bigcommerce/big-design-theme';
-import { css, FlattenSimpleInterpolation } from 'styled-components';
+import {
+  Breakpoints,
+  breakpointsOrder,
+  CSSRules,
+  ThemeInterface,
+} from '@bigcommerce/big-design-theme';
+import { css } from 'styled-components';
 
 import { DisplayOverload, DisplayProps } from './types';
 
@@ -11,7 +16,7 @@ const getDisplayStyles: DisplayOverload = (
   displayProp: any,
   theme: ThemeInterface,
   cssKey: any,
-): FlattenSimpleInterpolation => {
+): CSSRules => {
   if (typeof displayProp === 'object') {
     return getResponsiveDisplay(displayProp, theme, cssKey);
   }
@@ -23,10 +28,7 @@ const getDisplayStyles: DisplayOverload = (
   return [];
 };
 
-const getSimpleDisplay = (
-  displayProp: string | number,
-  cssKey: string,
-): FlattenSimpleInterpolation => css`
+const getSimpleDisplay = (displayProp: string | number, cssKey: string): CSSRules => css`
   ${cssKey}: ${displayProp}
 `;
 
@@ -34,7 +36,7 @@ const getResponsiveDisplay: DisplayOverload = (
   displayProp: any,
   theme: ThemeInterface,
   cssKey: string,
-): FlattenSimpleInterpolation[] => {
+): CSSRules[] => {
   const breakpointKeys = Object.keys(displayProp).sort(
     (firstBreakpoint, secondBreakpoint) =>
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/big-design/src/helpers/display/types.ts
+++ b/packages/big-design/src/helpers/display/types.ts
@@ -1,5 +1,4 @@
-import { ThemeInterface } from '@bigcommerce/big-design-theme';
-import { FlattenSimpleInterpolation } from 'styled-components';
+import { CSSRules, ThemeInterface } from '@bigcommerce/big-design-theme';
 
 import { ResponsiveProp } from '../../types';
 
@@ -15,4 +14,4 @@ export type DisplayOverload = (
   displayProp: DisplayProp,
   theme: ThemeInterface,
   cssKey: 'display',
-) => FlattenSimpleInterpolation;
+) => CSSRules;


### PR DESCRIPTION
Jira: [TRAC-1302](https://bigcommercecloud.atlassian.net/browse/TRAC-1302)

## What?

Removes `FlattenSimpleInterpolation` and `StyledComponent` from 4 call sites in our published `.d.ts` files. `FlattenSimpleInterpolation` (11 files) is replaced with a derived, version-agnostic alias `CSSRules = ReturnType<typeof css>`, defined in `big-design-theme`'s `helpers.ts` and consumed via `@bigcommerce/big-design-theme` everywhere else. The `styled<StyledComponent<...>>(...)` call sites in `Alert`, `Message`, `InlineMessage`, and `Fieldset/Legend` drop the explicit generic in favor of inferred typing, using the standard `.attrs()`/tagged-template generic merge instead.

`Form/Label`, `Radio/Label`, and `Checkbox/Label` still use the `StyledComponent`-based generic and are intentionally left out of this PR — see Why.

## Why?

Both type names only exist in styled-components v5's types (`@types/styled-components`) and vanish once we move to v6 (which ships its own types). Leaving them in the public type surface would break every v5 consumer's build the moment we cut over, so they need to come out now, ahead of the v6 upgrade, using aliases that resolve against either version's types.

Removing the explicit generic on the Radio/Checkbox/Form label components surfaces a latent, unsound type: their public props (`StyledLabelProps`/`FormControlLabelProps`) extend the native `label` HTML attributes, while the underlying styled component is built on `Text`/`H4` (i.e. a `p`/`h4` element), which only ever exposes `p`/`h4` attributes. The old generic cast silently hid the fact that these never actually matched once merged honestly (event handlers like `onCopy` are typed per-element and aren't interchangeable between `label` and `p`/`h4`). Fixing that properly (without narrowing the public prop shape or resorting to a cast) means rebuilding those 3 components on a native `styled.label` base rather than wrapping `Text`/`H4`, which is a real structural change beyond a type-name swap — it's being done as a separate PR (#1872) so it gets its own focused review and snapshot verification.

## Screenshots/Screen Recordings

No visual changes — type-only refactor with no rendering differences.

## Testing/Proof

`pnpm run lint`, `pnpm run typecheck`, and `pnpm run test` all pass (70 suites / 1115 tests / 182 snapshots, no snapshot updates needed). Confirmed no new type assertions or eslint-disables introduced. Added a `patch` changeset for `@bigcommerce/big-design` and `@bigcommerce/big-design-theme`.

[TRAC-1302]: https://bigcommercecloud.atlassian.net/browse/TRAC-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
