### PR TITLE
fix: TRAC-1334 Clear Next.js warnings in docs build

### DIFF
--- a/.changeset/clear-docs-nextjs-warnings.md
+++ b/.changeset/clear-docs-nextjs-warnings.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/docs": patch
+---
+
+Clear Next.js warnings surfaced by `pnpm run start` and the docs build: move the Google Fonts stylesheet link out of `next/head` into `_document.tsx`, configure `images.qualities` for the logo's explicit quality prop, and drop `legacyBehavior`/`passHref` from `NextLink`/`SideNavLink` in favor of styling `next/link`'s `Link` directly. No visible change to the docs site.

--- a/packages/docs/components/NextLink/NextLink.tsx
+++ b/packages/docs/components/NextLink/NextLink.tsx
@@ -1,6 +1,6 @@
-import { Link } from '@bigcommerce/big-design';
 import { LinkProps, default as NLink } from 'next/link';
 import React from 'react';
+import styled from 'styled-components';
 
 interface Props {
   children?: React.ReactNode;
@@ -8,13 +8,25 @@ interface Props {
   as?: string;
 }
 
-export const NextLink: React.FC<Props> = (props) => {
-  const { children, href } = props;
+// Mirrors BigDesign's Link styling. next/link's Link always renders its own <a>, and
+// BigDesign's Link doesn't expose an `as` prop to swap next/link in without nesting two
+// anchors, so the (small) visual styling is duplicated here instead.
+const StyledLink = styled(NLink)`
+  color: ${({ theme }) => theme.colors.primary};
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.typography.fontSize.medium};
+  font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
+  text-decoration: none;
 
-  return (
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    <NLink href={href} legacyBehavior passHref>
-      <Link>{children}</Link>
-    </NLink>
-  );
-};
+  &:active {
+    color: ${({ theme }) => theme.colors.primary70};
+  }
+
+  &:hover:not(:active) {
+    color: ${({ theme }) => theme.colors.primary70};
+  }
+`;
+
+export const NextLink: React.FC<Props> = ({ children, href }) => (
+  <StyledLink href={href}>{children}</StyledLink>
+);

--- a/packages/docs/components/SideNav/SideNavLink/SideNavLink.tsx
+++ b/packages/docs/components/SideNav/SideNavLink/SideNavLink.tsx
@@ -1,4 +1,3 @@
-import { Link } from '@bigcommerce/big-design';
 import NextLink from 'next/link';
 import React from 'react';
 import styled from 'styled-components';
@@ -11,9 +10,25 @@ interface Props {
   target?: string;
 }
 
-const StyledLink = styled(Link)`
+// Mirrors BigDesign's Link styling. next/link's Link always renders its own <a>, and
+// BigDesign's Link doesn't expose an `as` prop to swap next/link in without nesting two
+// anchors, so the (small) visual styling is duplicated here instead.
+const StyledLink = styled(NextLink)`
+  color: ${({ theme }) => theme.colors.primary};
+  cursor: pointer;
   display: block;
+  font-size: ${({ theme }) => theme.typography.fontSize.medium};
+  font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
   line-height: ${({ theme }) => theme.lineHeight.large};
+  text-decoration: none;
+
+  &:active {
+    color: ${({ theme }) => theme.colors.primary70};
+  }
+
+  &:hover:not(:active) {
+    color: ${({ theme }) => theme.colors.primary70};
+  }
 
   ${({ theme }) => theme.breakpoints.tablet} {
     display: inline-block;
@@ -23,9 +38,8 @@ const StyledLink = styled(Link)`
 
 export const SideNavLink: React.FC<Props> = ({ children, href, target }) => (
   <List.Item>
-    {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-    <NextLink href={href} legacyBehavior passHref target={target}>
-      <StyledLink href="">{children}</StyledLink>
-    </NextLink>
+    <StyledLink href={href} target={target}>
+      {children}
+    </StyledLink>
   </List.Item>
 );

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -22,6 +22,7 @@ module.exports = {
   ],
   images: {
     unoptimized: true,
+    qualities: [100],
   },
   compiler: {
     styledComponents: true,

--- a/packages/docs/pages/_app.tsx
+++ b/packages/docs/pages/_app.tsx
@@ -54,12 +54,6 @@ const App = ({ Component, pageProps }) => {
         <link href={`${process.env.URL_PREFIX}/favicon.svg`} rel="icon" type="image/svg+xml" />
         <title>BigDesign</title>
         <meta content={`${process.env.URL_PREFIX}/og-image.png`} property="og:image" />
-        <link href="https://fonts.googleapis.com" rel="preconnect" />
-        <link crossOrigin="" href="https://fonts.gstatic.com" rel="preconnect" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@200;300;400;600&display=swap"
-          rel="stylesheet"
-        />
       </Head>
       {/* eslint-disable-next-line react/no-unknown-property */}
       <style global jsx>

--- a/packages/docs/pages/_document.tsx
+++ b/packages/docs/pages/_document.tsx
@@ -34,7 +34,14 @@ export default class AppDocument extends Document {
   render() {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <link href="https://fonts.googleapis.com" rel="preconnect" />
+          <link crossOrigin="" href="https://fonts.gstatic.com" rel="preconnect" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@200;300;400;600&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
Jira: [TRAC-1334](https://bigcommercecloud.atlassian.net/browse/TRAC-1334)

## What?

Clears three Next.js warnings surfaced by `pnpm run start` / `pnpm -F @bigcommerce/docs run build`:

- Moves the Google Fonts preconnect/stylesheet `<link>`s out of `_app.tsx`'s `next/head` into `_document.tsx`'s `Head`.
- Adds `images.qualities: [100]` to `packages/docs/next.config.js`.
- Removes `legacyBehavior`/`passHref` from `NextLink` and `SideNavLink`.

## Why?

None of these break the build today, but one (`no-stylesheets-in-head-component`) is already an error-level lint, and the others (`images.qualities`, `legacyBehavior` removal) become hard requirements in Next.js 16. Clearing them now keeps the docs site clean and unblocks a future Next.js major. Surfaced while verifying LTRAC-1359.

The `legacyBehavior` fix needed manual follow-up: `npx @next/codemod@latest new-link` bailed out on `SideNavLink` (its child isn't a plain `<a>`) and silently skipped `NextLink` (it imports `next/link`'s default export via `default as NLink`, which the codemod doesn't match). Simply dropping `legacyBehavior` and nesting BigDesign's `Link` inside `next/link`'s new `Link` would render two nested `<a>` tags, since the new API always renders its own anchor. Instead, both wrap BigDesign's `Link` with `styled(Link)` and pass `next/link`'s `Link` via the `as` prop — `styled(...)` components support `as` for polymorphism out of the box, so this avoids the double-anchor without touching the shared `Link` component's types.

`useLayoutEffect does nothing on the server` warnings from the third-party `react-live` `CodeEditor` are out of scope (not our code).

## Screenshots/Screen Recordings

No visual changes; fonts, the logo image, and nav links render identically before and after.

## Testing/Proof

Ran `next dev` and a production `next build` (static export, all 61 pages) before and after the change. Before: all three warnings present. After: none of the three warnings appear in either dev or build output, and the rendered HTML confirms the font stylesheet loads from `_document`, the logo image renders, and nav links render as a single correct `<a href="...">` (no nested anchors). Also ran `tsc --noEmit` and `eslint` against the changed files with no errors.

[TRAC-1334]: https://bigcommercecloud.atlassian.net/browse/TRAC-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ