### PR TITLE
refactor: TRAC-1302 rebuild label components on native styled.label

### DIFF
--- a/.changeset/native-label-styled-components.md
+++ b/.changeset/native-label-styled-components.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Rebuild `RadioLabel`, `CheckboxLabel`, and `FormControlLabel`'s underlying styled component on a native `styled.label` base instead of wrapping the `Text`/`H4` typography primitives with an `as: 'label'` override. This removes the last `styled<StyledComponent<...>>(...)` generic from the public `.d.ts` output (a v5-only styled-components type name) without narrowing the public prop types, which still extend the full native `label` element attributes. No visible rendering change; only the internal generated class names shift.

--- a/packages/big-design/src/components/Checkbox/Label/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/Label/styled.tsx
@@ -1,21 +1,28 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { hideVisually } from 'polished';
 import { ComponentPropsWithoutRef } from 'react';
-import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import { StyleableText } from '../../Typography/private';
-import { TextProps } from '../../Typography/types';
+import { withMargins } from '../../../helpers';
 
 export interface StyledLabelProps extends ComponentPropsWithoutRef<'label'> {
   hidden?: boolean;
   disabled?: boolean;
 }
 
-export const StyledLabel = styled<
-  StyledComponent<'label' | 'p', DefaultTheme, Partial<TextProps>> & StyledLabelProps
->(StyleableText).attrs({
-  as: 'label',
-})<StyledLabelProps>`
+export const StyledLabel = styled.label<StyledLabelProps>`
+  color: ${({ theme }) => theme.colors.secondary70};
+  font-size: ${({ theme }) => theme.typography.fontSize.medium};
+  font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
+  line-height: ${({ theme }) => theme.lineHeight.medium};
+  margin: 0 0 ${({ theme }) => theme.spacing.medium};
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  ${withMargins()};
+
   cursor: pointer;
 
   ${({ disabled }) =>

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -9,18 +9,15 @@ exports[`render Checkbox checked 1`] = `
 
 .c7 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
 }
 
 .c7:last-child {
   margin-bottom: 0;
-}
-
-.c8 {
-  cursor: pointer;
 }
 
 .c6 {
@@ -136,7 +133,7 @@ exports[`render Checkbox checked 1`] = `
     class="c6"
   >
     <label
-      class="c7 c8"
+      class="c7"
       for=":r0:"
       id=":r1:"
     >
@@ -155,19 +152,16 @@ exports[`render Checkbox disabled checked 1`] = `
 
 .c7 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c7:last-child {
   margin-bottom: 0;
-}
-
-.c8 {
-  cursor: pointer;
-  cursor: not-allowed;
 }
 
 .c6 {
@@ -285,7 +279,7 @@ exports[`render Checkbox disabled checked 1`] = `
   >
     <label
       aria-hidden="true"
-      class="c7 c8"
+      class="c7"
       disabled=""
       for=":rl:"
       id=":rm:"
@@ -305,19 +299,16 @@ exports[`render Checkbox disabled indeterminate 1`] = `
 
 .c7 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c7:last-child {
   margin-bottom: 0;
-}
-
-.c8 {
-  cursor: pointer;
-  cursor: not-allowed;
 }
 
 .c6 {
@@ -433,7 +424,7 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   >
     <label
       aria-hidden="true"
-      class="c7 c8"
+      class="c7"
       disabled=""
       for=":rr:"
       id=":rs:"
@@ -453,19 +444,16 @@ exports[`render Checkbox disabled unchecked 1`] = `
 
 .c7 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c7:last-child {
   margin-bottom: 0;
-}
-
-.c8 {
-  cursor: pointer;
-  cursor: not-allowed;
 }
 
 .c6 {
@@ -582,7 +570,7 @@ exports[`render Checkbox disabled unchecked 1`] = `
   >
     <label
       aria-hidden="true"
-      class="c7 c8"
+      class="c7"
       disabled=""
       for=":ro:"
       id=":rp:"
@@ -602,18 +590,15 @@ exports[`render Checkbox indeterminate 1`] = `
 
 .c7 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
 }
 
 .c7:last-child {
   margin-bottom: 0;
-}
-
-.c8 {
-  cursor: pointer;
 }
 
 .c6 {
@@ -727,7 +712,7 @@ exports[`render Checkbox indeterminate 1`] = `
     class="c6"
   >
     <label
-      class="c7 c8"
+      class="c7"
       for=":ri:"
       id=":rj:"
     >
@@ -746,18 +731,15 @@ exports[`render Checkbox unchecked 1`] = `
 
 .c7 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
 }
 
 .c7:last-child {
   margin-bottom: 0;
-}
-
-.c8 {
-  cursor: pointer;
 }
 
 .c6 {
@@ -872,7 +854,7 @@ exports[`render Checkbox unchecked 1`] = `
     class="c6"
   >
     <label
-      class="c7 c8"
+      class="c7"
       for=":r3:"
       id=":r4:"
     >
@@ -891,17 +873,18 @@ exports[`render Checkbox with description object 1`] = `
 
 .c7 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
 }
 
 .c7:last-child {
   margin-bottom: 0;
 }
 
-.c9 {
+.c8 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -911,15 +894,11 @@ exports[`render Checkbox with description object 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c9:last-child {
+.c8:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
-  cursor: pointer;
-}
-
-.c10 {
+.c9 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -932,15 +911,15 @@ exports[`render Checkbox with description object 1`] = `
   text-decoration: none;
 }
 
-.c10:active {
+.c9:active {
   color: #0024A6;
 }
 
-.c10:hover:not(:active) {
+.c9:hover:not(:active) {
   color: #0024A6;
 }
 
-.c11 {
+.c10 {
   font-size: 0.875rem;
 }
 
@@ -1057,19 +1036,19 @@ exports[`render Checkbox with description object 1`] = `
     class="c6"
   >
     <label
-      class="c7 c8"
+      class="c7"
       for=":r6:"
       id=":r7:"
     >
       Unchecked
     </label>
     <p
-      class="c9"
+      class="c8"
     >
       description
        
       <a
-        class="c10 c11"
+        class="c9 c10"
         href="bar"
         target="foo"
       >
@@ -1089,17 +1068,18 @@ exports[`render Checkbox with description string 1`] = `
 
 .c7 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
 }
 
 .c7:last-child {
   margin-bottom: 0;
 }
 
-.c9 {
+.c8 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -1109,12 +1089,8 @@ exports[`render Checkbox with description string 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c9:last-child {
+.c8:last-child {
   margin-bottom: 0;
-}
-
-.c8 {
-  cursor: pointer;
 }
 
 .c6 {
@@ -1230,14 +1206,14 @@ exports[`render Checkbox with description string 1`] = `
     class="c6"
   >
     <label
-      class="c7 c8"
+      class="c7"
       for=":rf:"
       id=":rg:"
     >
       Unchecked
     </label>
     <p
-      class="c9"
+      class="c8"
     >
       description text
     </p>
@@ -1254,18 +1230,15 @@ exports[`render Checkbox with img props 1`] = `
 
 .c8 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
 }
 
 .c8:last-child {
   margin-bottom: 0;
-}
-
-.c9 {
-  cursor: pointer;
 }
 
 .c7 {
@@ -1396,7 +1369,7 @@ exports[`render Checkbox with img props 1`] = `
     class="c7"
   >
     <label
-      class="c8 c9"
+      class="c8"
       for=":rc:"
       id=":rd:"
     >

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -1,23 +1,22 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import styled, { DefaultTheme, StyledComponent } from 'styled-components';
+import styled from 'styled-components';
 
-import { StyleableH4 } from '../../Typography/private';
-import { HeadingProps } from '../../Typography/types';
+import { withMargins } from '../../../helpers';
 
 import { type FormControlLabelProps } from './Label';
 
-interface StyledLabelArgument extends Omit<FormControlLabelProps, 'localization'> {
-  theme: DefaultTheme;
-}
+export const StyledLabel = styled.label<FormControlLabelProps>`
+  color: ${({ theme }) => theme.colors.secondary70};
+  font-size: ${({ theme }) => theme.typography.fontSize.medium};
+  font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
+  line-height: ${({ theme }) => theme.lineHeight.medium};
+  margin: 0 0 ${({ theme }) => theme.spacing.xSmall};
 
-export const StyledLabel = styled<
-  StyledComponent<'label' | 'h4', DefaultTheme, Partial<HeadingProps>> & FormControlLabelProps
->(StyleableH4).attrs({
-  as: 'label',
-})<FormControlLabelProps>`
+  ${withMargins()};
+
   cursor: pointer;
   display: inline-block;
-  margin-bottom: ${({ theme }: StyledLabelArgument) => theme.spacing.xxSmall};
+  margin-bottom: ${({ theme }) => theme.spacing.xxSmall};
 `;
 
 StyledLabel.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -148,6 +148,11 @@ exports[`simple form render 1`] = `
 }
 
 .c5 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0 0 0.5rem;
   cursor: pointer;
   display: inline-block;
   margin-bottom: 0.25rem;
@@ -182,7 +187,7 @@ exports[`simple form render 1`] = `
     >
       <div>
         <label
-          class="c1 c5"
+          class="c5"
           for=":r0:"
         >
           First Name
@@ -212,7 +217,7 @@ exports[`simple form render 1`] = `
     >
       <div>
         <label
-          class="c1 c5"
+          class="c5"
           for=":r1:"
         >
           Middle Name

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -1,22 +1,13 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders all together 1`] = `
-.c5 {
+.c4 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c0 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.5rem;
-  margin: 0 0 0.5rem;
-}
-
-.c2 {
+.c1 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -26,11 +17,11 @@ exports[`renders all together 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c2:last-child {
+.c1:last-child {
   margin-bottom: 0;
 }
 
-.c3 {
+.c2 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border,box-shadow;
@@ -53,15 +44,15 @@ exports[`renders all together 1`] = `
   border: 1px solid #D9DCE9;
 }
 
-.c3:hover:not([disabled]) {
+.c2:hover:not([disabled]) {
   border: 1px solid #B4BAD1;
 }
 
-.c3[disabled] {
+.c2[disabled] {
   background-color: #ECEEF5;
 }
 
-.c7 {
+.c6 {
   background-color: inherit;
   border: 0;
   box-sizing: border-box;
@@ -78,41 +69,41 @@ exports[`renders all together 1`] = `
   min-height: 2.125rem;
 }
 
-.c7:focus {
+.c6:focus {
   outline: none;
 }
 
-.c7::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #B4BAD1;
   font-size: 1rem;
 }
 
-.c7::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #B4BAD1;
   font-size: 1rem;
 }
 
-.c7:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #B4BAD1;
   font-size: 1rem;
 }
 
-.c7::placeholder {
+.c6::placeholder {
   color: #B4BAD1;
   font-size: 1rem;
 }
 
-.c7:-webkit-autofill {
+.c6:-webkit-autofill {
   background-color: #F0F3FF !important;
   -webkit-box-shadow: 0 0 0px 1000px #F0F3FF inset;
 }
 
-.c7[disabled] {
+.c6[disabled] {
   background-color: #ECEEF5;
   color: #5E637A;
 }
 
-.c4 {
+.c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -130,7 +121,7 @@ exports[`renders all together 1`] = `
   left: 0;
 }
 
-.c8 {
+.c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -148,7 +139,7 @@ exports[`renders all together 1`] = `
   right: 0;
 }
 
-.c6 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -167,7 +158,12 @@ exports[`renders all together 1`] = `
   height: 100%;
 }
 
-.c1 {
+.c0 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0 0 0.5rem;
   cursor: pointer;
   display: inline-block;
   margin-bottom: 0.25rem;
@@ -175,25 +171,25 @@ exports[`renders all together 1`] = `
 
 <div>
   <label
-    class="c0 c1"
+    class="c0"
     for=":rp:"
   >
     This is a label
   </label>
   <p
-    class="c2"
+    class="c1"
   >
     This is a description
   </p>
   <span
-    class="c3"
+    class="c2"
   >
     <div
-      class="c4"
+      class="c3"
     >
       <svg
         aria-hidden="true"
-        class="c5"
+        class="c4"
         data-testid="icon-left"
         fill="currentColor"
         height="24"
@@ -212,19 +208,19 @@ exports[`renders all together 1`] = `
       </svg>
     </div>
     <div
-      class="c6"
+      class="c5"
     >
       <input
-        class="c7"
+        class="c6"
         id=":rp:"
       />
     </div>
     <div
-      class="c8"
+      class="c7"
     >
       <svg
         aria-hidden="true"
-        class="c5"
+        class="c4"
         data-testid="icon-right"
         fill="currentColor"
         height="24"

--- a/packages/big-design/src/components/Radio/Label/styled.tsx
+++ b/packages/big-design/src/components/Radio/Label/styled.tsx
@@ -1,18 +1,26 @@
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { ComponentPropsWithoutRef } from 'react';
-import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import { TextProps } from '../../Typography';
-import { StyleableText } from '../../Typography/private';
+import { withMargins } from '../../../helpers';
 
 export interface StyledLabelProps extends ComponentPropsWithoutRef<'label'> {
   disabled?: boolean;
 }
 
-export const StyledLabel = styled<
-  StyledComponent<'label' | 'p', DefaultTheme, Partial<TextProps>> & StyledLabelProps
->(StyleableText).attrs({
-  as: 'label',
-})<StyledLabelProps>`
+export const StyledLabel = styled.label<StyledLabelProps>`
+  color: ${({ theme }) => theme.colors.secondary70};
+  font-size: ${({ theme }) => theme.typography.fontSize.medium};
+  font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
+  line-height: ${({ theme }) => theme.lineHeight.medium};
+  margin: 0 0 ${({ theme }) => theme.spacing.medium};
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  ${withMargins()};
+
   cursor: pointer;
 
   ${({ disabled }) =>
@@ -21,3 +29,5 @@ export const StyledLabel = styled<
       cursor: not-allowed;
     `}
 `;
+
+StyledLabel.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
@@ -3,19 +3,16 @@
 exports[`render Radio (checked + disabled) 1`] = `
 .c6 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6:last-child {
   margin-bottom: 0;
-}
-
-.c7 {
-  cursor: pointer;
-  cursor: not-allowed;
 }
 
 .c5 {
@@ -122,7 +119,7 @@ exports[`render Radio (checked + disabled) 1`] = `
   >
     <label
       aria-hidden="true"
-      class="c6 c7"
+      class="c6"
       disabled=""
       for=":r8:"
       id=":r9:"
@@ -136,18 +133,15 @@ exports[`render Radio (checked + disabled) 1`] = `
 exports[`render Radio (checked) 1`] = `
 .c6 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
 }
 
 .c6:last-child {
   margin-bottom: 0;
-}
-
-.c7 {
-  cursor: pointer;
 }
 
 .c5 {
@@ -253,7 +247,7 @@ exports[`render Radio (checked) 1`] = `
     class="c5"
   >
     <label
-      class="c6 c7"
+      class="c6"
       for=":r0:"
       id=":r1:"
     >
@@ -264,19 +258,7 @@ exports[`render Radio (checked) 1`] = `
 `;
 
 exports[`render Radio (unchecked + description object) 1`] = `
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-}
-
-.c6:last-child {
-  margin-bottom: 0;
-}
-
-.c8 {
+.c7 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -286,11 +268,11 @@ exports[`render Radio (unchecked + description object) 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c8:last-child {
+.c7:last-child {
   margin-bottom: 0;
 }
 
-.c9 {
+.c8 {
   -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
   -webkit-transition-property: color;
@@ -303,20 +285,29 @@ exports[`render Radio (unchecked + description object) 1`] = `
   text-decoration: none;
 }
 
-.c9:active {
+.c8:active {
   color: #0024A6;
 }
 
-.c9:hover:not(:active) {
+.c8:hover:not(:active) {
   color: #0024A6;
 }
 
-.c10 {
+.c9 {
   font-size: 0.875rem;
 }
 
-.c7 {
+.c6 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0 0 1rem;
   cursor: pointer;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
 }
 
 .c5 {
@@ -417,19 +408,19 @@ exports[`render Radio (unchecked + description object) 1`] = `
     class="c5"
   >
     <label
-      class="c6 c7"
+      class="c6"
       for=":r4:"
       id=":r5:"
     >
       Unchecked
     </label>
     <p
-      class="c8"
+      class="c7"
     >
       description
        
       <a
-        class="c9 c10"
+        class="c8 c9"
         href="bar"
         target="foo"
       >
@@ -441,19 +432,7 @@ exports[`render Radio (unchecked + description object) 1`] = `
 `;
 
 exports[`render Radio (unchecked + description text) 1`] = `
-.c6 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-}
-
-.c6:last-child {
-  margin-bottom: 0;
-}
-
-.c8 {
+.c7 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -463,12 +442,21 @@ exports[`render Radio (unchecked + description text) 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c8:last-child {
+.c7:last-child {
   margin-bottom: 0;
 }
 
-.c7 {
+.c6 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0 0 1rem;
   cursor: pointer;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
 }
 
 .c5 {
@@ -569,14 +557,14 @@ exports[`render Radio (unchecked + description text) 1`] = `
     class="c5"
   >
     <label
-      class="c6 c7"
+      class="c6"
       for=":r6:"
       id=":r7:"
     >
       Unchecked
     </label>
     <p
-      class="c8"
+      class="c7"
     >
       description
     </p>
@@ -587,19 +575,16 @@ exports[`render Radio (unchecked + description text) 1`] = `
 exports[`render Radio (unchecked + disabled) 1`] = `
 .c6 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6:last-child {
   margin-bottom: 0;
-}
-
-.c7 {
-  cursor: pointer;
-  cursor: not-allowed;
 }
 
 .c5 {
@@ -701,7 +686,7 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   >
     <label
       aria-hidden="true"
-      class="c6 c7"
+      class="c6"
       disabled=""
       for=":ra:"
       id=":rb:"
@@ -715,18 +700,15 @@ exports[`render Radio (unchecked + disabled) 1`] = `
 exports[`render Radio (unchecked) 1`] = `
 .c6 {
   color: #313440;
-  margin: 0 0 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
 }
 
 .c6:last-child {
   margin-bottom: 0;
-}
-
-.c7 {
-  cursor: pointer;
 }
 
 .c5 {
@@ -827,7 +809,7 @@ exports[`render Radio (unchecked) 1`] = `
     class="c5"
   >
     <label
-      class="c6 c7"
+      class="c6"
       for=":r2:"
       id=":r3:"
     >

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -759,7 +759,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   box-sizing: border-box;
 }
 
-.c15 {
+.c14 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
@@ -807,19 +807,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   flex-shrink: 0;
 }
 
-.c12 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-}
-
-.c12:last-child {
-  margin-bottom: 0;
-}
-
-.c14 {
+.c13 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -828,11 +816,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin-left: 0.75rem;
 }
 
-.c14:last-child {
+.c13:last-child {
   margin-bottom: 0;
 }
 
-.c16 {
+.c15 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -841,11 +829,16 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0;
 }
 
-.c16:last-child {
+.c15:last-child {
   margin-bottom: 0;
 }
 
-.c13 {
+.c12 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0 0 1rem;
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -857,6 +850,10 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+.c12:last-child {
+  margin-bottom: 0;
 }
 
 .c11 {
@@ -1003,7 +1000,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
           class="c11"
         >
           <label
-            class="c12 c13"
+            class="c12"
             for=":r36:"
             hidden=""
             id=":r37:"
@@ -1013,17 +1010,17 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         </div>
       </div>
       <p
-        class="c14"
+        class="c13"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c15 c2"
+    class="c14 c2"
   >
     <p
-      class="c16"
+      class="c15"
     >
       Product
     </p>

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -819,7 +819,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   box-sizing: border-box;
 }
 
-.c15 {
+.c14 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
@@ -867,19 +867,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   flex-shrink: 0;
 }
 
-.c12 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-}
-
-.c12:last-child {
-  margin-bottom: 0;
-}
-
-.c14 {
+.c13 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -888,11 +876,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin-left: 0.75rem;
 }
 
-.c14:last-child {
+.c13:last-child {
   margin-bottom: 0;
 }
 
-.c16 {
+.c15 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -901,11 +889,16 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0;
 }
 
-.c16:last-child {
+.c15:last-child {
   margin-bottom: 0;
 }
 
-.c13 {
+.c12 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0 0 1rem;
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -917,6 +910,10 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+.c12:last-child {
+  margin-bottom: 0;
 }
 
 .c11 {
@@ -1063,7 +1060,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
           class="c11"
         >
           <label
-            class="c12 c13"
+            class="c12"
             for=":r8k:"
             hidden=""
             id=":r8l:"
@@ -1073,17 +1070,17 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         </div>
       </div>
       <p
-        class="c14"
+        class="c13"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c15 c2"
+    class="c14 c2"
   >
     <p
-      class="c16"
+      class="c15"
     >
       Product
     </p>
@@ -1107,7 +1104,7 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   box-sizing: border-box;
 }
 
-.c15 {
+.c14 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
@@ -1155,19 +1152,7 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   flex-shrink: 0;
 }
 
-.c12 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-}
-
-.c12:last-child {
-  margin-bottom: 0;
-}
-
-.c14 {
+.c13 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1176,11 +1161,11 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   margin-left: 0.75rem;
 }
 
-.c14:last-child {
+.c13:last-child {
   margin-bottom: 0;
 }
 
-.c16 {
+.c15 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1189,11 +1174,16 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   margin: 0;
 }
 
-.c16:last-child {
+.c15:last-child {
   margin-bottom: 0;
 }
 
-.c13 {
+.c12 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0 0 1rem;
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -1205,6 +1195,10 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+.c12:last-child {
+  margin-bottom: 0;
 }
 
 .c11 {
@@ -1359,7 +1353,7 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
           class="c11"
         >
           <label
-            class="c12 c13"
+            class="c12"
             for=":r9a:"
             hidden=""
             id=":r9b:"
@@ -1369,17 +1363,17 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
         </div>
       </div>
       <p
-        class="c14"
+        class="c13"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c15 c2"
+    class="c14 c2"
   >
     <p
-      class="c16"
+      class="c15"
     >
       Product
     </p>
@@ -1403,7 +1397,7 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   box-sizing: border-box;
 }
 
-.c15 {
+.c14 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
@@ -1451,19 +1445,7 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   flex-shrink: 0;
 }
 
-.c12 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-}
-
-.c12:last-child {
-  margin-bottom: 0;
-}
-
-.c14 {
+.c13 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1472,11 +1454,11 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   margin-left: 0.75rem;
 }
 
-.c14:last-child {
+.c13:last-child {
   margin-bottom: 0;
 }
 
-.c16 {
+.c15 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1485,11 +1467,16 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   margin: 0;
 }
 
-.c16:last-child {
+.c15:last-child {
   margin-bottom: 0;
 }
 
-.c13 {
+.c12 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0 0 1rem;
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -1501,6 +1488,10 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+.c12:last-child {
+  margin-bottom: 0;
 }
 
 .c11 {
@@ -1655,7 +1646,7 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
           class="c11"
         >
           <label
-            class="c12 c13"
+            class="c12"
             for=":rd1:"
             hidden=""
             id=":rd2:"
@@ -1665,17 +1656,17 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
         </div>
       </div>
       <p
-        class="c14"
+        class="c13"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c15 c2"
+    class="c14 c2"
   >
     <p
-      class="c16"
+      class="c15"
     >
       Product
     </p>

--- a/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
@@ -1,16 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders all together 1`] = `
-.c0 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.5rem;
-  margin: 0 0 0.5rem;
-}
-
-.c2 {
+.c1 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -20,11 +11,11 @@ exports[`renders all together 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c2:last-child {
+.c1:last-child {
   margin-bottom: 0;
 }
 
-.c3 {
+.c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -36,7 +27,7 @@ exports[`renders all together 1`] = `
   position: relative;
 }
 
-.c4 {
+.c3 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border,box-shadow;
@@ -53,44 +44,49 @@ exports[`renders all together 1`] = `
   border: 1px solid #D9DCE9;
 }
 
-.c4:hover:not([disabled]) {
+.c3:hover:not([disabled]) {
   border: 1px solid #B4BAD1;
 }
 
-.c4:focus {
+.c3:focus {
   outline: none;
   box-shadow: 0 0 0 4px #DBE3FE;
 }
 
-.c4[disabled] {
+.c3[disabled] {
   background-color: #ECEEF5;
 }
 
-.c4::-webkit-input-placeholder {
+.c3::-webkit-input-placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
 }
 
-.c4::-moz-placeholder {
+.c3::-moz-placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
 }
 
-.c4:-ms-input-placeholder {
+.c3:-ms-input-placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
 }
 
-.c4::placeholder {
+.c3::placeholder {
   color: #B4BAD1;
   line-height: 1.5rem;
   font-size: 1rem;
 }
 
-.c1 {
+.c0 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5rem;
+  margin: 0 0 0.5rem;
   cursor: pointer;
   display: inline-block;
   margin-bottom: 0.25rem;
@@ -98,21 +94,21 @@ exports[`renders all together 1`] = `
 
 <div>
   <label
-    class="c0 c1"
+    class="c0"
     for=":rp:"
   >
     This is a label
   </label>
   <p
-    class="c2"
+    class="c1"
   >
     This is a description
   </p>
   <span
-    class="c3"
+    class="c2"
   >
     <textarea
-      class="c4"
+      class="c3"
       id=":rp:"
       rows="3"
     />

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -87,7 +87,7 @@ exports[`renders worksheet 1`] = `
   opacity: 1;
 }
 
-.c31 {
+.c30 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: border-color,background,box-shadow,color,opacity;
@@ -121,7 +121,7 @@ exports[`renders worksheet 1`] = `
   width: 1.25rem;
 }
 
-.c31:hover {
+.c30:hover {
   border-color: #B4BAD1;
 }
 
@@ -129,7 +129,7 @@ exports[`renders worksheet 1`] = `
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c31 svg {
+.c30 svg {
   opacity: 0;
 }
 
@@ -138,16 +138,16 @@ exports[`renders worksheet 1`] = `
   box-sizing: border-box;
 }
 
-.c22 {
-  box-sizing: border-box;
-}
-
-.c24 {
-  padding-right: 0.75rem;
+.c21 {
   box-sizing: border-box;
 }
 
 .c23 {
+  padding-right: 0.75rem;
+  box-sizing: border-box;
+}
+
+.c22 {
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
@@ -168,7 +168,7 @@ exports[`renders worksheet 1`] = `
   display: flex;
 }
 
-.c25 {
+.c24 {
   -webkit-align-self: auto;
   -ms-flex-item-align: auto;
   align-self: auto;
@@ -185,18 +185,6 @@ exports[`renders worksheet 1`] = `
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
-}
-
-.c20 {
-  color: #313440;
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-}
-
-.c20:last-child {
-  margin-bottom: 0;
 }
 
 .c9 {
@@ -219,7 +207,7 @@ exports[`renders worksheet 1`] = `
   margin-bottom: 0;
 }
 
-.c27 {
+.c26 {
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
   -webkit-transition-property: background-color,border-color,box-shadow,color;
@@ -268,37 +256,37 @@ exports[`renders worksheet 1`] = `
   color: #3C64F4;
 }
 
-.c27:focus {
+.c26:focus {
   outline: none;
 }
 
-.c27[disabled] {
+.c26[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c27 + .bd-button {
+.c26 + .bd-button {
   margin-top: 0.5rem;
 }
 
-.c27:active {
+.c26:active {
   background-color: #DBE3FE;
 }
 
-.c27:focus {
+.c26:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c27:hover:not(:active) {
+.c26:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c27[disabled] {
+.c26[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
 
-.c29 {
+.c28 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -311,7 +299,12 @@ exports[`renders worksheet 1`] = `
   grid-gap: 0.5rem;
 }
 
-.c21 {
+.c20 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0 0 1rem;
   cursor: pointer;
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -325,6 +318,10 @@ exports[`renders worksheet 1`] = `
   width: 1px;
 }
 
+.c20:last-child {
+  margin-bottom: 0;
+}
+
 .c12 > div {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -332,23 +329,23 @@ exports[`renders worksheet 1`] = `
   justify-content: center;
 }
 
-.c28 {
+.c27 {
   font-size: 0.875rem;
   height: auto;
   line-height: 1.25rem;
   padding: 0;
 }
 
-.c28:hover:not(:active) {
+.c27:hover:not(:active) {
   background-color: inherit;
   color: #0024A6;
 }
 
-.c28:active {
+.c27:active {
   background-color: inherit;
 }
 
-.c26 {
+.c25 {
   overflow: hidden;
 }
 
@@ -392,7 +389,7 @@ exports[`renders worksheet 1`] = `
   margin: 0;
 }
 
-.c30 {
+.c29 {
   position: relative;
   background-color: inherit;
   border: 0.03125rem solid #D9DCE9;
@@ -405,14 +402,14 @@ exports[`renders worksheet 1`] = `
   user-select: none;
 }
 
-.c30 p {
+.c29 p {
   display: block;
   white-space: inherit;
   word-break: break-word;
   margin: 0;
 }
 
-.c33 {
+.c32 {
   position: relative;
   background-color: inherit;
   border: 0.03125rem solid #D9DCE9;
@@ -426,14 +423,14 @@ exports[`renders worksheet 1`] = `
   border: 0.03125rem double #DB3643;
 }
 
-.c33 p {
+.c32 p {
   display: block;
   white-space: inherit;
   word-break: break-word;
   margin: 0;
 }
 
-.c34 {
+.c33 {
   position: relative;
   background-color: inherit;
   border: 0.03125rem solid #D9DCE9;
@@ -447,7 +444,7 @@ exports[`renders worksheet 1`] = `
   border: 0.03125rem double #DB3643;
 }
 
-.c34 p {
+.c33 p {
   display: block;
   white-space: inherit;
   word-break: break-word;
@@ -476,7 +473,7 @@ exports[`renders worksheet 1`] = `
   width: 0.25rem;
 }
 
-.c32 {
+.c31 {
   background-color: #D9DCE9;
   border-top: 0.03125rem solid #D9DCE9;
   box-sizing: border-box;
@@ -552,7 +549,7 @@ exports[`renders worksheet 1`] = `
 }
 
 @media (min-width:0px) {
-  .c23 {
+  .c22 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -560,7 +557,7 @@ exports[`renders worksheet 1`] = `
 }
 
 @media (min-width:720px) {
-  .c23 {
+  .c22 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -568,14 +565,14 @@ exports[`renders worksheet 1`] = `
 }
 
 @media (min-width:720px) {
-  .c27 + .bd-button {
+  .c26 + .bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:720px) {
-  .c27 {
+  .c26 {
     width: auto;
   }
 }
@@ -720,7 +717,7 @@ exports[`renders worksheet 1`] = `
               >
                 <label
                   aria-hidden="false"
-                  class="c20 c21"
+                  class="c20"
                   for=":r4:"
                   hidden=""
                   id=":r5:"
@@ -756,10 +753,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c21 c22"
           >
             <div
-              class="c24 c25 c26"
+              class="c23 c24 c25"
             >
               <p
                 class="c9"
@@ -770,10 +767,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c26 c27"
             >
               <span
-                class="c29"
+                class="c28"
               >
                 Edit
               </span>
@@ -785,7 +782,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c29"
           type="number"
         >
           <p
@@ -868,7 +865,7 @@ exports[`renders worksheet 1`] = `
               >
                 <label
                   aria-hidden="false"
-                  class="c20 c21"
+                  class="c20"
                   for=":rc:"
                   hidden=""
                   id=":rd:"
@@ -904,10 +901,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c21 c22"
           >
             <div
-              class="c24 c25 c26"
+              class="c23 c24 c25"
             >
               <p
                 class="c9"
@@ -918,10 +915,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c26 c27"
             >
               <span
-                class="c29"
+                class="c28"
               >
                 Edit
               </span>
@@ -933,7 +930,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c29"
           type="number"
         >
           <p
@@ -988,7 +985,7 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c31"
+                class="c16 c30"
                 for=":rk:"
               >
                 <svg
@@ -1015,7 +1012,7 @@ exports[`renders worksheet 1`] = `
               >
                 <label
                   aria-hidden="false"
-                  class="c20 c21"
+                  class="c20"
                   for=":rk:"
                   hidden=""
                   id=":rl:"
@@ -1049,10 +1046,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c21 c22"
           >
             <div
-              class="c24 c25 c26"
+              class="c23 c24 c25"
             >
               <p
                 class="c9"
@@ -1063,10 +1060,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c26 c27"
             >
               <span
-                class="c29"
+                class="c28"
               >
                 Edit
               </span>
@@ -1078,7 +1075,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c29"
           type="number"
         >
           <p
@@ -1161,7 +1158,7 @@ exports[`renders worksheet 1`] = `
               >
                 <label
                   aria-hidden="false"
-                  class="c20 c21"
+                  class="c20"
                   for=":rs:"
                   hidden=""
                   id=":rt:"
@@ -1197,10 +1194,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c21 c22"
           >
             <div
-              class="c24 c25 c26"
+              class="c23 c24 c25"
             >
               <p
                 class="c9"
@@ -1211,10 +1208,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c26 c27"
             >
               <span
-                class="c29"
+                class="c28"
               >
                 Edit
               </span>
@@ -1226,7 +1223,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c29"
           type="number"
         >
           <p
@@ -1244,10 +1241,10 @@ exports[`renders worksheet 1`] = `
       </tr>
       <tr>
         <td
-          class="c32"
+          class="c31"
         />
         <td
-          class="c33"
+          class="c32"
           type="text"
         >
           <p
@@ -1278,7 +1275,7 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c31"
+                class="c16 c30"
                 for=":r14:"
               >
                 <svg
@@ -1305,7 +1302,7 @@ exports[`renders worksheet 1`] = `
               >
                 <label
                   aria-hidden="false"
-                  class="c20 c21"
+                  class="c20"
                   for=":r14:"
                   hidden=""
                   id=":r15:"
@@ -1339,10 +1336,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c21 c22"
           >
             <div
-              class="c24 c25 c26"
+              class="c23 c24 c25"
             >
               <p
                 class="c9"
@@ -1351,10 +1348,10 @@ exports[`renders worksheet 1`] = `
               />
             </div>
             <button
-              class="c27 c28"
+              class="c26 c27"
             >
               <span
-                class="c29"
+                class="c28"
               >
                 Edit
               </span>
@@ -1366,7 +1363,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c34"
+          class="c33"
           type="number"
         >
           <p
@@ -1447,7 +1444,7 @@ exports[`renders worksheet 1`] = `
               >
                 <label
                   aria-hidden="false"
-                  class="c20 c21"
+                  class="c20"
                   for=":r1c:"
                   hidden=""
                   id=":r1d:"
@@ -1483,10 +1480,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c21 c22"
           >
             <div
-              class="c24 c25 c26"
+              class="c23 c24 c25"
             >
               <p
                 class="c9"
@@ -1497,10 +1494,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c26 c27"
             >
               <span
-                class="c29"
+                class="c28"
               >
                 Edit
               </span>
@@ -1512,7 +1509,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c29"
           type="number"
         >
           <p
@@ -1530,7 +1527,7 @@ exports[`renders worksheet 1`] = `
       </tr>
       <tr>
         <td
-          class="c32"
+          class="c31"
         />
         <td
           class="c8"
@@ -1567,7 +1564,7 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c31"
+                class="c16 c30"
                 for=":r1k:"
               >
                 <svg
@@ -1594,7 +1591,7 @@ exports[`renders worksheet 1`] = `
               >
                 <label
                   aria-hidden="false"
-                  class="c20 c21"
+                  class="c20"
                   for=":r1k:"
                   hidden=""
                   id=":r1l:"
@@ -1630,10 +1627,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c21 c22"
           >
             <div
-              class="c24 c25 c26"
+              class="c23 c24 c25"
             >
               <p
                 class="c9"
@@ -1644,10 +1641,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c26 c27"
             >
               <span
-                class="c29"
+                class="c28"
               >
                 Edit
               </span>
@@ -1659,7 +1656,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c34"
+          class="c33"
           type="number"
         >
           <p
@@ -1742,7 +1739,7 @@ exports[`renders worksheet 1`] = `
               >
                 <label
                   aria-hidden="false"
-                  class="c20 c21"
+                  class="c20"
                   for=":r1s:"
                   hidden=""
                   id=":r1t:"
@@ -1778,10 +1775,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c21 c22"
           >
             <div
-              class="c24 c25 c26"
+              class="c23 c24 c25"
             >
               <p
                 class="c9"
@@ -1792,10 +1789,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c26 c27"
             >
               <span
-                class="c29"
+                class="c28"
               >
                 Edit
               </span>
@@ -1807,7 +1804,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c29"
           type="number"
         >
           <p
@@ -1890,7 +1887,7 @@ exports[`renders worksheet 1`] = `
               >
                 <label
                   aria-hidden="false"
-                  class="c20 c21"
+                  class="c20"
                   for=":r24:"
                   hidden=""
                   id=":r25:"
@@ -1926,10 +1923,10 @@ exports[`renders worksheet 1`] = `
           type="modal"
         >
           <div
-            class="c22 c23"
+            class="c21 c22"
           >
             <div
-              class="c24 c25 c26"
+              class="c23 c24 c25"
             >
               <p
                 class="c9"
@@ -1940,10 +1937,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c27 c28"
+              class="c26 c27"
             >
               <span
-                class="c29"
+                class="c28"
               >
                 Edit
               </span>
@@ -1955,7 +1952,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c30"
+          class="c29"
           type="number"
         >
           <p


### PR DESCRIPTION
Jira: [TRAC-1302](https://bigcommercecloud.atlassian.net/browse/TRAC-1302)

## What?

Follow-up to #1870. Rebuilds `RadioLabel`, `CheckboxLabel`, and `FormControlLabel`'s underlying styled component on a native `styled.label` base, instead of wrapping the `Text`/`H4` typography primitives (`styled.p`/`styled.h4`) with an `as: 'label'` attrs override. This removes the last `styled<StyledComponent<...>>(...)` generic (a v5-only styled-components type name) from our published `.d.ts` files, without narrowing the public prop types — `StyledLabelProps`/`FormControlLabelProps` still extend the full native `label` element attributes, unchanged.

## Why?

#1870 covered the straightforward call sites, but Radio/Checkbox/Form Label needed more thought: their public props extend the native `label` HTML attributes, while the underlying styled component was built on `Text`/`H4` (i.e. a `p`/`h4` element). `.attrs({ as: 'label' })` only ever changes the *runtime* tag — styled-components never changes the *static* element type from it — so the old `styled<StyledComponent<...>>(...)` generic was the only thing making TypeScript believe otherwise (it faked the static element as `'label'`). Removing it surfaces a real type conflict: DOM event handlers generically parameterized by `HTMLLabelElement` aren't assignable where `HTMLParagraphElement`/`HTMLHeadingElement` is expected, since those have a deprecated `align` attribute `label` lacks.

Rather than narrow the public prop type to work around that (a real, if minor, API shape change), this rebuilds all three on a native `styled.label`, reproducing the exact CSS the wrapped `Text`/`H4` component provided (color/font-size/font-weight/line-height/margin) plus each component's own rules (cursor, hidden, margin overrides) directly. The static element is now genuinely `'label'`, so the full `ComponentPropsWithoutRef<'label'>` type-checks honestly with no narrowing, no assertions, and no `eslint-disable`s.

## Screenshots/Screen Recordings

No visual changes. Verified in the docs site that Radio, Checkbox, and Form labels render identically (same computed styles, confirmed via snapshot diffs below).

<img width="1026" height="609" alt="Screenshot 2026-07-28 at 09 34 56" src="https://github.com/user-attachments/assets/04161253-1a25-4d1f-bf88-955b97326037" />

## Testing/Proof

`pnpm run lint` and `pnpm run typecheck` pass clean. `pnpm run test` passes (1115 tests); 23 snapshots needed updating (`Checkbox`, `Form`, `Input`, `Radio`, `Table`, `TableNext`, `Textarea`, `Worksheet`) — reviewed every diff and confirmed the only change is generated class-name numbering/merging (styled-components previously emitted a separate class for the extended definition; the native base now emits one), with every actual CSS declaration (color, font-size, font-weight, line-height, margin, cursor) byte-identical to before. Confirmed no remaining `StyledComponent`/`FlattenSimpleInterpolation` references in `Radio/Label`, `Checkbox/Label`, or `Form/Label`, and no new type assertions or eslint-disables introduced. Added a `patch` changeset for `@bigcommerce/big-design`.

[TRAC-1302]: https://bigcommercecloud.atlassian.net/browse/TRAC-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
