### PR TITLE
feat: TRAC-1297 Migrate Table drag-and-drop to pragmatic-drag-and-drop

### DIFF
--- a/.changeset/table-pragmatic-drag-and-drop.md
+++ b/.changeset/table-pragmatic-drag-and-drop.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": minor
+---
+
+Migrate `Table` (and `StatefulTable`) drag-and-drop from the archived `react-beautiful-dnd` to `@atlaskit/pragmatic-drag-and-drop`, unblocking React 19 consumers (`react-beautiful-dnd`'s React peer caps at 18). The public API is unchanged: `onRowDrop(from, to)` still fires with the same `from`/`to` indices and no drag-and-drop library types leak into public props. Pointer dragging shows a floating preview of the row under the cursor plus a phantom placeholder row at the drop position (the source row is hidden while it shows, so the table doesn't shift); keyboard-only reordering (grab with `Space`/`Enter`, move with the arrow keys, drop with `Space`/`Enter`, cancel with `Escape`) and screen-reader announcements are provided explicitly for WCAG 2.2 AA parity. `TableNext` continues to use `react-beautiful-dnd` for now.

--- a/packages/big-design/jest.config.js
+++ b/packages/big-design/jest.config.js
@@ -5,10 +5,12 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
   coverageThreshold: {
     global: {
-      statements: 97.14,
+      // Pointer drag-and-drop paths (native HTML5 drag) can't run in jsdom and are
+      // excluded via `istanbul ignore`; these floors reflect the remaining reachable code.
+      statements: 97.05,
       branches: 88.69,
-      functions: 98.08,
-      lines: 97.54,
+      functions: 97.95,
+      lines: 97.45,
     },
   },
 };

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -33,6 +33,9 @@
   },
   "prettier": "@bigcommerce/eslint-config/prettier",
   "dependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.0.0",
+    "@atlaskit/pragmatic-drag-and-drop-live-region": "^2.0.0",
     "@babel/runtime": "^7.26.10",
     "@bigcommerce/big-design-icons": "workspace:^",
     "@bigcommerce/big-design-theme": "workspace:^",

--- a/packages/big-design/src/components/StatefulTable/spec.tsx
+++ b/packages/big-design/src/components/StatefulTable/spec.tsx
@@ -65,34 +65,31 @@ test('pagination can be enabled', async () => {
 });
 
 test('dragAndDrop can be enabled', async () => {
-  const spaceKey = { keyCode: 32 };
-  const downKey = { keyCode: 40 };
   const name = 'Product A - 1';
   const onRowDrop = jest.fn();
-  const { container, getAllByTestId } = render(getSimpleTable({ onRowDrop }));
+  const { getAllByTestId } = render(getSimpleTable({ onRowDrop }));
 
-  let dragEls = container.querySelectorAll<HTMLButtonElement>('[data-rbd-draggable-id]');
+  const dragHandles = screen.getAllByRole<HTMLButtonElement>('button', { name: /reorder row/i });
 
   let names = getAllByTestId('name');
 
   // Item at index 0 has product name Product A - 1
   expect(names[0]).toHaveTextContent(name);
 
-  dragEls[0].focus();
+  dragHandles[0].focus();
 
-  expect(dragEls[0]).toHaveFocus();
+  expect(dragHandles[0]).toHaveFocus();
 
-  fireEvent.keyDown(dragEls[0], spaceKey);
-  fireEvent.keyDown(dragEls[0], downKey);
-  fireEvent.keyDown(dragEls[0], spaceKey);
-
-  dragEls = container.querySelectorAll('[data-rbd-draggable-id]');
+  fireEvent.keyDown(dragHandles[0], { key: ' ' }); // grab
+  fireEvent.keyDown(dragHandles[0], { key: 'ArrowDown' }); // move down
+  fireEvent.keyDown(dragHandles[0], { key: ' ' }); // drop
 
   names = getAllByTestId('name');
 
-  // After drag and drop item at index 1 has product name Product A - 1
+  // After keyboard reorder the item is at index 1
   expect(names[1]).toHaveTextContent(name);
-  expect(onRowDrop).toHaveBeenCalled();
+  expect(onRowDrop).toHaveBeenCalledTimes(1);
+  expect(onRowDrop.mock.calls[0][0][1]).toEqual(expect.objectContaining({ name }));
 });
 
 test('changing pagination page changes the displayed items', async () => {

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -41,7 +41,6 @@ export interface HeaderCheckboxCellProps {
 
 export interface DragIconCellProps {
   actionsRef: RefObject<HTMLDivElement>;
-  headerCellIconRef: RefObject<HTMLTableCellElement>;
 }
 
 const InternalHeaderCell = <T extends TableItem>({
@@ -137,12 +136,10 @@ export const HeaderCheckboxCell: React.FC<HeaderCheckboxCellProps> = memo(
   },
 );
 
-export const DragIconHeaderCell: React.FC<DragIconCellProps> = memo(
-  ({ actionsRef, headerCellIconRef }) => {
-    const actionsSize = useComponentSize(actionsRef);
+export const DragIconHeaderCell: React.FC<DragIconCellProps> = memo(({ actionsRef }) => {
+  const actionsSize = useComponentSize(actionsRef);
 
-    return <StyledTableHeaderIcon ref={headerCellIconRef} stickyHeight={actionsSize.height} />;
-  },
-);
+  return <StyledTableHeaderIcon stickyHeight={actionsSize.height} />;
+});
 
 export const HeaderCell = typedMemo(InternalHeaderCell);

--- a/packages/big-design/src/components/Table/Row/Row.tsx
+++ b/packages/big-design/src/components/Table/Row/Row.tsx
@@ -1,88 +1,233 @@
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+import {
+  draggable,
+  dropTargetForElements,
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { preserveOffsetOnSource } from '@atlaskit/pragmatic-drag-and-drop/element/preserve-offset-on-source';
+import { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
+import { attachClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { announce } from '@atlaskit/pragmatic-drag-and-drop-live-region';
 import { DragIndicatorIcon } from '@bigcommerce/big-design-icons';
-import React, { ComponentPropsWithoutRef, forwardRef } from 'react';
+import React, { ComponentPropsWithoutRef, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { typedMemo } from '../../../utils';
 import { Checkbox } from '../../Checkbox';
 import { DataCell } from '../DataCell';
 import { TableColumn, TableItem } from '../types';
 
-import { StyledTableRow } from './styled';
+import { StyledDragHandle, StyledDragPreview, StyledTableRow } from './styled';
 
 export interface RowProps<T> extends ComponentPropsWithoutRef<'tr'> {
   columns: Array<TableColumn<T>>;
-  headerCellWidths: Array<number | string>;
+  index: number;
   item: T;
-  isDragging?: boolean;
+  itemCount: number;
+  isHidden?: boolean;
+  isPhantom?: boolean;
   isSelected?: boolean;
   isSelectable?: boolean;
   showDragIcon?: boolean;
+  tableId: string;
   onItemSelect?(item: T): void;
-}
-
-interface PrivateProps {
-  forwardedRef?: React.Ref<HTMLTableRowElement>;
+  onRowDrop?(from: number, to: number): void;
 }
 
 const InternalRow = <T extends TableItem>({
   columns,
-  forwardedRef,
-  headerCellWidths,
-  isDragging = false,
+  index,
+  isHidden = false,
+  isPhantom = false,
   isSelectable = false,
   isSelected = false,
   item,
+  itemCount,
   showDragIcon = false,
+  tableId,
   onItemSelect,
+  onRowDrop,
   ...rest
-}: RowProps<T> & PrivateProps) => {
+}: RowProps<T>) => {
+  const rowRef = useRef<HTMLTableRowElement | null>(null);
+  const dragHandleRef = useRef<HTMLButtonElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isGrabbed, setIsGrabbed] = useState(false);
+  const [dragPreview, setDragPreview] = useState<{ container: HTMLElement; width: number } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    const rowElement = rowRef.current;
+    const dragHandleElement = dragHandleRef.current;
+
+    if (isPhantom || !showDragIcon || !rowElement || !dragHandleElement) {
+      return;
+    }
+
+    /* istanbul ignore next -- pointer drag callbacks only run in a real browser */
+    return combine(
+      draggable({
+        element: rowElement,
+        dragHandle: dragHandleElement,
+        getInitialData: () => ({ index, tableId }),
+        onGenerateDragPreview: ({ location, nativeSetDragImage }) => {
+          const { width } = rowElement.getBoundingClientRect();
+
+          setCustomNativeDragPreview({
+            nativeSetDragImage,
+            getOffset: preserveOffsetOnSource({
+              element: rowElement,
+              input: location.current.input,
+            }),
+            render: ({ container }) => {
+              setDragPreview({ container, width });
+
+              return () => setDragPreview(null);
+            },
+          });
+        },
+        onDragStart: () => setIsDragging(true),
+        onDrop: () => setIsDragging(false),
+      }),
+      dropTargetForElements({
+        element: rowElement,
+        canDrop: ({ source }) => source.data.tableId === tableId,
+        getData: ({ input, element }) =>
+          attachClosestEdge({ index }, { element, input, allowedEdges: ['top', 'bottom'] }),
+        getIsSticky: () => true,
+      }),
+    );
+  }, [index, isPhantom, showDragIcon, tableId]);
+
   const onChange = () => {
     if (onItemSelect) {
       onItemSelect(item);
     }
   };
 
+  const onDragHandleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    /* istanbul ignore next -- defensive: the handle only renders when onRowDrop is set */
+    if (typeof onRowDrop !== 'function') {
+      return;
+    }
+
+    const { key } = event;
+
+    if (key === ' ' || key === 'Enter') {
+      event.preventDefault();
+
+      const nextGrabbed = !isGrabbed;
+
+      setIsGrabbed(nextGrabbed);
+      announce(
+        nextGrabbed
+          ? `Grabbed row ${index + 1} of ${itemCount}. Use the arrow keys to move, space to drop.`
+          : `Dropped row at position ${index + 1} of ${itemCount}.`,
+      );
+
+      return;
+    }
+
+    if (!isGrabbed) {
+      return;
+    }
+
+    if (key === 'ArrowUp' && index > 0) {
+      event.preventDefault();
+      onRowDrop(index, index - 1);
+      announce(`Moved row to position ${index} of ${itemCount}.`);
+    } else if (key === 'ArrowDown' && index < itemCount - 1) {
+      event.preventDefault();
+      onRowDrop(index, index + 1);
+      announce(`Moved row to position ${index + 2} of ${itemCount}.`);
+    } else if (key === 'Escape') {
+      event.preventDefault();
+      setIsGrabbed(false);
+      announce('Movement cancelled.');
+    }
+  };
+
   const label = isSelected ? `Selected` : `Unselected`;
 
+  const dataCells: React.ReactNode[] = columns.map(
+    (
+      { render: CellContent, align, display, verticalAlign, width, withPadding = true },
+      columnIndex,
+    ) => (
+      <DataCell
+        align={align}
+        display={display}
+        key={columnIndex}
+        verticalAlign={verticalAlign}
+        width={width}
+        withPadding={withPadding}
+      >
+        <CellContent {...item} />
+      </DataCell>
+    ),
+  );
+
+  /* istanbul ignore next -- the custom drag preview only renders during a real browser drag */
+  const dragPreviewPortal =
+    dragPreview !== null
+      ? createPortal(
+          <StyledDragPreview style={{ width: dragPreview.width }}>
+            <tbody>
+              <tr>
+                {showDragIcon && (
+                  <DataCell>
+                    <DragIndicatorIcon />
+                  </DataCell>
+                )}
+                {dataCells}
+              </tr>
+            </tbody>
+          </StyledDragPreview>,
+          dragPreview.container,
+        )
+      : null;
+
   return (
-    <StyledTableRow isDragging={isDragging} isSelected={isSelected} ref={forwardedRef} {...rest}>
-      {showDragIcon && (
-        <DataCell width={headerCellWidths[0]}>
-          <DragIndicatorIcon />
-        </DataCell>
-      )}
-      {isSelectable && (
-        <DataCell isCheckbox={true} key="data-checkbox">
-          <Checkbox checked={isSelected} hiddenLabel label={label} onChange={onChange} />
-        </DataCell>
-      )}
+    <>
+      <StyledTableRow
+        isDragging={isDragging}
+        isGrabbed={isGrabbed}
+        isHidden={isHidden}
+        isPhantom={isPhantom}
+        isSelected={isSelected}
+        ref={rowRef}
+        {...rest}
+      >
+        {showDragIcon && (
+          <DataCell>
+            {isPhantom ? (
+              <DragIndicatorIcon />
+            ) : (
+              <StyledDragHandle
+                aria-label={`Reorder row ${index + 1} of ${itemCount}`}
+                aria-pressed={isGrabbed}
+                onBlur={() => setIsGrabbed(false)}
+                onKeyDown={onDragHandleKeyDown}
+                ref={dragHandleRef}
+                type="button"
+              >
+                <DragIndicatorIcon />
+              </StyledDragHandle>
+            )}
+          </DataCell>
+        )}
+        {isSelectable && (
+          <DataCell isCheckbox={true} key="data-checkbox">
+            <Checkbox checked={isSelected} hiddenLabel label={label} onChange={onChange} />
+          </DataCell>
+        )}
 
-      {columns.map(
-        (
-          { render: CellContent, align, display, verticalAlign, width, withPadding = true },
-          columnIndex,
-        ) => {
-          const cellWidth = headerCellWidths[columnIndex + 1];
+        {dataCells}
+      </StyledTableRow>
 
-          return (
-            <DataCell
-              align={align}
-              display={display}
-              key={columnIndex}
-              verticalAlign={verticalAlign}
-              width={isDragging ? cellWidth : width}
-              withPadding={withPadding}
-            >
-              <CellContent {...item} />
-            </DataCell>
-          );
-        },
-      )}
-    </StyledTableRow>
+      {dragPreviewPortal}
+    </>
   );
 };
 
-export const Row = typedMemo(
-  forwardRef<HTMLTableRowElement, RowProps<any>>((props, ref) => (
-    <InternalRow {...props} forwardedRef={ref} />
-  )),
-);
+export const Row = typedMemo(InternalRow);

--- a/packages/big-design/src/components/Table/Row/styled.tsx
+++ b/packages/big-design/src/components/Table/Row/styled.tsx
@@ -5,15 +5,42 @@ import { withTransition } from '../../../helpers/transitions';
 
 interface StyledTableRowProps {
   isDragging: boolean;
+  isGrabbed: boolean;
+  isHidden: boolean;
+  isPhantom: boolean;
   isSelected: boolean;
 }
 
 export const StyledTableRow = styled.tr<StyledTableRowProps>`
   ${withTransition(['background-color'])}
-  display: ${({ isDragging }) => (isDragging ? 'table' : 'table-row')};
 
-  background-color: ${({ isSelected, theme }) =>
-    isSelected ? theme.colors.primary10 : 'transparent'};
+  display: ${({ isHidden }) => (isHidden ? 'none' : 'table-row')};
+  background-color: ${({ isPhantom, isSelected, theme }) =>
+    isPhantom || isSelected ? theme.colors.primary10 : 'transparent'};
+  opacity: ${({ isDragging, isPhantom }) => {
+    if (isDragging) {
+      return 0.4;
+    }
+
+    if (isPhantom) {
+      return 0.6;
+    }
+
+    return 1;
+  }};
+  outline: ${({ isGrabbed, isPhantom, theme }) => {
+    if (isPhantom) {
+      return `2px dashed ${theme.colors.primary}`;
+    }
+
+    if (isGrabbed) {
+      return `2px solid ${theme.colors.primary}`;
+    }
+
+    return 'none';
+  }};
+  outline-offset: -2px;
+  pointer-events: ${({ isPhantom }) => (isPhantom ? 'none' : 'auto')};
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.secondary10};
@@ -21,3 +48,35 @@ export const StyledTableRow = styled.tr<StyledTableRowProps>`
 `;
 
 StyledTableRow.defaultProps = { theme: defaultTheme };
+
+export const StyledDragPreview = styled.table`
+  ${({ theme }) => theme.shadow.floating}
+
+  background-color: ${({ theme }) => theme.colors.white};
+  border-collapse: collapse;
+  border-radius: ${({ theme }) => theme.borderRadius.normal};
+  overflow: hidden;
+  table-layout: fixed;
+`;
+
+StyledDragPreview.defaultProps = { theme: defaultTheme };
+
+export const StyledDragHandle = styled.button`
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: grab;
+  display: inline-flex;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+
+  &:focus-visible {
+    outline: ${({ theme }) => `2px solid ${theme.colors.primary}`};
+    outline-offset: 2px;
+  }
+`;
+
+StyledDragHandle.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -1,5 +1,11 @@
+import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index';
+import {
+  announce,
+  cleanup as cleanupLiveRegion,
+} from '@atlaskit/pragmatic-drag-and-drop-live-region';
 import React, { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
-import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 
 import { MarginProps } from '../../helpers';
 import { useEventCallback } from '../../hooks';
@@ -55,10 +61,11 @@ const InternalTable = <T extends TableItem>(
   const actionsRef = useRef<HTMLDivElement>(null);
   const uniqueTableId = useId();
   const tableIdRef = useRef(id || uniqueTableId);
+  const tableId = tableIdRef.current;
   const isSelectable = Boolean(selectable);
+  const isDraggable = typeof onRowDrop === 'function';
   const [selectedItems, setSelectedItems] = useState<Set<T>>(new Set());
-  const [headerCellWidths, setHeaderCellWidths] = useState<Array<number | string>>([]);
-  const headerCellIconRef = useRef<HTMLTableCellElement>(null);
+  const [phantom, setPhantom] = useState<{ insertIndex: number; sourceIndex: number } | null>(null);
   const eventCallback = useEventCallback((item: T) => {
     if (!selectable || !item) {
       return;
@@ -100,40 +107,85 @@ const InternalTable = <T extends TableItem>(
     [sortable],
   );
 
-  const onDragEnd = useCallback(
-    (result: DropResult) => {
-      const { destination, source } = result;
+  // Pointer-based reordering: a single monitor per table resolves the source and
+  // closest-edge drop target into a `from`/`to` pair. While dragging, it also tracks
+  // where a phantom placeholder row should render (`onDrag`). Keyboard reordering is
+  // handled directly on each row's drag handle (see Row). Both paths announce via the
+  // live region.
+  useEffect(() => {
+    if (typeof onRowDrop !== 'function') {
+      return;
+    }
 
-      if (!destination) {
-        return;
-      }
+    /* istanbul ignore next -- monitor callbacks only run during a real browser drag */
+    const stopMonitoring = monitorForElements({
+      canMonitor: ({ source }) => source.data.tableId === tableId,
+      onDrag: ({ location, source }) => {
+        const target = location.current.dropTargets[0];
 
-      if (destination.droppableId === source.droppableId && destination.index === source.index) {
-        return;
-      }
+        if (!target) {
+          setPhantom(null);
 
-      if (typeof onRowDrop === 'function') {
-        onRowDrop(source.index, destination.index);
-      }
+          return;
+        }
 
-      setHeaderCellWidths([]);
-    },
-    [onRowDrop],
-  );
+        const sourceIndex = Number(source.data.index);
+        const indexOfTarget = Number(target.data.index);
+        const closestEdgeOfTarget = extractClosestEdge(target.data);
+        const finishIndex = getReorderDestinationIndex({
+          axis: 'vertical',
+          closestEdgeOfTarget,
+          indexOfTarget,
+          startIndex: sourceIndex,
+        });
 
-  const onBeforeDragStart = () => {
-    const headerCellIconWidth = headerCellIconRef.current?.offsetWidth ?? 'auto';
+        // No visible move: don't render a phantom that sits next to the source row.
+        if (finishIndex === sourceIndex) {
+          setPhantom(null);
 
-    const headerCellsWidths = columns.map((_column, index) => {
-      const headerCellElement = window.document.getElementById(`header-cell-${index}`);
+          return;
+        }
 
-      return headerCellElement?.getBoundingClientRect().width ?? 'auto';
+        const insertIndex = closestEdgeOfTarget === 'bottom' ? indexOfTarget + 1 : indexOfTarget;
+
+        setPhantom((current) =>
+          current?.insertIndex === insertIndex && current.sourceIndex === sourceIndex
+            ? current
+            : { insertIndex, sourceIndex },
+        );
+      },
+      onDrop: ({ location, source }) => {
+        setPhantom(null);
+
+        const target = location.current.dropTargets[0];
+
+        if (!target) {
+          return;
+        }
+
+        const startIndex = Number(source.data.index);
+        const indexOfTarget = Number(target.data.index);
+        const finishIndex = getReorderDestinationIndex({
+          axis: 'vertical',
+          closestEdgeOfTarget: extractClosestEdge(target.data),
+          indexOfTarget,
+          startIndex,
+        });
+
+        if (finishIndex === startIndex) {
+          return;
+        }
+
+        onRowDrop(startIndex, finishIndex);
+        announce(`Moved row from position ${startIndex + 1} to ${finishIndex + 1}.`);
+      },
     });
 
-    const allHeaderWidths = [headerCellIconWidth, ...headerCellsWidths];
-
-    setHeaderCellWidths(allHeaderWidths);
-  };
+    return () => {
+      stopMonitoring();
+      cleanupLiveRegion();
+    };
+  }, [onRowDrop, tableId]);
 
   const shouldRenderActions = () => {
     return Boolean(actions) || Boolean(pagination) || Boolean(selectable) || Boolean(itemName);
@@ -150,22 +202,18 @@ const InternalTable = <T extends TableItem>(
   const renderHeaders = () => (
     <Head hidden={headerless}>
       <tr>
-        {typeof onRowDrop === 'function' && (
-          <DragIconHeaderCell actionsRef={actionsRef} headerCellIconRef={headerCellIconRef} />
-        )}
+        {isDraggable && <DragIconHeaderCell actionsRef={actionsRef} />}
         {isSelectable && <HeaderCheckboxCell actionsRef={actionsRef} stickyHeader={stickyHeader} />}
 
         {columns.map((column, index) => {
           const { display, hash, header, isSortable, hideHeader, width } = column;
           const isSorted = isSortable && hash === sortable?.columnHash;
           const sortDirection = sortable?.direction;
-          const headerCellWidth = headerCellWidths[index + 1];
-          const widthColumn = headerCellWidth ?? width;
 
           return (
             <HeaderCell
               actionsRef={actionsRef}
-              column={{ ...column, width: widthColumn }}
+              column={{ ...column, width }}
               display={display}
               hide={hideHeader}
               id={`header-cell-${index}`}
@@ -184,63 +232,49 @@ const InternalTable = <T extends TableItem>(
     </Head>
   );
 
-  const renderDroppableItems = () => (
-    <Droppable droppableId={`${uniqueTableId}-bd-droppable`}>
-      {(provided) => (
-        <Body ref={provided.innerRef} withFirstRowBorder={headerless} {...provided.droppableProps}>
-          {items.map((item: T, index) => {
-            const key = getItemKey(item, index);
-            const isSelected = selectedItems.has(item);
+  const renderItems = () => {
+    const rows = items.map((item: T, index) => {
+      const key = getItemKey(item, index);
 
-            return (
-              <Draggable draggableId={String(key)} index={index} key={key}>
-                {(provided, snapshot) => (
-                  <Row
-                    isDragging={snapshot.isDragging}
-                    {...provided.dragHandleProps}
-                    {...provided.draggableProps}
-                    columns={columns}
-                    headerCellWidths={headerCellWidths}
-                    isSelectable={isSelectable}
-                    isSelected={isSelected}
-                    item={item}
-                    onItemSelect={onItemSelect}
-                    ref={provided.innerRef}
-                    showDragIcon={true}
-                  />
-                )}
-              </Draggable>
-            );
-          })}
-          {provided.placeholder}
-        </Body>
-      )}
-    </Droppable>
-  );
+      return (
+        <Row
+          columns={columns}
+          index={index}
+          isHidden={phantom?.sourceIndex === index}
+          isSelectable={isSelectable}
+          isSelected={selectedItems.has(item)}
+          item={item}
+          itemCount={items.length}
+          key={key}
+          onItemSelect={onItemSelect}
+          onRowDrop={onRowDrop}
+          showDragIcon={isDraggable}
+          tableId={tableId}
+        />
+      );
+    });
 
-  const renderItems = () =>
-    onRowDrop ? (
-      renderDroppableItems()
-    ) : (
-      <Body withFirstRowBorder={headerless}>
-        {items.map((item: T, index) => {
-          const key = getItemKey(item, index);
-          const isSelected = selectedItems.has(item);
+    /* istanbul ignore next -- the phantom row only renders during a real browser drag */
+    if (phantom && phantom.sourceIndex < items.length) {
+      rows.splice(
+        phantom.insertIndex,
+        0,
+        <Row
+          columns={columns}
+          index={phantom.sourceIndex}
+          isPhantom
+          isSelectable={isSelectable}
+          item={items[phantom.sourceIndex]}
+          itemCount={items.length}
+          key="bd-drag-phantom"
+          showDragIcon={isDraggable}
+          tableId={tableId}
+        />,
+      );
+    }
 
-          return (
-            <Row
-              columns={columns}
-              headerCellWidths={headerCellWidths}
-              isSelectable={isSelectable}
-              isSelected={isSelected}
-              item={item}
-              key={key}
-              onItemSelect={onItemSelect}
-            />
-          );
-        })}
-      </Body>
-    );
+    return <Body withFirstRowBorder={headerless}>{rows}</Body>;
+  };
 
   const renderEmptyState = () => {
     if (items.length === 0 && emptyComponent) {
@@ -262,21 +296,12 @@ const InternalTable = <T extends TableItem>(
           pagination={pagination}
           selectedItems={selectedItems}
           stickyHeader={stickyHeader}
-          tableId={tableIdRef.current}
+          tableId={tableId}
         />
       )}
-      <StyledTable {...rest} id={tableIdRef.current}>
-        {onRowDrop ? (
-          <DragDropContext onBeforeDragStart={onBeforeDragStart} onDragEnd={onDragEnd}>
-            {renderHeaders()}
-            {renderItems()}
-          </DragDropContext>
-        ) : (
-          <>
-            {renderHeaders()}
-            {renderItems()}
-          </>
-        )}
+      <StyledTable {...rest} id={tableId}>
+        {renderHeaders()}
+        {renderItems()}
       </StyledTable>
 
       {renderEmptyState()}

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -568,6 +568,10 @@ exports[`renders a simple table 1`] = `
   transition-property: background-color;
   display: table-row;
   background-color: transparent;
+  opacity: 1;
+  outline: none;
+  outline-offset: -2px;
+  pointer-events: auto;
 }
 
 .c5:hover {

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -718,30 +718,111 @@ describe('draggable', () => {
     ];
   });
 
-  test('renders drag and drop icon', () => {
-    const { container } = render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
-    const dragIcons = container.querySelectorAll('svg');
-
-    expect(dragIcons).toHaveLength(items.length);
-  });
-
-  test('onRowDrop called with expected args when a row is dropped', async () => {
-    const spaceKey = { keyCode: 32 };
-    const downKey = { keyCode: 40 };
-
+  test('renders a drag handle for every row', () => {
     render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
 
-    const dragEls = await screen.findAllByRole<HTMLButtonElement>('button');
-    const dragEl = dragEls[0];
+    const dragHandles = screen.getAllByRole('button', { name: /reorder row/i });
 
-    dragEl.focus();
+    expect(dragHandles).toHaveLength(items.length);
+  });
 
-    expect(dragEl).toHaveFocus();
+  test('onRowDrop called with expected args when a grabbed row is moved down', async () => {
+    render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
 
-    fireEvent.keyDown(dragEl, spaceKey);
-    fireEvent.keyDown(dragEl, downKey);
-    fireEvent.keyDown(dragEl, spaceKey);
+    const dragHandle = screen.getAllByRole<HTMLButtonElement>('button', {
+      name: /reorder row/i,
+    })[0];
 
+    dragHandle.focus();
+
+    expect(dragHandle).toHaveFocus();
+
+    fireEvent.keyDown(dragHandle, { key: ' ' }); // grab
+    fireEvent.keyDown(dragHandle, { key: 'ArrowDown' }); // move down
+    fireEvent.keyDown(dragHandle, { key: ' ' }); // drop
+
+    expect(onRowDrop).toHaveBeenCalledTimes(1);
+    expect(onRowDrop).toHaveBeenCalledWith(0, 1);
+  });
+
+  test('onRowDrop called with expected args when a grabbed row is moved up', () => {
+    render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
+
+    const dragHandle = screen.getAllByRole<HTMLButtonElement>('button', {
+      name: /reorder row/i,
+    })[2];
+
+    fireEvent.keyDown(dragHandle, { key: ' ' }); // grab
+    fireEvent.keyDown(dragHandle, { key: 'ArrowUp' }); // move up
+
+    expect(onRowDrop).toHaveBeenCalledWith(2, 1);
+  });
+
+  test('does not reorder when arrow keys are pressed before grabbing', () => {
+    render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
+
+    const dragHandle = screen.getAllByRole<HTMLButtonElement>('button', {
+      name: /reorder row/i,
+    })[0];
+
+    fireEvent.keyDown(dragHandle, { key: 'ArrowDown' });
+
+    expect(onRowDrop).not.toHaveBeenCalled();
+  });
+
+  test('does not move a grabbed row past the list boundary', () => {
+    render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
+
+    const dragHandle = screen.getAllByRole<HTMLButtonElement>('button', {
+      name: /reorder row/i,
+    })[0];
+
+    fireEvent.keyDown(dragHandle, { key: ' ' }); // grab first row
+    fireEvent.keyDown(dragHandle, { key: 'ArrowUp' }); // already at the top
+
+    expect(onRowDrop).not.toHaveBeenCalled();
+  });
+
+  test('pressing Escape cancels a grab so later arrow keys do not reorder', () => {
+    render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
+
+    const dragHandle = screen.getAllByRole<HTMLButtonElement>('button', {
+      name: /reorder row/i,
+    })[0];
+
+    fireEvent.keyDown(dragHandle, { key: ' ' }); // grab
+    fireEvent.keyDown(dragHandle, { key: 'Escape' }); // cancel
+    fireEvent.keyDown(dragHandle, { key: 'ArrowDown' }); // ignored, no longer grabbed
+
+    expect(onRowDrop).not.toHaveBeenCalled();
+  });
+
+  test('blurring the drag handle cancels a grab', () => {
+    render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
+
+    const dragHandle = screen.getAllByRole<HTMLButtonElement>('button', {
+      name: /reorder row/i,
+    })[0];
+
+    fireEvent.keyDown(dragHandle, { key: ' ' }); // grab
+    fireEvent.blur(dragHandle); // focus leaves the handle
+    fireEvent.keyDown(dragHandle, { key: 'ArrowDown' }); // ignored, no longer grabbed
+
+    expect(onRowDrop).not.toHaveBeenCalled();
+  });
+
+  test('supports Enter to grab and drop a row', () => {
+    render(<Table columns={columns} items={items} onRowDrop={onRowDrop} />);
+
+    const dragHandle = screen.getAllByRole<HTMLButtonElement>('button', {
+      name: /reorder row/i,
+    })[0];
+
+    fireEvent.keyDown(dragHandle, { key: 'Enter' }); // grab
+    fireEvent.keyDown(dragHandle, { key: 'ArrowDown' }); // move down
+    fireEvent.keyDown(dragHandle, { key: 'Enter' }); // drop
+
+    expect(onRowDrop).toHaveBeenCalledTimes(1);
     expect(onRowDrop).toHaveBeenCalledWith(0, 1);
   });
 });

--- a/packages/docs/pages/table.tsx
+++ b/packages/docs/pages/table.tsx
@@ -47,11 +47,12 @@ const sort = (items: Item[], columnHash: string, direction: string) => {
 };
 
 const dragEnd = (items: Item[], from: number, to: number) => {
-  const item = items.splice(from, 1);
+  const nextItems = [...items];
+  const [movedItem] = nextItems.splice(from, 1);
 
-  items.splice(to, 0, ...item);
+  nextItems.splice(to, 0, movedItem);
 
-  return items;
+  return nextItems;
 };
 
 const TablePage = () => {
@@ -398,6 +399,7 @@ const TablePage = () => {
                           { header: 'Stock', hash: 'stock', render: ({ stock }) => stock },
                         ]}
                         items={items}
+                        keyField="sku"
                         onRowDrop={onDragEnd}
                       />
                     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,15 @@ importers:
 
   packages/big-design:
     dependencies:
+      '@atlaskit/pragmatic-drag-and-drop':
+        specifier: ^2.0.1
+        version: 2.0.1
+      '@atlaskit/pragmatic-drag-and-drop-hitbox':
+        specifier: ^2.0.0
+        version: 2.0.0
+      '@atlaskit/pragmatic-drag-and-drop-live-region':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@babel/runtime':
         specifier: ^7.26.10
         version: 7.26.10
@@ -673,6 +682,15 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@atlaskit/pragmatic-drag-and-drop-hitbox@2.0.0':
+    resolution: {integrity: sha512-vkXCB/23pT8YgYU8biGmR9uu0fr9oWoaq2GMSKyiNPk3reA12XVrCdgB2SLBoB24Ic1FOm9PdaQJ9ZSUQdCVpw==}
+
+  '@atlaskit/pragmatic-drag-and-drop-live-region@2.0.0':
+    resolution: {integrity: sha512-GrlZdZQSw4yegSrU8EDcaO6IBDEAYbSMgv3tTTfkbdmOjpEnwXmNGHe7CiA3GR9LgUNiKpERR9tlfa+viXIGvA==}
+
+  '@atlaskit/pragmatic-drag-and-drop@2.0.1':
+    resolution: {integrity: sha512-5iSbCveKuWYh0HijDxfSsYKD2VE0UPObI9jO1pqq+RBk9LzaoOYeKyW0Fobv/6db8HAPcyT3vhRy8bmk5TMcMw==}
 
   '@babel/cli@7.28.3':
     resolution: {integrity: sha512-n1RU5vuCX0CsaqaXm9I0KUCNKNQMy5epmzl/xdSSm70bSqhg9GWhgeosypyQLc0bK24+Xpk1WGzZlI9pJtkZdg==}
@@ -3307,6 +3325,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bind-event-listener@3.0.0:
+    resolution: {integrity: sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -5415,6 +5436,9 @@ packages:
   raf-schd@4.0.2:
     resolution: {integrity: sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==}
 
+  raf-schd@4.0.3:
+    resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
+
   react-beautiful-dnd@13.1.1:
     resolution: {integrity: sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==}
     deprecated: 'react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672'
@@ -6423,6 +6447,21 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@atlaskit/pragmatic-drag-and-drop-hitbox@2.0.0':
+    dependencies:
+      '@atlaskit/pragmatic-drag-and-drop': 2.0.1
+      '@babel/runtime': 7.28.4
+
+  '@atlaskit/pragmatic-drag-and-drop-live-region@2.0.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+
+  '@atlaskit/pragmatic-drag-and-drop@2.0.1':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      bind-event-listener: 3.0.0
+      raf-schd: 4.0.3
 
   '@babel/cli@7.28.3(@babel/core@7.28.0)':
     dependencies:
@@ -9572,6 +9611,8 @@ snapshots:
   binary-extensions@2.3.0:
     optional: true
 
+  bind-event-listener@3.0.0: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -12179,6 +12220,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   raf-schd@4.0.2: {}
+
+  raf-schd@4.0.3: {}
 
   react-beautiful-dnd@13.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:


### PR DESCRIPTION
Jira: [TRAC-1297](<https://bigcommercecloud.atlassian.net/browse/TRAC-1297>)

## What?

Replaces `react-beautiful-dnd` with `@atlaskit/pragmatic-drag-and-drop` (+ `-hitbox` for closest-edge detection and `-live-region` for announcements) as the drag-and-drop engine behind `Table` and `StatefulTable`. The public `onRowDrop(from, to)` API is unchanged and no drag-and-drop library type leaks into public props. `react-beautiful-dnd` stays installed for now; `TableNext` is migrated separately in [LTRAC-1360](https://linear.app/commerce/issue/LTRAC-1360/tablenext-migrate-drag-and-drop-to-pragmatic-drag-and-drop-drop-react).

## Why?

`react-beautiful-dnd` is archived and its React peer caps at `^18`, so it hard-fails `npm install` for React 19 consumers. This is groundwork for the BigDesign React 19 major (it's a no-op for current React 18 consumers).

A few non-obvious implementation notes for reviewers:

* **Row wiring is imperative.** Pragmatic DnD attaches behavior to DOM nodes via effects rather than render-prop wrappers, so each row registers `draggable` (using the drag-handle button as the `dragHandle`) and `dropTargetForElements` in a `useEffect`. A single table-level `monitorForElements`, scoped by `tableId`, resolves the source index + closest-edge target into `from`/`to` and fires `onRowDrop`.
* **The rbd column-width-freeze machinery is gone** (`onBeforeDragStart`, `headerCellWidths`, `headerCellIconRef`). rbd cloned the dragged row out of the table, which required snapshotting column widths; pragmatic keeps the row in flow, so this is unnecessary.
* **Drag visuals.** During a pointer drag a floating preview of the row follows the cursor (`setCustomNativeDragPreview` + a portal), and a **phantom placeholder row** renders at the computed drop position (driven by the monitor's `onDrag` + closest-edge). The source row is hidden (`display: none`) while the phantom is shown, so the row count stays constant and the table doesn't shift when the drop lands.
* **Accessibility is explicit, not free.** rbd gave keyboard reorder for free; pragmatic's element adapter is pointer-only, so the drag handle is a real `<button>` with a keyboard model (Space/Enter to grab, arrows to move, Space/Enter to drop, Escape to cancel) and every move is announced via the live region for WCAG 2.2 AA parity.
* **Docs example fix.** The Table Drag & Drop example's reorder helper mutated the `items` array in place and returned the same reference, so `setItems` bailed out of re-rendering and rows never actually moved. It now returns a new array (and sets `keyField` so keyboard focus follows the moved row).

## Screenshots/Screen Recordings

*Pointer drag (floating preview + phantom placeholder row), keyboard reorder, and screen-reader announcements to be verified manually via* `pnpm run start` *on the Table docs page.*

https://github.com/user-attachments/assets/4db2be8d-d1bc-4c27-b31e-54d565cab58d

## Testing/Proof

* `pnpm run lint`, `pnpm run typecheck`, and `pnpm run test` are green (1118 tests). Package build including declaration emit succeeds, and the docs Table page compiles/serves cleanly (`pnpm run start`).
* Updated the `Table` and `StatefulTable` DnD specs for the new internals without weakening assertions: the keyboard reorder path (grab → arrow → drop) still asserts `onRowDrop` fires with the correct `from`/`to`, and `StatefulTable` still reorders the item to the expected position. Added up/bounds/pre-grab coverage.
* jsdom can't drive native HTML5 pointer drag (and Playwright/Chromium isn't available in this environment), so the pointer + phantom + screen-reader flows are covered by the manual docs pass above; the automated suite covers the keyboard path and the callback contract.

Refs [LTRAC-1297](https://linear.app/commerce/issue/LTRAC-1297/revive-b2b-makeswift-upgrade-to-makeswift-190)

[TRAC-1297]: https://bigcommercecloud.atlassian.net/browse/TRAC-1297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ