### PR TITLE
refactor(component): $-prefix ProgressCircle bespoke props

### DIFF
--- a/.changeset/transient-props-progresscircle.md
+++ b/.changeset/transient-props-progresscircle.md
@@ -1,0 +1,7 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Migrate `ProgressCircle` to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 6). `ProgressCircleProps` (public) was reused directly as the styled generic across all four styled components, including inside `StyledCircle`'s `.attrs()` callback that computes SVG `cx`/`cy`/`r` geometry. Introduces an internal `StyledProgressCircleProps` (`$size`, `$percent`) and updates the `.attrs()` destructure, every CSS interpolation, and `ProgressCircle.tsx`'s JSX call sites together, since this one couldn't be split styled-file-vs-consumer like other components in this migration.
+
+Public `ProgressCircleProps` and CSS output are unchanged; all 182 snapshots pass with zero diffs (neither `size` nor `percent` currently leaks onto the rendered `<svg>`/`<circle>`/`<text>` elements under styled-components 5, so this is a true no-op).

--- a/packages/big-design/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/big-design/src/components/ProgressCircle/ProgressCircle.tsx
@@ -46,9 +46,9 @@ export const ProgressCircle: React.FC<ProgressCircleProps> = typedMemo(
     const renderedCircle = useMemo(() => {
       if (typeof percent !== 'number') {
         return (
-          <StyledProgressCircle role="progressbar" size={size}>
-            <StyledCircle size={size} />
-            <StyledCircleFiller size={size} />
+          <StyledProgressCircle $size={size} role="progressbar">
+            <StyledCircle $size={size} />
+            <StyledCircleFiller $size={size} />
           </StyledProgressCircle>
         );
       }
@@ -59,16 +59,16 @@ export const ProgressCircle: React.FC<ProgressCircleProps> = typedMemo(
 
       return (
         <StyledProgressCircle
+          $size={size}
           aria-valuemax={100}
           aria-valuemin={0}
           aria-valuenow={percent}
           role="progressbar"
-          size={size}
         >
-          <StyledCircle size={size} />
-          <StyledCircleFiller percent={percent} size={size} />
+          <StyledCircle $size={size} />
+          <StyledCircleFiller $percent={percent} $size={size} />
           {(size === 'large' || size === 'medium') && (
-            <StyledText size={size}>{percent ? Math.floor(percent) : 0}%</StyledText>
+            <StyledText $size={size}>{percent ? Math.floor(percent) : 0}%</StyledText>
           )}
         </StyledProgressCircle>
       );

--- a/packages/big-design/src/components/ProgressCircle/styled.tsx
+++ b/packages/big-design/src/components/ProgressCircle/styled.tsx
@@ -4,39 +4,44 @@ import styled, { css, keyframes } from 'styled-components';
 import { CIRCLE_CIRCUMFERENCES, CIRCLE_DIMENSIONS, CIRCLE_STROKE_WIDTHS } from './constants';
 import { ProgressCircleProps } from './ProgressCircle';
 
-export const StyledProgressCircle = styled.svg<ProgressCircleProps>`
-  ${({ size, theme }) => css`
-    height: ${theme.helpers.remCalc(getDimensions(size))};
-    width: ${theme.helpers.remCalc(getDimensions(size))};
+interface StyledProgressCircleProps {
+  $percent?: ProgressCircleProps['percent'];
+  $size?: ProgressCircleProps['size'];
+}
+
+export const StyledProgressCircle = styled.svg<StyledProgressCircleProps>`
+  ${({ $size, theme }) => css`
+    height: ${theme.helpers.remCalc(getDimensions($size))};
+    width: ${theme.helpers.remCalc(getDimensions($size))};
   `}
 `;
 
-export const StyledCircle = styled.circle.attrs<ProgressCircleProps>(({ size, theme }) => ({
+export const StyledCircle = styled.circle.attrs<StyledProgressCircleProps>(({ $size, theme }) => ({
   // rem not usable for circle svg cx, cy, and r values in Safari 14
-  cx: theme.helpers.emCalc(getDimensions(size) / 2),
-  cy: theme.helpers.emCalc(getDimensions(size) / 2),
-  r: theme.helpers.emCalc(getDimensions(size) / 2 - getStrokeWidth(size) / 2),
-}))<ProgressCircleProps>`
+  cx: theme.helpers.emCalc(getDimensions($size) / 2),
+  cy: theme.helpers.emCalc(getDimensions($size) / 2),
+  r: theme.helpers.emCalc(getDimensions($size) / 2 - getStrokeWidth($size) / 2),
+}))<StyledProgressCircleProps>`
   fill: transparent;
-  stroke-width: ${({ size, theme }) => theme.helpers.remCalc(getStrokeWidth(size))};
+  stroke-width: ${({ $size, theme }) => theme.helpers.remCalc(getStrokeWidth($size))};
   stroke: ${({ theme }) => theme.colors.secondary20};
 `;
 
-export const StyledCircleFiller = styled(StyledCircle)<ProgressCircleProps>`
-  stroke-dasharray: ${({ size }) => getStrokeDashArray(size)};
+export const StyledCircleFiller = styled(StyledCircle)<StyledProgressCircleProps>`
+  stroke-dasharray: ${({ $size }) => getStrokeDashArray($size)};
   stroke: ${({ theme }) => theme.colors.primary};
   transform-origin: 50% 50%;
 
-  ${({ percent, size }) =>
-    typeof percent === 'number'
+  ${({ $percent, $size }) =>
+    typeof $percent === 'number'
       ? css`
-          stroke-dashoffset: ${typeof percent === 'number' ? `${fillLength(percent, size)}` : 0};
+          stroke-dashoffset: ${typeof $percent === 'number' ? `${fillLength($percent, $size)}` : 0};
           transform: rotate(-90deg);
           transition: stroke-dashoffset 0.35s;
         `
       : css`
-          animation: ${spin(size)} 1s ease-out infinite;
-          stroke-dashoffset: ${fillLength(0, size)};
+          animation: ${spin($size)} 1s ease-out infinite;
+          stroke-dashoffset: ${fillLength(0, $size)};
           transform: rotate(-90deg);
           transition: stroke-dashoffset 0.35s;
         `};
@@ -47,11 +52,11 @@ export const StyledText = styled.text.attrs(() => ({
   textAnchor: 'middle',
   x: '50%',
   y: '50%',
-}))<ProgressCircleProps>`
-  font-size: ${({ size, theme }) =>
-    size === 'large' ? theme.typography.fontSize.large : theme.typography.fontSize.small};
-  font-weight: ${({ size, theme }) =>
-    size === 'large' ? theme.typography.fontWeight.semiBold : theme.typography.fontWeight.regular};
+}))<StyledProgressCircleProps>`
+  font-size: ${({ $size, theme }) =>
+    $size === 'large' ? theme.typography.fontSize.large : theme.typography.fontSize.small};
+  font-weight: ${({ $size, theme }) =>
+    $size === 'large' ? theme.typography.fontWeight.semiBold : theme.typography.fontWeight.regular};
 `;
 
 const spin = (size: ProgressCircleProps['size']) => keyframes`


### PR DESCRIPTION
## What?

Migrate `ProgressCircle` to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1396, Stage 6).

`ProgressCircleProps` (public) was reused directly as the styled generic across all four `ProgressCircle` styled components — including inside `StyledCircle`'s `.attrs()` callback, which reads `size` to compute the SVG `cx`/`cy`/`r` geometry. Introduces an internal `StyledProgressCircleProps` (`$size`, `$percent`), touching the `.attrs()` destructure, every CSS interpolation, and `ProgressCircle.tsx`'s JSX call sites together in this one PR, since — per the ticket — this component can't be split styled-file-vs-consumer the way other components in this migration were.

Public `ProgressCircleProps` is unchanged.

## Why?

Same rationale as the rest of this migration: styled-components 6 drops v5's automatic filtering of unknown props on tag-target styled components, so bespoke props read directly by a template (or an `.attrs()` callback) would start leaking onto the DOM.

## Testing/Proof

- `pnpm --filter @bigcommerce/big-design run typecheck` — clean
- `pnpm --filter @bigcommerce/big-design run lint` — clean
- `pnpm --filter @bigcommerce/big-design run test` — 70 suites, 1152 tests, 182 snapshots pass with **zero diffs**. Checked empirically (not assumed): neither `size` nor `percent` currently leaks onto the rendered `<svg>`/`<circle>`/`<text>` elements under styled-components 5, so this is a true no-op.
- `pnpm --filter @bigcommerce/big-design run build:dt` — confirmed no internal `StyledProgressCircleProps`/`$size`/`$percent` leak into the public `dist/index.d.ts`.
- No cross-file consumers of ProgressCircle's internal styled exports exist outside its own directory (verified via grep).

Refs [TRAC-1370](https://bigcommercecloud.atlassian.net/browse/TRAC-1370)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TRAC-1370]: https://bigcommercecloud.atlassian.net/browse/TRAC-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ