### PR TITLE
refactor: TRAC-1349 $-prefix Input and Flex/Item bespoke props

### DIFF
--- a/.changeset/transient-props-input-flexitem.md
+++ b/.changeset/transient-props-input-flexitem.md
@@ -1,0 +1,13 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 3). `Input` blind-spread `error`/`focus`/`chips`/`iconLeft`/`iconRight` across its four styled tag targets (`StyledInputWrapper`, `StyledInput`, `StyledIconWrapper`, `StyledInputContent`); destructure them out and route them as explicit `$`-prefixed JSX props, plus route `StyledIconWrapper`'s padding through the existing `toTransientPaddingProps()`-backed `withPaddings()` helper.
+
+`Flex/Item` blind-spread its Flex-specific bespoke props (`alignSelf`, `flexBasis`, `flexGrow`, `flexOrder`, `flexShrink`) with zero destructuring onto `StyledFlexItem` (`styled(Box)`). Added a new `toTransientFlexedItemProps()` utility (`Flex/withFlex.ts`) and `TransientFlexedItemProps` type (`Flex/types.ts`), mirroring the shared margin/padding/display helpers; since `withFlexedItems()` has a single consumer, no dual-read shim was needed for a straight rename. `Flex`'s own container props (`backgroundColor`, `margin`, etc.) continue to flow through unchanged, since `Box` — already migrated — intercepts and converts them at its own layer regardless of how many `styled(Component)` wrapper layers sit above it.
+
+A required knock-on fix outside this stage's own target list: `Counter` wraps `Input`'s `StyledInputWrapper`/`StyledInput` directly (via `Counter/styled.ts`) and passed bare `error`/`focus`; updated those call sites to `$error`/`$focus` (and dropped a redundant `error` prop pass to `StyledCounterInput`/`StyledInput`, which never read it internally in either component).
+
+Also flagging, not fixing: `Flex` (the container, not `Flex/Item`) has the identical blind-spread pattern via `withFlexedContainer()` but isn't on this stage's explicit target list; it needs the same treatment in a follow-up.
+
+Public `InputProps`/`FlexItemProps`/`CounterProps` and CSS output are unchanged; all 182 snapshots pass with zero diffs.

--- a/packages/big-design/src/components/Counter/Counter.tsx
+++ b/packages/big-design/src/components/Counter/Counter.tsx
@@ -200,7 +200,7 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
       <div>
         {renderedLabel}
         {renderedDescription}
-        <StyledCounterWrapper disabled={disabled} error={errors} focus={focus}>
+        <StyledCounterWrapper $error={errors} $focus={focus} disabled={disabled}>
           <StyledCounterButton
             disabled={disabled || value <= Number(min)}
             iconOnly={<RemoveCircleOutlineIcon title={localization.decreaseCount} />}
@@ -210,7 +210,6 @@ export const StylableCounter: React.FC<CounterProps & PrivateProps> = typedMemo(
           <StyledCounterInput
             {...props}
             disabled={disabled}
-            error={errors}
             id={id}
             onBlur={handleBlur}
             onChange={handleChange}

--- a/packages/big-design/src/components/Flex/Item/Item.tsx
+++ b/packages/big-design/src/components/Flex/Item/Item.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 
 import { BoxProps } from '../../Box';
 import { FlexedItemProps } from '../types';
+import { toTransientFlexedItemProps } from '../withFlex';
 
 import { StyledFlexItem } from './styled';
 
@@ -11,9 +12,19 @@ interface PrivateProps {
 
 export type FlexItemProps = BoxProps & FlexedItemProps;
 
-const RawFlexItem: React.FC<FlexItemProps & PrivateProps> = ({ as, forwardedRef, ...props }) => (
-  <StyledFlexItem forwardedAs={as} ref={forwardedRef} {...props} />
-);
+const RawFlexItem: React.FC<FlexItemProps & PrivateProps> = (props) => {
+  const { as, forwardedRef, alignSelf, flexBasis, flexGrow, flexOrder, flexShrink, ...domProps } =
+    props;
+
+  return (
+    <StyledFlexItem
+      forwardedAs={as}
+      ref={forwardedRef}
+      {...domProps}
+      {...toTransientFlexedItemProps(props)}
+    />
+  );
+};
 
 export const FlexItem = forwardRef<HTMLDivElement, FlexItemProps>((props, ref) => (
   <RawFlexItem {...props} forwardedRef={ref} />

--- a/packages/big-design/src/components/Flex/Item/styled.tsx
+++ b/packages/big-design/src/components/Flex/Item/styled.tsx
@@ -2,20 +2,25 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { Box } from '../../Box';
+import { TransientFlexedItemProps } from '../types';
 import { withFlexedItems } from '../withFlex';
 
 import { FlexItemProps } from './Item';
 
+interface StyledFlexItemProps extends TransientFlexedItemProps {
+  forwardedAs?: FlexItemProps['as'];
+}
+
 // TODO: Remove the `forwardedAs` manual prop definition when @types get updated
-export const StyledFlexItem = styled(Box)<FlexItemProps & { forwardedAs?: FlexItemProps['as'] }>`
+export const StyledFlexItem = styled(Box)<StyledFlexItemProps>`
   ${withFlexedItems()}
 `;
 
 StyledFlexItem.defaultProps = {
-  alignSelf: 'auto',
-  flexBasis: 'auto',
-  flexGrow: 0,
-  flexOrder: 0,
-  flexShrink: 1,
+  $alignSelf: 'auto',
+  $flexBasis: 'auto',
+  $flexGrow: 0,
+  $flexOrder: 0,
+  $flexShrink: 1,
   theme: defaultTheme,
 };

--- a/packages/big-design/src/components/Flex/types.ts
+++ b/packages/big-design/src/components/Flex/types.ts
@@ -97,6 +97,17 @@ export type FlexedItemProps = Partial<{
   flexShrink: FlexShrink;
 }>;
 
+// Internal, transient (`$`-prefixed) counterpart of `FlexedItemProps`. styled-components
+// never forwards `$`-prefixed props to the DOM, so tag-target styled components read
+// these instead of the public names to avoid leaking them onto real DOM nodes.
+export type TransientFlexedItemProps = Partial<{
+  $alignSelf: AlignSelf;
+  $flexBasis: FlexBasis;
+  $flexGrow: FlexGrow;
+  $flexOrder: FlexOrder;
+  $flexShrink: FlexShrink;
+}>;
+
 export interface FlexedOverload {
   (flexedProp: AlignContent, theme: ThemeInterface, cssKey: 'align-content'): CSSRules;
   (flexedProp: AlignItems, theme: ThemeInterface, cssKey: 'align-items'): CSSRules;

--- a/packages/big-design/src/components/Flex/withFlex.ts
+++ b/packages/big-design/src/components/Flex/withFlex.ts
@@ -6,7 +6,7 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { FlexedItemProps, FlexedOverload, FlexedProps } from './types';
+import { FlexedItemProps, FlexedOverload, FlexedProps, TransientFlexedItemProps } from './types';
 
 export const withFlexedContainer = () => css<FlexedProps>`
   ${({ alignContent, theme }) =>
@@ -23,16 +23,32 @@ export const withFlexedContainer = () => css<FlexedProps>`
     justifyContent && getFlexedStyles(justifyContent, theme, 'justify-content')};
 `;
 
-export const withFlexedItems = () => css<FlexedItemProps>`
-  ${({ alignSelf, theme }) => alignSelf && getFlexedStyles(alignSelf, theme, 'align-self')};
-  ${({ flexBasis, theme }) => flexBasis && getFlexedStyles(flexBasis, theme, 'flex-basis')};
-  ${({ flexGrow, theme }) =>
-    typeof flexGrow !== 'undefined' && getFlexedStyles(flexGrow, theme, 'flex-grow')};
-  ${({ flexOrder, theme }) =>
-    typeof flexOrder !== 'undefined' && getFlexedStyles(flexOrder, theme, 'order')};
-  ${({ flexShrink, theme }) =>
-    typeof flexShrink !== 'undefined' && getFlexedStyles(flexShrink, theme, 'flex-shrink')};
+export const withFlexedItems = () => css<TransientFlexedItemProps>`
+  ${({ $alignSelf, theme }) => $alignSelf && getFlexedStyles($alignSelf, theme, 'align-self')};
+  ${({ $flexBasis, theme }) => $flexBasis && getFlexedStyles($flexBasis, theme, 'flex-basis')};
+  ${({ $flexGrow, theme }) =>
+    typeof $flexGrow !== 'undefined' && getFlexedStyles($flexGrow, theme, 'flex-grow')};
+  ${({ $flexOrder, theme }) =>
+    typeof $flexOrder !== 'undefined' && getFlexedStyles($flexOrder, theme, 'order')};
+  ${({ $flexShrink, theme }) =>
+    typeof $flexShrink !== 'undefined' && getFlexedStyles($flexShrink, theme, 'flex-shrink')};
 `;
+
+// Rename-and-keep helper: maps FlexedItemProps' public fields to their transient
+// ($-prefixed) names for hand-off to a tag-target styled component. withFlexedItems()
+// has a single consumer (Flex/Item/styled.tsx), so unlike the shared margin/padding/
+// display helpers, no dual-read shim is needed here.
+export function toTransientFlexedItemProps(props: FlexedItemProps): TransientFlexedItemProps {
+  const { alignSelf, flexBasis, flexGrow, flexOrder, flexShrink } = props;
+
+  return {
+    $alignSelf: alignSelf,
+    $flexBasis: flexBasis,
+    $flexGrow: flexGrow,
+    $flexOrder: flexOrder,
+    $flexShrink: flexShrink,
+  };
+}
 
 const getFlexedStyles: FlexedOverload = (
   flexedProp: any,

--- a/packages/big-design/src/components/Input/Input.tsx
+++ b/packages/big-design/src/components/Input/Input.tsx
@@ -32,23 +32,27 @@ interface PrivateProps {
 
 export type InputProps = Props & ComponentPropsWithoutRef<'input'>;
 
-const StyleableInput: React.FC<InputProps & PrivateProps> = ({
-  chips,
-  description,
-  disabled,
-  error,
-  forwardedRef,
-  label,
-  labelId,
-  ...props
-}) => {
+const StyleableInput: React.FC<InputProps & PrivateProps> = (props) => {
+  const {
+    chips,
+    description,
+    disabled,
+    error,
+    forwardedRef,
+    iconLeft,
+    iconRight,
+    label,
+    labelId,
+    ...domProps
+  } = props;
+
   const [focus, setFocus] = useState(false);
   const uniqueInputId = useId();
-  const id = props.id ? props.id : uniqueInputId;
+  const id = domProps.id ? domProps.id : uniqueInputId;
   const { errors } = useInputErrors(id, error);
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-    const { onFocus } = props;
+    const { onFocus } = domProps;
 
     setFocus(true);
 
@@ -58,7 +62,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
   };
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    const { onBlur } = props;
+    const { onBlur } = domProps;
 
     setFocus(false);
 
@@ -74,7 +78,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
 
     if (typeof label === 'string') {
       return (
-        <FormControlLabel htmlFor={id} id={labelId} required={props.required}>
+        <FormControlLabel htmlFor={id} id={labelId} required={domProps.required}>
           {label}
         </FormControlLabel>
       );
@@ -91,7 +95,7 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
     }
 
     warning('label must be either a string or a FormControlLabel component.');
-  }, [id, label, labelId, props.required]);
+  }, [id, label, labelId, domProps.required]);
 
   const renderedDescription = useMemo(() => {
     if (!description) {
@@ -110,28 +114,28 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
   }, [description]);
 
   const renderedIconLeft = useMemo(() => {
-    if (!props.iconLeft) {
+    if (!iconLeft) {
       return null;
     }
 
     return (
-      <StyledIconWrapper paddingLeft="xSmall" paddingRight="xxSmall">
-        {props.iconLeft}
+      <StyledIconWrapper $paddingLeft="xSmall" $paddingRight="xxSmall">
+        {iconLeft}
       </StyledIconWrapper>
     );
-  }, [props.iconLeft]);
+  }, [iconLeft]);
 
   const renderedIconRight = useMemo(() => {
-    if (!props.iconRight) {
+    if (!iconRight) {
       return null;
     }
 
     return (
-      <StyledIconWrapper paddingLeft="xxSmall" paddingRight="xSmall">
-        {props.iconRight}
+      <StyledIconWrapper $paddingLeft="xxSmall" $paddingRight="xSmall">
+        {iconRight}
       </StyledIconWrapper>
     );
-  }, [props.iconRight]);
+  }, [iconRight]);
 
   const renderedChips = useMemo(() => {
     if (!chips) {
@@ -147,15 +151,16 @@ const StyleableInput: React.FC<InputProps & PrivateProps> = ({
     <div>
       {renderedLabel}
       {renderedDescription}
-      <StyledInputWrapper disabled={disabled} error={errors} focus={focus}>
+      <StyledInputWrapper $error={errors} $focus={focus} disabled={disabled}>
         {renderedIconLeft}
-        <StyledInputContent chips={chips}>
+        <StyledInputContent $chips={chips}>
           {renderedChips}
           <StyledInput
-            {...props}
-            chips={chips}
+            {...domProps}
+            $chips={chips}
+            $iconLeft={iconLeft}
+            $iconRight={iconRight}
             disabled={disabled}
-            error={errors}
             id={id}
             onBlur={handleBlur}
             onFocus={handleFocus}

--- a/packages/big-design/src/components/Input/styled.tsx
+++ b/packages/big-design/src/components/Input/styled.tsx
@@ -1,13 +1,16 @@
 import { addValues, theme as defaultTheme, remCalc } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { PaddingProps, withPaddings } from '../../helpers';
+import { withPaddings } from '../../helpers';
+import { TransientPaddingProps } from '../../helpers/paddings/paddings';
 import { withTransition } from '../../helpers/transitions';
 
 import { InputProps } from './Input';
 
-export interface StyledInputWrapperProps extends InputProps {
-  focus: boolean;
+export interface StyledInputWrapperProps {
+  disabled?: boolean;
+  $error?: InputProps['error'];
+  $focus?: boolean;
 }
 
 export const StyledInputWrapper = styled.span<StyledInputWrapperProps>`
@@ -23,13 +26,13 @@ export const StyledInputWrapper = styled.span<StyledInputWrapperProps>`
   position: relative;
   width: 100%;
 
-  ${({ error, theme }) => css`
-    border: ${error ? theme.border.boxError : theme.border.box};
+  ${({ $error, theme }) => css`
+    border: ${$error ? theme.border.boxError : theme.border.box};
   `};
 
   &:hover:not([disabled]) {
-    ${({ error, theme }) =>
-      error
+    ${({ $error, theme }) =>
+      $error
         ? css`
             border: ${theme.border.boxError};
           `
@@ -38,11 +41,11 @@ export const StyledInputWrapper = styled.span<StyledInputWrapperProps>`
           `}
   }
 
-  ${({ error, focus, theme }) =>
-    focus &&
+  ${({ $error, $focus, theme }) =>
+    $focus &&
     css`
       outline: none;
-      box-shadow: 0 0 0 4px ${error ? theme.colors.danger20 : theme.colors.primary20};
+      box-shadow: 0 0 0 4px ${$error ? theme.colors.danger20 : theme.colors.primary20};
     `};
 
   &[disabled] {
@@ -50,7 +53,13 @@ export const StyledInputWrapper = styled.span<StyledInputWrapperProps>`
   }
 `;
 
-export const StyledInput = styled.input<InputProps>`
+export interface StyledInputProps {
+  $chips?: InputProps['chips'];
+  $iconLeft?: InputProps['iconLeft'];
+  $iconRight?: InputProps['iconRight'];
+}
+
+export const StyledInput = styled.input<StyledInputProps>`
   background-color: inherit;
   border: 0;
   box-sizing: border-box;
@@ -77,34 +86,34 @@ export const StyledInput = styled.input<InputProps>`
     -webkit-box-shadow: 0 0 0px 1000px ${({ theme }) => theme.colors.primary10} inset;
   }
 
-  ${({ iconRight, theme }) =>
-    iconRight &&
+  ${({ $iconRight, theme }) =>
+    $iconRight &&
     css`
       padding-right: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
     `};
 
-  ${({ iconLeft, theme }) =>
-    iconLeft &&
+  ${({ $iconLeft, theme }) =>
+    $iconLeft &&
     css`
       padding-left: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
     `};
 
-  ${({ chips, theme }) =>
-    chips &&
+  ${({ $chips, theme }) =>
+    $chips &&
     css`
       min-height: ${theme.spacing.xLarge};
       padding-left: ${theme.spacing.xxSmall};
       padding-right: ${theme.spacing.none};
     `};
 
-  ${({ chips, theme }) =>
-    chips?.length &&
+  ${({ $chips, theme }) =>
+    $chips?.length &&
     css`
       margin-top: ${theme.spacing.xxSmall};
     `};
 
-  ${({ chips }) =>
-    !chips &&
+  ${({ $chips }) =>
+    !$chips &&
     css`
       min-height: ${remCalc(34)};
     `};
@@ -115,7 +124,7 @@ export const StyledInput = styled.input<InputProps>`
   }
 `;
 
-export const StyledIconWrapper = styled.div<PaddingProps>`
+export const StyledIconWrapper = styled.div<TransientPaddingProps>`
   align-items: center;
   color: ${({ theme }) => theme.colors.secondary60};
   display: flex;
@@ -125,20 +134,24 @@ export const StyledIconWrapper = styled.div<PaddingProps>`
 
   ${withPaddings()}
 
-  ${({ paddingLeft }) =>
-    paddingLeft === 'xSmall' &&
+  ${({ $paddingLeft }) =>
+    $paddingLeft === 'xSmall' &&
     css`
       left: 0;
     `}
 
-  ${({ paddingRight }) =>
-    paddingRight === 'xSmall' &&
+  ${({ $paddingRight }) =>
+    $paddingRight === 'xSmall' &&
     css`
       right: 0;
     `}
 `;
 
-export const StyledInputContent = styled.div<InputProps>`
+interface StyledInputContentProps {
+  $chips?: InputProps['chips'];
+}
+
+export const StyledInputContent = styled.div<StyledInputContentProps>`
   align-items: center;
   box-sizing: border-box;
   display: flex;
@@ -146,15 +159,15 @@ export const StyledInputContent = styled.div<InputProps>`
   flex: 1;
   height: 100%;
 
-  ${({ chips, theme }) =>
-    chips &&
+  ${({ $chips, theme }) =>
+    $chips &&
     css`
       margin-left: ${theme.spacing.xxSmall};
       padding-right: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
     `};
 
-  ${({ chips, theme }) =>
-    chips?.length &&
+  ${({ $chips, theme }) =>
+    $chips?.length &&
     css`
       margin-bottom: ${theme.spacing.xxSmall};
     `};


### PR DESCRIPTION
## What?

Stage 3 (5/7) of the transient-props migration (LTRAC-1396/LTRAC-1405). `Input` blind-spread `error`/`focus`/`chips`/`iconLeft`/`iconRight` across its four styled tag targets (`StyledInputWrapper`, `StyledInput`, `StyledIconWrapper`, `StyledInputContent`); destructure them out and route them as explicit `$`-prefixed JSX props, plus route `StyledIconWrapper`'s padding through the existing `withPaddings()` helper.

`Flex/Item` blind-spread its Flex-specific bespoke props (`alignSelf`, `flexBasis`, `flexGrow`, `flexOrder`, `flexShrink`) with **zero destructuring** onto `StyledFlexItem` (`styled(Box)`). Added a new `toTransientFlexedItemProps()` utility (`Flex/withFlex.ts`) and `TransientFlexedItemProps` type (`Flex/types.ts`), mirroring the shared margin/padding/display helpers from Stage 0; since `withFlexedItems()` has a single consumer, no dual-read shim was needed for a straight rename. `Flex`'s own container props (`backgroundColor`, `margin`, etc.) continue to flow through unchanged — `Box` (already migrated) intercepts and converts them at its own layer regardless of how many `styled(Component)` wrapper layers sit above it.

**Required knock-on fix** outside this stage's target list: `Counter` wraps `Input`'s `StyledInputWrapper`/`StyledInput` directly (via `Counter/styled.ts`) and passed bare `error`/`focus`; updated those call sites to `$error`/`$focus`, and dropped a redundant `error` prop pass to `StyledCounterInput`/`StyledInput`, which never read it internally in either component.

**Flagging, not fixing:** `Flex` (the container, not `Flex/Item`) has the identical blind-spread pattern via `withFlexedContainer()` but isn't on this stage's explicit target list — needs the same treatment in a follow-up.

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on `styled.<tag>` components. Transient (`$`-prefixed) props are the fix.

## Screenshots/Screen Recordings

No visual change. Public `InputProps`/`FlexItemProps`/`CounterProps` and CSS output are unchanged.

## Testing/Proof

`pnpm --filter @bigcommerce/big-design run lint && run typecheck && run test`: all green, **1152 tests / 182 snapshots pass with zero diffs**. `build:dt` confirms no internal `Styled*Props`/`TransientFlexedItemProps` types leak into the public `dist/index.d.ts`.

Refs TRAC-1349