### PR TITLE
fix: TRAC-1300 Add prop filtering to tag-target styled components (A-M)

### DIFF
--- a/.changeset/prop-filtering-tag-target-styled-a-m.md
+++ b/.changeset/prop-filtering-tag-target-styled-a-m.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Add `.withConfig({ shouldForwardProp: isPropValid })` to tag-target styled components (`styled.div`, `styled.span`, etc.) across A-M components (Box, Button, Checkbox, Datepicker, FeatureSet, Fieldset, FileUploader, Form, InfoCard, Input, Link, List, Lozenge, Modal, and others). styled-components 6 drops v5's automatic filtering of unknown props on tag targets, so system props like `backgroundColor`, `border`, and margin/padding props would otherwise leak onto the DOM as invalid HTML attributes and trigger React unknown-prop warnings. `@emotion/is-prop-valid` is the same predicate styled-components 5 used internally, and `withConfig` has been supported since styled-components 5.2.1, so this is a behavior-preserving no-op under the current styled-components 5. `styled(Component)` composition is untouched since it already inherits the base component's prop filtering. N-Z components, icons, and patterns are covered in a follow-up.

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -39,6 +39,7 @@
     "@babel/runtime": "^7.26.10",
     "@bigcommerce/big-design-icons": "workspace:^",
     "@bigcommerce/big-design-theme": "workspace:^",
+    "@emotion/is-prop-valid": "^1.4.0",
     "@popperjs/core": "^2.11.6",
     "date-fns": "4.1.0",
     "downshift": "9.0.10",

--- a/packages/big-design/src/components/AnchorNav/styled.ts
+++ b/packages/big-design/src/components/AnchorNav/styled.ts
@@ -1,7 +1,11 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
-export const StyledAnchorNavList = styled.nav`
+export const StyledAnchorNavList = styled.nav.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   position: sticky;
   inset-block-start: 0;
   width: ${({ theme }) => theme.helpers.remCalc(266)};

--- a/packages/big-design/src/components/Badge/styled.tsx
+++ b/packages/big-design/src/components/Badge/styled.tsx
@@ -1,11 +1,15 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../helpers';
 
 import { BadgeProps } from './Badge';
 
-export const StyledBadge = styled.span<Omit<BadgeProps, 'label'>>`
+export const StyledBadge = styled.span.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<Omit<BadgeProps, 'label'>>`
   ${withMargins()};
 
   color: ${({ theme }) => theme.colors.white};

--- a/packages/big-design/src/components/Box/styled.tsx
+++ b/packages/big-design/src/components/Box/styled.tsx
@@ -1,4 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import { clearFix } from 'polished';
 import styled, { css } from 'styled-components';
 
@@ -6,7 +7,10 @@ import { withDisplay, withMargins, withPaddings } from '../../helpers';
 
 import { BoxProps } from './Box';
 
-export const StyledBox = styled.div<BoxProps>`
+export const StyledBox = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<BoxProps>`
   ${withDisplay()}
   ${withMargins()}
   ${withPaddings()}

--- a/packages/big-design/src/components/Button/styled.tsx
+++ b/packages/big-design/src/components/Button/styled.tsx
@@ -1,4 +1,5 @@
 import { addValues, theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled, { css } from 'styled-components';
 
 import { MarginProps, withMargins } from '../../helpers';
@@ -7,7 +8,10 @@ import { Flex } from '../Flex';
 
 import { ButtonProps } from './index';
 
-export const StyledButton = styled.button<ButtonProps & MarginProps>`
+export const StyledButton = styled.button.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<ButtonProps & MarginProps>`
   ${withTransition(['background-color', 'border-color', 'box-shadow', 'color'])}
 
   && {
@@ -82,9 +86,12 @@ export const StyledButton = styled.button<ButtonProps & MarginProps>`
   ${(props) => getButtonStyles(props)}
 `;
 
-export const ContentWrapper = styled.span.attrs<Record<string, unknown>, { isLoading?: boolean }>(
-  {},
-)`
+export const ContentWrapper = styled.span
+  .withConfig({
+    shouldForwardProp: (prop, defaultValidatorFn) =>
+      typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+  })
+  .attrs<Record<string, unknown>, { isLoading?: boolean }>({})`
   align-content: center;
   align-items: center;
   display: inline-grid;

--- a/packages/big-design/src/components/Checkbox/Label/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/Label/styled.tsx
@@ -1,4 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import { hideVisually } from 'polished';
 import { ComponentPropsWithoutRef } from 'react';
 import styled, { css } from 'styled-components';
@@ -10,7 +11,10 @@ export interface StyledLabelProps extends ComponentPropsWithoutRef<'label'> {
   disabled?: boolean;
 }
 
-export const StyledLabel = styled.label<StyledLabelProps>`
+export const StyledLabel = styled.label.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<StyledLabelProps>`
   color: ${({ theme }) => theme.colors.secondary70};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -1,4 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import { hideVisually } from 'polished';
 import styled, { css } from 'styled-components';
 
@@ -15,26 +16,45 @@ export interface StyledLabelProps {
   disabled?: boolean;
 }
 
-export const CheckboxLabelContainer = styled.div<{ hasContent?: boolean }>`
+export const CheckboxLabelContainer = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<{
+  hasContent?: boolean;
+}>`
   margin-left: ${({ hasContent, theme }) => (hasContent ? theme.spacing.xSmall : 0)};
 `;
 
-export const CheckboxImgContainer = styled.img`
+export const CheckboxImgContainer = styled.img.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   margin-inline-start: ${({ theme }) => theme.spacing.xSmall};
   object-fit: contain;
   flex-shrink: 0;
 `;
 
-export const CheckboxContainer = styled.div<{ hasImg?: boolean }>`
+export const CheckboxContainer = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<{
+  hasImg?: boolean;
+}>`
   align-items: ${({ hasImg }) => (hasImg ? 'center' : 'flex-start')};
   display: flex;
 `;
 
-export const HiddenCheckbox = styled.input`
+export const HiddenCheckbox = styled.input.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   ${hideVisually()}
 `;
 
-export const StyledCheckbox = styled.label<StyledCheckboxProps>`
+export const StyledCheckbox = styled.label.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<StyledCheckboxProps>`
   ${withTransition(['border-color', 'background', 'box-shadow', 'color', 'opacity'])}
 
   align-items: center;

--- a/packages/big-design/src/components/Datepicker/styled.ts
+++ b/packages/big-design/src/components/Datepicker/styled.ts
@@ -1,7 +1,11 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
-export const StyledDatepicker = styled.div`
+export const StyledDatepicker = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   & .react-datepicker-wrapper {
     display: inline-block;
     width: 100%;

--- a/packages/big-design/src/components/FeatureSet/Tag/styled.tsx
+++ b/packages/big-design/src/components/FeatureSet/Tag/styled.tsx
@@ -1,7 +1,13 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
-export const StyledLi = styled.li.attrs({ theme: defaultTheme })`
+export const StyledLi = styled.li
+  .withConfig({
+    shouldForwardProp: (prop, defaultValidatorFn) =>
+      typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+  })
+  .attrs({ theme: defaultTheme })`
   align-items: center;
   background-color: ${({ theme }) => theme.colors.secondary20};
   border-radius: ${({ theme }) => theme.borderRadius.normal};

--- a/packages/big-design/src/components/FeatureSet/styled.tsx
+++ b/packages/big-design/src/components/FeatureSet/styled.tsx
@@ -1,9 +1,15 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
 import { withMargins } from '../../helpers';
 
-export const StyledUl = styled.ul.attrs({ theme: defaultTheme })`
+export const StyledUl = styled.ul
+  .withConfig({
+    shouldForwardProp: (prop, defaultValidatorFn) =>
+      typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+  })
+  .attrs({ theme: defaultTheme })`
   ${({ theme }) => theme.helpers.listReset}
 
   ${withMargins()};

--- a/packages/big-design/src/components/Fieldset/styled.tsx
+++ b/packages/big-design/src/components/Fieldset/styled.tsx
@@ -1,7 +1,11 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
-export const StyledFieldset = styled.fieldset`
+export const StyledFieldset = styled.fieldset.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   border: none;
   margin: 0 0 ${({ theme }) => theme.spacing.xLarge};
   padding: 0;

--- a/packages/big-design/src/components/FileUploader/styled.ts
+++ b/packages/big-design/src/components/FileUploader/styled.ts
@@ -1,4 +1,5 @@
 import { theme as defaultTheme, remCalc } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import { ellipsis } from 'polished';
 import styled, { css } from 'styled-components';
 
@@ -73,12 +74,18 @@ export const StyledFile = styled(Flex)<{ isValid: boolean }>`
   background-color: ${({ theme }) => theme.colors.white};
 `;
 
-export const StyledImage = styled.img`
+export const StyledImage = styled.img.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   height: ${remCalc(40)};
   width: ${remCalc(40)};
 `;
 
-export const StyledFileUploaderWrapper = styled.div`
+export const StyledFileUploaderWrapper = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   display: flex;
   flex-direction: column;
 `;
@@ -92,7 +99,10 @@ export const StyledButton = styled(StyleableButton)`
     disabled ? theme.colors.secondary60 : theme.colors.primary} !important;
 `;
 
-export const StyledList = styled.ul`
+export const StyledList = styled.ul.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   list-style: none;
   padding: 0;
   margin: 0;

--- a/packages/big-design/src/components/Form/Group/styled.tsx
+++ b/packages/big-design/src/components/Form/Group/styled.tsx
@@ -1,4 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled, { css } from 'styled-components';
 
 import { Flex } from '../../Flex';
@@ -22,11 +23,17 @@ export const StyledError = styled(Flex)`
   flex-direction: row;
 `;
 
-export const StyledGroup = styled.div`
+export const StyledGroup = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   ${SharedGroupStyles};
 `;
 
-export const StyledInlineGroup = styled.div<StyledProps>`
+export const StyledInlineGroup = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<StyledProps>`
   ${SharedGroupStyles};
 
   ${({ theme }) => theme.breakpoints.tablet} {

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -1,11 +1,15 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
 import { withMargins } from '../../../helpers';
 
 import { type FormControlLabelProps } from './Label';
 
-export const StyledLabel = styled.label<FormControlLabelProps>`
+export const StyledLabel = styled.label.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<FormControlLabelProps>`
   color: ${({ theme }) => theme.colors.secondary70};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};

--- a/packages/big-design/src/components/Form/styled.tsx
+++ b/packages/big-design/src/components/Form/styled.tsx
@@ -1,4 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
 import { withMargins } from '../../helpers';
@@ -8,7 +9,10 @@ import { StyledTextareaWrapper } from '../Textarea/styled';
 
 import { FormProps } from './Form';
 
-export const StyledForm = styled.form<FormProps>`
+export const StyledForm = styled.form.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<FormProps>`
   ${withMargins()}
 
   ${({ theme }) => theme.breakpoints.tablet} {

--- a/packages/big-design/src/components/InfoCard/styled.tsx
+++ b/packages/big-design/src/components/InfoCard/styled.tsx
@@ -1,7 +1,11 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
-export const InfoCardImgContainer = styled.img`
+export const InfoCardImgContainer = styled.img.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   margin-inline-end: ${({ theme }) => theme.spacing.xSmall};
   object-fit: contain;
   flex-shrink: 0;

--- a/packages/big-design/src/components/Input/styled.tsx
+++ b/packages/big-design/src/components/Input/styled.tsx
@@ -1,4 +1,5 @@
 import { addValues, theme as defaultTheme, remCalc } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled, { css } from 'styled-components';
 
 import { PaddingProps, withPaddings } from '../../helpers';
@@ -10,7 +11,10 @@ export interface StyledInputWrapperProps extends InputProps {
   focus: boolean;
 }
 
-export const StyledInputWrapper = styled.span<StyledInputWrapperProps>`
+export const StyledInputWrapper = styled.span.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<StyledInputWrapperProps>`
   ${withTransition(['border', 'box-shadow'])}
 
   align-items: center;
@@ -50,7 +54,10 @@ export const StyledInputWrapper = styled.span<StyledInputWrapperProps>`
   }
 `;
 
-export const StyledInput = styled.input<InputProps>`
+export const StyledInput = styled.input.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<InputProps>`
   background-color: inherit;
   border: 0;
   box-sizing: border-box;
@@ -115,7 +122,10 @@ export const StyledInput = styled.input<InputProps>`
   }
 `;
 
-export const StyledIconWrapper = styled.div<PaddingProps>`
+export const StyledIconWrapper = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<PaddingProps>`
   align-items: center;
   color: ${({ theme }) => theme.colors.secondary60};
   display: flex;
@@ -138,7 +148,10 @@ export const StyledIconWrapper = styled.div<PaddingProps>`
     `}
 `;
 
-export const StyledInputContent = styled.div<InputProps>`
+export const StyledInputContent = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<InputProps>`
   align-items: center;
   box-sizing: border-box;
   display: flex;

--- a/packages/big-design/src/components/Link/styled.tsx
+++ b/packages/big-design/src/components/Link/styled.tsx
@@ -1,4 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import { ellipsis } from 'polished';
 import styled, { css } from 'styled-components';
 
@@ -7,7 +8,10 @@ import { withTransition } from '../../helpers/transitions';
 
 import { LinkProps } from './Link';
 
-export const StyledLink = styled.a<LinkProps & { isExternal?: boolean }>`
+export const StyledLink = styled.a.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<LinkProps & { isExternal?: boolean }>`
   ${withMargins()};
   ${withTransition(['color'], '70ms')}
   ${(props) => props.ellipsis && ellipsis()};

--- a/packages/big-design/src/components/List/GroupHeader/styled.tsx
+++ b/packages/big-design/src/components/List/GroupHeader/styled.tsx
@@ -1,7 +1,11 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
-export const StyledGroupHeader = styled.li`
+export const StyledGroupHeader = styled.li.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   align-items: center;
   box-sizing: border-box;
   color: ${({ theme }) => theme.colors.secondary50};

--- a/packages/big-design/src/components/List/GroupSeparator/styled.tsx
+++ b/packages/big-design/src/components/List/GroupSeparator/styled.tsx
@@ -1,5 +1,9 @@
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
-export const StyledListItem = styled.li`
+export const StyledListItem = styled.li.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   line-height: 0;
 `;

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -1,13 +1,15 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled, { css } from 'styled-components';
 
 import { withTransition } from '../../../helpers/transitions';
 
 import { ListItemProps } from '.';
 
-export const StyledListItem = styled.li<
-  Omit<ListItemProps<unknown>, 'getItemProps' | 'item' | 'index'>
->`
+export const StyledListItem = styled.li.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<Omit<ListItemProps<unknown>, 'getItemProps' | 'item' | 'index'>>`
   ${withTransition(['background-color', 'color'])}
 
   align-items: center;
@@ -79,7 +81,10 @@ export const StyledListItem = styled.li<
   }
 `;
 
-export const StyledLink = styled.a`
+export const StyledLink = styled.a.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   ${withTransition(['background-color', 'color'])}
 
   align-items: center;

--- a/packages/big-design/src/components/List/styled.tsx
+++ b/packages/big-design/src/components/List/styled.tsx
@@ -1,9 +1,13 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from 'styled-components';
 
 import { ListProps } from './List';
 
-export const StyledListOverflowWrapper = styled.div`
+export const StyledListOverflowWrapper = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   ${({ theme }) => theme.shadow.raised}
 
   height: 100%;
@@ -13,7 +17,10 @@ export const StyledListOverflowWrapper = styled.div`
 
 StyledListOverflowWrapper.defaultProps = { theme: defaultTheme };
 
-export const StyledList = styled.ul<Partial<ListProps<unknown>>>`
+export const StyledList = styled.ul.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<Partial<ListProps<unknown>>>`
   ${({ theme }) => theme.shadow.raised};
 
   background-color: ${({ theme }) => theme.colors.white};

--- a/packages/big-design/src/components/Lozenge/styled.tsx
+++ b/packages/big-design/src/components/Lozenge/styled.tsx
@@ -1,4 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import styled, { css } from 'styled-components';
 
 import { Box } from '../Box';
@@ -107,7 +108,10 @@ export const StyledLozenge = styled(Box)<StyledLozengeProps>`
   ${({ variant = 'new' }) => variantStyles[variant].idle};
 `;
 
-export const StyledLozengeButton = styled.button<StyledLozengeProps>`
+export const StyledLozengeButton = styled.button.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})<StyledLozengeProps>`
   ${sharedLozengeStyles}
   padding-inline-end: ${({ theme }) => theme.spacing.xxSmall};
   user-select: none;

--- a/packages/big-design/src/components/Modal/styled.tsx
+++ b/packages/big-design/src/components/Modal/styled.tsx
@@ -1,4 +1,5 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import isPropValid from '@emotion/is-prop-valid';
 import { rgba } from 'polished';
 import styled, { css } from 'styled-components';
 
@@ -6,11 +7,16 @@ import { Flex } from '../Flex';
 
 import { ModalProps } from './Modal';
 
-export const StyledModal = styled.div.attrs({
-  'aria-modal': true,
-  role: 'dialog',
-  tabIndex: -1,
-})<Partial<ModalProps>>`
+export const StyledModal = styled.div
+  .withConfig({
+    shouldForwardProp: (prop, defaultValidatorFn) =>
+      typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+  })
+  .attrs({
+    'aria-modal': true,
+    role: 'dialog',
+    tabIndex: -1,
+  })<Partial<ModalProps>>`
   align-items: center;
   display: flex;
   height: 100%;
@@ -72,7 +78,10 @@ export const StyledModalActions = styled(Flex)`
   }
 `;
 
-export const StyledModalHeader = styled.div`
+export const StyledModalHeader = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   padding: ${({ theme }) => theme.spacing.medium};
 
   ${({ theme }) => theme.breakpoints.tablet} {
@@ -80,7 +89,10 @@ export const StyledModalHeader = styled.div`
   }
 `;
 
-export const StyledModalClose = styled.div`
+export const StyledModalClose = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   position: absolute;
   top: ${({ theme }) => theme.spacing.xxSmall};
   right: ${({ theme }) => theme.spacing.xxSmall};
@@ -90,7 +102,10 @@ export const StyledModalClose = styled.div`
   }
 `;
 
-export const StyledModalBody = styled.div`
+export const StyledModalBody = styled.div.withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop),
+})`
   flex-grow: 1;
   padding: 0 ${({ theme }) => theme.spacing.medium};
   overflow-y: auto;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@bigcommerce/big-design-theme':
         specifier: workspace:^
         version: link:../big-design-theme
+      '@emotion/is-prop-valid':
+        specifier: ^1.4.0
+        version: 1.4.0
       '@popperjs/core':
         specifier: ^2.11.6
         version: 2.11.8
@@ -1704,11 +1707,11 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
-  '@emotion/is-prop-valid@1.1.2':
-    resolution: {integrity: sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==}
+  '@emotion/is-prop-valid@1.4.0':
+    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
 
-  '@emotion/memoize@0.7.5':
-    resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
 
   '@emotion/stylis@0.8.5':
     resolution: {integrity: sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==}
@@ -2973,9 +2976,11 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4272,6 +4277,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -7558,7 +7564,7 @@ snapshots:
       '@typescript-eslint/parser': 8.46.2(eslint@8.57.0)(typescript@5.9.3)
       eslint: 8.57.0
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-gettext: 1.2.0
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(jest@30.2.0(@types/node@24.10.4))(typescript@5.9.3)
@@ -7591,7 +7597,7 @@ snapshots:
       '@typescript-eslint/parser': 8.46.2(eslint@8.57.0)(typescript@5.9.3)
       eslint: 8.57.0
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-gettext: 1.2.0
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(jest@30.2.0(@types/node@25.0.3))(typescript@5.9.3)
@@ -7927,11 +7933,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emotion/is-prop-valid@1.1.2':
+  '@emotion/is-prop-valid@1.4.0':
     dependencies:
-      '@emotion/memoize': 0.7.5
+      '@emotion/memoize': 0.9.0
 
-  '@emotion/memoize@0.7.5': {}
+  '@emotion/memoize@0.9.0': {}
 
   '@emotion/stylis@0.8.5': {}
 
@@ -10322,7 +10328,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10344,7 +10350,7 @@ snapshots:
       '@typescript-eslint/parser': 8.46.2(eslint@8.57.0)(typescript@5.9.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12775,7 +12781,7 @@ snapshots:
     dependencies:
       '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/traverse': 7.25.3(supports-color@5.5.0)
-      '@emotion/is-prop-valid': 1.1.2
+      '@emotion/is-prop-valid': 1.4.0
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
       babel-plugin-styled-components: 2.1.4(@babel/core@7.28.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))(supports-color@5.5.0)


### PR DESCRIPTION
Jira: [TRAC-1300](https://bigcommercecloud.atlassian.net/browse/TRAC-1300)

## What?

Adds `.withConfig({ shouldForwardProp })` using `@emotion/is-prop-valid` to every tag-target styled component (`styled.div`, `styled.button`, etc.) in components A through M: `AnchorNav`, `Badge`, `Box`, `Button`, `Checkbox`, `Datepicker`, `FeatureSet`, `Fieldset`, `FileUploader`, `Form`, `InfoCard`, `Input`, `Link`, `List`, `Lozenge`, and `Modal` (39 declarations across 23 files). `styled(Component)` composition (e.g. `styled(Flex)`, `styled(Box)`) is untouched since it already inherits the base component's filtering. N-Z components, icons, and patterns are covered in a follow-up (LTRAC-1363).

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on tag targets, so system props like `backgroundColor`, `border`, `clearfix`, and margin/padding props would leak onto the DOM as invalid HTML attributes and trigger React unknown-prop warnings once we're on v6. `@emotion/is-prop-valid` is the same predicate styled-components 5 used internally, and `withConfig` has been supported since styled-components 5.2.1, so this lands and soaks now as a behavior-preserving no-op under our current v5.

One non-obvious wrinkle for reviewers: `@emotion/is-prop-valid`'s exported predicate is typed `(arg: string) => boolean`, but `@types/styled-components` v5's `shouldForwardProp` expects `(prop: keyof O, defaultValidatorFn) => boolean`, which resolves to `string | number` for every styled component regardless of its actual prop types (an artifact of how the v5 types fake extra-prop support for `as`). Passing `isPropValid` directly fails `tsc`, so each call site wraps it: `(prop, defaultValidatorFn) => typeof prop === 'string' ? isPropValid(prop) : defaultValidatorFn(prop)`. Kept inline per component rather than extracted to a shared helper, per the ticket's scoping.

## Screenshots/Screen Recordings

No visual changes — this only affects which props reach the DOM node; CSS output is identical under styled-components 5. Confirmed via zero snapshot diffs (see Testing/Proof).

## Testing/Proof

`pnpm run lint`, `pnpm run typecheck`, and `pnpm run test` all pass (70 suites / 1145 tests / 182 snapshots, no snapshot updates needed), confirming this is a true no-op under the current styled-components 5. Added a `patch` changeset for `@bigcommerce/big-design`.

[TRAC-1300]: https://bigcommercecloud.atlassian.net/browse/TRAC-1300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ