### PR TITLE
refactor: TRAC-1349 $-prefix Form and Tabs bespoke props

### DIFF
--- a/.changeset/transient-props-form-tabs.md
+++ b/.changeset/transient-props-form-tabs.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 3). `$`-prefix the one bespoke custom prop each of `Form` (`$fullWidth`) and `Tabs` (`$activeTab`) reads at the styled layer, plus route `Form`'s margin props through the existing `toTransientMarginProps()` utility instead of blind-spreading them.
+
+`Tabs`'s `activeTab` flows through `StyledTab` (`styled(StyleableButton)`) down to `Button`'s own blind `{...props}` spread onto its plain-tag `StyledButton`, so the rename has to happen at the `Tabs`/`StyledTab` layer where the value originates; it rides the existing blind spread through `Button`'s internals unaffected, since styled-components strips `$`-prefixed props at whichever tag-target layer finally renders, regardless of how many component layers it passes through first.
+
+Public `FormProps`/`TabsProps` and CSS output are unchanged; all 182 snapshots pass with zero diffs.

--- a/packages/big-design/src/components/Form/Form.tsx
+++ b/packages/big-design/src/components/Form/Form.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentPropsWithoutRef, forwardRef, Ref } from 'react';
 
 import { MarginProps } from '../../helpers';
+import { toTransientMarginProps } from '../../helpers/margins/margins';
 import { typedMemo } from '../../utils';
 
 import { StyledForm } from './styled';
@@ -15,10 +16,28 @@ export type FormProps = ComponentPropsWithoutRef<'form'> &
     fullWidth?: boolean;
   };
 
-const StyleableForm: React.FC<PrivateProps & FormProps> = ({ forwardedRef, ...props }) => {
+const StyleableForm: React.FC<PrivateProps & FormProps> = (props) => {
+  const {
+    forwardedRef,
+    fullWidth,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
+
   return (
-    <FormContext.Provider value={{ fullWidth: props.fullWidth }}>
-      <StyledForm {...props} ref={forwardedRef} />
+    <FormContext.Provider value={{ fullWidth }}>
+      <StyledForm
+        {...domProps}
+        {...toTransientMarginProps(props)}
+        $fullWidth={fullWidth}
+        ref={forwardedRef}
+      />
     </FormContext.Provider>
   );
 };

--- a/packages/big-design/src/components/Form/styled.tsx
+++ b/packages/big-design/src/components/Form/styled.tsx
@@ -2,20 +2,23 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withMargins } from '../../helpers';
+import { TransientMarginProps } from '../../helpers/margins/margins';
 import { StyledFileUploaderWrapper } from '../FileUploader/styled';
 import { StyledInputWrapper } from '../Input/styled';
 import { StyledTextareaWrapper } from '../Textarea/styled';
 
-import { FormProps } from './Form';
+interface StyledFormProps extends TransientMarginProps {
+  $fullWidth?: boolean;
+}
 
-export const StyledForm = styled.form<FormProps>`
+export const StyledForm = styled.form<StyledFormProps>`
   ${withMargins()}
 
   ${({ theme }) => theme.breakpoints.tablet} {
     ${StyledInputWrapper},
     ${StyledTextareaWrapper},
     ${StyledFileUploaderWrapper} {
-      max-width: ${({ fullWidth, theme }) => (fullWidth ? '100%' : theme.helpers.remCalc(416))};
+      max-width: ${({ $fullWidth, theme }) => ($fullWidth ? '100%' : theme.helpers.remCalc(416))};
     }
   }
 `;

--- a/packages/big-design/src/components/Tabs/Tabs.tsx
+++ b/packages/big-design/src/components/Tabs/Tabs.tsx
@@ -45,7 +45,7 @@ export const Tabs: React.FC<TabsProps> = memo(
       <StyledTabs {...props} flexDirection="row" role="tablist">
         {items.map(({ ariaControls, id, title, disabled }) => (
           <StyledTab
-            activeTab={activeTab}
+            $activeTab={activeTab}
             aria-controls={ariaControls || `${id}-content`}
             aria-selected={id === activeTab ? 'true' : 'false'}
             disabled={disabled}

--- a/packages/big-design/src/components/Tabs/styled.tsx
+++ b/packages/big-design/src/components/Tabs/styled.tsx
@@ -7,7 +7,7 @@ import { Flex } from '../Flex';
 import { TabItem } from './Tabs';
 
 interface TabProps extends Omit<TabItem, 'title'> {
-  activeTab?: string;
+  $activeTab?: string;
 }
 
 export const StyledTabs = styled(Flex)`
@@ -18,14 +18,14 @@ export const StyledTab = styled(StyleableButton)<TabProps>`
   border: none;
   border-bottom: ${({ theme }) => theme.spacing.xxSmall} solid transparent;
   border-bottom-color: ${(props) =>
-    props.id === props.activeTab ? props.theme.colors.primary40 : 'transparent'};
+    props.id === props.$activeTab ? props.theme.colors.primary40 : 'transparent'};
   border-radius: 0;
   color: ${({ theme }) => theme.colors.primary};
-  pointer-events: ${(props) => (props.id === props.activeTab ? 'none' : 'auto')};
+  pointer-events: ${(props) => (props.id === props.$activeTab ? 'none' : 'auto')};
   width: auto;
 
   ${(props) =>
-    props.id === props.activeTab &&
+    props.id === props.$activeTab &&
     css`
       color: ${props.theme.colors.secondary70};
 


### PR DESCRIPTION
## What?

Stage 3 (2/7) of the transient-props migration (LTRAC-1396/LTRAC-1405). `$`-prefix the one bespoke custom prop each of `Form` (`$fullWidth`) and `Tabs` (`$activeTab`) reads at the styled layer, plus route `Form`'s margin props through the existing `toTransientMarginProps()` utility instead of blind-spreading them onto `StyledForm`.

`Tabs`'s `activeTab` flows through `StyledTab` (`styled(StyleableButton)`) down to `Button`'s own blind `{...props}` spread onto its plain-tag `StyledButton`, so the rename has to happen at the `Tabs`/`StyledTab` layer where the value originates. It rides the existing blind spread through `Button`'s internals unaffected — styled-components strips `$`-prefixed props at whichever tag-target layer finally renders, regardless of how many component layers it passes through first.

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on `styled.<tag>` components. Transient (`$`-prefixed) props are the fix.

## Screenshots/Screen Recordings

No visual change. Public `FormProps`/`TabsProps` and CSS output are unchanged.

## Testing/Proof

`pnpm --filter @bigcommerce/big-design run lint && run typecheck && run test`: all green, **1152 tests / 182 snapshots pass with zero diffs**.

Refs TRAC-1349