### PR TITLE
refactor(component): $-prefix Table bespoke props

### DIFF
--- a/.changeset/transient-props-table.md
+++ b/.changeset/transient-props-table.md
@@ -1,0 +1,11 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 4, Table half). `$`-prefix the bespoke props read by `Table`'s `Row`, `DataCell`, `HeaderCell`, `Head`, and `Body` styled components: `$isDragging`/`$isGrabbed`/`$isHidden`/`$isPhantom`/`$isSelected` (Row), `$align`/`$verticalAlign`/`$width`/`$withBorder`/`$withPadding`/`$isCheckbox` (DataCell), `$isSortable`/`$stickyHeader`/`$stickyHeight`/`$width`/`$align`/`$hide` (HeaderCell), and `$withFirstRowBorder` (Body). Public `Props` interfaces are unchanged.
+
+Also fixes a genuine DOM leak in `Table`'s own `withTableColumnDisplay()` helper: `display` was forwarded as a literal DOM attribute (e.g. `display="[object Object]"` for responsive breakpoint objects), the same category of bug fixed for `Box` in Stage 0. Introduces an internal `TransientTableColumnDisplayProps` type (`$display`) so the public `display` prop is untouched.
+
+`Head`'s `hidden` prop is deliberately left un-prefixed: it's a real DOM attribute, and an existing test relies on the native `hidden` attribute leaking through for `jest-dom`'s `toBeVisible()` assertion to resolve correctly (`hideVisually()` CSS alone doesn't satisfy it). Prefixing it would silently change tested behavior.
+
+All 182 snapshots pass; one snapshot updated to reflect the `display` leak removal (a `-`-only diff, no CSS change). `TableNext`'s near-duplicate sub-files are addressed in a follow-up PR.

--- a/packages/big-design/src/components/Table/Body/Body.tsx
+++ b/packages/big-design/src/components/Table/Body/Body.tsx
@@ -10,9 +10,11 @@ interface PrivateProps {
   forwardedRef?: React.Ref<HTMLTableSectionElement>;
 }
 
-const RawBody: React.FC<BodyProps & PrivateProps> = (props) => (
-  <StyledTableBody ref={props.forwardedRef} {...props} />
-);
+const RawBody: React.FC<BodyProps & PrivateProps> = ({
+  forwardedRef,
+  withFirstRowBorder,
+  ...domProps
+}) => <StyledTableBody $withFirstRowBorder={withFirstRowBorder} ref={forwardedRef} {...domProps} />;
 
 export const Body = memo(
   forwardRef<HTMLTableSectionElement, BodyProps>((props, ref) => (

--- a/packages/big-design/src/components/Table/Body/styled.tsx
+++ b/packages/big-design/src/components/Table/Body/styled.tsx
@@ -1,11 +1,13 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { BodyProps } from './Body';
+interface StyledTableBodyProps {
+  $withFirstRowBorder?: boolean;
+}
 
-export const StyledTableBody = styled.tbody<BodyProps>`
-  ${({ theme, withFirstRowBorder }) =>
-    withFirstRowBorder &&
+export const StyledTableBody = styled.tbody<StyledTableBodyProps>`
+  ${({ theme, $withFirstRowBorder }) =>
+    $withFirstRowBorder &&
     css`
       tr:first-of-type > td {
         border-top: ${theme.border.box};

--- a/packages/big-design/src/components/Table/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/Table/DataCell/DataCell.tsx
@@ -27,21 +27,21 @@ export const DataCell: React.FC<DataCellProps> = memo(
   }: DataCellProps) => {
     return isCheckbox ? (
       <StyledTableDataCheckbox
-        align={align}
-        display={display}
-        width={width}
-        withBorder={withBorder}
+        $align={align}
+        $display={display}
+        $width={width}
+        $withBorder={withBorder}
       >
         {children}
       </StyledTableDataCheckbox>
     ) : (
       <StyledTableDataCell
-        align={align}
-        display={display}
-        verticalAlign={verticalAlign}
-        width={width}
-        withBorder={withBorder}
-        withPadding={withPadding}
+        $align={align}
+        $display={display}
+        $verticalAlign={verticalAlign}
+        $width={width}
+        $withBorder={withBorder}
+        $withPadding={withPadding}
       >
         {children}
       </StyledTableDataCell>

--- a/packages/big-design/src/components/Table/DataCell/styled.tsx
+++ b/packages/big-design/src/components/Table/DataCell/styled.tsx
@@ -2,49 +2,59 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { withTableColumnDisplay } from '../helpers';
+import { TransientTableColumnDisplayProps } from '../helpers/display/types';
 
 import { DataCellProps } from './DataCell';
 
+interface StyledTableDataCellProps extends TransientTableColumnDisplayProps {
+  $align?: DataCellProps['align'];
+  $isCheckbox?: boolean;
+  $verticalAlign?: DataCellProps['verticalAlign'];
+  $width?: DataCellProps['width'];
+  $withBorder?: boolean;
+  $withPadding?: boolean;
+}
+
 // TODO: Use PaddingProps
-export const StyledTableDataCell = styled.td<DataCellProps>`
+export const StyledTableDataCell = styled.td<StyledTableDataCellProps>`
   ${withTableColumnDisplay()}
 
   background-color: ${({ theme }) => theme.colors.white};
   box-sizing: border-box;
   color: ${({ theme }) => theme.colors.secondary70};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
-  padding: ${({ theme, withPadding }) => (withPadding ? theme.spacing.small : 0)};
+  padding: ${({ theme, $withPadding }) => ($withPadding ? theme.spacing.small : 0)};
 
   &:first-of-type {
-    padding-left: ${({ theme, withPadding }) => (withPadding ? theme.spacing.xLarge : 0)};
+    padding-left: ${({ theme, $withPadding }) => ($withPadding ? theme.spacing.xLarge : 0)};
   }
 
   &:last-of-type {
-    padding-right: ${({ theme, withPadding }) => (withPadding ? theme.spacing.xLarge : 0)};
+    padding-right: ${({ theme, $withPadding }) => ($withPadding ? theme.spacing.xLarge : 0)};
   }
 
-  ${({ theme, withBorder }) =>
-    withBorder &&
+  ${({ theme, $withBorder }) =>
+    $withBorder &&
     css`
       border-bottom: ${theme.border.box};
     `}
 
-  ${({ align }) =>
-    align &&
+  ${({ $align }) =>
+    $align &&
     css`
-      text-align: ${align};
+      text-align: ${$align};
     `};
 
-  ${({ verticalAlign }) =>
-    verticalAlign &&
+  ${({ $verticalAlign }) =>
+    $verticalAlign &&
     css`
-      vertical-align: ${verticalAlign};
+      vertical-align: ${$verticalAlign};
     `};
 
-  ${({ width }) =>
-    width !== undefined &&
+  ${({ $width }) =>
+    $width !== undefined &&
     css`
-      width: ${typeof width === 'string' ? width : `${width}px`};
+      width: ${typeof $width === 'string' ? $width : `${$width}px`};
     `};
 `;
 
@@ -63,7 +73,7 @@ export const StyledTableDataCheckbox = styled(StyledTableDataCell)`
   }
 
   ${(props) =>
-    props.isCheckbox &&
+    props.$isCheckbox &&
     css`
       width: ${({ theme }) => theme.helpers.addValues(theme.spacing.xLarge, theme.spacing.small)};
       white-space: nowrap;

--- a/packages/big-design/src/components/Table/Head/styled.tsx
+++ b/packages/big-design/src/components/Table/Head/styled.tsx
@@ -4,6 +4,9 @@ import styled from 'styled-components';
 
 import { HeadProps } from './Head';
 
+// `hidden` intentionally stays un-prefixed: it's a real DOM attribute, and jest-dom's
+// toBeVisible() relies on it leaking through (hideVisually() alone doesn't satisfy it).
+// $-prefixing changes tested behavior.
 export const StyledTableHead = styled.thead<HeadProps>`
   ${({ hidden }) => hidden && hideVisually()}
 `;

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -110,15 +110,15 @@ const InternalHeaderCell = <T extends TableItem>({
 
   return (
     <StyledTableHeaderCell
-      display={display}
+      $display={display}
+      $isSortable={isSortable}
+      $stickyHeader={stickyHeader}
+      $stickyHeight={actionsSize.height}
+      $width={width}
       id={id}
-      isSortable={isSortable}
       onClick={handleClick}
-      stickyHeader={stickyHeader}
-      stickyHeight={actionsSize.height}
-      width={width}
     >
-      <StyledFlex align={align} alignItems="center" flexDirection="row" hide={hide}>
+      <StyledFlex $align={align} $hide={hide} alignItems="center" flexDirection="row">
         {children}
         {!hide && renderSortIcon()}
         {renderTooltip()}
@@ -132,14 +132,16 @@ export const HeaderCheckboxCell: React.FC<HeaderCheckboxCellProps> = memo(
   ({ stickyHeader, actionsRef }) => {
     const actionsSize = useComponentSize(actionsRef);
 
-    return <StyledTableHeaderIcon stickyHeader={stickyHeader} stickyHeight={actionsSize.height} />;
+    return (
+      <StyledTableHeaderIcon $stickyHeader={stickyHeader} $stickyHeight={actionsSize.height} />
+    );
   },
 );
 
 export const DragIconHeaderCell: React.FC<DragIconCellProps> = memo(({ actionsRef }) => {
   const actionsSize = useComponentSize(actionsRef);
 
-  return <StyledTableHeaderIcon stickyHeight={actionsSize.height} />;
+  return <StyledTableHeaderIcon $stickyHeight={actionsSize.height} />;
 });
 
 export const HeaderCell = typedMemo(InternalHeaderCell);

--- a/packages/big-design/src/components/Table/HeaderCell/styled.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/styled.tsx
@@ -3,18 +3,19 @@ import { hideVisually } from 'polished';
 import styled, { css } from 'styled-components';
 
 import { Flex } from '../../Flex';
-import { TableColumnDisplayProps, withTableColumnDisplay } from '../helpers';
+import { withTableColumnDisplay } from '../helpers';
+import { TransientTableColumnDisplayProps } from '../helpers/display/types';
 
-interface StyledTableHeaderCellProps extends TableColumnDisplayProps {
-  isSortable?: boolean;
-  width?: number | string;
-  stickyHeader?: boolean;
-  stickyHeight: number;
+interface StyledTableHeaderCellProps extends TransientTableColumnDisplayProps {
+  $isSortable?: boolean;
+  $width?: number | string;
+  $stickyHeader?: boolean;
+  $stickyHeight: number;
 }
 
 interface StyledFlexProps {
-  align?: 'left' | 'center' | 'right';
-  hide: boolean;
+  $align?: 'left' | 'center' | 'right';
+  $hide: boolean;
 }
 
 export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
@@ -36,25 +37,25 @@ export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
     padding-right: ${({ theme }) => theme.spacing.xLarge};
   }
 
-  ${({ isSortable }) =>
-    isSortable &&
+  ${({ $isSortable }) =>
+    $isSortable &&
     css`
       cursor: pointer;
     `};
 
-  ${({ width }) =>
-    width !== undefined &&
+  ${({ $width }) =>
+    $width !== undefined &&
     css`
-      width: ${typeof width === 'string' ? width : `${width}px`};
+      width: ${typeof $width === 'string' ? $width : `${$width}px`};
     `};
 
-  ${({ theme, stickyHeader, stickyHeight }) =>
-    stickyHeader &&
-    stickyHeight >= 0 &&
+  ${({ theme, $stickyHeader, $stickyHeight }) =>
+    $stickyHeader &&
+    $stickyHeight >= 0 &&
     css`
       ${theme.breakpoints.tablet} {
         position: sticky;
-        top: ${theme.helpers.remCalc(stickyHeight)};
+        top: ${theme.helpers.remCalc($stickyHeight)};
         z-index: ${theme.zIndex.sticky};
       }
     `}
@@ -66,8 +67,8 @@ export const StyledTableHeaderIcon = styled(StyledTableHeaderCell)`
 `;
 
 export const StyledFlex = styled(Flex)<StyledFlexProps>`
-  ${({ align }) => {
-    switch (align) {
+  ${({ $align }) => {
+    switch ($align) {
       case 'center':
         return css`
           justify-content: center;
@@ -84,7 +85,7 @@ export const StyledFlex = styled(Flex)<StyledFlexProps>`
         `;
     }
   }};
-  ${({ hide }) => hide && hideVisually()};
+  ${({ $hide }) => $hide && hideVisually()};
 `;
 
 StyledFlex.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Table/Row/Row.tsx
+++ b/packages/big-design/src/components/Table/Row/Row.tsx
@@ -190,11 +190,11 @@ const InternalRow = <T extends TableItem>({
   return (
     <>
       <StyledTableRow
-        isDragging={isDragging}
-        isGrabbed={isGrabbed}
-        isHidden={isHidden}
-        isPhantom={isPhantom}
-        isSelected={isSelected}
+        $isDragging={isDragging}
+        $isGrabbed={isGrabbed}
+        $isHidden={isHidden}
+        $isPhantom={isPhantom}
+        $isSelected={isSelected}
         ref={rowRef}
         {...rest}
       >

--- a/packages/big-design/src/components/Table/Row/styled.tsx
+++ b/packages/big-design/src/components/Table/Row/styled.tsx
@@ -4,43 +4,43 @@ import styled from 'styled-components';
 import { withTransition } from '../../../helpers/transitions';
 
 interface StyledTableRowProps {
-  isDragging: boolean;
-  isGrabbed: boolean;
-  isHidden: boolean;
-  isPhantom: boolean;
-  isSelected: boolean;
+  $isDragging: boolean;
+  $isGrabbed: boolean;
+  $isHidden: boolean;
+  $isPhantom: boolean;
+  $isSelected: boolean;
 }
 
 export const StyledTableRow = styled.tr<StyledTableRowProps>`
   ${withTransition(['background-color'])}
 
-  display: ${({ isHidden }) => (isHidden ? 'none' : 'table-row')};
-  background-color: ${({ isPhantom, isSelected, theme }) =>
-    isPhantom || isSelected ? theme.colors.primary10 : 'transparent'};
-  opacity: ${({ isDragging, isPhantom }) => {
-    if (isDragging) {
+  display: ${({ $isHidden }) => ($isHidden ? 'none' : 'table-row')};
+  background-color: ${({ $isPhantom, $isSelected, theme }) =>
+    $isPhantom || $isSelected ? theme.colors.primary10 : 'transparent'};
+  opacity: ${({ $isDragging, $isPhantom }) => {
+    if ($isDragging) {
       return 0.4;
     }
 
-    if (isPhantom) {
+    if ($isPhantom) {
       return 0.6;
     }
 
     return 1;
   }};
-  outline: ${({ isGrabbed, isPhantom, theme }) => {
-    if (isPhantom) {
+  outline: ${({ $isGrabbed, $isPhantom, theme }) => {
+    if ($isPhantom) {
       return `2px dashed ${theme.colors.primary}`;
     }
 
-    if (isGrabbed) {
+    if ($isGrabbed) {
       return `2px solid ${theme.colors.primary}`;
     }
 
     return 'none';
   }};
   outline-offset: -2px;
-  pointer-events: ${({ isPhantom }) => (isPhantom ? 'none' : 'auto')};
+  pointer-events: ${({ $isPhantom }) => ($isPhantom ? 'none' : 'auto')};
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.secondary10};

--- a/packages/big-design/src/components/Table/helpers/display/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/helpers/display/__snapshots__/spec.tsx.snap
@@ -15,6 +15,5 @@ exports[`responsive display 1`] = `
 
 <div
   class="c0"
-  display="[object Object]"
 />
 `;

--- a/packages/big-design/src/components/Table/helpers/display/display.tsx
+++ b/packages/big-design/src/components/Table/helpers/display/display.tsx
@@ -6,10 +6,10 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { TableColumnDisplayOverload, TableColumnDisplayProps } from './types';
+import { TableColumnDisplayOverload, TransientTableColumnDisplayProps } from './types';
 
-export const withTableColumnDisplay = () => css<TableColumnDisplayProps>`
-  ${({ display, theme }) => display && getDisplayStyles(display, theme, 'display')};
+export const withTableColumnDisplay = () => css<TransientTableColumnDisplayProps>`
+  ${({ $display, theme }) => $display && getDisplayStyles($display, theme, 'display')};
 `;
 
 const getDisplayStyles: TableColumnDisplayOverload = (

--- a/packages/big-design/src/components/Table/helpers/display/spec.tsx
+++ b/packages/big-design/src/components/Table/helpers/display/spec.tsx
@@ -5,23 +5,23 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { withTableColumnDisplay } from './display';
-import { TableColumnDisplayProps } from './types';
+import { TransientTableColumnDisplayProps } from './types';
 
-const TestComponent = styled.div<TableColumnDisplayProps>`
+const TestComponent = styled.div<TransientTableColumnDisplayProps>`
   ${withTableColumnDisplay()};
 `;
 
 TestComponent.defaultProps = { theme: defaultTheme };
 
 test('display', () => {
-  const { container } = render(<TestComponent display="table-cell" />);
+  const { container } = render(<TestComponent $display="table-cell" />);
 
   expect(container.firstChild).toHaveStyle('display: table-cell');
 });
 
 test('responsive display', () => {
   const { container } = render(
-    <TestComponent display={{ mobile: 'none', tablet: 'table-cell' }} />,
+    <TestComponent $display={{ mobile: 'none', tablet: 'table-cell' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();

--- a/packages/big-design/src/components/Table/helpers/display/types.ts
+++ b/packages/big-design/src/components/Table/helpers/display/types.ts
@@ -8,6 +8,12 @@ export type TableColumnDisplayProps = Partial<{
   display: TableColumnDisplayProp;
 }>;
 
+// Internal-only transient shape for the styled boundary (LTRAC-1396); TableColumnDisplayProps
+// (public) is unchanged.
+export type TransientTableColumnDisplayProps = Partial<{
+  $display: TableColumnDisplayProp;
+}>;
+
 export type TableColumnDisplayOverload = (
   displayProp: TableColumnDisplayProp,
   theme: ThemeInterface,


### PR DESCRIPTION
## What?

Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 4, Table half — TableNext follows in a separate PR).

`$`-prefix the bespoke props read by Table's `Row`, `DataCell`, `HeaderCell`, `Head`, and `Body` styled components:
- **Row**: `$isDragging`, `$isGrabbed`, `$isHidden`, `$isPhantom`, `$isSelected`
- **DataCell**: `$align`, `$verticalAlign`, `$width`, `$withBorder`, `$withPadding`, `$isCheckbox`
- **HeaderCell**: `$isSortable`, `$stickyHeader`, `$stickyHeight`, `$width`, `$align`, `$hide`
- **Body**: `$withFirstRowBorder`

Public `Props` interfaces are unchanged; consumers still write e.g. `<DataCell align="left" />`.

## Why?

styled-components 6 drops v5's automatic filtering of unknown props on tag-target styled components, so any bespoke (non-DOM) prop read directly by a `styled.td`/`styled.tr`/etc. template would start leaking onto the real DOM node and trigger React's "unknown prop" warning. Transient (`$`) props are never forwarded regardless of styled-components version.

While auditing, I found a genuine pre-existing DOM leak in Table's own `withTableColumnDisplay()` helper: `display` was forwarded as a literal DOM attribute (`display="[object Object]"` for responsive breakpoint objects) — the same category of bug already fixed for `Box` in Stage 0. Fixed it here via a new internal `TransientTableColumnDisplayProps` type, keeping the public `display` prop untouched.

`Head`'s `hidden` prop is deliberately **left un-prefixed**. It's a real DOM attribute, and `Table/spec.tsx`'s "renders headers by default and hides them via prop" test relies on the native `hidden` attribute leaking through for jest-dom's `toBeVisible()` to resolve correctly (`hideVisually()` CSS alone doesn't satisfy that assertion). I confirmed this empirically — prefixing it broke that exact test — so it stays as a documented exception, matching how `disabled`/`checked` are treated elsewhere in this migration.

## Testing/Proof

- `pnpm --filter @bigcommerce/big-design run typecheck` — clean
- `pnpm --filter @bigcommerce/big-design run lint` — clean
- `pnpm --filter @bigcommerce/big-design run test` — 70 suites, 1152 tests, 182 snapshots pass. One snapshot updated (`Table/helpers/display/spec.tsx`) reflecting the `display` leak removal — a leak-removal-only diff, no CSS change.
- `pnpm --filter @bigcommerce/big-design run build:dt` — confirmed no internal `Styled*Props` types leak into the public `dist/index.d.ts`.
- No cross-file consumers of Table's internal styled exports exist outside `Table/` (verified via grep), so no forced fixes elsewhere.

Refs [TRAC-1354](https://bigcommercecloud.atlassian.net/browse/TRAC-1354)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TRAC-1354]: https://bigcommercecloud.atlassian.net/browse/TRAC-1354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ