### PR TITLE
refactor: TRAC-1349 route FeatureSet margins through transient props

### DIFF
--- a/.changeset/transient-props-featureset.md
+++ b/.changeset/transient-props-featureset.md
@@ -1,0 +1,7 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 3). Route `FeatureSet`'s margin props through the existing `toTransientMarginProps()` utility instead of blind-spreading them onto its styled `<ul>`, matching the `Box` template. Public `FeatureSetProps` and CSS output are unchanged; all 182 snapshots pass with zero diffs.
+
+`Form/Label` and `Radio/Label` were also audited in this pass: both call the shared `withMargins()` helper, but their public prop types (`FormControlLabelProps`, `StyledLabelProps`) don't extend `MarginProps`, so margin is not reachable via the typed public API today. Since this is a pre-existing type gap rather than something this migration renames, no changes were made to either component; closing that gap (if desired) is a separate, out-of-scope follow-up.

--- a/packages/big-design/src/components/FeatureSet/FeatureSet.tsx
+++ b/packages/big-design/src/components/FeatureSet/FeatureSet.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentPropsWithoutRef, memo } from 'react';
 
 import { MarginProps } from '../../helpers';
+import { toTransientMarginProps } from '../../helpers/margins/margins';
 
 import { StyledUl } from './styled';
 import { Tag, TagProps } from './Tag';
@@ -9,16 +10,28 @@ export interface FeatureSetProps extends ComponentPropsWithoutRef<'ul'>, MarginP
   tags: TagProps[];
 }
 
-export const FeatureSet: React.FC<FeatureSetProps> = memo(
-  ({ tags, className, style, ...props }) => {
-    return tags && tags.length > 0 ? (
-      <StyledUl {...props}>
-        {tags.map((tag, index) => (
-          <Tag {...tag} key={index} />
-        ))}
-      </StyledUl>
-    ) : null;
-  },
-);
+export const FeatureSet: React.FC<FeatureSetProps> = memo((props) => {
+  const {
+    tags,
+    className,
+    style,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
+
+  return tags && tags.length > 0 ? (
+    <StyledUl {...domProps} {...toTransientMarginProps(props)}>
+      {tags.map((tag, index) => (
+        <Tag {...tag} key={index} />
+      ))}
+    </StyledUl>
+  ) : null;
+});
 
 FeatureSet.displayName = 'FeatureSet';

--- a/packages/big-design/src/components/FeatureSet/styled.tsx
+++ b/packages/big-design/src/components/FeatureSet/styled.tsx
@@ -2,8 +2,9 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withMargins } from '../../helpers';
+import { TransientMarginProps } from '../../helpers/margins/margins';
 
-export const StyledUl = styled.ul.attrs({ theme: defaultTheme })`
+export const StyledUl = styled.ul.attrs({ theme: defaultTheme })<TransientMarginProps>`
   ${({ theme }) => theme.helpers.listReset}
 
   ${withMargins()};


### PR DESCRIPTION
## What?

Stage 3 (1/7) of the transient-props migration (LTRAC-1396/LTRAC-1405). `FeatureSet` blind-spread its margin props onto its styled `<ul>`; destructure them out and route through the existing `toTransientMarginProps()` utility, matching the `Box` template from Stage 0.

Also audited `Form/Label` and `Radio/Label`: both call the shared `withMargins()` helper, but their public prop types (`FormControlLabelProps`, `StyledLabelProps`) don't extend `MarginProps`, so margin is unreachable via the typed public API today — a pre-existing gap, not something this migration renames. Left both unchanged rather than expand their public surface to close it; flagging as a separate, out-of-scope follow-up if closing that gap is ever wanted.

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on `styled.<tag>` components. `FeatureSet`'s blind spread meant any margin prop passed through would forward to the real `<ul>` DOM node under v6. Transient (`$`-prefixed) props are the fix.

## Screenshots/Screen Recordings

No visual change. Public `FeatureSetProps` and CSS output are unchanged.

## Testing/Proof

`pnpm --filter @bigcommerce/big-design run lint && run typecheck && run test`: all green, **1152 tests / 182 snapshots pass with zero diffs**.

Refs TRAC-1349