### PR TITLE
refactor(docs): $-prefix Code/List/MethodBadge bespoke props

### DIFF
--- a/packages/docs/components/Code/Code.tsx
+++ b/packages/docs/components/Code/Code.tsx
@@ -8,6 +8,8 @@ export interface CodeProps {
   highlight?: boolean;
 }
 
-export const Code: React.FC<CodeProps> = (props) => <StyledCode {...props} />;
+export const Code: React.FC<CodeProps> = ({ highlight, primary, ...domProps }) => (
+  <StyledCode $highlight={highlight} $primary={primary} {...domProps} />
+);
 
 Code.defaultProps = { highlight: true };

--- a/packages/docs/components/Code/styled.tsx
+++ b/packages/docs/components/Code/styled.tsx
@@ -2,20 +2,25 @@ import styled, { css } from 'styled-components';
 
 import { CodeProps } from './';
 
-export const StyledCode = styled.code<CodeProps>`
+interface StyledCodeProps {
+  $highlight?: CodeProps['highlight'];
+  $primary?: CodeProps['primary'];
+}
+
+export const StyledCode = styled.code<StyledCodeProps>`
   color: ${({ theme }) => theme.colors.secondary70};
   white-space: nowrap;
 
-  ${({ highlight, primary, theme }) =>
-    highlight &&
-    !primary &&
+  ${({ $highlight, $primary, theme }) =>
+    $highlight &&
+    !$primary &&
     css`
       background-color: ${theme.colors.warning20};
       padding: ${theme.spacing.xxSmall};
     `};
 
-  ${({ primary, theme }) =>
-    primary &&
+  ${({ $primary, theme }) =>
+    $primary &&
     css`
       color: ${theme.colors.primary70};
     `};

--- a/packages/docs/components/List/List.tsx
+++ b/packages/docs/components/List/List.tsx
@@ -18,12 +18,13 @@ export const List = ({
   columnGap = 'normal',
   as = 'ul',
   children,
+  reset,
   ...props
 }: ListProps): ReactElement<ListProps> => {
   const ElementType = as === 'ol' ? StyledOrderedList : StyledUnorderedList;
 
   return (
-    <ElementType columnCount={columnCount} columnGap={columnGap} {...props}>
+    <ElementType $columnCount={columnCount} $columnGap={columnGap} $reset={reset} {...props}>
       {children}
     </ElementType>
   );

--- a/packages/docs/components/List/styled.tsx
+++ b/packages/docs/components/List/styled.tsx
@@ -2,7 +2,13 @@ import styled, { css } from 'styled-components';
 
 import { ListProps } from './List';
 
-const SharedListStyles = css<ListProps>`
+interface StyledListProps {
+  $columnCount?: ListProps['columnCount'];
+  $columnGap?: ListProps['columnGap'];
+  $reset?: ListProps['reset'];
+}
+
+const SharedListStyles = css<StyledListProps>`
   color: ${({ theme }) => theme.colors.secondary70};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
@@ -10,21 +16,21 @@ const SharedListStyles = css<ListProps>`
   padding-left: ${({ theme }) => theme.spacing.xLarge};
 
   ${({ theme }) => theme.breakpoints.tablet} {
-    column-count: ${({ columnCount }) => columnCount};
-    column-gap: ${({ columnGap }) => columnGap};
+    column-count: ${({ $columnCount }) => $columnCount};
+    column-gap: ${({ $columnGap }) => $columnGap};
   }
 
-  ${({ reset, theme }) =>
-    reset &&
+  ${({ $reset, theme }) =>
+    $reset &&
     css`
       ${theme.helpers.listReset};
     `}
 `;
 
-export const StyledOrderedList = styled.ol<ListProps>`
+export const StyledOrderedList = styled.ol<StyledListProps>`
   ${SharedListStyles};
 `;
 
-export const StyledUnorderedList = styled.ul<ListProps>`
+export const StyledUnorderedList = styled.ul<StyledListProps>`
   ${SharedListStyles}
 `;

--- a/packages/docs/components/MethodBadge/MethodBadge.tsx
+++ b/packages/docs/components/MethodBadge/MethodBadge.tsx
@@ -7,6 +7,29 @@ export interface MethodBadgeProps extends ComponentPropsWithoutRef<'div'>, Margi
   label: string;
 }
 
-export const MethodBadge: React.FC<MethodBadgeProps> = ({ className, style, label, ...props }) => (
-  <StyledMethodBadge {...props}>{label}</StyledMethodBadge>
+export const MethodBadge: React.FC<MethodBadgeProps> = ({
+  className,
+  style,
+  label,
+  margin,
+  marginTop,
+  marginRight,
+  marginBottom,
+  marginLeft,
+  marginVertical,
+  marginHorizontal,
+  ...props
+}) => (
+  <StyledMethodBadge
+    {...props}
+    $margin={margin}
+    $marginBottom={marginBottom}
+    $marginHorizontal={marginHorizontal}
+    $marginLeft={marginLeft}
+    $marginRight={marginRight}
+    $marginTop={marginTop}
+    $marginVertical={marginVertical}
+  >
+    {label}
+  </StyledMethodBadge>
 );

--- a/packages/docs/components/MethodBadge/styled.ts
+++ b/packages/docs/components/MethodBadge/styled.ts
@@ -1,9 +1,19 @@
-import { withMargins } from '@bigcommerce/big-design';
+import { MarginProps, withMargins } from '@bigcommerce/big-design';
 import styled from 'styled-components';
 
 import { MethodBadgeProps } from './MethodBadge';
 
-export const StyledMethodBadge = styled.span<Omit<MethodBadgeProps, 'label'>>`
+interface StyledMethodBadgeProps extends Omit<MethodBadgeProps, 'label' | keyof MarginProps> {
+  $margin?: MarginProps['margin'];
+  $marginTop?: MarginProps['marginTop'];
+  $marginRight?: MarginProps['marginRight'];
+  $marginBottom?: MarginProps['marginBottom'];
+  $marginLeft?: MarginProps['marginLeft'];
+  $marginVertical?: MarginProps['marginVertical'];
+  $marginHorizontal?: MarginProps['marginHorizontal'];
+}
+
+export const StyledMethodBadge = styled.span<StyledMethodBadgeProps>`
   ${withMargins()};
 
   background-color: ${({ theme }) => theme.colors.secondary70};


### PR DESCRIPTION
## What?

Continue the transient-props migration (LTRAC-1396, Stage 7) for the `docs` app, which consumes `@bigcommerce/big-design` as a package rather than being part of its source.

- `Code`: `highlight`/`primary` → `$highlight`/`$primary`
- `List`: `columnCount`/`columnGap`/`reset` → `$columnCount`/`$columnGap`/`$reset`
- `MethodBadge`: margin fields → `$`-prefixed, via manual destructure-and-rename (rather than `toTransientMarginProps()`, since that utility isn't part of big-design's public API surface — it's deliberately not re-exported from `helpers/index.ts`)

`big-design-patterns/Header/styled.tsx` needs **no changes**: neither `StyledBackLink` nor `StyledActionsWrapper` declares a custom prop generic, so there's nothing to convert (confirmed by reading both the styled file and its call sites in `Header.tsx`).

Public component prop interfaces are unchanged.

**Note:** This PR is stacked on #1891 (Stage 6, still open) since that branch was the latest unmerged work in this series — will rebase onto `main` once #1891 merges.

## Why?

Same rationale as the rest of this migration: styled-components 6 drops v5's automatic filtering of unknown props on tag-target styled components.

## Testing/Proof

- `pnpm --filter docs run lint` — clean
- `npx tsc --noEmit` in `packages/docs` — no new errors (2 pre-existing, unrelated errors in `SideNavLogo.tsx` and `_app.tsx`, both about Next.js-specific typing that requires the full Next build pipeline, not bare `tsc`)
- `docs` has no test suite (confirmed via `package.json` — only `lint`/`build`/`start` scripts)
- No cross-file consumers of `Code`/`List`/`MethodBadge`'s styled exports exist outside their own directories (verified via grep)

Refs [TRAC-1371](https://bigcommercecloud.atlassian.net/browse/TRAC-1371)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TRAC-1371]: https://bigcommercecloud.atlassian.net/browse/TRAC-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ