### PR TITLE
refactor: TRAC-1349 $-prefix Alert/Message/InlineMessage onClose

### DIFF
--- a/.changeset/transient-props-alert-message-inlinemessage.md
+++ b/.changeset/transient-props-alert-message-inlinemessage.md
@@ -1,0 +1,11 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 3). `Alert`, `Message`, and `InlineMessage` all blind-spread `onClose` onto their `styled(Grid)` target; destructure it out and route it as an explicit `$onClose` JSX prop. Also drop the `messages={messages}` prop pass to each styled target — none of the three ever read `messages` in their own CSS, so it was dead weight (the same pattern as `error` on `Input`'s `StyledInput` from a prior PR in this stage).
+
+`type` is deliberately left un-prefixed on all three: it already leaks onto the real DOM node today (confirmed via the existing snapshots, e.g. a literal `type="success"` attribute), because their target is `styled(Grid)` — a component, not a plain tag — so styled-components' v5 attribute-name filtering never applied to it in the first place. Since `type` is a real HTML attribute name, this leak is identical on v5 and v6 (not the "only breaks under v6" problem this migration targets), and $-prefixing it would change existing DOM/snapshot output rather than being a no-op. Flagging as a separate, out-of-scope pre-existing bug.
+
+Introduced internal `StyledAlertProps`/`StyledMessageProps`/`StyledInlineMessageProps` types (just `type` + `$onClose`) instead of reusing the public `AlertProps`/`MessageProps`/`InlineMessageProps` interfaces directly on the styled component's generic, matching the `Box` template.
+
+Public prop interfaces and CSS output are unchanged; all 182 snapshots pass with zero diffs.

--- a/packages/big-design/src/components/Alert/Alert.tsx
+++ b/packages/big-design/src/components/Alert/Alert.tsx
@@ -14,7 +14,7 @@ export interface AlertProps extends Omit<SharedMessagingProps, 'actions'> {
 }
 
 export const Alert: React.FC<AlertProps> = memo(
-  ({ className, style, header, messages = [], type = 'success', ...props }) => {
+  ({ className, style, header, messages = [], onClose, type = 'success', ...props }) => {
     const headerId = useId();
     const filteredProps = excludePaddingProps(props);
     const icon = useMemo(() => type && getMessagingIcon(type), [type]);
@@ -38,8 +38,8 @@ export const Alert: React.FC<AlertProps> = memo(
     return (
       <StyledAlert
         {...filteredProps}
+        $onClose={onClose}
         aria-labelledby={header && headerId}
-        messages={messages}
         role="alert"
         type={type}
       >
@@ -48,9 +48,9 @@ export const Alert: React.FC<AlertProps> = memo(
           {renderedHeader}
           {renderedMessages}
         </GridItem>
-        {props.onClose && (
+        {onClose && (
           <GridItem>
-            <MessagingButton iconOnly={<CloseIcon size="large" />} onClick={props.onClose} />
+            <MessagingButton iconOnly={<CloseIcon size="large" />} onClick={onClose} />
           </GridItem>
         )}
       </StyledAlert>

--- a/packages/big-design/src/components/Alert/styled.ts
+++ b/packages/big-design/src/components/Alert/styled.ts
@@ -9,7 +9,12 @@ import { TextProps } from '../Typography/types';
 
 import { AlertProps } from './Alert';
 
-export const StyledAlert = styled(Grid)<AlertProps>`
+interface StyledAlertProps {
+  type?: AlertProps['type'];
+  $onClose?: AlertProps['onClose'];
+}
+
+export const StyledAlert = styled(Grid)<StyledAlertProps>`
   ${({ theme }) => theme.shadow.floating}
 
   animation: ${({ theme }) => theme.keyframes.fadeIn} .5s ease-in-out;
@@ -22,8 +27,8 @@ export const StyledAlert = styled(Grid)<AlertProps>`
   top: ${({ theme }) => theme.spacing.medium};
   z-index: ${({ theme }) => theme.zIndex.fixed};
 
-  ${({ onClose }) =>
-    onClose
+  ${({ $onClose }) =>
+    $onClose
       ? css`
           grid-template-areas: 'icon messages close';
           grid-template-columns: ${({ theme }) =>

--- a/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
+++ b/packages/big-design/src/components/InlineMessage/InlineMessage.tsx
@@ -34,6 +34,7 @@ export const InlineMessage: React.FC<InlineMessageProps> = memo(
     header,
     localization = defaultLocalization,
     messages = [],
+    onClose,
     type = 'success',
     ...props
   }) => {
@@ -77,8 +78,8 @@ export const InlineMessage: React.FC<InlineMessageProps> = memo(
     return (
       <StyledInlineMessage
         {...filteredProps}
+        $onClose={onClose}
         backgroundColor="white"
-        messages={messages}
         role="alert"
         type={type}
       >
@@ -88,11 +89,11 @@ export const InlineMessage: React.FC<InlineMessageProps> = memo(
           {renderedMessages}
           {renderedActions}
         </GridItem>
-        {props.onClose && (
+        {onClose && (
           <GridItem>
             <MessagingButton
               iconOnly={<CloseIcon size="medium" title={localization.close} />}
-              onClick={props.onClose}
+              onClick={onClose}
             />
           </GridItem>
         )}

--- a/packages/big-design/src/components/InlineMessage/styled.ts
+++ b/packages/big-design/src/components/InlineMessage/styled.ts
@@ -10,15 +10,20 @@ import { TextProps } from '../Typography/types';
 
 import { InlineMessageProps } from './InlineMessage';
 
-export const StyledInlineMessage = styled(Grid)<InlineMessageProps>`
+interface StyledInlineMessageProps {
+  type?: InlineMessageProps['type'];
+  $onClose?: InlineMessageProps['onClose'];
+}
+
+export const StyledInlineMessage = styled(Grid)<StyledInlineMessageProps>`
   border: ${({ theme }) => theme.border.box};
   border-radius: ${({ theme }) => theme.borderRadius.normal};
   grid-gap: ${({ theme }) => theme.spacing.xSmall};
   grid-template-columns: ${({ theme }) => `${theme.spacing.large} 1fr ${theme.spacing.large}`};
   padding: ${({ theme }) => theme.spacing.xSmall};
 
-  ${({ onClose }) =>
-    onClose
+  ${({ $onClose }) =>
+    $onClose
       ? css`
           grid-template-areas: 'icon messages close';
           grid-template-columns: ${({ theme }) =>

--- a/packages/big-design/src/components/Message/Message.tsx
+++ b/packages/big-design/src/components/Message/Message.tsx
@@ -34,6 +34,7 @@ export const Message: React.FC<MessageProps> = memo(
     style,
     header,
     messages = [],
+    onClose,
     type = 'success',
     ...props
   }) => {
@@ -77,8 +78,8 @@ export const Message: React.FC<MessageProps> = memo(
     return (
       <StyledMessage
         {...filteredProps}
+        $onClose={onClose}
         backgroundColor="white"
-        messages={messages}
         role="alert"
         type={type}
       >
@@ -88,11 +89,11 @@ export const Message: React.FC<MessageProps> = memo(
           {renderedMessages}
           {renderedActions}
         </GridItem>
-        {props.onClose && (
+        {onClose && (
           <GridItem>
             <MessagingButton
               iconOnly={<CloseIcon size="large" title={localization.close} />}
-              onClick={props.onClose}
+              onClick={onClose}
             />
           </GridItem>
         )}

--- a/packages/big-design/src/components/Message/styled.ts
+++ b/packages/big-design/src/components/Message/styled.ts
@@ -10,14 +10,19 @@ import { TextProps } from '../Typography/types';
 
 import { MessageProps } from './Message';
 
-export const StyledMessage = styled(Grid)<MessageProps>`
+interface StyledMessageProps {
+  type?: MessageProps['type'];
+  $onClose?: MessageProps['onClose'];
+}
+
+export const StyledMessage = styled(Grid)<StyledMessageProps>`
   ${({ theme }) => theme.shadow.raised}
 
   grid-gap: ${({ theme }) => theme.spacing.small};
   padding: ${({ theme }) => theme.spacing.small};
 
-  ${({ onClose }) =>
-    onClose
+  ${({ $onClose }) =>
+    $onClose
       ? css`
           grid-template-areas: 'icon messages close';
           grid-template-columns: ${({ theme }) =>


### PR DESCRIPTION
## What?

Stage 3 (6/7) of the transient-props migration (LTRAC-1396/LTRAC-1405). `Alert`, `Message`, and `InlineMessage` all blind-spread `onClose` onto their `styled(Grid)` target; destructure it out and route it as an explicit `$onClose` JSX prop. Also drop the `messages={messages}` prop pass to each styled target — none of the three ever read `messages` in their own CSS, so it was dead weight (same pattern as `error` on `Input`'s `StyledInput`, PR bigcommerce/big-design#1885 in this stage).

Introduced internal `StyledAlertProps`/`StyledMessageProps`/`StyledInlineMessageProps` types (just `type` + `$onClose`) instead of reusing the public `AlertProps`/`MessageProps`/`InlineMessageProps` interfaces directly on the styled component's generic — matching the `Box` template.

`type` **is deliberately left un-prefixed** on all three: it already leaks onto the real DOM node today (a literal `type="success"` attribute is present in the existing snapshots), because their target is `styled(Grid)` — a component, not a plain tag — so styled-components' v5 attribute-name filtering never applied to it. Since `type` is a real HTML attribute name, this leak is identical on v5 and v6 (not the "only breaks under v6" problem this migration targets), and `$`-prefixing it would change existing DOM/snapshot output rather than being a no-op. Flagging as a separate, out-of-scope pre-existing bug rather than folding a behavior change into this migration.

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on `styled.<tag>` components. Transient (`$`-prefixed) props are the fix.

## Screenshots/Screen Recordings

No visual change. Public prop interfaces and CSS output are unchanged.

## Testing/Proof

`pnpm --filter @bigcommerce/big-design run lint && run typecheck && run test`: all green, **1152 tests / 182 snapshots pass with zero diffs**. `build:dt` confirms no internal `Styled*Props` types leak into the public `dist/index.d.ts`.

Refs [LTRAC-1349](https://linear.app/commerce/issue/LTRAC-1349/user-wants-to-test-automation-loop)