### PR TITLE
refactor(component): remove transient-props migration shim

### DIFF
--- a/.changeset/transient-props-shim-removal.md
+++ b/.changeset/transient-props-shim-removal.md
@@ -11,6 +11,4 @@ This also converts the last few remaining consumers found by an audit of every `
 
 `withPaddings()` had no outstanding non-converted consumers.
 
-**Note for reviewers:** `withMargins()`/`withPaddings()`/`withDisplay()`, and their `Transient*Props`/`toTransient*Props()` counterparts, are exported from `@bigcommerce/big-design`'s public API via `helpers/index.ts`'s wildcard re-export (contrary to earlier assumptions in this migration that they weren't). Their exported return-type signatures narrow slightly (`css<MarginProps & TransientMarginProps>` → `css<TransientMarginProps>`, etc.). Within this monorepo, the only consumer using these utilities outside `packages/big-design`'s own source was `docs/MethodBadge`, already converted here. Any *external* consumer of the published package calling these directly with bare (non-`$`) props would need to update — an unlikely usage pattern for what are effectively internal-only utilities, but worth flagging explicitly.
-
 All 182 snapshots pass; one snapshot updated (`helpers/display/spec.tsx`'s own test) reflecting a `display` leak removal, the same category of fix as Stage 0's `Box` and Stage 4's `Table`/`TableNext`. No public component `Props` interface changed.

--- a/.changeset/transient-props-shim-removal.md
+++ b/.changeset/transient-props-shim-removal.md
@@ -1,0 +1,16 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Complete the transient-props migration (LTRAC-1396) by removing the temporary dual-read shim from the three shared helpers, `withMargins()`, `withPaddings()`, and `withDisplay()`. They previously read both the public (`margin`) and transient (`$margin`) prop names (`$margin ?? margin`) so components could migrate one PR at a time; now that every consumer in this repo passes `$`-prefixed props, they read only the transient name.
+
+This also converts the last few remaining consumers found by an audit of every `withMargins()`/`withPaddings()`/`withDisplay()` call site, none of which were on the original stage list:
+- `Table`'s and `TableNext`'s `TableFigure`/`TableFigureNext` (margin)
+- `Typography`'s `Text`, `Small`, `HR`, `H0`–`H4` (margin) — plus three forced fixes at cross-file call sites that bypass the public wrapper and use the internal `Styleable*` exports directly: `Tree/TreeNode.tsx`, `Panel.tsx`, `FileUploader/File.tsx`, `FeatureSet/Tag.tsx`, and `InfoCard.tsx`
+- `Flex` and `Grid` (display) — previously flagged in Stage 3 as follow-up work, now required since they call `withDisplay()` directly on their own `styled(Box)` wrapper layer, independent of `Box`'s own (already-converted) internal handling
+
+`withPaddings()` had no outstanding non-converted consumers.
+
+**Note for reviewers:** `withMargins()`/`withPaddings()`/`withDisplay()`, and their `Transient*Props`/`toTransient*Props()` counterparts, are exported from `@bigcommerce/big-design`'s public API via `helpers/index.ts`'s wildcard re-export (contrary to earlier assumptions in this migration that they weren't). Their exported return-type signatures narrow slightly (`css<MarginProps & TransientMarginProps>` → `css<TransientMarginProps>`, etc.). Within this monorepo, the only consumer using these utilities outside `packages/big-design`'s own source was `docs/MethodBadge`, already converted here. Any *external* consumer of the published package calling these directly with bare (non-`$`) props would need to update — an unlikely usage pattern for what are effectively internal-only utilities, but worth flagging explicitly.
+
+All 182 snapshots pass; one snapshot updated (`helpers/display/spec.tsx`'s own test) reflecting a `display` leak removal, the same category of fix as Stage 0's `Box` and Stage 4's `Table`/`TableNext`. No public component `Props` interface changed.

--- a/packages/big-design/src/components/FeatureSet/Tag/Tag.tsx
+++ b/packages/big-design/src/components/FeatureSet/Tag/Tag.tsx
@@ -15,7 +15,7 @@ export const Tag: React.FC<TagProps> = memo(({ icon, label }) => {
   return label ? (
     <StyledLi aria-labelledby={id}>
       {icon}
-      <StyleableSmall as="span" color="currentColor" ellipsis id={id} margin="none">
+      <StyleableSmall $margin="none" as="span" color="currentColor" ellipsis id={id}>
         {label}
       </StyleableSmall>
     </StyledLi>

--- a/packages/big-design/src/components/FileUploader/File.tsx
+++ b/packages/big-design/src/components/FileUploader/File.tsx
@@ -64,7 +64,7 @@ export const File = ({ actions, name, idx, isValid, previewSrc, onRemove, ...pro
       paddingHorizontal="small"
     >
       {renderedFilePreview}
-      <StyledText marginBottom="none" marginLeft="xSmall" marginRight="auto">
+      <StyledText $marginBottom="none" $marginLeft="xSmall" $marginRight="auto">
         {name}
       </StyledText>
       {renderedActions}

--- a/packages/big-design/src/components/Flex/Flex.tsx
+++ b/packages/big-design/src/components/Flex/Flex.tsx
@@ -11,6 +11,10 @@ interface PrivateProps {
   forwardedRef: React.Ref<HTMLDivElement>;
 }
 
+// `display` is passed twice deliberately: StyledFlex composes over Box (a component, not
+// a tag), so `display` also needs to reach Box's own internal $-prefixed handling
+// untouched (its public contract), while `$display` feeds StyledFlex's own separate
+// withDisplay() call on its outer layer.
 const RawFlex: React.FC<FlexProps & PrivateProps> = ({ as, display, forwardedRef, ...rest }) => (
   <StyledFlex $display={display} display={display} forwardedAs={as} ref={forwardedRef} {...rest} />
 );

--- a/packages/big-design/src/components/Flex/Flex.tsx
+++ b/packages/big-design/src/components/Flex/Flex.tsx
@@ -11,8 +11,8 @@ interface PrivateProps {
   forwardedRef: React.Ref<HTMLDivElement>;
 }
 
-const RawFlex: React.FC<FlexProps & PrivateProps> = ({ as, forwardedRef, ...rest }) => (
-  <StyledFlex forwardedAs={as} ref={forwardedRef} {...rest} />
+const RawFlex: React.FC<FlexProps & PrivateProps> = ({ as, display, forwardedRef, ...rest }) => (
+  <StyledFlex $display={display} display={display} forwardedAs={as} ref={forwardedRef} {...rest} />
 );
 
 export const Flex = forwardRef<HTMLDivElement, FlexProps>((props, ref) => (

--- a/packages/big-design/src/components/Flex/styled.tsx
+++ b/packages/big-design/src/components/Flex/styled.tsx
@@ -2,13 +2,16 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withDisplay } from '../../helpers';
+import { TransientDisplayProps } from '../../helpers/display/types';
 import { Box } from '../Box';
 
 import { FlexProps } from './Flex';
 import { withFlexedContainer } from './withFlex';
 
 // TODO: Remove the `forwardedAs` manual prop definition when @types get updated
-export const StyledFlex = styled(Box)<FlexProps & { forwardedAs?: FlexProps['as'] }>`
+export const StyledFlex = styled(Box)<
+  FlexProps & TransientDisplayProps & { forwardedAs?: FlexProps['as'] }
+>`
   ${withFlexedContainer()}
 
   display: flex;

--- a/packages/big-design/src/components/Grid/Grid.tsx
+++ b/packages/big-design/src/components/Grid/Grid.tsx
@@ -11,8 +11,8 @@ interface PrivateProps {
   forwardedRef: React.Ref<HTMLDivElement>;
 }
 
-const RawGrid: React.FC<GridProps & PrivateProps> = ({ as, forwardedRef, ...rest }) => (
-  <StyledGrid forwardedAs={as} ref={forwardedRef} {...rest} />
+const RawGrid: React.FC<GridProps & PrivateProps> = ({ as, display, forwardedRef, ...rest }) => (
+  <StyledGrid $display={display} display={display} forwardedAs={as} ref={forwardedRef} {...rest} />
 );
 
 export const Grid = forwardRef<HTMLDivElement, GridProps>((props, ref) => (

--- a/packages/big-design/src/components/Grid/Grid.tsx
+++ b/packages/big-design/src/components/Grid/Grid.tsx
@@ -11,6 +11,10 @@ interface PrivateProps {
   forwardedRef: React.Ref<HTMLDivElement>;
 }
 
+// `display` is passed twice deliberately: StyledGrid composes over Box (a component, not
+// a tag), so `display` also needs to reach Box's own internal $-prefixed handling
+// untouched (its public contract), while `$display` feeds StyledGrid's own separate
+// withDisplay() call on its outer layer.
 const RawGrid: React.FC<GridProps & PrivateProps> = ({ as, display, forwardedRef, ...rest }) => (
   <StyledGrid $display={display} display={display} forwardedAs={as} ref={forwardedRef} {...rest} />
 );

--- a/packages/big-design/src/components/Grid/styled.tsx
+++ b/packages/big-design/src/components/Grid/styled.tsx
@@ -2,13 +2,16 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withDisplay } from '../../helpers';
+import { TransientDisplayProps } from '../../helpers/display/types';
 import { Box } from '../Box';
 
 import { GridProps } from './Grid';
 import { withGridedContainer } from './withGrid';
 
 // TODO: Remove the `forwardedAs` manual prop definition when @types get updated
-export const StyledGrid = styled(Box)<GridProps & { forwardedAs?: GridProps['as'] }>`
+export const StyledGrid = styled(Box)<
+  GridProps & TransientDisplayProps & { forwardedAs?: GridProps['as'] }
+>`
   ${withGridedContainer()}
 
   display: grid;

--- a/packages/big-design/src/components/InfoCard/InfoCard.tsx
+++ b/packages/big-design/src/components/InfoCard/InfoCard.tsx
@@ -21,7 +21,7 @@ export const InfoCard: React.FC<InfoCardProps> = ({ img, title, badge, descripti
     <Flex alignItems="center">
       {img && <InfoCardImgContainer height={40} width={40} {...imgProps} alt={img.alt ?? ''} />}
       <Box>
-        <StyleableText margin="none">
+        <StyleableText $margin="none">
           {title}
           {badge ? <Badge marginLeft="xSmall" {...badge} /> : null}
         </StyleableText>

--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -44,7 +44,7 @@ export const RawPanel: React.FC<PanelProps & PrivateProps> = memo(({ forwardedRe
     return (
       <Flex flexDirection="row">
         {Boolean(header) && (
-          <StyledH2 id={headerId} marginBottom="none">
+          <StyledH2 $marginBottom="none" id={headerId}>
             {header}
             {badge && <Badge marginLeft="xSmall" {...badge} />}
           </StyledH2>

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -8,6 +8,7 @@ import {
 import React, { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import { MarginProps } from '../../helpers';
+import { toTransientMarginProps } from '../../helpers/margins/margins';
 import { useEventCallback } from '../../hooks';
 import { typedMemo } from '../../utils';
 
@@ -310,6 +311,8 @@ const InternalTable = <T extends TableItem>(
 };
 
 export const Table = typedMemo(InternalTable);
-export const TableFigure: React.FC<{ children?: React.ReactNode } & MarginProps> = memo((props) => (
-  <StyledTableFigure {...props} />
-));
+export const TableFigure: React.FC<{ children?: React.ReactNode } & MarginProps> = memo(
+  ({ children, ...props }) => (
+    <StyledTableFigure {...toTransientMarginProps(props)}>{children}</StyledTableFigure>
+  ),
+);

--- a/packages/big-design/src/components/Table/styled.tsx
+++ b/packages/big-design/src/components/Table/styled.tsx
@@ -1,9 +1,10 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
-import { MarginProps, withMargins } from '../../helpers';
+import { withMargins } from '../../helpers';
+import { TransientMarginProps } from '../../helpers/margins/margins';
 
-export const StyledTableFigure = styled.figure<MarginProps>`
+export const StyledTableFigure = styled.figure<TransientMarginProps>`
   margin: 0;
   max-width: 100%;
   overflow-x: auto;

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -8,6 +8,7 @@ import {
 import React, { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import { MarginProps } from '../../helpers';
+import { toTransientMarginProps } from '../../helpers/margins/margins';
 import { typedMemo } from '../../utils';
 
 import { Actions } from './Actions';
@@ -337,5 +338,7 @@ const InternalTableNext = <T extends TableItem>(
 
 export const TableNext = typedMemo(InternalTableNext);
 export const TableFigureNext: React.FC<{ children?: React.ReactNode } & MarginProps> = memo(
-  (props) => <StyledTableFigure {...props} />,
+  ({ children, ...props }) => (
+    <StyledTableFigure {...toTransientMarginProps(props)}>{children}</StyledTableFigure>
+  ),
 );

--- a/packages/big-design/src/components/TableNext/styled.tsx
+++ b/packages/big-design/src/components/TableNext/styled.tsx
@@ -1,9 +1,10 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
-import { MarginProps, withMargins } from '../../helpers';
+import { withMargins } from '../../helpers';
+import { TransientMarginProps } from '../../helpers/margins/margins';
 
-export const StyledTableFigure = styled.figure<MarginProps>`
+export const StyledTableFigure = styled.figure<TransientMarginProps>`
   margin: 0;
   max-width: 100%;
   overflow-x: auto;

--- a/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
@@ -285,10 +285,10 @@ const InternalTreeNode = <T,>({
           {renderedSelectable}
           {renderedIcon}
           <StyledText
+            $marginLeft="xxSmall"
             as="span"
             color={isDisabled ? 'secondary50' : 'secondary70'}
             ellipsis
-            marginLeft="xxSmall"
           >
             {label}
             {selectedChildrenCount ? (

--- a/packages/big-design/src/components/Typography/Typography.tsx
+++ b/packages/big-design/src/components/Typography/Typography.tsx
@@ -1,5 +1,7 @@
 import React, { memo } from 'react';
 
+import { toTransientMarginProps } from '../../helpers/margins/margins';
+
 import {
   StyledH0,
   StyledH1,
@@ -25,36 +27,156 @@ export const StyleableH4 = StyledH4;
 export const StyleableHR = StyledHR;
 
 // Public
-export const Text: React.FC<TextProps> = memo(({ className, style, ...props }) => (
-  <StyleableText {...props} />
-));
-export const Small: React.FC<TextProps> = memo(({ className, style, ...props }) => (
-  <StyleableSmall {...props} />
-));
+export const Text: React.FC<TextProps> = memo((props) => {
+  const {
+    className,
+    style,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
 
-export const HR: React.FC<HRProps> = memo(({ className, style, ...props }) => (
-  <StyleableHR {...props} />
-));
+  return <StyleableText {...domProps} {...toTransientMarginProps(props)} />;
+});
 
-export const H0: React.FC<HeadingProps> = memo(({ className, style, as, ...props }) => (
-  <StyleableH0 as={getHeadingTag('h1', as)} {...props} />
-));
+export const Small: React.FC<TextProps> = memo((props) => {
+  const {
+    className,
+    style,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
 
-export const H1: React.FC<HeadingProps> = memo(({ className, style, as, ...props }) => (
-  <StyleableH1 as={getHeadingTag('h1', as)} {...props} />
-));
+  return <StyleableSmall {...domProps} {...toTransientMarginProps(props)} />;
+});
 
-export const H2: React.FC<HeadingProps> = memo(({ className, style, as, ...props }) => (
-  <StyleableH2 as={getHeadingTag('h2', as)} {...props} />
-));
+export const HR: React.FC<HRProps> = memo((props) => {
+  const {
+    className,
+    style,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
 
-export const H3: React.FC<HeadingProps> = memo(({ className, style, as, ...props }) => (
-  <StyleableH3 as={getHeadingTag('h3', as)} {...props} />
-));
+  return <StyleableHR {...domProps} {...toTransientMarginProps(props)} />;
+});
 
-export const H4: React.FC<HeadingProps> = memo(({ className, style, as, ...props }) => (
-  <StyleableH4 as={getHeadingTag('h4', as)} {...props} />
-));
+export const H0: React.FC<HeadingProps> = memo((props) => {
+  const {
+    className,
+    style,
+    as,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
+
+  return (
+    <StyleableH0 as={getHeadingTag('h1', as)} {...domProps} {...toTransientMarginProps(props)} />
+  );
+});
+
+export const H1: React.FC<HeadingProps> = memo((props) => {
+  const {
+    className,
+    style,
+    as,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
+
+  return (
+    <StyleableH1 as={getHeadingTag('h1', as)} {...domProps} {...toTransientMarginProps(props)} />
+  );
+});
+
+export const H2: React.FC<HeadingProps> = memo((props) => {
+  const {
+    className,
+    style,
+    as,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
+
+  return (
+    <StyleableH2 as={getHeadingTag('h2', as)} {...domProps} {...toTransientMarginProps(props)} />
+  );
+});
+
+export const H3: React.FC<HeadingProps> = memo((props) => {
+  const {
+    className,
+    style,
+    as,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
+
+  return (
+    <StyleableH3 as={getHeadingTag('h3', as)} {...domProps} {...toTransientMarginProps(props)} />
+  );
+});
+
+export const H4: React.FC<HeadingProps> = memo((props) => {
+  const {
+    className,
+    style,
+    as,
+    margin,
+    marginTop,
+    marginRight,
+    marginBottom,
+    marginLeft,
+    marginVertical,
+    marginHorizontal,
+    ...domProps
+  } = props;
+
+  return (
+    <StyleableH4 as={getHeadingTag('h4', as)} {...domProps} {...toTransientMarginProps(props)} />
+  );
+});
 
 const getHeadingTag = (defaultTag: HeadingTag, tag?: HeadingTag): HeadingTag => {
   return tag && validHeadingTags.has(tag) ? tag : defaultTag;

--- a/packages/big-design/src/components/Typography/styled.tsx
+++ b/packages/big-design/src/components/Typography/styled.tsx
@@ -2,9 +2,14 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { ellipsis } from 'polished';
 import styled, { css } from 'styled-components';
 
-import { withMargins } from '../../helpers';
+import { MarginProps, withMargins } from '../../helpers';
+import { TransientMarginProps } from '../../helpers/margins/margins';
 
 import { HeadingProps, HRProps, TextProps, TypographyProps } from './types';
+
+type StyledHeadingProps = Omit<HeadingProps, keyof MarginProps> & TransientMarginProps;
+type StyledTextProps = Omit<TextProps, keyof MarginProps> & TransientMarginProps;
+type StyledHRProps = Omit<HRProps, keyof MarginProps> & TransientMarginProps;
 
 const commonTextStyles = (props: TypographyProps) => css`
   color: ${({ theme }) => (props.color ? theme.colors[props.color] : theme.colors.secondary70)};
@@ -57,7 +62,7 @@ const textModifiers = (props: TextProps) => css`
     `}
 `;
 
-export const StyledH0 = styled.h1<HeadingProps>`
+export const StyledH0 = styled.h1<StyledHeadingProps>`
   ${(props) => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.xxxLarge};
   font-weight: ${({ theme }) => theme.typography.fontWeight.extraLight};
@@ -66,7 +71,7 @@ export const StyledH0 = styled.h1<HeadingProps>`
   ${withMargins()};
 `;
 
-export const StyledH1 = styled.h1<HeadingProps>`
+export const StyledH1 = styled.h1<StyledHeadingProps>`
   ${(props) => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.xxLarge};
   font-weight: ${({ theme }) => theme.typography.fontWeight.light};
@@ -75,7 +80,7 @@ export const StyledH1 = styled.h1<HeadingProps>`
   ${withMargins()};
 `;
 
-export const StyledH2 = styled.h2<HeadingProps>`
+export const StyledH2 = styled.h2<StyledHeadingProps>`
   ${(props) => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.xLarge};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
@@ -83,7 +88,7 @@ export const StyledH2 = styled.h2<HeadingProps>`
   ${withMargins()};
 `;
 
-export const StyledH3 = styled.h3<HeadingProps>`
+export const StyledH3 = styled.h3<StyledHeadingProps>`
   ${(props) => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.large};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
@@ -92,7 +97,7 @@ export const StyledH3 = styled.h3<HeadingProps>`
   ${withMargins()};
 `;
 
-export const StyledH4 = styled.h4<HeadingProps>`
+export const StyledH4 = styled.h4<StyledHeadingProps>`
   ${(props) => commonTextStyles(props)};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
@@ -101,7 +106,7 @@ export const StyledH4 = styled.h4<HeadingProps>`
   ${withMargins()};
 `;
 
-export const StyledText = styled.p<TextProps>`
+export const StyledText = styled.p<StyledTextProps>`
   ${(props) => commonTextStyles(props)}
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};
@@ -115,7 +120,7 @@ export const StyledText = styled.p<TextProps>`
   ${withMargins()};
 `;
 
-export const StyledSmall = styled.p<TextProps>`
+export const StyledSmall = styled.p<StyledTextProps>`
   ${(props) => commonTextStyles(props)};
   color: ${({ color, theme }) => (color ? theme.colors[color] : theme.colors.secondary60)};
   font-size: ${({ theme }) => theme.typography.fontSize.small};
@@ -131,7 +136,7 @@ export const StyledSmall = styled.p<TextProps>`
   ${withMargins()};
 `;
 
-export const StyledHR = styled.hr<HRProps>`
+export const StyledHR = styled.hr<StyledHRProps>`
   ${withMargins()};
 
   border: 0;

--- a/packages/big-design/src/helpers/display/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/helpers/display/__snapshots__/spec.tsx.snap
@@ -18,6 +18,5 @@ exports[`responsive display 1`] = `
 
 <div
   class="c0"
-  display="[object Object]"
 />
 `;

--- a/packages/big-design/src/helpers/display/display.tsx
+++ b/packages/big-design/src/helpers/display/display.tsx
@@ -8,17 +8,8 @@ import { css } from 'styled-components';
 
 import { DisplayOverload, DisplayProps, TransientDisplayProps } from './types';
 
-// MIGRATION SHIM (LTRAC-1396): reads both the public (`display`) and transient
-// (`$display`) prop names so components can be migrated to transient props one PR at
-// a time while unconverted consumers keep rendering identically. Once every consumer
-// passes `$display`, drop the `?? display` fallback (and `DisplayProps` from the
-// generic) to leave a pure transient read.
-export const withDisplay = () => css<DisplayProps & TransientDisplayProps>`
-  ${({ display, $display, theme }) => {
-    const value = $display ?? display;
-
-    return value && getDisplayStyles(value, theme, 'display');
-  }};
+export const withDisplay = () => css<TransientDisplayProps>`
+  ${({ $display, theme }) => $display && getDisplayStyles($display, theme, 'display')};
 `;
 
 // Rename-and-keep helper: maps the public `display` prop to its transient (`$`-prefixed)

--- a/packages/big-design/src/helpers/display/spec.tsx
+++ b/packages/big-design/src/helpers/display/spec.tsx
@@ -5,22 +5,22 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { withDisplay } from './display';
-import { DisplayProps } from './types';
+import { TransientDisplayProps } from './types';
 
-const TestComponent = styled.div<DisplayProps>`
+const TestComponent = styled.div<TransientDisplayProps>`
   ${withDisplay()};
 `;
 
 TestComponent.defaultProps = { theme: defaultTheme };
 
 test('display', () => {
-  const { container } = render(<TestComponent display="inline-block" />);
+  const { container } = render(<TestComponent $display="inline-block" />);
 
   expect(container.firstChild).toHaveStyle('display: inline-block');
 });
 
 test('responsive display', () => {
-  const { container } = render(<TestComponent display={{ mobile: 'none', tablet: 'flex' }} />);
+  const { container } = render(<TestComponent $display={{ mobile: 'none', tablet: 'flex' }} />);
 
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/packages/big-design/src/helpers/margins/margins.tsx
+++ b/packages/big-design/src/helpers/margins/margins.tsx
@@ -29,47 +29,18 @@ export type TransientMarginProps = Partial<{
   $marginHorizontal: MarginProp;
 }>;
 
-// MIGRATION SHIM (LTRAC-1396): reads both the public (`margin`) and transient
-// (`$margin`) prop names so components can be migrated to transient props one PR at
-// a time while unconverted consumers keep rendering identically. Once every consumer
-// passes `$`-prefixed props, drop the `?? margin*` fallbacks (and `MarginProps` from
-// the generic) to leave a pure transient read.
-export const withMargins = () => css<MarginProps & TransientMarginProps>`
-  ${({ margin, $margin, theme }) => {
-    const value = $margin ?? margin;
-
-    return value && getSpacingStyles(value, theme, 'margin');
-  }};
-  ${({ marginTop, $marginTop, theme }) => {
-    const value = $marginTop ?? marginTop;
-
-    return value && getSpacingStyles(value, theme, 'margin-top');
-  }};
-  ${({ marginRight, $marginRight, theme }) => {
-    const value = $marginRight ?? marginRight;
-
-    return value && getSpacingStyles(value, theme, 'margin-right');
-  }};
-  ${({ marginBottom, $marginBottom, theme }) => {
-    const value = $marginBottom ?? marginBottom;
-
-    return value && getSpacingStyles(value, theme, 'margin-bottom');
-  }};
-  ${({ marginLeft, $marginLeft, theme }) => {
-    const value = $marginLeft ?? marginLeft;
-
-    return value && getSpacingStyles(value, theme, 'margin-left');
-  }};
-  ${({ marginVertical, $marginVertical, theme }) => {
-    const value = $marginVertical ?? marginVertical;
-
-    return value && getSpacingStyles(value, theme, 'margin-top', 'margin-bottom');
-  }};
-  ${({ marginHorizontal, $marginHorizontal, theme }) => {
-    const value = $marginHorizontal ?? marginHorizontal;
-
-    return value && getSpacingStyles(value, theme, 'margin-left', 'margin-right');
-  }};
+export const withMargins = () => css<TransientMarginProps>`
+  ${({ $margin, theme }) => $margin && getSpacingStyles($margin, theme, 'margin')};
+  ${({ $marginTop, theme }) => $marginTop && getSpacingStyles($marginTop, theme, 'margin-top')};
+  ${({ $marginRight, theme }) =>
+    $marginRight && getSpacingStyles($marginRight, theme, 'margin-right')};
+  ${({ $marginBottom, theme }) =>
+    $marginBottom && getSpacingStyles($marginBottom, theme, 'margin-bottom')};
+  ${({ $marginLeft, theme }) => $marginLeft && getSpacingStyles($marginLeft, theme, 'margin-left')};
+  ${({ $marginVertical, theme }) =>
+    $marginVertical && getSpacingStyles($marginVertical, theme, 'margin-top', 'margin-bottom')};
+  ${({ $marginHorizontal, theme }) =>
+    $marginHorizontal && getSpacingStyles($marginHorizontal, theme, 'margin-left', 'margin-right')};
 `;
 
 export function excludeMarginProps<T extends Record<string, any>>(

--- a/packages/big-design/src/helpers/margins/spec.tsx
+++ b/packages/big-design/src/helpers/margins/spec.tsx
@@ -4,22 +4,22 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import styled from 'styled-components';
 
-import { excludeMarginProps, MarginProps, withMargins } from './margins';
+import { excludeMarginProps, MarginProps, TransientMarginProps, withMargins } from './margins';
 
-const TestComponent = styled.div<MarginProps>`
+const TestComponent = styled.div<TransientMarginProps>`
   ${withMargins()};
 `;
 
 TestComponent.defaultProps = { theme: defaultTheme };
 
 test('margin', () => {
-  const { container } = render(<TestComponent margin="medium" />);
+  const { container } = render(<TestComponent $margin="medium" />);
 
   expect(container.firstChild).toHaveStyle('margin: 1rem');
 });
 
 test('marginTop', () => {
-  const { container } = render(<TestComponent marginTop="medium" />);
+  const { container } = render(<TestComponent $marginTop="medium" />);
 
   expect(container.firstChild).toHaveStyle('margin-top: 1rem');
 
@@ -30,7 +30,7 @@ test('marginTop', () => {
 });
 
 test('marginRight', () => {
-  const { container } = render(<TestComponent marginRight="medium" />);
+  const { container } = render(<TestComponent $marginRight="medium" />);
 
   expect(container.firstChild).toHaveStyle('margin-right: 1rem');
 
@@ -41,7 +41,7 @@ test('marginRight', () => {
 });
 
 test('marginBottom', () => {
-  const { container } = render(<TestComponent marginBottom="medium" />);
+  const { container } = render(<TestComponent $marginBottom="medium" />);
 
   expect(container.firstChild).toHaveStyle('margin-bottom: 1rem');
 
@@ -52,7 +52,7 @@ test('marginBottom', () => {
 });
 
 test('marginLeft', () => {
-  const { container } = render(<TestComponent marginLeft="medium" />);
+  const { container } = render(<TestComponent $marginLeft="medium" />);
 
   expect(container.firstChild).toHaveStyle('margin-left: 1rem');
 
@@ -63,7 +63,7 @@ test('marginLeft', () => {
 });
 
 test('marginVertical', () => {
-  const { container } = render(<TestComponent marginVertical="medium" />);
+  const { container } = render(<TestComponent $marginVertical="medium" />);
 
   expect(container.firstChild).toHaveStyle('margin-top: 1rem');
   expect(container.firstChild).toHaveStyle('margin-bottom: 1rem');
@@ -74,7 +74,7 @@ test('marginVertical', () => {
 });
 
 test('marginHorizontal', () => {
-  const { container } = render(<TestComponent marginHorizontal="medium" />);
+  const { container } = render(<TestComponent $marginHorizontal="medium" />);
 
   expect(container.firstChild).toHaveStyle('margin-left: 1rem');
   expect(container.firstChild).toHaveStyle('margin-right: 1rem');
@@ -86,7 +86,7 @@ test('marginHorizontal', () => {
 
 test('simple margins combination', () => {
   const { container } = render(
-    <TestComponent marginBottom="none" marginRight="small" marginTop="medium" />,
+    <TestComponent $marginBottom="none" $marginRight="small" $marginTop="medium" />,
   );
 
   expect(container.firstChild).toHaveStyle('margin-top: 1rem');
@@ -96,7 +96,7 @@ test('simple margins combination', () => {
 
 test('responsive margin', () => {
   const { container } = render(
-    <TestComponent margin={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $margin={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -104,7 +104,7 @@ test('responsive margin', () => {
 
 test('responsive marginTop', () => {
   const { container } = render(
-    <TestComponent marginTop={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $marginTop={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -112,7 +112,7 @@ test('responsive marginTop', () => {
 
 test('responsive marginRight', () => {
   const { container } = render(
-    <TestComponent marginRight={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $marginRight={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -120,7 +120,7 @@ test('responsive marginRight', () => {
 
 test('responsive marginBottom', () => {
   const { container } = render(
-    <TestComponent marginBottom={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $marginBottom={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -128,7 +128,7 @@ test('responsive marginBottom', () => {
 
 test('responsive marginLeft', () => {
   const { container } = render(
-    <TestComponent marginLeft={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $marginLeft={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -136,7 +136,7 @@ test('responsive marginLeft', () => {
 
 test('responsive marginVertical', () => {
   const { container } = render(
-    <TestComponent marginVertical={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $marginVertical={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -144,7 +144,7 @@ test('responsive marginVertical', () => {
 
 test('responsive marginHorizontal', () => {
   const { container } = render(
-    <TestComponent marginHorizontal={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $marginHorizontal={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -153,9 +153,9 @@ test('responsive marginHorizontal', () => {
 test('responsive and non responsive combination', () => {
   const { container } = render(
     <TestComponent
-      marginBottom="medium"
-      marginLeft={{ mobile: 'none', tablet: 'small', desktop: 'medium' }}
-      marginTop="none"
+      $marginBottom="medium"
+      $marginLeft={{ mobile: 'none', tablet: 'small', desktop: 'medium' }}
+      $marginTop="none"
     />,
   );
 
@@ -178,7 +178,7 @@ test('excludeMarginProps removes all margin props from an object', () => {
 });
 
 test('non-spacing value auto', () => {
-  const { container } = render(<TestComponent margin="auto" />);
+  const { container } = render(<TestComponent $margin="auto" />);
 
   expect(container.firstChild).toHaveStyle('margin: auto');
 });

--- a/packages/big-design/src/helpers/paddings/paddings.tsx
+++ b/packages/big-design/src/helpers/paddings/paddings.tsx
@@ -29,47 +29,20 @@ export type TransientPaddingProps = Partial<{
   $paddingHorizontal: PaddingProp;
 }>;
 
-// MIGRATION SHIM (LTRAC-1396): reads both the public (`padding`) and transient
-// (`$padding`) prop names so components can be migrated to transient props one PR at
-// a time while unconverted consumers keep rendering identically. Once every consumer
-// passes `$`-prefixed props, drop the `?? padding*` fallbacks (and `PaddingProps` from
-// the generic) to leave a pure transient read.
-export const withPaddings = () => css<PaddingProps & TransientPaddingProps>`
-  ${({ padding, $padding, theme }) => {
-    const value = $padding ?? padding;
-
-    return value && getSpacingStyles(value, theme, 'padding');
-  }};
-  ${({ paddingTop, $paddingTop, theme }) => {
-    const value = $paddingTop ?? paddingTop;
-
-    return value && getSpacingStyles(value, theme, 'padding-top');
-  }};
-  ${({ paddingRight, $paddingRight, theme }) => {
-    const value = $paddingRight ?? paddingRight;
-
-    return value && getSpacingStyles(value, theme, 'padding-right');
-  }};
-  ${({ paddingBottom, $paddingBottom, theme }) => {
-    const value = $paddingBottom ?? paddingBottom;
-
-    return value && getSpacingStyles(value, theme, 'padding-bottom');
-  }};
-  ${({ paddingLeft, $paddingLeft, theme }) => {
-    const value = $paddingLeft ?? paddingLeft;
-
-    return value && getSpacingStyles(value, theme, 'padding-left');
-  }};
-  ${({ paddingVertical, $paddingVertical, theme }) => {
-    const value = $paddingVertical ?? paddingVertical;
-
-    return value && getSpacingStyles(value, theme, 'padding-top', 'padding-bottom');
-  }};
-  ${({ paddingHorizontal, $paddingHorizontal, theme }) => {
-    const value = $paddingHorizontal ?? paddingHorizontal;
-
-    return value && getSpacingStyles(value, theme, 'padding-left', 'padding-right');
-  }};
+export const withPaddings = () => css<TransientPaddingProps>`
+  ${({ $padding, theme }) => $padding && getSpacingStyles($padding, theme, 'padding')};
+  ${({ $paddingTop, theme }) => $paddingTop && getSpacingStyles($paddingTop, theme, 'padding-top')};
+  ${({ $paddingRight, theme }) =>
+    $paddingRight && getSpacingStyles($paddingRight, theme, 'padding-right')};
+  ${({ $paddingBottom, theme }) =>
+    $paddingBottom && getSpacingStyles($paddingBottom, theme, 'padding-bottom')};
+  ${({ $paddingLeft, theme }) =>
+    $paddingLeft && getSpacingStyles($paddingLeft, theme, 'padding-left')};
+  ${({ $paddingVertical, theme }) =>
+    $paddingVertical && getSpacingStyles($paddingVertical, theme, 'padding-top', 'padding-bottom')};
+  ${({ $paddingHorizontal, theme }) =>
+    $paddingHorizontal &&
+    getSpacingStyles($paddingHorizontal, theme, 'padding-left', 'padding-right')};
 `;
 
 export function excludePaddingProps<T extends Record<string, any>>(

--- a/packages/big-design/src/helpers/paddings/spec.tsx
+++ b/packages/big-design/src/helpers/paddings/spec.tsx
@@ -4,22 +4,22 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import styled from 'styled-components';
 
-import { excludePaddingProps, PaddingProps, withPaddings } from './paddings';
+import { excludePaddingProps, PaddingProps, TransientPaddingProps, withPaddings } from './paddings';
 
-const TestComponent = styled.div<PaddingProps>`
+const TestComponent = styled.div<TransientPaddingProps>`
   ${withPaddings()};
 `;
 
 TestComponent.defaultProps = { theme: defaultTheme };
 
 test('padding', () => {
-  const { container } = render(<TestComponent padding="medium" />);
+  const { container } = render(<TestComponent $padding="medium" />);
 
   expect(container.firstChild).toHaveStyle('padding: 1rem');
 });
 
 test('paddingTop', () => {
-  const { container } = render(<TestComponent paddingTop="medium" />);
+  const { container } = render(<TestComponent $paddingTop="medium" />);
 
   expect(container.firstChild).toHaveStyle('padding-top: 1rem');
 
@@ -30,7 +30,7 @@ test('paddingTop', () => {
 });
 
 test('paddingRight', () => {
-  const { container } = render(<TestComponent paddingRight="medium" />);
+  const { container } = render(<TestComponent $paddingRight="medium" />);
 
   expect(container.firstChild).toHaveStyle('padding-right: 1rem');
 
@@ -41,7 +41,7 @@ test('paddingRight', () => {
 });
 
 test('paddingBottom', () => {
-  const { container } = render(<TestComponent paddingBottom="medium" />);
+  const { container } = render(<TestComponent $paddingBottom="medium" />);
 
   expect(container.firstChild).toHaveStyle('padding-bottom: 1rem');
 
@@ -52,7 +52,7 @@ test('paddingBottom', () => {
 });
 
 test('paddingLeft', () => {
-  const { container } = render(<TestComponent paddingLeft="medium" />);
+  const { container } = render(<TestComponent $paddingLeft="medium" />);
 
   expect(container.firstChild).toHaveStyle('padding-left: 1rem');
 
@@ -63,7 +63,7 @@ test('paddingLeft', () => {
 });
 
 test('paddingVertical', () => {
-  const { container } = render(<TestComponent paddingVertical="medium" />);
+  const { container } = render(<TestComponent $paddingVertical="medium" />);
 
   expect(container.firstChild).toHaveStyle('padding-top: 1rem');
   expect(container.firstChild).toHaveStyle('padding-bottom: 1rem');
@@ -74,7 +74,7 @@ test('paddingVertical', () => {
 });
 
 test('paddingHorizontal', () => {
-  const { container } = render(<TestComponent paddingHorizontal="medium" />);
+  const { container } = render(<TestComponent $paddingHorizontal="medium" />);
 
   expect(container.firstChild).toHaveStyle('padding-left: 1rem');
   expect(container.firstChild).toHaveStyle('padding-right: 1rem');
@@ -86,7 +86,7 @@ test('paddingHorizontal', () => {
 
 test('simple paddings combination', () => {
   const { container } = render(
-    <TestComponent paddingBottom="none" paddingRight="small" paddingTop="medium" />,
+    <TestComponent $paddingBottom="none" $paddingRight="small" $paddingTop="medium" />,
   );
 
   expect(container.firstChild).toHaveStyle('padding-top: 1rem');
@@ -96,7 +96,7 @@ test('simple paddings combination', () => {
 
 test('responsive padding', () => {
   const { container } = render(
-    <TestComponent padding={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $padding={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -104,7 +104,7 @@ test('responsive padding', () => {
 
 test('responsive paddingTop', () => {
   const { container } = render(
-    <TestComponent paddingTop={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $paddingTop={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -112,7 +112,7 @@ test('responsive paddingTop', () => {
 
 test('responsive paddingRight', () => {
   const { container } = render(
-    <TestComponent paddingRight={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $paddingRight={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -120,7 +120,7 @@ test('responsive paddingRight', () => {
 
 test('responsive paddingBottom', () => {
   const { container } = render(
-    <TestComponent paddingBottom={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $paddingBottom={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -128,7 +128,7 @@ test('responsive paddingBottom', () => {
 
 test('responsive paddingLeft', () => {
   const { container } = render(
-    <TestComponent paddingLeft={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $paddingLeft={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -136,7 +136,7 @@ test('responsive paddingLeft', () => {
 
 test('responsive paddingVertical', () => {
   const { container } = render(
-    <TestComponent paddingVertical={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $paddingVertical={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -144,7 +144,7 @@ test('responsive paddingVertical', () => {
 
 test('responsive paddingHorizontal', () => {
   const { container } = render(
-    <TestComponent paddingHorizontal={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
+    <TestComponent $paddingHorizontal={{ mobile: 'none', tablet: 'small', desktop: 'medium' }} />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -153,9 +153,9 @@ test('responsive paddingHorizontal', () => {
 test('responsive and non responsive combination', () => {
   const { container } = render(
     <TestComponent
-      paddingBottom="medium"
-      paddingLeft={{ mobile: 'none', tablet: 'small', desktop: 'medium' }}
-      paddingTop="none"
+      $paddingBottom="medium"
+      $paddingLeft={{ mobile: 'none', tablet: 'small', desktop: 'medium' }}
+      $paddingTop="none"
     />,
   );
 


### PR DESCRIPTION
## What?

Complete LTRAC-1396 by removing the dual-read fallback (`$prop ?? prop`) from `withMargins()`, `withPaddings()`, and `withDisplay()` in `packages/big-design/src/helpers/{margins,paddings,display}/*.tsx`, now that every consumer in this repo passes `$`-prefixed props.

Before removing it, I ran a full-repo audit of every remaining `withMargins()`/`withPaddings()`/`withDisplay()` call site (not just the ones on the original per-stage lists) to confirm removal was actually safe. It found a few consumers that were never on any stage's explicit list and still needed conversion:

- **`withMargins()`**: `Table`'s and `TableNext`'s `TableFigure`/`TableFigureNext`, and `Typography`'s `Text`/`Small`/`HR`/`H0`–`H4`. The Typography fix also required forced fixes at five cross-file call sites that bypass the public `Text`/`H1`/etc. wrapper components and use the internal `Styleable*` exports directly: `Tree/TreeNode.tsx`, `Panel.tsx`, `FileUploader/File.tsx`, `FeatureSet/Tag.tsx`, and `InfoCard.tsx`.
- **`withDisplay()`**: `Flex` and `Grid` — flagged as follow-up work back in Stage 3 but never converted. Both call `withDisplay()` directly on their own `styled(Box)` wrapper layer (separate from `Box`'s own, already-converted internal handling), so they still needed fixing even though `Box` itself has worked correctly since Stage 0.
- **`withPaddings()`**: no outstanding consumers — everything was already converted.

## Why?

Same rationale as the rest of this migration, plus this specific step removes the temporary bridging mechanism that let every other stage ship independently. Once this merges, no component in the repo can silently regress back to reading a bare (non-`$`) margin/padding/display prop without a real, visible break (matching the original intent of transient props: fail loudly, not silently).

## A note for reviewers

`withMargins()`/`withPaddings()`/`withDisplay()`, and their `Transient*Props`/`toTransient*Props()` counterparts, are exported from `@bigcommerce/big-design`'s public API via `helpers/index.ts`'s wildcard re-export — contrary to an assumption made earlier in this migration (that they weren't re-exported). I found this by checking the actual compiled `dist/helpers/**/*.d.ts` tree rather than just `dist/index.d.ts`'s shallow barrel file. Their exported return-type signatures narrow slightly as a result of this PR (`css<MarginProps & TransientMarginProps>` → `css<TransientMarginProps>`, etc.).

Within this monorepo, the only consumer using these utilities outside `packages/big-design`'s own source was `docs/MethodBadge` (already converted in #1892). Any *external* consumer of the published npm package calling these directly with bare props would need to update — an unlikely usage pattern for what are effectively internal-only utilities, but worth flagging explicitly since it's a real, if narrow, breaking change.

## Testing/Proof

- `pnpm --filter @bigcommerce/big-design run typecheck` — clean
- `pnpm --filter @bigcommerce/big-design run lint` — clean
- `pnpm --filter @bigcommerce/big-design run test` — 70 suites, 1152 tests, 182 snapshots pass. One snapshot updated (`helpers/display/spec.tsx`'s own test) reflecting a `display` leak removal — the same category of fix as Stage 0's `Box` and Stage 4's `Table`/`TableNext`.
- `pnpm --filter @bigcommerce/big-design run build:dt` — confirmed no new internal type leaks beyond the pre-existing `Transient*Props` exports noted above.
- No public component `Props` interface changed.

Refs [TRAC-1371](https://bigcommercecloud.atlassian.net/browse/TRAC-1371)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TRAC-1371]: https://bigcommercecloud.atlassian.net/browse/TRAC-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ