### PR TITLE
refactor(component): $-prefix remaining Tree bespoke props

### DIFF
--- a/.changeset/transient-props-tree.md
+++ b/.changeset/transient-props-tree.md
@@ -1,0 +1,7 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Finish migrating `Tree` to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 5). `Tree` was the original precedent this migration is modeled on (`$maxHeight`, `$virtualized`, `$height`, `$level` were already transient); this closes the last few stragglers. `$`-prefix `TreeNode`'s `StyledArrowWrapper.expanded` and `StyledFlex.selected`. `Tree/styled.ts`'s `StyledUl.show` turned out to be dead code (never read in its template, never passed at its one call site), so it's removed entirely rather than renamed to an unused `$show`.
+
+Public `Props` interfaces are unchanged; all 182 snapshots pass with zero diffs (none of these prop names collide with real DOM attributes, so this is a true no-op under styled-components 5).

--- a/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
@@ -170,7 +170,7 @@ const InternalTreeNode = <T,>({
   const renderedArrow = useMemo(
     () =>
       children ? (
-        <StyledArrowWrapper expanded={isExpanded} flexShrink={0}>
+        <StyledArrowWrapper $expanded={isExpanded} flexShrink={0}>
           <ChevronRightIcon color="secondary60" focusable={false} size="xLarge" />
         </StyledArrowWrapper>
       ) : (
@@ -276,10 +276,10 @@ const InternalTreeNode = <T,>({
         {...additionalProps}
       >
         <StyledFlex
+          $selected={isSelected}
           alignItems="center"
           flexDirection="row"
           onClick={handleNodeToggle}
-          selected={isSelected}
         >
           {renderedArrow}
           {renderedSelectable}

--- a/packages/big-design/src/components/Tree/TreeNode/styled.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/styled.tsx
@@ -16,11 +16,11 @@ export const StyledLi = styled.li<{ $level?: number }>`
       : ''}
 `;
 
-export const StyledArrowWrapper = styled(FlexItem)<{ expanded: boolean }>`
+export const StyledArrowWrapper = styled(FlexItem)<{ $expanded: boolean }>`
   z-index: 1;
 
-  ${({ expanded }) =>
-    expanded &&
+  ${({ $expanded }) =>
+    $expanded &&
     css`
       transform: rotate(90deg);
     `};
@@ -42,7 +42,7 @@ const sharedAfterStyles = css`
   z-index: 0;
 `;
 
-export const StyledFlex = styled(Flex)<{ selected?: boolean }>`
+export const StyledFlex = styled(Flex)<{ $selected?: boolean }>`
   cursor: pointer;
   min-height: ${({ theme }) =>
     theme.helpers.addValues(theme.spacing.xxLarge, theme.spacing.xSmall)};
@@ -62,8 +62,8 @@ export const StyledFlex = styled(Flex)<{ selected?: boolean }>`
     vertical-align: middle;
   }
 
-  ${({ theme, selected }) =>
-    selected &&
+  ${({ theme, $selected }) =>
+    $selected &&
     css`
       &::after {
         ${sharedAfterStyles}

--- a/packages/big-design/src/components/Tree/styled.ts
+++ b/packages/big-design/src/components/Tree/styled.ts
@@ -9,7 +9,6 @@ export const getTreeIndentUnit = (theme: ThemeInterface) =>
 export const StyledUl = styled.ul<{
   $maxHeight?: number;
   $virtualized?: boolean;
-  show?: boolean;
 }>`
   list-style-type: none;
   margin: 0;


### PR DESCRIPTION
## What?

Finish migrating `Tree` to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 5). `Tree` was the original precedent this whole migration is modeled on (`$maxHeight`, `$virtualized`, `$height`, `$level` were already transient) — this closes the last few stragglers.

- `TreeNode/styled.tsx`: `StyledArrowWrapper.expanded` → `$expanded`, `StyledFlex.selected` → `$selected`, both updated at their `TreeNode.tsx` call sites.
- `Tree/styled.ts`: `StyledUl.show` — turned out to be **dead code**. Not read anywhere in its template, and never passed at the one call site (`Tree.tsx`, which uses fully explicit named props, no spread). Removed entirely rather than renamed to an unused `$show`.

Public `Props` interfaces are unchanged.

## Why?

Same rationale as the rest of this migration: styled-components 6 drops v5's automatic filtering of unknown props on tag-target styled components, so bespoke props read directly by a template need to be transient to avoid leaking onto the DOM and triggering React's "unknown prop" warning.

## Testing/Proof

- `pnpm --filter @bigcommerce/big-design run typecheck` — clean
- `pnpm --filter @bigcommerce/big-design run lint` — clean
- `pnpm --filter @bigcommerce/big-design run test` — 70 suites, 1152 tests, 182 snapshots pass with **zero diffs** (true no-op — none of `expanded`/`selected`/`show` collide with real DOM attribute names).
- `pnpm --filter @bigcommerce/big-design run build:dt` — confirmed no internal `$`-prop types leak into the public `dist/index.d.ts`.
- No cross-file consumers of Tree's internal styled exports exist outside `Tree/` (verified via grep).

Refs [TRAC-1369](https://bigcommercecloud.atlassian.net/browse/TRAC-1369)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TRAC-1369]: https://bigcommercecloud.atlassian.net/browse/TRAC-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ