### PR TITLE
refactor: TRAC-1349 $-prefix Badge and Link bespoke props

### DIFF
--- a/.changeset/transient-props-badge-link.md
+++ b/.changeset/transient-props-badge-link.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 3). `Badge` and `Link` both blind-spread onto their styled `<span>`/`<a>`; destructure their bespoke props (`variant` on `Badge`; `ellipsis`, `isExternal` on `Link`) out and route them as explicit `$`-prefixed JSX props, plus route margins through the existing `toTransientMarginProps()` utility. Introduce internal-only `StyledBadgeProps`/`StyledLinkProps` types instead of reusing the public `BadgeProps`/`LinkProps` interfaces directly on the styled component's generic, matching the `Box` template. Public prop interfaces and CSS output are unchanged; all 182 snapshots pass with zero diffs.

--- a/packages/big-design/src/components/Badge/Badge.tsx
+++ b/packages/big-design/src/components/Badge/Badge.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentPropsWithoutRef, memo } from 'react';
 
 import { MarginProps } from '../../helpers';
+import { toTransientMarginProps } from '../../helpers/margins/margins';
 
 import { StyledBadge } from './styled';
 
@@ -9,8 +10,27 @@ export interface BadgeProps extends ComponentPropsWithoutRef<'span'>, MarginProp
   variant?: 'danger' | 'secondary' | 'success' | 'warning' | 'primary';
 }
 
-export const Badge: React.FC<BadgeProps> = memo(({ className, style, label, ...props }) =>
-  typeof label === 'string' ? <StyledBadge {...props}>{label}</StyledBadge> : null,
-);
+export const Badge: React.FC<BadgeProps> = memo((props) => {
+  const {
+    className,
+    style,
+    label,
+    variant,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
+
+  return typeof label === 'string' ? (
+    <StyledBadge {...domProps} {...toTransientMarginProps(props)} $variant={variant}>
+      {label}
+    </StyledBadge>
+  ) : null;
+});
 
 Badge.displayName = 'Badge';

--- a/packages/big-design/src/components/Badge/styled.tsx
+++ b/packages/big-design/src/components/Badge/styled.tsx
@@ -2,10 +2,15 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../helpers';
+import { TransientMarginProps } from '../../helpers/margins/margins';
 
 import { BadgeProps } from './Badge';
 
-export const StyledBadge = styled.span<Omit<BadgeProps, 'label'>>`
+interface StyledBadgeProps extends TransientMarginProps {
+  $variant?: BadgeProps['variant'];
+}
+
+export const StyledBadge = styled.span<StyledBadgeProps>`
   ${withMargins()};
 
   color: ${({ theme }) => theme.colors.white};
@@ -19,33 +24,33 @@ export const StyledBadge = styled.span<Omit<BadgeProps, 'label'>>`
   vertical-align: middle;
   padding: 0 ${({ theme }) => theme.spacing.xSmall};
 
-  ${({ theme, variant }) =>
-    variant === 'secondary' &&
+  ${({ theme, $variant }) =>
+    $variant === 'secondary' &&
     css`
       background-color: ${theme.colors.secondary60};
     `}
 
-  ${({ theme, variant }) =>
-    variant === 'success' &&
+  ${({ theme, $variant }) =>
+    $variant === 'success' &&
     css`
       background-color: ${theme.colors.success50};
     `}
 
-  ${({ theme, variant }) =>
-    variant === 'warning' &&
+  ${({ theme, $variant }) =>
+    $variant === 'warning' &&
     css`
       color: ${theme.colors.secondary70};
       background-color: ${theme.colors.warning40};
     `}
 
-  ${({ theme, variant }) =>
-    variant === 'danger' &&
+  ${({ theme, $variant }) =>
+    $variant === 'danger' &&
     css`
       background-color: ${theme.colors.danger40};
     `}
 
-  ${({ theme, variant }) =>
-    variant === 'primary' &&
+  ${({ theme, $variant }) =>
+    $variant === 'primary' &&
     css`
       background-color: ${theme.colors.primary40};
     `}
@@ -53,5 +58,5 @@ export const StyledBadge = styled.span<Omit<BadgeProps, 'label'>>`
 
 StyledBadge.defaultProps = {
   theme: defaultTheme,
-  variant: 'secondary',
+  $variant: 'secondary',
 };

--- a/packages/big-design/src/components/Link/Link.tsx
+++ b/packages/big-design/src/components/Link/Link.tsx
@@ -2,6 +2,7 @@ import { OpenInNewIcon } from '@bigcommerce/big-design-icons';
 import React, { ComponentPropsWithoutRef, forwardRef, memo, Ref } from 'react';
 
 import { MarginProps } from '../../helpers';
+import { toTransientMarginProps } from '../../helpers/margins/margins';
 
 import { StyledLink } from './styled';
 
@@ -16,9 +17,29 @@ interface PrivateProps {
   isExternal?: boolean;
 }
 
-const StyleableLink: React.FC<LinkProps & PrivateProps> = memo((props) => (
-  <StyledLink {...props} />
-));
+const StyleableLink: React.FC<LinkProps & PrivateProps> = memo((props) => {
+  const {
+    ellipsis,
+    isExternal,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
+
+  return (
+    <StyledLink
+      {...domProps}
+      {...toTransientMarginProps(props)}
+      $ellipsis={ellipsis}
+      $isExternal={isExternal}
+    />
+  );
+});
 
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
   ({ children, external, ...props }, ref) => {

--- a/packages/big-design/src/components/Link/styled.tsx
+++ b/packages/big-design/src/components/Link/styled.tsx
@@ -3,14 +3,18 @@ import { ellipsis } from 'polished';
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../helpers';
+import { TransientMarginProps } from '../../helpers/margins/margins';
 import { withTransition } from '../../helpers/transitions';
 
-import { LinkProps } from './Link';
+interface StyledLinkProps extends TransientMarginProps {
+  $ellipsis?: boolean;
+  $isExternal?: boolean;
+}
 
-export const StyledLink = styled.a<LinkProps & { isExternal?: boolean }>`
+export const StyledLink = styled.a<StyledLinkProps>`
   ${withMargins()};
   ${withTransition(['color'], '70ms')}
-  ${(props) => props.ellipsis && ellipsis()};
+  ${(props) => props.$ellipsis && ellipsis()};
 
   color: ${({ theme }) => theme.colors.primary};
   cursor: pointer;
@@ -26,8 +30,8 @@ export const StyledLink = styled.a<LinkProps & { isExternal?: boolean }>`
     color: ${({ theme }) => theme.colors.primary70};
   }
 
-  ${({ isExternal, theme }) =>
-    isExternal &&
+  ${({ $isExternal, theme }) =>
+    $isExternal &&
     css`
       display: inline-flex;
       align-items: center;


### PR DESCRIPTION
## What?

Stage 3 (3/7) of the transient-props migration (LTRAC-1396/LTRAC-1405). `Badge` and `Link` both blind-spread onto their styled tag targets; destructure their bespoke props out (`variant` on `Badge`; `ellipsis`, `isExternal` on `Link`) and route them as explicit `$`-prefixed JSX props, plus route margins through the existing `toTransientMarginProps()` utility.

Introduced internal-only `StyledBadgeProps`/`StyledLinkProps` types instead of reusing the public `BadgeProps`/`LinkProps` interfaces directly on the styled component's generic — matching the `Box` template from Stage 0.

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on `styled.<tag>` components. Transient (`$`-prefixed) props are the fix.

## Screenshots/Screen Recordings

No visual change. Public `BadgeProps`/`LinkProps` and CSS output are unchanged.

## Testing/Proof

`pnpm --filter @bigcommerce/big-design run lint && run typecheck && run test`: all green, **1152 tests / 182 snapshots pass with zero diffs**.

Refs TRAC-1349