### PR TITLE
refactor: TRAC-1349 $-prefix Button bespoke props

### DIFF
--- a/.changeset/transient-props-button.md
+++ b/.changeset/transient-props-button.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 3). `Button` blind-spread `iconOnly`/`iconLeft`/`iconRight` onto its styled `<button>` and read `actionType`/`variant`/`mobileWidth` (plus `isLoading` on its `ContentWrapper`) directly; destructure them out and route them as explicit `$`-prefixed JSX props, plus route margins through the existing `toTransientMarginProps()` utility. Introduce an internal `StyledButtonProps` type instead of reusing the public `ButtonProps` interface directly on the styled component's generic, matching the `Box` template.
+
+`FileUploader/DropZone.tsx` renders `Button`'s `StyledButton` directly (via a thin wrapper in `FileUploader/styled.ts`) and passed it bare `marginTop`/`variant` — update those two call sites to the new `$`-prefixed names as a required knock-on fix; this does not touch `DropZone`'s own `StyledDropzone` bespoke props (`isDragOver`/`isValid`), which are a separate, later stage.
+
+Public `ButtonProps` and CSS output are unchanged; all 182 snapshots pass with zero diffs, including `Button`'s especially heavy snapshot suite.

--- a/packages/big-design/src/components/Button/Button.tsx
+++ b/packages/big-design/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentPropsWithoutRef, forwardRef, memo, Ref } from 'react';
 
 import { MarginProps } from '../../helpers';
+import { toTransientMarginProps } from '../../helpers/margins/margins';
 import { ProgressCircle } from '../ProgressCircle';
 
 import { ContentWrapper, LoadingSpinnerWrapper, StyledButton } from './styled';
@@ -26,37 +27,51 @@ const LoadingSpinner = () => (
   </LoadingSpinnerWrapper>
 );
 
-const RawButton: React.FC<ButtonProps & PrivateProps> = memo(
-  ({
+const RawButton: React.FC<ButtonProps & PrivateProps> = memo((props) => {
+  const {
     forwardedRef,
     actionType = 'normal',
     isLoading = false,
     mobileWidth = '100%',
     variant = 'primary',
     disabled,
-    ...props
-  }) => {
-    return (
-      <StyledButton
-        className="bd-button"
-        {...props}
-        actionType={actionType}
-        disabled={isLoading || disabled}
-        mobileWidth={mobileWidth}
-        ref={forwardedRef}
-        variant={variant}
-      >
-        {isLoading ? <LoadingSpinner /> : null}
-        <ContentWrapper isLoading={isLoading}>
-          {!props.iconOnly && props.iconLeft}
-          {props.iconOnly}
-          {!props.iconOnly && props.children}
-          {!props.iconOnly && props.iconRight}
-        </ContentWrapper>
-      </StyledButton>
-    );
-  },
-);
+    iconLeft,
+    iconOnly,
+    iconRight,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
+
+  return (
+    <StyledButton
+      className="bd-button"
+      {...domProps}
+      {...toTransientMarginProps(props)}
+      $actionType={actionType}
+      $iconLeft={iconLeft}
+      $iconOnly={iconOnly}
+      $iconRight={iconRight}
+      $mobileWidth={mobileWidth}
+      $variant={variant}
+      disabled={isLoading || disabled}
+      ref={forwardedRef}
+    >
+      {isLoading ? <LoadingSpinner /> : null}
+      <ContentWrapper $isLoading={isLoading}>
+        {!iconOnly && iconLeft}
+        {iconOnly}
+        {!iconOnly && props.children}
+        {!iconOnly && iconRight}
+      </ContentWrapper>
+    </StyledButton>
+  );
+});
 
 export const StyleableButton = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => (
   <RawButton {...props} forwardedRef={ref} />

--- a/packages/big-design/src/components/Button/styled.tsx
+++ b/packages/big-design/src/components/Button/styled.tsx
@@ -1,13 +1,23 @@
 import { addValues, theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { MarginProps, withMargins } from '../../helpers';
+import { withMargins } from '../../helpers';
+import { TransientMarginProps } from '../../helpers/margins/margins';
 import { withTransition } from '../../helpers/transitions';
 import { Flex } from '../Flex';
 
 import { ButtonProps } from './index';
 
-export const StyledButton = styled.button<ButtonProps & MarginProps>`
+export interface StyledButtonProps extends TransientMarginProps {
+  $actionType?: ButtonProps['actionType'];
+  $iconLeft?: ButtonProps['iconLeft'];
+  $iconOnly?: ButtonProps['iconOnly'];
+  $iconRight?: ButtonProps['iconRight'];
+  $mobileWidth?: ButtonProps['mobileWidth'];
+  $variant?: ButtonProps['variant'];
+}
+
+export const StyledButton = styled.button<StyledButtonProps>`
   ${withTransition(['background-color', 'border-color', 'box-shadow', 'color'])}
 
   && {
@@ -35,7 +45,7 @@ export const StyledButton = styled.button<ButtonProps & MarginProps>`
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  width: ${({ mobileWidth }) => (mobileWidth === 'auto' ? 'auto' : '100%')};
+  width: ${({ $mobileWidth }) => ($mobileWidth === 'auto' ? 'auto' : '100%')};
 
   &:focus {
     outline: none;
@@ -47,8 +57,8 @@ export const StyledButton = styled.button<ButtonProps & MarginProps>`
   }
 
   & + .bd-button {
-    margin-top: ${({ mobileWidth, theme }) => mobileWidth === '100%' && theme.spacing.xSmall};
-    margin-left: ${({ mobileWidth, theme }) => mobileWidth === 'auto' && theme.spacing.xSmall};
+    margin-top: ${({ $mobileWidth, theme }) => $mobileWidth === '100%' && theme.spacing.xSmall};
+    margin-left: ${({ $mobileWidth, theme }) => $mobileWidth === 'auto' && theme.spacing.xSmall};
 
     ${({ theme }) => theme.breakpoints.tablet} {
       margin-top: ${({ theme }) => theme.spacing.none};
@@ -59,22 +69,22 @@ export const StyledButton = styled.button<ButtonProps & MarginProps>`
   ${({ theme }) => theme.breakpoints.tablet} {
     width: auto;
 
-    ${({ iconOnly: icon, theme }) =>
-      icon &&
+    ${({ $iconOnly, theme }) =>
+      $iconOnly &&
       css`
         padding: 0;
         min-width: ${addValues(theme.spacing.xxLarge, theme.spacing.xxSmall)};
       `};
   }
 
-  ${({ iconLeft, theme }) =>
-    iconLeft &&
+  ${({ $iconLeft, theme }) =>
+    $iconLeft &&
     css`
       padding-left: ${theme.spacing.xSmall};
     `};
 
-  ${({ iconRight, theme }) =>
-    iconRight &&
+  ${({ $iconRight, theme }) =>
+    $iconRight &&
     css`
       padding-right: ${theme.spacing.xSmall};
     `};
@@ -82,7 +92,7 @@ export const StyledButton = styled.button<ButtonProps & MarginProps>`
   ${(props) => getButtonStyles(props)}
 `;
 
-export const ContentWrapper = styled.span.attrs<Record<string, unknown>, { isLoading?: boolean }>(
+export const ContentWrapper = styled.span.attrs<Record<string, unknown>, { $isLoading?: boolean }>(
   {},
 )`
   align-content: center;
@@ -91,8 +101,8 @@ export const ContentWrapper = styled.span.attrs<Record<string, unknown>, { isLoa
   grid-auto-flow: column;
   grid-gap: ${({ theme }) => theme.spacing.xSmall};
 
-  ${({ isLoading }) =>
-    isLoading &&
+  ${({ $isLoading }) =>
+    $isLoading &&
     css`
       visibility: hidden;
     `};
@@ -292,21 +302,21 @@ const ButtonUtilityDestructive = css<ButtonProps>`
   }
 `;
 
-function getButtonStyles(props: ButtonProps) {
-  const { actionType, variant } = props;
+function getButtonStyles(props: StyledButtonProps) {
+  const { $actionType, $variant } = props;
 
-  switch (variant) {
+  switch ($variant) {
     case 'primary':
-      return actionType === 'destructive' ? ButtonPrimaryDestructive : ButtonPrimary;
+      return $actionType === 'destructive' ? ButtonPrimaryDestructive : ButtonPrimary;
 
     case 'secondary':
-      return actionType === 'destructive' ? ButtonSecondaryDestructive : ButtonSecondary;
+      return $actionType === 'destructive' ? ButtonSecondaryDestructive : ButtonSecondary;
 
     case 'subtle':
-      return actionType === 'destructive' ? ButtonSubtleDestructive : ButtonSubtle;
+      return $actionType === 'destructive' ? ButtonSubtleDestructive : ButtonSubtle;
 
     case 'utility':
-      return actionType === 'destructive' ? ButtonUtilityDestructive : ButtonUtility;
+      return $actionType === 'destructive' ? ButtonUtilityDestructive : ButtonUtility;
   }
 }
 

--- a/packages/big-design/src/components/FileUploader/DropZone.tsx
+++ b/packages/big-design/src/components/FileUploader/DropZone.tsx
@@ -162,8 +162,9 @@ export const DropZone = ({
     return (
       <StyledButton
         {...excludeMarginProps(actionProps)}
+        $marginTop={isRowView ? 'none' : 'medium'}
+        $variant="subtle"
         color="secondary"
-        marginTop={isRowView ? 'none' : 'medium'}
         onClick={(event) => {
           event.preventDefault();
           event.stopPropagation();
@@ -173,7 +174,6 @@ export const DropZone = ({
           }
         }}
         type="button"
-        variant="subtle"
       >
         {label}
       </StyledButton>
@@ -225,12 +225,12 @@ export const DropZone = ({
           <Flex flexDirection="row">
             {renderedAction}
             <StyledButton
+              $marginTop={isRowView ? 'none' : 'medium'}
+              $variant="subtle"
               color="secondary"
               disabled={disabled}
-              marginTop={isRowView ? 'none' : 'medium'}
               onClick={(e) => e.preventDefault()}
               type="button"
-              variant="subtle"
             >
               {localization.upload}
             </StyledButton>


### PR DESCRIPTION
## What?

Stage 3 (4/7) of the transient-props migration (LTRAC-1396/LTRAC-1405) — the largest and highest snapshot-risk group. `Button` blind-spread `iconOnly`/`iconLeft`/`iconRight` onto its styled `<button>` and read `actionType`/`variant`/`mobileWidth` (plus `isLoading` on its `ContentWrapper`) directly; destructure them out and route them as explicit `$`-prefixed JSX props, plus route margins through the existing `toTransientMarginProps()` utility.

Introduced an internal `StyledButtonProps` type instead of reusing the public `ButtonProps` interface directly on the styled component's generic — matching the `Box` template.

`FileUploader/DropZone.tsx` renders `Button`'s `StyledButton` directly (via a thin wrapper in `FileUploader/styled.ts`) and passed it bare `marginTop`/`variant` — updated those two call sites to the new `$`-prefixed names as a required knock-on fix (TS otherwise fails to compile `FileUploader/styled.ts`'s own declaration, since it wraps `StyleableButton` without an explicit generic and structurally inherits Button's prop type). This does **not** touch `DropZone`'s own `StyledDropzone` bespoke props (`isDragOver`/`isValid`) — that's a separate, later stage.

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on `styled.<tag>` components. Transient (`$`-prefixed) props are the fix.

## Screenshots/Screen Recordings

No visual change. Public `ButtonProps` and CSS output are unchanged.

## Testing/Proof

`pnpm --filter @bigcommerce/big-design run lint && run typecheck && run test`: all green, **1152 tests / 182 snapshots pass with zero diffs**, including `Button`'s especially heavy snapshot suite. `build:dt` confirms `StyledButtonProps` (needed module-internal export for `FileUploader/styled.ts`'s declaration emission) does not leak into the public `dist/index.d.ts`.

Refs TRAC-1349