### PR TITLE
fix(patterns): $-prefix StyledPageBackground's background prop

### DIFF
--- a/.changeset/transient-props-page-background.md
+++ b/.changeset/transient-props-page-background.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design-patterns": patch
+---
+
+`$`-prefix `StyledPageBackground`'s `background` prop ahead of styled-components 6 (LTRAC-1396 follow-up). Public `PageProps.background` is unchanged.

--- a/packages/big-design-patterns/src/components/Page/Page.tsx
+++ b/packages/big-design-patterns/src/components/Page/Page.tsx
@@ -52,7 +52,7 @@ const PageMessage = ({ message }: Required<Pick<PageProps, 'message'>>) => {
 export const Page = ({ actionBar, background, children, header, message }: PageProps) => {
   return (
     <StyledPageBackground
-      background={background}
+      $background={background}
       backgroundColor="secondary10"
       gridGap="0"
       gridTemplate="1fr auto / auto"

--- a/packages/big-design-patterns/src/components/Page/spec.tsx
+++ b/packages/big-design-patterns/src/components/Page/spec.tsx
@@ -84,6 +84,22 @@ test('renders with default background styles', () => {
     `);
 });
 
+test('does not leak background prop onto the DOM', () => {
+  const backgroundProps = {
+    src: 'test-image.jpg',
+  };
+
+  const { container } = render(<Page background={backgroundProps}>Page content</Page>);
+  // eslint-disable-next-line testing-library/no-node-access
+  const firstChild = container.firstElementChild;
+
+  if (!firstChild) {
+    throw new Error();
+  }
+
+  expect(firstChild).not.toHaveAttribute('background');
+});
+
 test('renders without background by default', () => {
   render(<Page>Page content</Page>);
 

--- a/packages/big-design-patterns/src/components/Page/styled.tsx
+++ b/packages/big-design-patterns/src/components/Page/styled.tsx
@@ -10,19 +10,19 @@ export interface Background {
 }
 
 export const StyledPageBackground = styled(Grid).attrs({ theme: defaultTheme })<{
-  background?: Background;
+  $background?: Background;
 }>`
   position: relative;
   min-height: 100dvh;
 
-  ${({ background }) => {
-    if (background) {
+  ${({ $background }) => {
+    if ($background) {
       const {
         src,
         backgroundPosition = 'top right',
         backgroundSize = 'contain',
         backgroundRepeat = 'no-repeat',
-      } = background;
+      } = $background;
 
       return css`
         background-image: url(${src});


### PR DESCRIPTION
## What?

`$`-prefix `Page/styled.tsx`'s `StyledPageBackground.background` prop as `$background`, per [LTRAC-1430](https://linear.app/commerce/issue/LTRAC-1430) (found during a re-audit of [LTRAC-1396](https://linear.app/commerce/issue/LTRAC-1396) for gaps after Stage 7 only explicitly checked `Header/styled.tsx`). `Page.tsx` now passes `$background={background}`, keeping the public `PageProps.background` name unchanged.

Added a regression test (`does not leak background prop onto the DOM`) asserting the rendered element never gets a `background` attribute, closing the coverage gap noted in the ticket — the package previously had zero tests asserting on rendered DOM attributes.

`ActionBar/styled.tsx` and `Page/styled.tsx`'s `StyledPage` needed no changes: none of `StyledActionBar`, `StyledActionBarContents`, or `StyledPage` declare a custom prop generic (composition-only, plain `.attrs()` theme injection).

## Why?

`StyledPageBackground` composes over `Grid` (a component, not a tag), so `background` isn't filtered there — it flows through `Grid` → `Box`'s own blind `...domProps` spread → `Box`'s `StyledBox`, which **is** a genuine tag-target (`styled.div`). Rendering `<Page background={{ src: 'x.jpg' }}>` and inspecting the DOM shows no leak today, because styled-components v5's `is-prop-valid` filters out `background` (a deprecated HTML attribute). That filtering is exactly what styled-components 6 removes for tag-targets, so this is the same "silent today, breaks under v6" pattern the rest of the LTRAC-1396 migration exists to close.

## Testing/Proof

- `pnpm --filter @bigcommerce/big-design-patterns run lint` — clean
- `pnpm --filter @bigcommerce/big-design-patterns run typecheck` — clean
- `pnpm --filter @bigcommerce/big-design-patterns run test` — 4 suites, 32 tests pass (includes the new DOM-attribute regression test)

Refs [TRAC-1373](https://bigcommercecloud.atlassian.net/browse/TRAC-1373)

[TRAC-1373]: https://bigcommercecloud.atlassian.net/browse/TRAC-1373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ