### PR TITLE
refactor: TRAC-1343 $-prefix internal props on already-explicit styled components

### DIFF
--- a/.changeset/transient-props-explicit-components.md
+++ b/.changeset/transient-props-explicit-components.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stages 1-2). Rename the internal-only custom props read by `Checkbox`, `Toggle`, `Modal`, `List`, `List/Item`, `Form/Group`, and the Worksheet `TextEditor` to `$`-prefixed names at both the styled definition and the JSX call site (e.g. `$isActive`, `$hasImg`, `$isIndeterminate`, `$backdrop`, `$variant`, `$maxHeight`). Public prop interfaces (`ModalProps`, `ListProps`, `ListItemProps`, `CheckboxProps`, etc.) and CSS output are unchanged. This is a true no-op under styled-components 5 (these custom props were already filtered from the DOM, so all 182 snapshots are unchanged); the `$` prefix guarantees they stay off the DOM under v6's default forwarding. The remaining tag-target components audited in Stage 1 (`Tooltip`, `Select`, `Stepper/Step`, `Table`/`TableNext` roots, `Radio`, `Switch`, `Fieldset`, and the `Checkbox`/`Radio` labels) read only DOM-valid props and need no change.

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -105,7 +105,7 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
   }, [description]);
 
   return (
-    <CheckboxContainer className={className} hasImg={Boolean(img)} onClick={onClick} style={style}>
+    <CheckboxContainer $hasImg={Boolean(img)} className={className} onClick={onClick} style={style}>
       <HiddenCheckbox
         checked={checked}
         disabled={disabled}
@@ -134,18 +134,18 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
       />
 
       <StyledCheckbox
+        $isIndeterminate={isIndeterminate}
         aria-hidden={true}
         checked={checked}
         disabled={disabled}
         htmlFor={id}
-        isIndeterminate={isIndeterminate}
       >
         {!checked && isIndeterminate ? <RemoveIcon /> : <CheckIcon />}
       </StyledCheckbox>
       {img ? (
         <CheckboxImgContainer height={40} width={40} {...imgProps} alt={img.alt ?? ''} />
       ) : null}
-      <CheckboxLabelContainer hasContent={Boolean(label) || Boolean(description)}>
+      <CheckboxLabelContainer $hasContent={Boolean(label) || Boolean(description)}>
         {renderedLabel}
         {renderedDescription}
       </CheckboxLabelContainer>

--- a/packages/big-design/src/components/Checkbox/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/styled.tsx
@@ -6,7 +6,7 @@ import { withTransition } from '../../helpers/transitions';
 
 interface StyledCheckboxProps {
   checked?: boolean;
-  isIndeterminate?: boolean;
+  $isIndeterminate?: boolean;
   disabled?: boolean;
 }
 
@@ -15,8 +15,8 @@ export interface StyledLabelProps {
   disabled?: boolean;
 }
 
-export const CheckboxLabelContainer = styled.div<{ hasContent?: boolean }>`
-  margin-left: ${({ hasContent, theme }) => (hasContent ? theme.spacing.xSmall : 0)};
+export const CheckboxLabelContainer = styled.div<{ $hasContent?: boolean }>`
+  margin-left: ${({ $hasContent, theme }) => ($hasContent ? theme.spacing.xSmall : 0)};
 `;
 
 export const CheckboxImgContainer = styled.img`
@@ -25,8 +25,8 @@ export const CheckboxImgContainer = styled.img`
   flex-shrink: 0;
 `;
 
-export const CheckboxContainer = styled.div<{ hasImg?: boolean }>`
-  align-items: ${({ hasImg }) => (hasImg ? 'center' : 'flex-start')};
+export const CheckboxContainer = styled.div<{ $hasImg?: boolean }>`
+  align-items: ${({ $hasImg }) => ($hasImg ? 'center' : 'flex-start')};
   display: flex;
 `;
 
@@ -38,12 +38,12 @@ export const StyledCheckbox = styled.label<StyledCheckboxProps>`
   ${withTransition(['border-color', 'background', 'box-shadow', 'color', 'opacity'])}
 
   align-items: center;
-  background: ${({ checked, isIndeterminate, theme }) =>
-    checked || isIndeterminate ? theme.colors.primary : theme.colors.white};
+  background: ${({ checked, $isIndeterminate, theme }) =>
+    checked || $isIndeterminate ? theme.colors.primary : theme.colors.white};
   box-sizing: border-box;
   border: ${({ theme }) => theme.border.box};
-  border-color: ${({ checked, isIndeterminate, theme }) =>
-    checked || isIndeterminate ? theme.colors.primary : theme.colors.secondary30};
+  border-color: ${({ checked, $isIndeterminate, theme }) =>
+    checked || $isIndeterminate ? theme.colors.primary : theme.colors.secondary30};
   border-radius: ${({ theme }) => theme.borderRadius.normal};
   color: ${({ theme }) => theme.colors.white};
   cursor: pointer;
@@ -55,20 +55,20 @@ export const StyledCheckbox = styled.label<StyledCheckboxProps>`
   user-select: none;
   width: ${({ theme }) => theme.spacing.large};
 
-  ${({ checked, disabled, isIndeterminate, theme }) =>
+  ${({ checked, disabled, $isIndeterminate, theme }) =>
     disabled &&
     css`
-      background: ${checked || isIndeterminate
+      background: ${checked || $isIndeterminate
         ? theme.colors.secondary30
         : theme.colors.secondary10};
       border-color: ${theme.colors.secondary30};
       cursor: not-allowed;
     `};
 
-  ${({ checked, isIndeterminate, disabled, theme }) =>
+  ${({ checked, $isIndeterminate, disabled, theme }) =>
     !disabled &&
     `&:hover {
-      border-color: ${checked || isIndeterminate ? theme.colors.primary : theme.colors.secondary40};
+      border-color: ${checked || $isIndeterminate ? theme.colors.primary : theme.colors.secondary40};
     }`}
 
   ${HiddenCheckbox}:focus + & {
@@ -76,7 +76,7 @@ export const StyledCheckbox = styled.label<StyledCheckboxProps>`
   }
 
   svg {
-    opacity: ${({ checked, isIndeterminate }) => (checked || isIndeterminate ? 1 : 0)};
+    opacity: ${({ checked, $isIndeterminate }) => (checked || $isIndeterminate ? 1 : 0)};
   }
 `;
 

--- a/packages/big-design/src/components/Form/Group/Group.tsx
+++ b/packages/big-design/src/components/Form/Group/Group.tsx
@@ -61,7 +61,7 @@ export const FormGroup: React.FC<FormGroupProps> = (props) => {
   return (
     <FormGroupContext.Provider value={contextValue}>
       {inline ? (
-        <StyledInlineGroup childrenCount={childrenCount} fullWidth={fullWidth}>
+        <StyledInlineGroup $childrenCount={childrenCount} $fullWidth={fullWidth}>
           {children}
           {renderErrors()}
         </StyledInlineGroup>

--- a/packages/big-design/src/components/Form/Group/styled.tsx
+++ b/packages/big-design/src/components/Form/Group/styled.tsx
@@ -4,8 +4,8 @@ import styled, { css } from 'styled-components';
 import { Flex } from '../../Flex';
 
 interface StyledProps {
-  childrenCount?: number;
-  fullWidth?: boolean;
+  $childrenCount?: number;
+  $fullWidth?: boolean;
 }
 
 const SharedGroupStyles = css`
@@ -30,20 +30,20 @@ export const StyledInlineGroup = styled.div<StyledProps>`
   ${SharedGroupStyles};
 
   ${({ theme }) => theme.breakpoints.tablet} {
-    ${({ childrenCount, fullWidth, theme }) =>
-      childrenCount === 2 &&
+    ${({ $childrenCount, $fullWidth, theme }) =>
+      $childrenCount === 2 &&
       css`
-        grid-template-columns: repeat(2, ${fullWidth ? '1fr' : theme.helpers.remCalc(200)});
+        grid-template-columns: repeat(2, ${$fullWidth ? '1fr' : theme.helpers.remCalc(200)});
 
         ${StyledError} {
           grid-column: 1 / 3;
         }
       `}
 
-    ${({ childrenCount, fullWidth, theme }) =>
-      childrenCount === 3 &&
+    ${({ $childrenCount, $fullWidth, theme }) =>
+      $childrenCount === 3 &&
       css`
-        grid-template-columns: repeat(3, ${fullWidth ? '1fr' : theme.helpers.remCalc(128)});
+        grid-template-columns: repeat(3, ${$fullWidth ? '1fr' : theme.helpers.remCalc(128)});
 
         ${StyledError} {
           grid-column: 1 / 4;

--- a/packages/big-design/src/components/List/Item/Item.tsx
+++ b/packages/big-design/src/components/List/Item/Item.tsx
@@ -72,11 +72,11 @@ const StyleableListItem = typedMemo(
           },
           ref: forwardedRef,
         })}
-        actionType={actionType}
-        autoWidth={autoWidth}
-        isAction={isAction}
-        isHighlighted={isHighlighted}
-        maxWidth={maxWidth}
+        $actionType={actionType}
+        $autoWidth={autoWidth}
+        $isAction={isAction}
+        $isHighlighted={isHighlighted}
+        $maxWidth={maxWidth}
       >
         <Checkbox
           checked={isChecked}
@@ -97,13 +97,13 @@ const StyleableListItem = typedMemo(
           item,
           ref: forwardedRef,
         })}
-        actionType={actionType}
-        autoWidth={autoWidth}
+        $actionType={actionType}
+        $autoWidth={autoWidth}
+        $isAction={isAction}
+        $isHighlighted={isHighlighted}
+        $isSelected={isSelected}
+        $maxWidth={maxWidth}
         disabled={item.disabled}
-        isAction={isAction}
-        isHighlighted={isHighlighted}
-        isSelected={isSelected}
-        maxWidth={maxWidth}
       >
         <Content isHighlighted={isHighlighted} item={item} wrapText={maxWidth !== undefined} />
         {isSelected && <CheckIcon color="primary" size="large" />}

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -5,26 +5,34 @@ import { withTransition } from '../../../helpers/transitions';
 
 import { ListItemProps } from '.';
 
-export const StyledListItem = styled.li<
-  Omit<ListItemProps<unknown>, 'getItemProps' | 'item' | 'index'>
->`
+interface StyledListItemProps {
+  disabled?: boolean;
+  $actionType?: ListItemProps<unknown>['actionType'];
+  $autoWidth?: ListItemProps<unknown>['autoWidth'];
+  $isAction?: ListItemProps<unknown>['isAction'];
+  $isHighlighted?: ListItemProps<unknown>['isHighlighted'];
+  $isSelected?: ListItemProps<unknown>['isSelected'];
+  $maxWidth?: ListItemProps<unknown>['maxWidth'];
+}
+
+export const StyledListItem = styled.li<StyledListItemProps>`
   ${withTransition(['background-color', 'color'])}
 
   align-items: center;
   box-sizing: border-box;
   cursor: pointer;
   display: flex;
-  font-weight: ${({ theme, isSelected }) =>
-    isSelected ? theme.typography.fontWeight.semiBold : theme.typography.fontWeight.regular};
+  font-weight: ${({ theme, $isSelected }) =>
+    $isSelected ? theme.typography.fontWeight.semiBold : theme.typography.fontWeight.regular};
   justify-content: space-between;
   min-height: ${({ theme }) => theme.helpers.remCalc(36)};
-  min-width: ${({ autoWidth, theme }) => (autoWidth ? 'auto' : theme.helpers.remCalc(256))};
+  min-width: ${({ $autoWidth, theme }) => ($autoWidth ? 'auto' : theme.helpers.remCalc(256))};
   outline: none;
   padding: ${({ theme }) => `${theme.spacing.xxSmall} ${theme.spacing.medium}`};
-  ${({ maxWidth, theme }) =>
-    maxWidth !== undefined &&
+  ${({ $maxWidth, theme }) =>
+    $maxWidth !== undefined &&
     css`
-      max-width: ${theme.helpers.remCalc(maxWidth)};
+      max-width: ${theme.helpers.remCalc($maxWidth)};
       overflow-wrap: break-word;
       white-space: normal;
       word-break: break-word;
@@ -43,10 +51,10 @@ export const StyledListItem = styled.li<
     }
   }
 
-  ${({ actionType, isAction, isHighlighted, theme }) =>
-    isHighlighted &&
-    (isAction
-      ? actionType === 'normal'
+  ${({ $actionType, $isAction, $isHighlighted, theme }) =>
+    $isHighlighted &&
+    ($isAction
+      ? $actionType === 'normal'
         ? css`
             background-color: ${theme.colors.primary10};
             color: ${theme.colors.primary};

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -304,7 +304,7 @@ const StyleableList = typedMemo(
             },
             ref: forwardedRef,
           })}
-          maxHeight={maxHeight}
+          $maxHeight={maxHeight}
         >
           {isOpen && renderChildren}
         </StyledList>

--- a/packages/big-design/src/components/List/styled.tsx
+++ b/packages/big-design/src/components/List/styled.tsx
@@ -13,13 +13,17 @@ export const StyledListOverflowWrapper = styled.div`
 
 StyledListOverflowWrapper.defaultProps = { theme: defaultTheme };
 
-export const StyledList = styled.ul<Partial<ListProps<unknown>>>`
+interface StyledListProps {
+  $maxHeight?: ListProps<unknown>['maxHeight'];
+}
+
+export const StyledList = styled.ul<StyledListProps>`
   ${({ theme }) => theme.shadow.raised};
 
   background-color: ${({ theme }) => theme.colors.white};
   color: ${({ theme }) => theme.colors.secondary70};
   margin: 0;
-  max-height: ${({ theme, maxHeight }) => (maxHeight ? theme.helpers.remCalc(maxHeight) : '')};
+  max-height: ${({ theme, $maxHeight }) => ($maxHeight ? theme.helpers.remCalc($maxHeight) : '')};
   outline: none;
   overflow-y: auto;
   padding: ${({ theme }) => theme.spacing.xSmall} 0;

--- a/packages/big-design/src/components/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Modal/Modal.tsx
@@ -168,12 +168,12 @@ const InternalModal: React.FC<ModalProps> = ({
 
   return (
     <StyledModal
-      backdrop={backdrop}
+      $backdrop={backdrop}
+      $variant={variant}
       onClick={onClickAway}
       onKeyDown={onKeyDown}
       ref={setModalRef}
       tabIndex={-1}
-      variant={variant}
     >
       <StyledModalContent aria-labelledby={headerUniqueId} flexDirection="column" variant={variant}>
         {renderedClose}

--- a/packages/big-design/src/components/Modal/styled.tsx
+++ b/packages/big-design/src/components/Modal/styled.tsx
@@ -6,11 +6,16 @@ import { Flex } from '../Flex';
 
 import { ModalProps } from './Modal';
 
+interface StyledModalProps {
+  $backdrop?: ModalProps['backdrop'];
+  $variant?: ModalProps['variant'];
+}
+
 export const StyledModal = styled.div.attrs({
   'aria-modal': true,
   role: 'dialog',
   tabIndex: -1,
-})<Partial<ModalProps>>`
+})<StyledModalProps>`
   align-items: center;
   display: flex;
   height: 100%;
@@ -22,10 +27,10 @@ export const StyledModal = styled.div.attrs({
   z-index: ${({ theme }) => theme.zIndex.modalBackdrop};
 
   ${(props) =>
-    props.backdrop &&
-    props.variant &&
+    props.$backdrop &&
+    props.$variant &&
     css`
-      background: ${rgba(props.theme.colors.secondary70, props.variant === 'dialog' ? 0.5 : 0.7)};
+      background: ${rgba(props.theme.colors.secondary70, props.$variant === 'dialog' ? 0.5 : 0.7)};
     `}
 `;
 

--- a/packages/big-design/src/components/Toggle/Toggle.tsx
+++ b/packages/big-design/src/components/Toggle/Toggle.tsx
@@ -87,10 +87,10 @@ export const Toggle = typedMemo(
         <Box aria-labelledby={labelId} display="flex" id={id} marginBottom="medium" role="group">
           {items.map(({ value: itemId, label, icon }, idx) => (
             <StyledButton
+              $isActive={itemId === activeValue}
+              $isIconType={!!icon}
               aria-checked={itemId === activeValue}
               disabled={disabled}
-              isActive={itemId === activeValue}
-              isIconType={!!icon}
               key={idx}
               onClick={handleClick(itemId)}
               role="switch"

--- a/packages/big-design/src/components/Toggle/styled.ts
+++ b/packages/big-design/src/components/Toggle/styled.ts
@@ -1,15 +1,16 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
-export const StyledButton = styled.button<{ isActive: boolean; isIconType: boolean }>`
+export const StyledButton = styled.button<{ $isActive: boolean; $isIconType: boolean }>`
   align-items: center;
   appearance: none;
-  background-color: ${({ isActive, theme }) =>
-    isActive ? theme.colors.primary20 : theme.colors.white};
+  background-color: ${({ $isActive, theme }) =>
+    $isActive ? theme.colors.primary20 : theme.colors.white};
   border: 1px solid
-    ${({ theme, isActive }) => (isActive ? theme.colors.primary30 : theme.colors.secondary30)};
+    ${({ theme, $isActive }) => ($isActive ? theme.colors.primary30 : theme.colors.secondary30)};
   border-radius: 0;
-  color: ${({ isActive, theme }) => (isActive ? theme.colors.primary60 : theme.colors.secondary60)};
+  color: ${({ $isActive, theme }) =>
+    $isActive ? theme.colors.primary60 : theme.colors.secondary60};
   cursor: pointer;
   flex: none;
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
@@ -37,8 +38,8 @@ export const StyledButton = styled.button<{ isActive: boolean; isIconType: boole
     z-index: 999;
   }
 
-  ${({ isActive, theme }) =>
-    isActive
+  ${({ $isActive, theme }) =>
+    $isActive
       ? `
     z-index: 1;
     `
@@ -68,8 +69,8 @@ export const StyledButton = styled.button<{ isActive: boolean; isIconType: boole
     `}
   }
 
-  ${({ isIconType }) =>
-    isIconType &&
+  ${({ $isIconType }) =>
+    $isIconType &&
     `
     display: flex;
     width: 36px;

--- a/packages/big-design/src/components/Worksheet/editors/TextEditor/TextEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/TextEditor/TextEditor.tsx
@@ -99,8 +99,8 @@ const InternalTextEditor = <T extends WorksheetItem>({
   return (
     <Flex alignItems="center" justifyContent="space-between">
       <StyledInput
+        $isEdited={isEdited}
         autoFocus
-        isEdited={isEdited}
         onBlur={(event?: React.FocusEvent<HTMLInputElement>) => {
           const isActionButtonFocused = event?.relatedTarget?.id === actionButtonId;
 

--- a/packages/big-design/src/components/Worksheet/editors/TextEditor/styled.ts
+++ b/packages/big-design/src/components/Worksheet/editors/TextEditor/styled.ts
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 
 import { StyleableButton } from '../../../Button/Button';
 
-export const StyledInput = styled.input<{ isEdited: boolean }>`
+export const StyledInput = styled.input<{ $isEdited: boolean }>`
   background-color: ${({ theme }) => theme.colors.inherit};
   border: 0;
   font-size: ${({ theme }) => theme.typography.fontSize.small};
@@ -17,8 +17,8 @@ export const StyledInput = styled.input<{ isEdited: boolean }>`
     outline: none;
   }
 
-  ${({ isEdited }) =>
-    isEdited &&
+  ${({ $isEdited }) =>
+    $isEdited &&
     css`
       background-color: ${({ theme }) => theme.colors.warning10};
     `}


### PR DESCRIPTION
## What?

Stages 1 & 2 of the transient-props migration ([LTRAC-1396](https://linear.app/commerce/issue/LTRAC-1396/migrate-bigdesign-styled-components-props-to-transient-dollar-prefixed); Stage 0 was bigcommerce/big-design#1879). `$`-prefix the internal-only custom props read by tag-target styled components so they don't leak onto real DOM nodes under styled-components 6:

* `$`**-renamed** (styled definition + JSX call site): `Checkbox` (`$hasImg`, `$hasContent`, `$isIndeterminate`), `Toggle` (`$isActive`, `$isIconType`), `Modal` (`$backdrop`, `$variant`), `List` (`$maxHeight`), `List/Item` (`$actionType`, `$autoWidth`, `$isAction`, `$isHighlighted`, `$isSelected`, `$maxWidth`), `Form/Group` (`$childrenCount`, `$fullWidth`), Worksheet `TextEditor` (`$isEdited`).
* Where the styled generic reused a public interface (`Partial<ModalProps>`, `Partial<ListProps>`, `Omit<ListItemProps, …>`), introduced an internal-only `Styled*Props` type with the `$`-prefixed shape, mirroring Box's Stage 0 template. Public interfaces are untouched.
* **Stage 1 audit — no change needed:** `Tooltip`, `Select`, `Stepper/Step`, `Table`/`TableNext` roots, `Radio`, `Switch`, `Fieldset`, and the `Checkbox`/`Radio` labels read only DOM-valid props (`checked`/`disabled`/`hidden`), which stay un-prefixed and keep forwarding. (docs `SideNavLogo` and patterns `Header` are deferred to Stage 7 — they consume the published package, not source.)

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on `styled.<tag>` components, so non-DOM props (`isActive`, `hasImg`, `backdrop`, …) would leak onto the DOM and fire React's unknown-prop warning on every render. Transient (`$`-prefixed) props are the idiomatic fix — styled-components never forwards them, at no per-render cost.

## Screenshots/Screen Recordings

No visual change. Public prop APIs (`ModalProps`, `ListProps`, `ListItemProps`, `CheckboxProps`, etc.) and CSS output are unchanged.

## Testing/Proof

`pnpm --filter @bigcommerce/big-design run lint && run typecheck && run test` all green: **1146 tests pass / 182 snapshots pass with zero diffs**. Unlike Stage 0 (where the SVG-valid `display` prop leaked on v5 and had to be scrubbed from snapshots), these custom props were already filtered by v5, so this is a true no-op on the current DOM output; the `$` prefix future-proofs them for v6. `setupTests.ts`'s `failOnConsole()` plus the full-DOM snapshot serializer act as the leak detector. `build:dt` succeeds with no internal `Styled*Props` / `$`-props in `dist/index.d.ts`.

The shared `withMargins`/`withPaddings`/`withDisplay` helpers still carry the temporary dual-read shim (`$prop ?? prop`) from Stage 0; it's removed in a final cleanup PR once every consumer is transient.

Refs [LTRAC-1343](https://linear.app/commerce/issue/LTRAC-1343/fresh-catalyst-install-generates-untracked-graphql-artefacts)