### PR TITLE
refactor(component): $-prefix TableNext bespoke props

### DIFF
--- a/.changeset/transient-props-tablenext.md
+++ b/.changeset/transient-props-tablenext.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 4, TableNext half — mirrors the `Table` PR). `$`-prefix the bespoke props read by `TableNext`'s `Row`, `DataCell`, `HeaderCell`, and `Body` styled components: `$isDragging`/`$isGrabbed`/`$isHidden`/`$isPhantom`/`$isSelected` (Row), `$align`/`$verticalAlign`/`$width`/`$withBorder`/`$isCheckbox`/`$isExpandable` plus transient padding props via the existing `toTransientPaddingProps()` helper (DataCell), `$isSortable`/`$stickyHeader`/`$stickyHeight`/`$width`/`$align`/`$hide` (HeaderCell), and `$withFirstRowBorder` (Body). Public `Props` interfaces are unchanged.
+
+Also fixes the same `display` DOM leak found and fixed in the `Table` PR, but in `TableNext`'s own separate (byte-identical but independently-maintained) copy of the `withTableColumnDisplay()` helper. `Head`'s `hidden` prop is likewise left un-prefixed for the same reason as `Table`: an equivalent existing test relies on the leaked native `hidden` attribute for `jest-dom`'s `toBeVisible()` to resolve correctly.
+
+All 182 snapshots pass; one snapshot updated to reflect the `display` leak removal (a `-`-only diff, no CSS change). This closes out Stage 4 (Table/TableNext dedupe) of LTRAC-1396.

--- a/packages/big-design/src/components/TableNext/Body/Body.tsx
+++ b/packages/big-design/src/components/TableNext/Body/Body.tsx
@@ -10,9 +10,11 @@ interface PrivateProps {
   forwardedRef?: React.Ref<HTMLTableSectionElement>;
 }
 
-const RawBody: React.FC<BodyProps & PrivateProps> = (props) => (
-  <StyledTableBody ref={props.forwardedRef} {...props} />
-);
+const RawBody: React.FC<BodyProps & PrivateProps> = ({
+  forwardedRef,
+  withFirstRowBorder,
+  ...domProps
+}) => <StyledTableBody $withFirstRowBorder={withFirstRowBorder} ref={forwardedRef} {...domProps} />;
 
 export const Body = memo(
   forwardRef<HTMLTableSectionElement, BodyProps>((props, ref) => (

--- a/packages/big-design/src/components/TableNext/Body/styled.tsx
+++ b/packages/big-design/src/components/TableNext/Body/styled.tsx
@@ -1,11 +1,13 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { BodyProps } from './Body';
+interface StyledTableBodyProps {
+  $withFirstRowBorder?: boolean;
+}
 
-export const StyledTableBody = styled.tbody<BodyProps>`
-  ${({ theme, withFirstRowBorder }) =>
-    withFirstRowBorder &&
+export const StyledTableBody = styled.tbody<StyledTableBodyProps>`
+  ${({ theme, $withFirstRowBorder }) =>
+    $withFirstRowBorder &&
     css`
       tr:first-of-type > td {
         border-top: ${theme.border.box};

--- a/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentPropsWithoutRef, memo } from 'react';
 
 import { PaddingProps } from '../../../helpers';
+import { toTransientPaddingProps } from '../../../helpers/paddings/paddings';
 import { TableColumnDisplayProps } from '../helpers';
 
 import { StyledTableDataCell, StyledTableDataCheckbox } from './styled';
@@ -35,25 +36,23 @@ export const DataCell: React.FC<DataCellProps> = memo(
   }: DataCellProps) => {
     return isCheckbox ? (
       <StyledTableDataCheckbox
-        align={align}
-        display={display}
-        isExpandable={isExpandable}
-        width={width}
-        withBorder={withBorder}
+        $align={align}
+        $display={display}
+        $isExpandable={isExpandable}
+        $width={width}
+        $withBorder={withBorder}
       >
         {children}
       </StyledTableDataCheckbox>
     ) : (
       <StyledTableDataCell
-        align={align}
+        $align={align}
+        $display={display}
+        $verticalAlign={verticalAlign}
+        $width={width}
+        $withBorder={withBorder}
         colSpan={colSpan}
-        display={display}
-        padding={padding}
-        paddingHorizontal={paddingHorizontal}
-        paddingVertical={paddingVertical}
-        verticalAlign={verticalAlign}
-        width={width}
-        withBorder={withBorder}
+        {...toTransientPaddingProps({ padding, paddingHorizontal, paddingVertical })}
       >
         {children}
       </StyledTableDataCell>

--- a/packages/big-design/src/components/TableNext/DataCell/styled.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/styled.tsx
@@ -2,51 +2,62 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { withPaddings } from '../../../helpers';
+import { TransientPaddingProps } from '../../../helpers/paddings/paddings';
 import { withTableColumnDisplay } from '../helpers';
+import { TransientTableColumnDisplayProps } from '../helpers/display/types';
 
 import { DataCellProps } from './DataCell';
 
-export const StyledTableDataCell = styled.td<DataCellProps>`
+interface StyledTableDataCellProps extends TransientTableColumnDisplayProps, TransientPaddingProps {
+  $align?: DataCellProps['align'];
+  $isCheckbox?: boolean;
+  $isExpandable?: boolean;
+  $verticalAlign?: DataCellProps['verticalAlign'];
+  $width?: DataCellProps['width'];
+  $withBorder?: boolean;
+}
+
+export const StyledTableDataCell = styled.td<StyledTableDataCellProps>`
   ${withTableColumnDisplay()}
   ${withPaddings()}
-  
+
   background-color: ${({ theme }) => theme.colors.white};
   box-sizing: border-box;
   color: ${({ theme }) => theme.colors.secondary70};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
 
   &:first-of-type {
-    padding-left: ${({ theme, paddingHorizontal, padding }) =>
-      padding || paddingHorizontal ? theme.spacing.xLarge : 0};
+    padding-left: ${({ theme, $paddingHorizontal, $padding }) =>
+      $padding || $paddingHorizontal ? theme.spacing.xLarge : 0};
   }
 
   &:last-of-type {
-    padding-right: ${({ theme, paddingHorizontal, padding }) =>
-      padding || paddingHorizontal ? theme.spacing.xLarge : 0};
+    padding-right: ${({ theme, $paddingHorizontal, $padding }) =>
+      $padding || $paddingHorizontal ? theme.spacing.xLarge : 0};
   }
 
-  ${({ theme, withBorder }) =>
-    withBorder &&
+  ${({ theme, $withBorder }) =>
+    $withBorder &&
     css`
       border-bottom: ${theme.border.box};
     `}
 
-  ${({ align }) =>
-    align &&
+  ${({ $align }) =>
+    $align &&
     css`
-      text-align: ${align};
+      text-align: ${$align};
     `};
 
-  ${({ verticalAlign }) =>
-    verticalAlign &&
+  ${({ $verticalAlign }) =>
+    $verticalAlign &&
     css`
-      vertical-align: ${verticalAlign};
+      vertical-align: ${$verticalAlign};
     `};
 
-  ${({ width }) =>
-    width !== undefined &&
+  ${({ $width }) =>
+    $width !== undefined &&
     css`
-      width: ${typeof width === 'string' ? width : `${width}px`};
+      width: ${typeof $width === 'string' ? $width : `${$width}px`};
     `};
 `;
 
@@ -60,14 +71,14 @@ export const StyledTableDataCheckbox = styled(StyledTableDataCell)`
     padding-left: ${({ theme }) => theme.spacing.xLarge};
   }
 
-  ${({ isExpandable }) =>
-    isExpandable &&
+  ${({ $isExpandable }) =>
+    $isExpandable &&
     css`
       padding-right: 0;
     `}
 
   ${(props) =>
-    props.isCheckbox &&
+    props.$isCheckbox &&
     css`
       width: ${({ theme }) => theme.helpers.addValues(theme.spacing.xLarge, theme.spacing.small)};
       white-space: nowrap;

--- a/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
@@ -106,15 +106,15 @@ const InternalHeaderCell = <T extends TableItem>({
 
   return (
     <StyledTableHeaderCell
-      display={display}
+      $display={display}
+      $isSortable={isSortable}
+      $stickyHeader={stickyHeader}
+      $stickyHeight={actionsSize.height}
+      $width={width}
       id={id}
-      isSortable={isSortable}
       onClick={handleClick}
-      stickyHeader={stickyHeader}
-      stickyHeight={actionsSize.height}
-      width={width}
     >
-      <StyledFlex align={align} alignItems="center" flexDirection="row" hide={hide}>
+      <StyledFlex $align={align} $hide={hide} alignItems="center" flexDirection="row">
         {children}
         {!hide && renderSortIcon()}
         {Boolean(tooltip) && renderTooltip()}
@@ -128,20 +128,22 @@ export const HeaderCheckboxCell: React.FC<HeaderCheckboxCellProps> = memo(
   ({ stickyHeader, actionsRef }) => {
     const actionsSize = useComponentSize(actionsRef);
 
-    return <StyledTableHeaderIcon stickyHeader={stickyHeader} stickyHeight={actionsSize.height} />;
+    return (
+      <StyledTableHeaderIcon $stickyHeader={stickyHeader} $stickyHeight={actionsSize.height} />
+    );
   },
 );
 
 export const DragIconHeaderCell: React.FC<DragIconCellProps> = memo(({ actionsRef }) => {
   const actionsSize = useComponentSize(actionsRef);
 
-  return <StyledTableHeaderIcon stickyHeight={actionsSize.height} />;
+  return <StyledTableHeaderIcon $stickyHeight={actionsSize.height} />;
 });
 
 export const ExpandableHeaderCell: React.FC<DragIconCellProps> = memo(({ actionsRef }) => {
   const actionsSize = useComponentSize(actionsRef);
 
-  return <StyledTableHeaderIcon stickyHeight={actionsSize.height} />;
+  return <StyledTableHeaderIcon $stickyHeight={actionsSize.height} />;
 });
 
 export const HeaderCell = typedMemo(InternalHeaderCell);

--- a/packages/big-design/src/components/TableNext/HeaderCell/styled.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/styled.tsx
@@ -3,18 +3,19 @@ import { hideVisually } from 'polished';
 import styled, { css } from 'styled-components';
 
 import { Flex } from '../../Flex';
-import { TableColumnDisplayProps, withTableColumnDisplay } from '../helpers';
+import { withTableColumnDisplay } from '../helpers';
+import { TransientTableColumnDisplayProps } from '../helpers/display/types';
 
-interface StyledTableHeaderCellProps extends TableColumnDisplayProps {
-  isSortable?: boolean;
-  width?: number | string;
-  stickyHeader?: boolean;
-  stickyHeight: number;
+interface StyledTableHeaderCellProps extends TransientTableColumnDisplayProps {
+  $isSortable?: boolean;
+  $width?: number | string;
+  $stickyHeader?: boolean;
+  $stickyHeight: number;
 }
 
 interface StyledFlexProps {
-  align?: 'left' | 'center' | 'right';
-  hide: boolean;
+  $align?: 'left' | 'center' | 'right';
+  $hide: boolean;
 }
 
 export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
@@ -36,25 +37,25 @@ export const StyledTableHeaderCell = styled.th<StyledTableHeaderCellProps>`
     padding-right: ${({ theme }) => theme.spacing.xLarge};
   }
 
-  ${({ isSortable }) =>
-    isSortable &&
+  ${({ $isSortable }) =>
+    $isSortable &&
     css`
       cursor: pointer;
     `};
 
-  ${({ width }) =>
-    width !== undefined &&
+  ${({ $width }) =>
+    $width !== undefined &&
     css`
-      width: ${typeof width === 'string' ? width : `${width}px`};
+      width: ${typeof $width === 'string' ? $width : `${$width}px`};
     `};
 
-  ${({ theme, stickyHeader, stickyHeight }) =>
-    stickyHeader &&
-    stickyHeight >= 0 &&
+  ${({ theme, $stickyHeader, $stickyHeight }) =>
+    $stickyHeader &&
+    $stickyHeight >= 0 &&
     css`
       ${theme.breakpoints.tablet} {
         position: sticky;
-        top: ${theme.helpers.remCalc(stickyHeight)};
+        top: ${theme.helpers.remCalc($stickyHeight)};
         z-index: ${theme.zIndex.sticky};
       }
     `}
@@ -66,8 +67,8 @@ export const StyledTableHeaderIcon = styled(StyledTableHeaderCell)`
 `;
 
 export const StyledFlex = styled(Flex)<StyledFlexProps>`
-  ${({ align }) => {
-    switch (align) {
+  ${({ $align }) => {
+    switch ($align) {
       case 'center':
         return css`
           justify-content: center;
@@ -84,7 +85,7 @@ export const StyledFlex = styled(Flex)<StyledFlexProps>`
         `;
     }
   }};
-  ${({ hide }) => hide && hideVisually()};
+  ${({ $hide }) => $hide && hideVisually()};
 `;
 
 StyledFlex.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -318,11 +318,11 @@ const InternalRow = <T extends TableItem>({
   return (
     <>
       <StyledTableRow
-        isDragging={isDragging}
-        isGrabbed={isGrabbed}
-        isHidden={isHidden}
-        isPhantom={isPhantom}
-        isSelected={isSelected}
+        $isDragging={isDragging}
+        $isGrabbed={isGrabbed}
+        $isHidden={isHidden}
+        $isPhantom={isPhantom}
+        $isSelected={isSelected}
         ref={rowRef}
         {...rest}
       >

--- a/packages/big-design/src/components/TableNext/Row/styled.tsx
+++ b/packages/big-design/src/components/TableNext/Row/styled.tsx
@@ -4,43 +4,43 @@ import styled from 'styled-components';
 import { withTransition } from '../../../helpers/transitions';
 
 interface StyledTableRowProps {
-  isDragging: boolean;
-  isGrabbed: boolean;
-  isHidden: boolean;
-  isPhantom: boolean;
-  isSelected: boolean;
+  $isDragging: boolean;
+  $isGrabbed: boolean;
+  $isHidden: boolean;
+  $isPhantom: boolean;
+  $isSelected: boolean;
 }
 
 export const StyledTableRow = styled.tr<StyledTableRowProps>`
   ${withTransition(['background-color'])}
 
-  display: ${({ isHidden }) => (isHidden ? 'none' : 'table-row')};
-  background-color: ${({ isPhantom, isSelected, theme }) =>
-    isPhantom || isSelected ? theme.colors.primary10 : 'transparent'};
-  opacity: ${({ isDragging, isPhantom }) => {
-    if (isDragging) {
+  display: ${({ $isHidden }) => ($isHidden ? 'none' : 'table-row')};
+  background-color: ${({ $isPhantom, $isSelected, theme }) =>
+    $isPhantom || $isSelected ? theme.colors.primary10 : 'transparent'};
+  opacity: ${({ $isDragging, $isPhantom }) => {
+    if ($isDragging) {
       return 0.4;
     }
 
-    if (isPhantom) {
+    if ($isPhantom) {
       return 0.6;
     }
 
     return 1;
   }};
-  outline: ${({ isGrabbed, isPhantom, theme }) => {
-    if (isPhantom) {
+  outline: ${({ $isGrabbed, $isPhantom, theme }) => {
+    if ($isPhantom) {
       return `2px dashed ${theme.colors.primary}`;
     }
 
-    if (isGrabbed) {
+    if ($isGrabbed) {
       return `2px solid ${theme.colors.primary}`;
     }
 
     return 'none';
   }};
   outline-offset: -2px;
-  pointer-events: ${({ isPhantom }) => (isPhantom ? 'none' : 'auto')};
+  pointer-events: ${({ $isPhantom }) => ($isPhantom ? 'none' : 'auto')};
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.secondary10};

--- a/packages/big-design/src/components/TableNext/helpers/display/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/helpers/display/__snapshots__/spec.tsx.snap
@@ -15,6 +15,5 @@ exports[`responsive display 1`] = `
 
 <div
   class="c0"
-  display="[object Object]"
 />
 `;

--- a/packages/big-design/src/components/TableNext/helpers/display/display.tsx
+++ b/packages/big-design/src/components/TableNext/helpers/display/display.tsx
@@ -6,10 +6,10 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { TableColumnDisplayOverload, TableColumnDisplayProps } from './types';
+import { TableColumnDisplayOverload, TransientTableColumnDisplayProps } from './types';
 
-export const withTableColumnDisplay = () => css<TableColumnDisplayProps>`
-  ${({ display, theme }) => display && getDisplayStyles(display, theme, 'display')};
+export const withTableColumnDisplay = () => css<TransientTableColumnDisplayProps>`
+  ${({ $display, theme }) => $display && getDisplayStyles($display, theme, 'display')};
 `;
 
 const getDisplayStyles: TableColumnDisplayOverload = (

--- a/packages/big-design/src/components/TableNext/helpers/display/spec.tsx
+++ b/packages/big-design/src/components/TableNext/helpers/display/spec.tsx
@@ -5,23 +5,23 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { withTableColumnDisplay } from './display';
-import { TableColumnDisplayProps } from './types';
+import { TransientTableColumnDisplayProps } from './types';
 
-const TestComponent = styled.div<TableColumnDisplayProps>`
+const TestComponent = styled.div<TransientTableColumnDisplayProps>`
   ${withTableColumnDisplay()};
 `;
 
 TestComponent.defaultProps = { theme: defaultTheme };
 
 test('display', () => {
-  const { container } = render(<TestComponent display="table-cell" />);
+  const { container } = render(<TestComponent $display="table-cell" />);
 
   expect(container.firstChild).toHaveStyle('display: table-cell');
 });
 
 test('responsive display', () => {
   const { container } = render(
-    <TestComponent display={{ mobile: 'none', tablet: 'table-cell' }} />,
+    <TestComponent $display={{ mobile: 'none', tablet: 'table-cell' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();

--- a/packages/big-design/src/components/TableNext/helpers/display/types.ts
+++ b/packages/big-design/src/components/TableNext/helpers/display/types.ts
@@ -8,6 +8,12 @@ export interface TableColumnDisplayProps {
   display?: TableColumnDisplayProp;
 }
 
+// Internal-only transient shape for the styled boundary (LTRAC-1396); TableColumnDisplayProps
+// (public) is unchanged.
+export interface TransientTableColumnDisplayProps {
+  $display?: TableColumnDisplayProp;
+}
+
 export type TableColumnDisplayOverload = (
   displayProp: TableColumnDisplayProp,
   theme: ThemeInterface,


### PR DESCRIPTION
## What?

Continue migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 4, TableNext half — mirrors #1888, the Table half).

`$`-prefix the bespoke props read by TableNext's `Row`, `DataCell`, `HeaderCell`, and `Body` styled components:
- **Row**: `$isDragging`, `$isGrabbed`, `$isHidden`, `$isPhantom`, `$isSelected`
- **DataCell**: `$align`, `$verticalAlign`, `$width`, `$withBorder`, `$isCheckbox`, `$isExpandable`, plus transient padding props via the existing `toTransientPaddingProps()` helper (Stage 0)
- **HeaderCell**: `$isSortable`, `$stickyHeader`, `$stickyHeight`, `$width`, `$align`, `$hide`
- **Body**: `$withFirstRowBorder`

Public `Props` interfaces are unchanged.

## Why?

Same rationale as #1888: styled-components 6 drops v5's automatic filtering of unknown props on tag-target styled components, so bespoke props read directly by a template would start leaking onto the DOM and trigger React's "unknown prop" warning.

Also fixes the same `display` DOM leak found and fixed in the Table PR — but in TableNext's own separate, byte-identical (yet independently-maintained) copy of the `withTableColumnDisplay()` helper. Confirmed via test that `Head`'s `hidden` prop needs the same exception as Table's: an equivalent existing test (`TableNext/spec.tsx`, "renders headers by default and hides them via prop") relies on the leaked native `hidden` attribute for jest-dom's `toBeVisible()` to resolve correctly, so it's deliberately left un-prefixed.

## Testing/Proof

- `pnpm --filter @bigcommerce/big-design run typecheck` — clean
- `pnpm --filter @bigcommerce/big-design run lint` — clean
- `pnpm --filter @bigcommerce/big-design run test` — 70 suites, 1152 tests, 182 snapshots pass. One snapshot updated (`TableNext/helpers/display/spec.tsx`) reflecting the `display` leak removal.
- `pnpm --filter @bigcommerce/big-design run build:dt` — confirmed no internal `Styled*Props` types leak into the public `dist/index.d.ts`.
- No cross-file consumers of TableNext's internal styled exports exist outside `TableNext/` (verified via grep).

This closes out Stage 4 (Table/TableNext dedupe) of LTRAC-1396.

Refs [TRAC-1354](https://bigcommercecloud.atlassian.net/browse/TRAC-1354)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TRAC-1354]: https://bigcommercecloud.atlassian.net/browse/TRAC-1354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ