### PR TITLE
refactor: TRAC-1349 $-prefix FileUploader DropZone bespoke props

### DIFF
--- a/.changeset/transient-props-fileuploader-dropzone.md
+++ b/.changeset/transient-props-fileuploader-dropzone.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 3, final group). `FileUploader/DropZone`'s `StyledDropzone` reads `isDragOver`/`isValid` as explicit (never blind-spread) local-state props; `$`-prefix both at the styled definition and the `DropZone.tsx` call site. `disabled` stays un-prefixed (a recognized DOM attribute name, consistent with every other component in this migration).
+
+Flagging, not fixing: `FileUploader/File.tsx`'s `StyledFile` has the identical `isValid` pattern but isn't on this stage's explicit target list; needs the same treatment in a follow-up.
+
+This closes out Stage 3 (blind-spread + shared-helper components) of LTRAC-1396. Public `Props` and CSS output are unchanged; all 182 snapshots pass with zero diffs.

--- a/packages/big-design/src/components/FileUploader/DropZone.tsx
+++ b/packages/big-design/src/components/FileUploader/DropZone.tsx
@@ -184,12 +184,12 @@ export const DropZone = ({
   return (
     <StyledDropzone
       {...props}
+      $isDragOver={isDragOver}
+      $isValid={isFilesValid}
       alignItems="center"
       aria-label="dropzone"
       disabled={disabled}
       flexDirection={isRowView ? 'row' : 'column'}
-      isDragOver={isDragOver}
-      isValid={isFilesValid}
       justifyContent={isRowView ? 'space-between' : 'center'}
       onClick={handleUploadClick}
       onDragEnter={handleDragEnter}

--- a/packages/big-design/src/components/FileUploader/styled.ts
+++ b/packages/big-design/src/components/FileUploader/styled.ts
@@ -14,30 +14,30 @@ const getDropZoneHeight = (height = defaultDropZoneHeight) =>
 
 export const StyledDropzone = styled(Flex)<{
   disabled?: boolean;
-  isDragOver: boolean;
-  isValid: boolean;
+  $isDragOver: boolean;
+  $isValid: boolean;
 }>`
   width: 100%;
   height: ${remCalc(defaultDropZoneHeight)};
   border: 1px dashed
-    ${({ theme, isDragOver, isValid, disabled }) => {
+    ${({ theme, $isDragOver, $isValid, disabled }) => {
       if (disabled) {
         return theme.colors.secondary30;
       }
 
-      return !isDragOver || isValid ? theme.colors.primary : theme.colors.danger40;
+      return !$isDragOver || $isValid ? theme.colors.primary : theme.colors.danger40;
     }};
   border-radius: ${({ theme }) => theme.borderRadius.normal};
-  background-color: ${({ theme, isDragOver, isValid, disabled }) => {
+  background-color: ${({ theme, $isDragOver, $isValid, disabled }) => {
     if (disabled) {
       return theme.colors.secondary20;
     }
 
-    if (!isDragOver) {
+    if (!$isDragOver) {
       return theme.colors.white;
     }
 
-    return isValid ? theme.colors.primary10 : theme.colors.danger10;
+    return $isValid ? theme.colors.primary10 : theme.colors.danger10;
   }};
   cursor: pointer;
 
@@ -52,12 +52,12 @@ export const StyledDropzone = styled(Flex)<{
   svg {
     width: ${remCalc(40)};
     height: ${remCalc(40)};
-    fill: ${({ theme, disabled, isValid, isDragOver }) => {
+    fill: ${({ theme, disabled, $isValid, $isDragOver }) => {
       if (disabled) {
         return theme.colors.secondary50;
       }
 
-      if (!isValid && isDragOver) {
+      if (!$isValid && $isDragOver) {
         return theme.colors.danger30;
       }
 


### PR DESCRIPTION
## What?

Stage 3 (7/7, final) of the transient-props migration (LTRAC-1396/LTRAC-1405). `FileUploader/DropZone`'s `StyledDropzone` reads `isDragOver`/`isValid` as explicit (never blind-spread) local-state props; `$`-prefix both at the styled definition and the `DropZone.tsx` call site. `disabled` stays un-prefixed (a recognized DOM attribute name, consistent with every other component in this migration).

**Flagging, not fixing:** `FileUploader/File.tsx`'s `StyledFile` has the identical `isValid` pattern but isn't on this stage's explicit target list — needs the same treatment in a follow-up.

This closes out Stage 3 (blind-spread + shared-helper components) of [LTRAC-1396](https://linear.app/commerce/issue/LTRAC-1396/migrate-bigdesign-styled-components-props-to-transient-dollar-prefixed).

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on `styled.<tag>` components. Transient (`$`-prefixed) props are the fix.

## Screenshots/Screen Recordings

No visual change. Public `Props` and CSS output are unchanged.

## Testing/Proof

`pnpm --filter @bigcommerce/big-design run lint && run typecheck && run test`: all green, **1152 tests / 182 snapshots pass with zero diffs**. `build:dt` clean.

Refs [LTRAC-1349](https://linear.app/commerce/issue/LTRAC-1349/user-wants-to-test-automation-loop)