### PR TITLE
refactor: TRAC-1340 migrate Box and shared helpers to transient styled props

### DIFF
--- a/.changeset/transient-props-foundation-box.md
+++ b/.changeset/transient-props-foundation-box.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Begin migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6, which drops v5's automatic prop filtering. This foundation change converts the shared `withMargins`/`withPaddings`/`withDisplay` helpers to read `$`-prefixed props (adding `toTransient{Margin,Padding,Display}Props` mapping utilities) and applies the pattern to its first consumer, `Box`. The helpers temporarily read both the public and `$`-prefixed names so remaining components can migrate one PR at a time; the fallback is removed once all consumers are converted. No public API change (consumers still write `<Box backgroundColor="primary" />`) and no CSS output change. Fixing `Box`'s internal prop hand-off does stop it leaking the `display` prop onto the real DOM node (`display` is a valid SVG attribute, so v5 forwarded it); snapshots for components that route `display` through `Box`/`Flex` are updated to drop that stray attribute.

--- a/packages/big-design/src/components/Box/Box.tsx
+++ b/packages/big-design/src/components/Box/Box.tsx
@@ -2,6 +2,9 @@ import { Border, BorderRadius, Colors, Shadow, ZIndex } from '@bigcommerce/big-d
 import React, { ComponentPropsWithoutRef, forwardRef, memo } from 'react';
 
 import { DisplayProps, MarginProps, PaddingProps } from '../../helpers';
+import { toTransientDisplayProps } from '../../helpers/display/display';
+import { toTransientMarginProps } from '../../helpers/margins/margins';
+import { toTransientPaddingProps } from '../../helpers/paddings/paddings';
 
 import { StyledBox } from './styled';
 
@@ -27,9 +30,57 @@ interface PrivateProps {
   forwardedRef: React.Ref<HTMLDivElement>;
 }
 
-const RawBox: React.FC<BoxProps & PrivateProps> = (props) => (
-  <StyledBox ref={props.forwardedRef} {...props} />
-);
+const RawBox: React.FC<BoxProps & PrivateProps> = (props) => {
+  const {
+    forwardedRef,
+    display,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    paddingVertical,
+    paddingHorizontal,
+    backgroundColor,
+    shadow,
+    border,
+    borderTop,
+    borderRight,
+    borderBottom,
+    borderLeft,
+    borderRadius,
+    clearfix,
+    zIndex,
+    ...domProps
+  } = props;
+
+  return (
+    <StyledBox
+      ref={forwardedRef}
+      {...domProps}
+      {...toTransientDisplayProps(props)}
+      {...toTransientMarginProps(props)}
+      {...toTransientPaddingProps(props)}
+      $backgroundColor={backgroundColor}
+      $border={border}
+      $borderBottom={borderBottom}
+      $borderLeft={borderLeft}
+      $borderRadius={borderRadius}
+      $borderRight={borderRight}
+      $borderTop={borderTop}
+      $clearfix={clearfix}
+      $shadow={shadow}
+      $zIndex={zIndex}
+    />
+  );
+};
 
 export const Box = memo(
   forwardRef<HTMLDivElement, BoxProps>((props, ref) => <RawBox {...props} forwardedRef={ref} />),

--- a/packages/big-design/src/components/Box/spec.tsx
+++ b/packages/big-design/src/components/Box/spec.tsx
@@ -96,3 +96,30 @@ test('box forwards ref', () => {
 
   expect(screen.getByText('test')).toBe(ref.current);
 });
+
+test('does not leak system props onto the DOM node', () => {
+  render(
+    <Box
+      backgroundColor="white"
+      border="box"
+      borderRadius="circle"
+      display="flex"
+      margin="medium"
+      padding="medium"
+      zIndex="sticky"
+    >
+      test
+    </Box>,
+  );
+
+  const element = screen.getByText('test');
+
+  // DOM lowercases custom attribute names, so assert against the lowercased forms.
+  expect(element).not.toHaveAttribute('backgroundcolor');
+  expect(element).not.toHaveAttribute('border');
+  expect(element).not.toHaveAttribute('borderradius');
+  expect(element).not.toHaveAttribute('display');
+  expect(element).not.toHaveAttribute('margin');
+  expect(element).not.toHaveAttribute('padding');
+  expect(element).not.toHaveAttribute('zindex');
+});

--- a/packages/big-design/src/components/Box/styled.tsx
+++ b/packages/big-design/src/components/Box/styled.tsx
@@ -3,65 +3,87 @@ import { clearFix } from 'polished';
 import styled, { css } from 'styled-components';
 
 import { withDisplay, withMargins, withPaddings } from '../../helpers';
+import { TransientDisplayProps } from '../../helpers/display/types';
+import { TransientMarginProps } from '../../helpers/margins/margins';
+import { TransientPaddingProps } from '../../helpers/paddings/paddings';
 
 import { BoxProps } from './Box';
 
-export const StyledBox = styled.div<BoxProps>`
+// Internal-only prop shape: bespoke system props are `$`-prefixed so styled-components
+// never forwards them to the underlying DOM node. The public `BoxProps` is unchanged;
+// `Box.tsx` maps its public props to these transient names before rendering.
+interface StyledBoxProps
+  extends TransientDisplayProps,
+    TransientMarginProps,
+    TransientPaddingProps {
+  $backgroundColor?: BoxProps['backgroundColor'];
+  $shadow?: BoxProps['shadow'];
+  $border?: BoxProps['border'];
+  $borderTop?: BoxProps['borderTop'];
+  $borderRight?: BoxProps['borderRight'];
+  $borderBottom?: BoxProps['borderBottom'];
+  $borderLeft?: BoxProps['borderLeft'];
+  $borderRadius?: BoxProps['borderRadius'];
+  $clearfix?: BoxProps['clearfix'];
+  $zIndex?: BoxProps['zIndex'];
+}
+
+export const StyledBox = styled.div<StyledBoxProps>`
   ${withDisplay()}
   ${withMargins()}
   ${withPaddings()}
   box-sizing: border-box;
 
-  ${({ clearfix }) => clearfix && clearFix()};
+  ${({ $clearfix }) => $clearfix && clearFix()};
 
-  ${({ backgroundColor, theme }) =>
-    backgroundColor &&
+  ${({ $backgroundColor, theme }) =>
+    $backgroundColor &&
     css`
-      background-color: ${theme.colors[backgroundColor]};
+      background-color: ${theme.colors[$backgroundColor]};
     `};
 
-  ${({ shadow, theme }) => shadow && theme.shadow[shadow]};
+  ${({ $shadow, theme }) => $shadow && theme.shadow[$shadow]};
 
-  ${({ border, theme }) =>
-    border &&
+  ${({ $border, theme }) =>
+    $border &&
     css`
-      border: ${theme.border[border]};
+      border: ${theme.border[$border]};
     `};
 
-  ${({ borderTop, theme }) =>
-    borderTop &&
+  ${({ $borderTop, theme }) =>
+    $borderTop &&
     css`
-      border-top: ${theme.border[borderTop]};
+      border-top: ${theme.border[$borderTop]};
     `};
 
-  ${({ borderRight, theme }) =>
-    borderRight &&
+  ${({ $borderRight, theme }) =>
+    $borderRight &&
     css`
-      border-right: ${theme.border[borderRight]};
+      border-right: ${theme.border[$borderRight]};
     `};
 
-  ${({ borderBottom, theme }) =>
-    borderBottom &&
+  ${({ $borderBottom, theme }) =>
+    $borderBottom &&
     css`
-      border-bottom: ${theme.border[borderBottom]};
+      border-bottom: ${theme.border[$borderBottom]};
     `};
 
-  ${({ borderLeft, theme }) =>
-    borderLeft &&
+  ${({ $borderLeft, theme }) =>
+    $borderLeft &&
     css`
-      border-left: ${theme.border[borderLeft]};
+      border-left: ${theme.border[$borderLeft]};
     `};
 
-  ${({ borderRadius, theme }) =>
-    borderRadius &&
+  ${({ $borderRadius, theme }) =>
+    $borderRadius &&
     css`
-      border-radius: ${theme.borderRadius[borderRadius]};
+      border-radius: ${theme.borderRadius[$borderRadius]};
     `};
 
-  ${({ zIndex, theme }) =>
-    zIndex &&
+  ${({ $zIndex, theme }) =>
+    $zIndex &&
     css`
-      z-index: ${theme.zIndex[zIndex]};
+      z-index: ${theme.zIndex[$zIndex]};
     `};
 `;
 

--- a/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
@@ -347,7 +347,6 @@ exports[`render offset pagination component 1`] = `
         data-popper-escaped="true"
         data-popper-placement="bottom-start"
         data-popper-reference-hidden="true"
-        display="none"
         style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
       >
         <div
@@ -782,7 +781,6 @@ exports[`render offset pagination component with invalid page info 1`] = `
         data-popper-escaped="true"
         data-popper-placement="bottom-start"
         data-popper-reference-hidden="true"
-        display="none"
         style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
       >
         <div
@@ -1217,7 +1215,6 @@ exports[`render offset pagination component with invalid range info 1`] = `
         data-popper-escaped="true"
         data-popper-placement="bottom-start"
         data-popper-reference-hidden="true"
-        display="none"
         style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
       >
         <div
@@ -1653,7 +1650,6 @@ exports[`render offset pagination component with no items 1`] = `
         data-popper-escaped="true"
         data-popper-placement="bottom-start"
         data-popper-reference-hidden="true"
-        display="none"
         style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
       >
         <div

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -364,7 +364,6 @@ exports[`dropdown is not visible if items fit 1`] = `
         data-popper-escaped="true"
         data-popper-placement="bottom-start"
         data-popper-reference-hidden="true"
-        display="none"
         style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
       >
         <div
@@ -747,7 +746,6 @@ exports[`it renders the given tabs 1`] = `
         data-popper-escaped="true"
         data-popper-placement="bottom-start"
         data-popper-reference-hidden="true"
-        display="none"
         style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
       >
         <div
@@ -1162,7 +1160,6 @@ exports[`only the pills that fit are visible 1`] = `
         data-popper-escaped="true"
         data-popper-placement="bottom-start"
         data-popper-reference-hidden="true"
-        display="none"
         style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
       >
         <div
@@ -1576,7 +1573,6 @@ exports[`only the pills that fit are visible 2 1`] = `
         data-popper-escaped="true"
         data-popper-placement="bottom-start"
         data-popper-reference-hidden="true"
-        display="none"
         style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
       >
         <div
@@ -1989,7 +1985,6 @@ exports[`renders all the filters if they fit 1`] = `
         data-popper-escaped="true"
         data-popper-placement="bottom-start"
         data-popper-reference-hidden="true"
-        display="none"
         style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
       >
         <div
@@ -2388,7 +2383,6 @@ exports[`renders dropdown if items do not fit 1`] = `
         data-popper-escaped="true"
         data-popper-placement="bottom-start"
         data-popper-reference-hidden="true"
-        display="none"
         style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
       >
         <div

--- a/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
@@ -344,7 +344,6 @@ exports[`render Stateless pagination component 1`] = `
       </button>
       <div
         class="c8"
-        display="none"
         style="position: fixed; left: 0px; top: 0px;"
       >
         <div

--- a/packages/big-design/src/components/Stepper/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Stepper/__snapshots__/spec.tsx.snap
@@ -356,7 +356,6 @@ exports[`renders Stepper 1`] = `
 >
   <div
     class="c2 c3 c4"
-    display="[object Object]"
   >
     <div
       class="c5 c6 c7"
@@ -383,7 +382,6 @@ exports[`renders Stepper 1`] = `
     </div>
     <div
       class="c9 c10"
-      display="[object Object]"
     />
     <p
       class="c11 c12"
@@ -394,7 +392,6 @@ exports[`renders Stepper 1`] = `
   </div>
   <div
     class="c13 c14 c4"
-    display="[object Object]"
   >
     <div
       class="c5 c6 c7"
@@ -416,7 +413,6 @@ exports[`renders Stepper 1`] = `
     </div>
     <div
       class="c16 c10"
-      display="[object Object]"
     />
     <p
       class="c11 c12"
@@ -427,7 +423,6 @@ exports[`renders Stepper 1`] = `
   </div>
   <div
     class="c2 c3 c4"
-    display="[object Object]"
   >
     <div
       class="c17 c6 c7"
@@ -449,7 +444,6 @@ exports[`renders Stepper 1`] = `
     </div>
     <div
       class="c18 c10"
-      display="[object Object]"
     />
     <p
       class="c19 c12"

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -399,7 +399,6 @@ exports[`offset pagination renders a pagination component 1`] = `
             data-popper-escaped="true"
             data-popper-placement="bottom-start"
             data-popper-reference-hidden="true"
-            display="none"
             style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
           >
             <div

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -399,7 +399,6 @@ exports[`offset pagination renders a pagination component 1`] = `
             data-popper-escaped="true"
             data-popper-placement="bottom-start"
             data-popper-reference-hidden="true"
-            display="none"
             style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
           >
             <div

--- a/packages/big-design/src/helpers/display/display.tsx
+++ b/packages/big-design/src/helpers/display/display.tsx
@@ -6,11 +6,26 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { DisplayOverload, DisplayProps } from './types';
+import { DisplayOverload, DisplayProps, TransientDisplayProps } from './types';
 
-export const withDisplay = () => css<DisplayProps>`
-  ${({ display, theme }) => display && getDisplayStyles(display, theme, 'display')};
+// MIGRATION SHIM (LTRAC-1396): reads both the public (`display`) and transient
+// (`$display`) prop names so components can be migrated to transient props one PR at
+// a time while unconverted consumers keep rendering identically. Once every consumer
+// passes `$display`, drop the `?? display` fallback (and `DisplayProps` from the
+// generic) to leave a pure transient read.
+export const withDisplay = () => css<DisplayProps & TransientDisplayProps>`
+  ${({ display, $display, theme }) => {
+    const value = $display ?? display;
+
+    return value && getDisplayStyles(value, theme, 'display');
+  }};
 `;
+
+// Rename-and-keep helper: maps the public `display` prop to its transient (`$`-prefixed)
+// name for hand-off to a tag-target styled component.
+export function toTransientDisplayProps(props: DisplayProps): TransientDisplayProps {
+  return { $display: props.display };
+}
 
 const getDisplayStyles: DisplayOverload = (
   displayProp: any,

--- a/packages/big-design/src/helpers/display/types.ts
+++ b/packages/big-design/src/helpers/display/types.ts
@@ -10,6 +10,13 @@ export type DisplayProps = Partial<{
   display: DisplayProp;
 }>;
 
+// Internal, transient (`$`-prefixed) counterpart of `DisplayProps`. styled-components
+// never forwards `$`-prefixed props to the DOM, so tag-target styled components read
+// this instead of the public name to avoid leaking it onto real DOM nodes.
+export type TransientDisplayProps = Partial<{
+  $display: DisplayProp;
+}>;
+
 export type DisplayOverload = (
   displayProp: DisplayProp,
   theme: ThemeInterface,

--- a/packages/big-design/src/helpers/margins/margins.tsx
+++ b/packages/big-design/src/helpers/margins/margins.tsx
@@ -16,18 +16,60 @@ export type MarginProps = Partial<{
   marginHorizontal: MarginProp;
 }>;
 
-export const withMargins = () => css<MarginProps>`
-  ${({ margin, theme }) => margin && getSpacingStyles(margin, theme, 'margin')};
-  ${({ marginTop, theme }) => marginTop && getSpacingStyles(marginTop, theme, 'margin-top')};
-  ${({ marginRight, theme }) =>
-    marginRight && getSpacingStyles(marginRight, theme, 'margin-right')};
-  ${({ marginBottom, theme }) =>
-    marginBottom && getSpacingStyles(marginBottom, theme, 'margin-bottom')};
-  ${({ marginLeft, theme }) => marginLeft && getSpacingStyles(marginLeft, theme, 'margin-left')};
-  ${({ marginVertical, theme }) =>
-    marginVertical && getSpacingStyles(marginVertical, theme, 'margin-top', 'margin-bottom')};
-  ${({ marginHorizontal, theme }) =>
-    marginHorizontal && getSpacingStyles(marginHorizontal, theme, 'margin-left', 'margin-right')};
+// Internal, transient (`$`-prefixed) counterpart of `MarginProps`. styled-components
+// never forwards `$`-prefixed props to the DOM, so tag-target styled components read
+// these instead of the public names to avoid leaking them onto real DOM nodes.
+export type TransientMarginProps = Partial<{
+  $margin: MarginProp;
+  $marginTop: MarginProp;
+  $marginRight: MarginProp;
+  $marginBottom: MarginProp;
+  $marginLeft: MarginProp;
+  $marginVertical: MarginProp;
+  $marginHorizontal: MarginProp;
+}>;
+
+// MIGRATION SHIM (LTRAC-1396): reads both the public (`margin`) and transient
+// (`$margin`) prop names so components can be migrated to transient props one PR at
+// a time while unconverted consumers keep rendering identically. Once every consumer
+// passes `$`-prefixed props, drop the `?? margin*` fallbacks (and `MarginProps` from
+// the generic) to leave a pure transient read.
+export const withMargins = () => css<MarginProps & TransientMarginProps>`
+  ${({ margin, $margin, theme }) => {
+    const value = $margin ?? margin;
+
+    return value && getSpacingStyles(value, theme, 'margin');
+  }};
+  ${({ marginTop, $marginTop, theme }) => {
+    const value = $marginTop ?? marginTop;
+
+    return value && getSpacingStyles(value, theme, 'margin-top');
+  }};
+  ${({ marginRight, $marginRight, theme }) => {
+    const value = $marginRight ?? marginRight;
+
+    return value && getSpacingStyles(value, theme, 'margin-right');
+  }};
+  ${({ marginBottom, $marginBottom, theme }) => {
+    const value = $marginBottom ?? marginBottom;
+
+    return value && getSpacingStyles(value, theme, 'margin-bottom');
+  }};
+  ${({ marginLeft, $marginLeft, theme }) => {
+    const value = $marginLeft ?? marginLeft;
+
+    return value && getSpacingStyles(value, theme, 'margin-left');
+  }};
+  ${({ marginVertical, $marginVertical, theme }) => {
+    const value = $marginVertical ?? marginVertical;
+
+    return value && getSpacingStyles(value, theme, 'margin-top', 'margin-bottom');
+  }};
+  ${({ marginHorizontal, $marginHorizontal, theme }) => {
+    const value = $marginHorizontal ?? marginHorizontal;
+
+    return value && getSpacingStyles(value, theme, 'margin-left', 'margin-right');
+  }};
 `;
 
 export function excludeMarginProps<T extends Record<string, any>>(
@@ -45,4 +87,28 @@ export function excludeMarginProps<T extends Record<string, any>>(
   } = props;
 
   return rest;
+}
+
+// Rename-and-keep counterpart of `excludeMarginProps`: maps the public margin props
+// to their transient (`$`-prefixed) names for hand-off to a tag-target styled component.
+export function toTransientMarginProps(props: MarginProps): TransientMarginProps {
+  const {
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+  } = props;
+
+  return {
+    $margin: margin,
+    $marginTop: marginTop,
+    $marginRight: marginRight,
+    $marginBottom: marginBottom,
+    $marginLeft: marginLeft,
+    $marginVertical: marginVertical,
+    $marginHorizontal: marginHorizontal,
+  };
 }

--- a/packages/big-design/src/helpers/paddings/paddings.tsx
+++ b/packages/big-design/src/helpers/paddings/paddings.tsx
@@ -16,20 +16,60 @@ export type PaddingProps = Partial<{
   paddingHorizontal: PaddingProp;
 }>;
 
-export const withPaddings = () => css<PaddingProps>`
-  ${({ padding, theme }) => padding && getSpacingStyles(padding, theme, 'padding')};
-  ${({ paddingTop, theme }) => paddingTop && getSpacingStyles(paddingTop, theme, 'padding-top')};
-  ${({ paddingRight, theme }) =>
-    paddingRight && getSpacingStyles(paddingRight, theme, 'padding-right')};
-  ${({ paddingBottom, theme }) =>
-    paddingBottom && getSpacingStyles(paddingBottom, theme, 'padding-bottom')};
-  ${({ paddingLeft, theme }) =>
-    paddingLeft && getSpacingStyles(paddingLeft, theme, 'padding-left')};
-  ${({ paddingVertical, theme }) =>
-    paddingVertical && getSpacingStyles(paddingVertical, theme, 'padding-top', 'padding-bottom')};
-  ${({ paddingHorizontal, theme }) =>
-    paddingHorizontal &&
-    getSpacingStyles(paddingHorizontal, theme, 'padding-left', 'padding-right')};
+// Internal, transient (`$`-prefixed) counterpart of `PaddingProps`. styled-components
+// never forwards `$`-prefixed props to the DOM, so tag-target styled components read
+// these instead of the public names to avoid leaking them onto real DOM nodes.
+export type TransientPaddingProps = Partial<{
+  $padding: PaddingProp;
+  $paddingTop: PaddingProp;
+  $paddingRight: PaddingProp;
+  $paddingBottom: PaddingProp;
+  $paddingLeft: PaddingProp;
+  $paddingVertical: PaddingProp;
+  $paddingHorizontal: PaddingProp;
+}>;
+
+// MIGRATION SHIM (LTRAC-1396): reads both the public (`padding`) and transient
+// (`$padding`) prop names so components can be migrated to transient props one PR at
+// a time while unconverted consumers keep rendering identically. Once every consumer
+// passes `$`-prefixed props, drop the `?? padding*` fallbacks (and `PaddingProps` from
+// the generic) to leave a pure transient read.
+export const withPaddings = () => css<PaddingProps & TransientPaddingProps>`
+  ${({ padding, $padding, theme }) => {
+    const value = $padding ?? padding;
+
+    return value && getSpacingStyles(value, theme, 'padding');
+  }};
+  ${({ paddingTop, $paddingTop, theme }) => {
+    const value = $paddingTop ?? paddingTop;
+
+    return value && getSpacingStyles(value, theme, 'padding-top');
+  }};
+  ${({ paddingRight, $paddingRight, theme }) => {
+    const value = $paddingRight ?? paddingRight;
+
+    return value && getSpacingStyles(value, theme, 'padding-right');
+  }};
+  ${({ paddingBottom, $paddingBottom, theme }) => {
+    const value = $paddingBottom ?? paddingBottom;
+
+    return value && getSpacingStyles(value, theme, 'padding-bottom');
+  }};
+  ${({ paddingLeft, $paddingLeft, theme }) => {
+    const value = $paddingLeft ?? paddingLeft;
+
+    return value && getSpacingStyles(value, theme, 'padding-left');
+  }};
+  ${({ paddingVertical, $paddingVertical, theme }) => {
+    const value = $paddingVertical ?? paddingVertical;
+
+    return value && getSpacingStyles(value, theme, 'padding-top', 'padding-bottom');
+  }};
+  ${({ paddingHorizontal, $paddingHorizontal, theme }) => {
+    const value = $paddingHorizontal ?? paddingHorizontal;
+
+    return value && getSpacingStyles(value, theme, 'padding-left', 'padding-right');
+  }};
 `;
 
 export function excludePaddingProps<T extends Record<string, any>>(
@@ -47,4 +87,28 @@ export function excludePaddingProps<T extends Record<string, any>>(
   } = props;
 
   return rest;
+}
+
+// Rename-and-keep counterpart of `excludePaddingProps`: maps the public padding props
+// to their transient (`$`-prefixed) names for hand-off to a tag-target styled component.
+export function toTransientPaddingProps(props: PaddingProps): TransientPaddingProps {
+  const {
+    padding,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    paddingVertical,
+    paddingHorizontal,
+  } = props;
+
+  return {
+    $padding: padding,
+    $paddingTop: paddingTop,
+    $paddingRight: paddingRight,
+    $paddingBottom: paddingBottom,
+    $paddingLeft: paddingLeft,
+    $paddingVertical: paddingVertical,
+    $paddingHorizontal: paddingHorizontal,
+  };
 }


### PR DESCRIPTION
Jira: [TRAC-1340](<https://bigcommercecloud.atlassian.net/browse/TRAC-1340>)

Stage 0 (foundation + first consumer) of [LTRAC-1396](https://linear.app/commerce/issue/LTRAC-1396/migrate-bigdesign-styled-components-props-to-transient-dollar-prefixed). Later stages migrate the remaining \~70 files in small per-component PRs.

## What?

* Convert the shared `withMargins` / `withPaddings` / `withDisplay` helpers to read transient (`$`-prefixed) props, and add internal `toTransient{Margin,Padding,Display}Props()` mapping utilities (not re-exported from `helpers/index.ts` — imported directly from the helper subpaths).
* Migrate the first consumer, `Box`: a new internal-only `StyledBoxProps` with `$`-prefixed system props. Public `BoxProps` and CSS output are unchanged; `Box.tsx` now destructures every non-DOM prop out of the blind `{...props}` spread and routes them through the transient utilities + explicit `$name` JSX props. This is the template later blind-spread components copy.
* Add non-leakage assertions (`not.toHaveAttribute('display')`, etc.) to `Box/spec.tsx`.

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on tag-target styled components, so system/style props (`backgroundColor`, `display`, `margin`, ...) would leak onto real DOM nodes and fire React's unknown-prop warning on every render once on v6. Transient props are the idiomatic fix — styled-components never forwards `$`-prefixed props to the DOM, at no per-render cost.

**Two deviations from the ticket, worth a careful look:**

1. **Temporary dual-read shim instead of "no shim".** The ticket argues no shim is needed because changing the helper generic "breaks tsc the instant the helper's generic shape changes," forcing an all-at-once conversion. That premise is false: the transient props are optional, so tsc stays green — but every unconverted consumer then silently drops its spacing/display CSS *at runtime* (54 snapshot failures when only Box was converted). The helpers therefore read `$prop ?? prop` (marked `MIGRATION SHIM (LTRAC-1396)`) so consumers migrate one PR at a time; the fallback is removed in a final cleanup PR once all are transient.
2. `display` **leaked on v5 too.** `display` is a valid SVG presentation attribute, so v5 forwarded it to the DOM. Fixing Box's blind spread removes `display="[object Object]"` / `display="none"` from components that route display through Box/Flex (Stepper, OffsetPagination, StatelessPagination, PillTabs, Table, TableNext). The updated snapshots are **removal-only** (all `-` lines, zero CSS or `+` changes) — verified.

## Screenshots/Screen Recordings

No visual change — this is an internal prop-plumbing refactor with identical CSS output. The only DOM difference is the removal of the stray leaked `display` attribute described above.

## Testing/Proof

`pnpm --filter @bigcommerce/big-design run lint && run typecheck && run test` all green: lint clean, typecheck clean, **1146 tests pass / 182 snapshots**. `setupTests.ts`'s `failOnConsole()` plus the snapshot serializer's full-DOM output together act as a leak detector — any non-`$` prop reaching a DOM node fails the suite. `build:dt` succeeds and `dist/index.d.ts` contains no `Transient*` / `toTransient*` symbols, confirming the public API is unchanged.

Refs [LTRAC-1340](https://linear.app/commerce/issue/LTRAC-1340/support-image-optimization-for-makeswift-and-static-images)

[TRAC-1340]: https://bigcommercecloud.atlassian.net/browse/TRAC-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ