### PR TITLE
feat(component): migrate Dropdown, Popover, Select, MultiSelect to @floating-ui/react

### DIFF
--- a/.changeset/floating-ui-internal-positioning.md
+++ b/.changeset/floating-ui-internal-positioning.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/big-design": minor
+---
+
+Migrate Dropdown, Popover, Select, and MultiSelect positioning from `react-popper` to `@floating-ui/react`. Placement, offsets, flipping, and overflow behavior are unchanged, and the `placement` props keep accepting the same values (including `auto*` placements, now handled via floating-ui's `autoPlacement` middleware). Tooltip still uses `react-popper` and is migrated separately.

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -39,6 +39,7 @@
     "@babel/runtime": "^7.26.10",
     "@bigcommerce/big-design-icons": "workspace:^",
     "@bigcommerce/big-design-theme": "workspace:^",
+    "@floating-ui/react": "^0.27.20",
     "@popperjs/core": "^2.11.6",
     "date-fns": "4.1.0",
     "downshift": "9.0.10",

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -1,16 +1,17 @@
+import { autoUpdate, offset, shift, useFloating } from '@floating-ui/react';
 import { useSelect, UseSelectProps, UseSelectState } from 'downshift';
 import React, {
   cloneElement,
   isValidElement,
   memo,
   useCallback,
+  useEffect,
   useId,
   useMemo,
-  useRef,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { usePopper } from 'react-popper';
 
+import { getFloatingPlacement } from '../../utils';
 import { Box } from '../Box';
 import { List } from '../List';
 
@@ -116,32 +117,21 @@ export const Dropdown = memo(
         toggleButtonId: toggle.props.id,
       });
 
-    const referenceElement = useRef<HTMLElement | null>(null);
-    const popperElement = useRef<HTMLDivElement | null>(null);
+    const { middleware: placementMiddleware, placement: floatingPlacement } =
+      getFloatingPlacement(placement);
 
-    const { attributes, styles, update } = usePopper(
-      referenceElement.current,
-      popperElement.current,
-      {
-        modifiers: [
-          {
-            name: 'eventListeners',
-            options: {
-              scroll: isOpen,
-              resize: isOpen,
-            },
-          },
-          {
-            name: 'offset',
-            options: {
-              offset: [0, 4],
-            },
-          },
-        ],
-        placement,
-        strategy: positionFixed ? 'fixed' : 'absolute',
-      },
-    );
+    const { floatingStyles, refs, update } = useFloating({
+      middleware: [offset(4), placementMiddleware, shift()],
+      placement: floatingPlacement,
+      strategy: positionFixed ? 'fixed' : 'absolute',
+    });
+
+    // Only track scroll/resize while open, matching popper's previous eventListeners config
+    useEffect(() => {
+      if (isOpen && refs.reference.current && refs.floating.current) {
+        return autoUpdate(refs.reference.current, refs.floating.current, update);
+      }
+    }, [isOpen, refs.reference, refs.floating, update]);
 
     const clonedToggle =
       isValidElement(toggle) &&
@@ -151,7 +141,7 @@ export const Dropdown = memo(
           // Downshift sets this to a label id that doesn't exist
           'aria-labelledby': undefined,
           disabled,
-          ref: referenceElement,
+          ref: refs.setReference,
           role: 'button',
         }),
       });
@@ -161,7 +151,7 @@ export const Dropdown = memo(
         {clonedToggle}
         {isOpen ? (
           createPortal(
-            <Box ref={popperElement} style={styles.popper} {...attributes.popper} zIndex="popover">
+            <Box ref={refs.setFloating} style={floatingStyles} zIndex="popover">
               <List
                 {...props}
                 autoWidth={autoWidth}
@@ -180,14 +170,8 @@ export const Dropdown = memo(
             document.body,
           )
         ) : (
-          // We need to render the menu hidden to ensure it has a reference for popper
-          <Box
-            ref={popperElement}
-            style={styles.popper}
-            {...attributes.popper}
-            display="none"
-            zIndex="popover"
-          >
+          // We need to render the menu hidden to ensure it has a reference for positioning
+          <Box display="none" ref={refs.setFloating} style={floatingStyles} zIndex="popover">
             <List
               {...props}
               autoWidth={autoWidth}

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -1,4 +1,3 @@
-import { State } from '@popperjs/core';
 import { UseComboboxPropGetters, UseSelectPropGetters } from 'downshift';
 import React, {
   ComponentPropsWithoutRef,
@@ -44,7 +43,7 @@ export interface ListProps<T> extends ComponentPropsWithoutRef<'ul'> {
   getMenuProps:
     | UseSelectPropGetters<any>['getMenuProps']
     | UseComboboxPropGetters<any>['getMenuProps'];
-  update: (() => Promise<Partial<State>>) | null;
+  update: (() => void) | null;
   localization?: { selectAll: MultiSelectLocalization['selectAll'] };
   removeItem?(item: SelectOption<T>): void;
 }
@@ -80,16 +79,12 @@ const StyleableList = typedMemo(
     const itemKey = useRef(0);
     const { height, width } = useWindowSize();
 
-    // Recalculate Popper for correct positioning
+    // Recalculate the floating position of the menu
     useIsomorphicLayoutEffect(() => {
-      async function scheduleUpdate() {
-        // Only update when menu is open
-        if (update && isOpen) {
-          await update();
-        }
+      // Only update when menu is open
+      if (update && isOpen) {
+        update();
       }
-
-      scheduleUpdate();
     }, [isOpen, height, width, selectedItems?.length]);
 
     const handleSelectAll = useCallback(

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -1,3 +1,4 @@
+import { autoUpdate, offset, shift, useFloating } from '@floating-ui/react';
 import {
   useCombobox,
   UseComboboxState,
@@ -14,12 +15,10 @@ import React, {
   useEffect,
   useId,
   useMemo,
-  useRef,
   useState,
 } from 'react';
-import { usePopper } from 'react-popper';
 
-import { typedMemo, warning } from '../../utils';
+import { getFloatingPlacement, typedMemo, warning } from '../../utils';
 import { Box } from '../Box';
 import { FormControlLabel } from '../Form';
 import { Input } from '../Input';
@@ -300,29 +299,21 @@ export const MultiSelect = typedMemo(
       stateReducer: handleStateReducer,
     });
 
-    // Popper
-    const referenceRef = useRef(null);
-    const popperRef = useRef(null);
+    const { middleware: placementMiddleware, placement: floatingPlacement } =
+      getFloatingPlacement(placement);
 
-    const { styles, attributes, update } = usePopper(referenceRef.current, popperRef.current, {
-      modifiers: [
-        {
-          name: 'eventListeners',
-          options: {
-            scroll: isOpen,
-            resize: isOpen,
-          },
-        },
-        {
-          name: 'offset',
-          options: {
-            offset: [0, 4],
-          },
-        },
-      ],
+    const { floatingStyles, refs, update } = useFloating({
+      middleware: [offset(4), placementMiddleware, shift()],
+      placement: floatingPlacement,
       strategy: positionFixed ? 'fixed' : 'absolute',
-      placement,
     });
+
+    // Only track scroll/resize while open, matching popper's previous eventListeners config
+    useEffect(() => {
+      if (isOpen && refs.reference.current && refs.floating.current) {
+        return autoUpdate(refs.reference.current, refs.floating.current, update);
+      }
+    }, [isOpen, refs.reference, refs.floating, update]);
 
     // Reset the value when Multiselect is closed
     useEffect(() => {
@@ -390,7 +381,7 @@ export const MultiSelect = typedMemo(
 
     const renderInput = useMemo(() => {
       return (
-        <StyledInputContainer ref={referenceRef}>
+        <StyledInputContainer ref={refs.setReference}>
           <Input
             {...getInputProps({
               ...props,
@@ -461,6 +452,7 @@ export const MultiSelect = typedMemo(
       openMenu,
       placeholder,
       props,
+      refs.setReference,
       removeItem,
       renderToggle,
       required,
@@ -477,7 +469,7 @@ export const MultiSelect = typedMemo(
       <div>
         {renderLabel}
         {renderInput}
-        <Box ref={popperRef} style={styles.popper} {...attributes.poppper} zIndex="popover">
+        <Box ref={refs.setFloating} style={floatingStyles} zIndex="popover">
           <List
             {...ariaLabelledBy}
             action={action}

--- a/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
@@ -344,10 +344,7 @@ exports[`render offset pagination component 1`] = `
       </button>
       <div
         class="c8"
-        data-popper-escaped="true"
-        data-popper-placement="bottom-start"
-        data-popper-reference-hidden="true"
-        style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c9"
@@ -374,7 +371,7 @@ exports[`render offset pagination component 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":r3:"
+          aria-labelledby=":r4:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -384,7 +381,7 @@ exports[`render offset pagination component 1`] = `
           width="24"
         >
           <title
-            id=":r3:"
+            id=":r4:"
           >
             Previous page
           </title>
@@ -406,7 +403,7 @@ exports[`render offset pagination component 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":r4:"
+          aria-labelledby=":r5:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -416,7 +413,7 @@ exports[`render offset pagination component 1`] = `
           width="24"
         >
           <title
-            id=":r4:"
+            id=":r5:"
           >
             Next page
           </title>
@@ -743,11 +740,11 @@ exports[`render offset pagination component with invalid page info 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":r5:-menu"
+        aria-controls=":r6:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
-        id=":r5:-toggle-button"
+        id=":r6:-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -778,18 +775,15 @@ exports[`render offset pagination component with invalid page info 1`] = `
       </button>
       <div
         class="c8"
-        data-popper-escaped="true"
-        data-popper-placement="bottom-start"
-        data-popper-reference-hidden="true"
-        style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c9"
         >
           <ul
-            aria-labelledby=":r5:-label"
+            aria-labelledby=":r6:-label"
             class="c10"
-            id=":r5:-menu"
+            id=":r6:-menu"
             role="menu"
           />
         </div>
@@ -808,7 +802,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":r8:"
+          aria-labelledby=":ra:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -818,7 +812,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
           width="24"
         >
           <title
-            id=":r8:"
+            id=":ra:"
           >
             Previous page
           </title>
@@ -840,7 +834,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":r9:"
+          aria-labelledby=":rb:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -850,7 +844,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
           width="24"
         >
           <title
-            id=":r9:"
+            id=":rb:"
           >
             Next page
           </title>
@@ -1177,11 +1171,11 @@ exports[`render offset pagination component with invalid range info 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":ra:-menu"
+        aria-controls=":rc:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
-        id=":ra:-toggle-button"
+        id=":rc:-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -1212,18 +1206,15 @@ exports[`render offset pagination component with invalid range info 1`] = `
       </button>
       <div
         class="c8"
-        data-popper-escaped="true"
-        data-popper-placement="bottom-start"
-        data-popper-reference-hidden="true"
-        style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c9"
         >
           <ul
-            aria-labelledby=":ra:-label"
+            aria-labelledby=":rc:-label"
             class="c10"
-            id=":ra:-menu"
+            id=":rc:-menu"
             role="menu"
           />
         </div>
@@ -1242,7 +1233,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":rd:"
+          aria-labelledby=":rg:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -1252,7 +1243,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
           width="24"
         >
           <title
-            id=":rd:"
+            id=":rg:"
           >
             Previous page
           </title>
@@ -1275,7 +1266,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":re:"
+          aria-labelledby=":rh:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -1285,7 +1276,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
           width="24"
         >
           <title
-            id=":re:"
+            id=":rh:"
           >
             Next page
           </title>
@@ -1612,11 +1603,11 @@ exports[`render offset pagination component with no items 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":rf:-menu"
+        aria-controls=":ri:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
-        id=":rf:-toggle-button"
+        id=":ri:-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -1647,18 +1638,15 @@ exports[`render offset pagination component with no items 1`] = `
       </button>
       <div
         class="c8"
-        data-popper-escaped="true"
-        data-popper-placement="bottom-start"
-        data-popper-reference-hidden="true"
-        style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c9"
         >
           <ul
-            aria-labelledby=":rf:-label"
+            aria-labelledby=":ri:-label"
             class="c10"
-            id=":rf:-menu"
+            id=":ri:-menu"
             role="menu"
           />
         </div>
@@ -1677,7 +1665,7 @@ exports[`render offset pagination component with no items 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":ri:"
+          aria-labelledby=":rm:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -1687,7 +1675,7 @@ exports[`render offset pagination component with no items 1`] = `
           width="24"
         >
           <title
-            id=":ri:"
+            id=":rm:"
           >
             Previous page
           </title>
@@ -1710,7 +1698,7 @@ exports[`render offset pagination component with no items 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":rj:"
+          aria-labelledby=":rn:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -1720,7 +1708,7 @@ exports[`render offset pagination component with no items 1`] = `
           width="24"
         >
           <title
-            id=":rj:"
+            id=":rn:"
           >
             Next page
           </title>

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -322,11 +322,11 @@ exports[`dropdown is not visible if items fit 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":r3:-menu"
+        aria-controls=":r4:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":r3:-toggle-button"
+        id=":r4:-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -335,7 +335,7 @@ exports[`dropdown is not visible if items fit 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":r5:"
+            aria-labelledby=":r7:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -345,7 +345,7 @@ exports[`dropdown is not visible if items fit 1`] = `
             width="24"
           >
             <title
-              id=":r5:"
+              id=":r7:"
             >
               add
             </title>
@@ -361,18 +361,15 @@ exports[`dropdown is not visible if items fit 1`] = `
       </button>
       <div
         class="c9"
-        data-popper-escaped="true"
-        data-popper-placement="bottom-start"
-        data-popper-reference-hidden="true"
-        style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c10"
         >
           <ul
-            aria-labelledby=":r3:-label"
+            aria-labelledby=":r4:-label"
             class="c11"
-            id=":r3:-menu"
+            id=":r4:-menu"
             role="menu"
           />
         </div>
@@ -717,7 +714,7 @@ exports[`it renders the given tabs 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":r2:"
+            aria-labelledby=":r3:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -727,7 +724,7 @@ exports[`it renders the given tabs 1`] = `
             width="24"
           >
             <title
-              id=":r2:"
+              id=":r3:"
             >
               add
             </title>
@@ -743,10 +740,7 @@ exports[`it renders the given tabs 1`] = `
       </button>
       <div
         class="c9"
-        data-popper-escaped="true"
-        data-popper-placement="bottom-start"
-        data-popper-reference-hidden="true"
-        style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c10"
@@ -1118,11 +1112,11 @@ exports[`only the pills that fit are visible 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":rc:-menu"
+        aria-controls=":rg:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":rc:-toggle-button"
+        id=":rg:-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -1131,7 +1125,7 @@ exports[`only the pills that fit are visible 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":re:"
+            aria-labelledby=":rj:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -1141,7 +1135,7 @@ exports[`only the pills that fit are visible 1`] = `
             width="24"
           >
             <title
-              id=":re:"
+              id=":rj:"
             >
               add
             </title>
@@ -1157,18 +1151,15 @@ exports[`only the pills that fit are visible 1`] = `
       </button>
       <div
         class="c9"
-        data-popper-escaped="true"
-        data-popper-placement="bottom-start"
-        data-popper-reference-hidden="true"
-        style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c10"
         >
           <ul
-            aria-labelledby=":rc:-label"
+            aria-labelledby=":rg:-label"
             class="c11"
-            id=":rc:-menu"
+            id=":rg:-menu"
             role="menu"
           />
         </div>
@@ -1531,11 +1522,11 @@ exports[`only the pills that fit are visible 2 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":rf:-menu"
+        aria-controls=":rk:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":rf:-toggle-button"
+        id=":rk:-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -1544,7 +1535,7 @@ exports[`only the pills that fit are visible 2 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":rh:"
+            aria-labelledby=":rn:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -1554,7 +1545,7 @@ exports[`only the pills that fit are visible 2 1`] = `
             width="24"
           >
             <title
-              id=":rh:"
+              id=":rn:"
             >
               add
             </title>
@@ -1570,18 +1561,15 @@ exports[`only the pills that fit are visible 2 1`] = `
       </button>
       <div
         class="c9"
-        data-popper-escaped="true"
-        data-popper-placement="bottom-start"
-        data-popper-reference-hidden="true"
-        style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c10"
         >
           <ul
-            aria-labelledby=":rf:-label"
+            aria-labelledby=":rk:-label"
             class="c11"
-            id=":rf:-menu"
+            id=":rk:-menu"
             role="menu"
           />
         </div>
@@ -1943,11 +1931,11 @@ exports[`renders all the filters if they fit 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":r9:-menu"
+        aria-controls=":rc:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":r9:-toggle-button"
+        id=":rc:-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -1956,7 +1944,7 @@ exports[`renders all the filters if they fit 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":rb:"
+            aria-labelledby=":rf:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -1966,7 +1954,7 @@ exports[`renders all the filters if they fit 1`] = `
             width="24"
           >
             <title
-              id=":rb:"
+              id=":rf:"
             >
               add
             </title>
@@ -1982,18 +1970,15 @@ exports[`renders all the filters if they fit 1`] = `
       </button>
       <div
         class="c9"
-        data-popper-escaped="true"
-        data-popper-placement="bottom-start"
-        data-popper-reference-hidden="true"
-        style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c10"
         >
           <ul
-            aria-labelledby=":r9:-label"
+            aria-labelledby=":rc:-label"
             class="c11"
-            id=":r9:-menu"
+            id=":rc:-menu"
             role="menu"
           />
         </div>
@@ -2341,11 +2326,11 @@ exports[`renders dropdown if items do not fit 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":r6:-menu"
+        aria-controls=":r8:-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":r6:-toggle-button"
+        id=":r8:-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -2354,7 +2339,7 @@ exports[`renders dropdown if items do not fit 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":r8:"
+            aria-labelledby=":rb:"
             class="c8"
             fill="currentColor"
             height="24"
@@ -2364,7 +2349,7 @@ exports[`renders dropdown if items do not fit 1`] = `
             width="24"
           >
             <title
-              id=":r8:"
+              id=":rb:"
             >
               add
             </title>
@@ -2380,18 +2365,15 @@ exports[`renders dropdown if items do not fit 1`] = `
       </button>
       <div
         class="c9"
-        data-popper-escaped="true"
-        data-popper-placement="bottom-start"
-        data-popper-reference-hidden="true"
-        style="position: absolute; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c10"
         >
           <ul
-            aria-labelledby=":r6:-label"
+            aria-labelledby=":r8:-label"
             class="c11"
-            id=":r6:-menu"
+            id=":r8:-menu"
             role="menu"
           />
         </div>

--- a/packages/big-design/src/components/Popover/Popover.tsx
+++ b/packages/big-design/src/components/Popover/Popover.tsx
@@ -1,9 +1,9 @@
-import { Modifier, Obj, Placement } from '@popperjs/core';
-import { OffsetModifier } from '@popperjs/core/lib/modifiers/offset';
-import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
-import { usePopper } from 'react-popper';
+import { autoUpdate, offset, shift, size, useFloating } from '@floating-ui/react';
+import { Placement } from '@popperjs/core';
+import React, { useEffect, useId, useRef, useState } from 'react';
 
 import { excludeMarginProps } from '../../helpers';
+import { getFloatingPlacement } from '../../utils';
 import { Box, BoxProps } from '../Box';
 
 // Margin can't be used with popper elements
@@ -81,37 +81,27 @@ const InternalPopover: React.FC<InternalPopoverProps> = ({
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
   const previousFocus = useRef(typeof document !== 'undefined' ? document.activeElement : null);
 
-  const popperModifiers = useMemo<[Partial<OffsetModifier>, Modifier<unknown, Obj>]>(
-    () => [
-      {
-        name: 'offset',
-        options: {
-          offset: [skidding, distance],
-        },
-      },
-      {
-        name: 'sameWidth',
-        enabled: matchAnchorElementWidth,
-        phase: 'beforeWrite',
-        requires: ['computeStyles'],
-        fn({ state }) {
-          state.styles.popper.width = `${state.rects.reference.width}px`;
-        },
-        effect({ state }) {
-          const element = state.elements.reference;
+  const { middleware: placementMiddleware, placement: floatingPlacement } =
+    getFloatingPlacement(placement);
 
-          if (element instanceof HTMLElement) {
-            state.elements.popper.style.width = `${element.offsetWidth}px`;
-          }
-        },
-      },
+  const { floatingStyles } = useFloating({
+    elements: { floating: popperElement, reference: anchorElement },
+    middleware: [
+      offset({ crossAxis: skidding, mainAxis: distance }),
+      placementMiddleware,
+      shift(),
+      ...(matchAnchorElementWidth
+        ? [
+            size({
+              apply({ elements, rects }) {
+                elements.floating.style.width = `${rects.reference.width}px`;
+              },
+            }),
+          ]
+        : []),
     ],
-    [skidding, distance, matchAnchorElementWidth],
-  );
-
-  const { styles, attributes } = usePopper(anchorElement, popperElement, {
-    modifiers: popperModifiers,
-    placement,
+    placement: floatingPlacement,
+    whileElementsMounted: autoUpdate,
   });
 
   useEffect(() => {
@@ -182,10 +172,9 @@ const InternalPopover: React.FC<InternalPopoverProps> = ({
       tabIndex={-1}
       zIndex="popover"
       {...props}
-      {...attributes.popper}
       id={id}
       ref={setPopperElement}
-      style={styles.popper}
+      style={floatingStyles}
     >
       {children}
     </Box>

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -1,3 +1,4 @@
+import { autoUpdate, offset, shift, useFloating } from '@floating-ui/react';
 import { useCombobox, UseComboboxState, UseComboboxStateChangeOptions } from 'downshift';
 import React, {
   cloneElement,
@@ -9,12 +10,10 @@ import React, {
   useEffect,
   useId,
   useMemo,
-  useRef,
   useState,
 } from 'react';
-import { usePopper } from 'react-popper';
 
-import { typedMemo, warning } from '../../utils';
+import { getFloatingPlacement, typedMemo, warning } from '../../utils';
 import { Box } from '../Box';
 import { FormControlLabel } from '../Form';
 import { Input } from '../Input';
@@ -226,29 +225,21 @@ export const Select = typedMemo(
       stateReducer: handleStateReducer,
     });
 
-    // Popper
-    const referenceRef = useRef(null);
-    const popperRef = useRef(null);
+    const { middleware: placementMiddleware, placement: floatingPlacement } =
+      getFloatingPlacement(placement);
 
-    const { styles, attributes, update } = usePopper(referenceRef.current, popperRef.current, {
-      modifiers: [
-        {
-          name: 'eventListeners',
-          options: {
-            scroll: isOpen,
-            resize: isOpen,
-          },
-        },
-        {
-          name: 'offset',
-          options: {
-            offset: [0, 4],
-          },
-        },
-      ],
+    const { floatingStyles, refs, update } = useFloating({
+      middleware: [offset(4), placementMiddleware, shift()],
+      placement: floatingPlacement,
       strategy: positionFixed ? 'fixed' : 'absolute',
-      placement,
     });
+
+    // Only track scroll/resize while open, matching popper's previous eventListeners config
+    useEffect(() => {
+      if (isOpen && refs.reference.current && refs.floating.current) {
+        return autoUpdate(refs.reference.current, refs.floating.current, update);
+      }
+    }, [isOpen, refs.reference, refs.floating, update]);
 
     const setCallbackRef = useCallback(
       (ref: HTMLInputElement) => {
@@ -309,7 +300,7 @@ export const Select = typedMemo(
 
     const renderInput = useMemo(() => {
       return (
-        <StyledInputContainer ref={referenceRef}>
+        <StyledInputContainer ref={refs.setReference}>
           <Input
             {...getInputProps({
               ...props,
@@ -378,13 +369,14 @@ export const Select = typedMemo(
       openMenu,
       onOptionChange,
       closeMenu,
+      refs.setReference,
     ]);
 
     return (
       <div>
         {renderLabel}
         {renderInput}
-        <Box ref={popperRef} style={styles.popper} {...attributes.poppper} zIndex="popover">
+        <Box ref={refs.setFloating} style={floatingStyles} zIndex="popover">
           <List
             {...ariaLabelledBy}
             action={action}

--- a/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
@@ -344,7 +344,7 @@ exports[`render Stateless pagination component 1`] = `
       </button>
       <div
         class="c8"
-        style="position: fixed; left: 0px; top: 0px;"
+        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
       >
         <div
           class="c9"
@@ -370,7 +370,7 @@ exports[`render Stateless pagination component 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":r3:"
+          aria-labelledby=":r4:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -380,7 +380,7 @@ exports[`render Stateless pagination component 1`] = `
           width="24"
         >
           <title
-            id=":r3:"
+            id=":r4:"
           >
             Previous page
           </title>
@@ -402,7 +402,7 @@ exports[`render Stateless pagination component 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":r4:"
+          aria-labelledby=":r5:"
           class="c12"
           fill="currentColor"
           height="24"
@@ -412,7 +412,7 @@ exports[`render Stateless pagination component 1`] = `
           width="24"
         >
           <title
-            id=":r4:"
+            id=":r5:"
           >
             Next page
           </title>

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -396,10 +396,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           </button>
           <div
             class="c11"
-            data-popper-escaped="true"
-            data-popper-placement="bottom-start"
-            data-popper-reference-hidden="true"
-            style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+            style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
           >
             <div
               class="c12"
@@ -426,7 +423,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r16:"
+              aria-labelledby=":r17:"
               class="c15"
               fill="currentColor"
               height="24"
@@ -436,7 +433,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r16:"
+                id=":r17:"
               >
                 Previous page
               </title>
@@ -458,7 +455,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r17:"
+              aria-labelledby=":r18:"
               class="c15"
               fill="currentColor"
               height="24"
@@ -468,7 +465,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r17:"
+                id=":r18:"
               >
                 Next page
               </title>
@@ -954,7 +951,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls=":r35:"
+  aria-controls=":r3a:"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -970,15 +967,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r37:"
+          aria-labelledby=":r3c:"
           class="c6 c7"
-          id=":r36:"
+          id=":r3b:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r36:"
+          for=":r3b:"
         >
           <svg
             aria-hidden="true"
@@ -1004,9 +1001,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c12"
-            for=":r36:"
+            for=":r3b:"
             hidden=""
-            id=":r37:"
+            id=":r3c:"
           >
             Select All
           </label>

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -396,10 +396,7 @@ exports[`offset pagination renders a pagination component 1`] = `
           </button>
           <div
             class="c11"
-            data-popper-escaped="true"
-            data-popper-placement="bottom-start"
-            data-popper-reference-hidden="true"
-            style="position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate(0px, 4px);"
+            style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
           >
             <div
               class="c12"
@@ -426,7 +423,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r16:"
+              aria-labelledby=":r17:"
               class="c15"
               fill="currentColor"
               height="24"
@@ -436,7 +433,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r16:"
+                id=":r17:"
               >
                 Previous page
               </title>
@@ -458,7 +455,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r17:"
+              aria-labelledby=":r18:"
               class="c15"
               fill="currentColor"
               height="24"
@@ -468,7 +465,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r17:"
+                id=":r18:"
               >
                 Next page
               </title>
@@ -1014,7 +1011,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls=":r8j:"
+  aria-controls=":r8v:"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -1030,15 +1027,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r8l:"
+          aria-labelledby=":r91:"
           class="c6 c7"
-          id=":r8k:"
+          id=":r90:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r8k:"
+          for=":r90:"
         >
           <svg
             aria-hidden="true"
@@ -1064,9 +1061,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c12"
-            for=":r8k:"
+            for=":r90:"
             hidden=""
-            id=":r8l:"
+            id=":r91:"
           >
             Select All
           </label>
@@ -1307,7 +1304,7 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
 }
 
 <div
-  aria-controls=":r99:"
+  aria-controls=":r9l:"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -1323,15 +1320,15 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r9b:"
+          aria-labelledby=":r9n:"
           class="c6 c7"
-          id=":r9a:"
+          id=":r9m:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r9a:"
+          for=":r9m:"
         >
           <svg
             aria-hidden="true"
@@ -1357,9 +1354,9 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
         >
           <label
             class="c12"
-            for=":r9a:"
+            for=":r9m:"
             hidden=""
-            id=":r9b:"
+            id=":r9n:"
           >
             Select All
           </label>
@@ -1600,7 +1597,7 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
 }
 
 <div
-  aria-controls=":rd0:"
+  aria-controls=":rdc:"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -1616,15 +1613,15 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
       >
         <input
           aria-checked="false"
-          aria-labelledby=":rd2:"
+          aria-labelledby=":rde:"
           class="c6 c7"
-          id=":rd1:"
+          id=":rdd:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":rd1:"
+          for=":rdd:"
         >
           <svg
             aria-hidden="true"
@@ -1650,9 +1647,9 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
         >
           <label
             class="c12"
-            for=":rd1:"
+            for=":rdd:"
             hidden=""
-            id=":rd2:"
+            id=":rde:"
           >
             Select All
           </label>

--- a/packages/big-design/src/utils/floatingPlacement.ts
+++ b/packages/big-design/src/utils/floatingPlacement.ts
@@ -1,0 +1,23 @@
+import { autoPlacement, flip, Middleware, Placement } from '@floating-ui/react';
+import { Placement as PopperPlacement } from '@popperjs/core';
+
+// Placement props are still typed with popper's Placement, which includes 'auto*'
+// values that floating-ui only supports via the autoPlacement middleware.
+export function getFloatingPlacement(placement: PopperPlacement): {
+  placement?: Placement;
+  middleware: Middleware;
+} {
+  switch (placement) {
+    case 'auto':
+      return { middleware: autoPlacement() };
+
+    case 'auto-start':
+      return { middleware: autoPlacement({ alignment: 'start' }) };
+
+    case 'auto-end':
+      return { middleware: autoPlacement({ alignment: 'end' }) };
+
+    default:
+      return { middleware: flip(), placement };
+  }
+}

--- a/packages/big-design/src/utils/index.ts
+++ b/packages/big-design/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './env';
+export * from './floatingPlacement';
 export * from './localizationProvider';
 export * from './messagingHelpers';
 export * from './treeHelpers';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@bigcommerce/big-design-theme':
         specifier: workspace:^
         version: link:../big-design-theme
+      '@floating-ui/react':
+        specifier: ^0.27.20
+        version: 0.27.20(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@popperjs/core':
         specifier: ^2.11.6
         version: 2.11.8


### PR DESCRIPTION
## What?

Swaps `react-popper`'s `usePopper` for `@floating-ui/react`'s `useFloating` in the four internal-only consumers: Dropdown, Popover, Select, and MultiSelect. Popper modifiers map to floating-ui middleware for behavior parity: `offset [0, 4]` → `offset(4)`, `preventOverflow` → `shift()`, default flip → `flip()`, Popover's custom `sameWidth` modifier → `size()`, and popper's scroll/resize `eventListeners` → `autoUpdate` gated on `isOpen` so listeners still only attach while a menu is open.

Tooltip still uses `react-popper` (it exposes popper types publicly and is migrated separately as a breaking change), so the dependency stays installed for now.

## Why?

`react-popper` is unmaintained (no release since 2021) and its React peer caps at 18, blocking React 19 support. `@floating-ui/react` is the successor project from the same maintainer.

No public API change: the `placement` props stay typed with popper's `Placement`. That type includes `auto`/`auto-start`/`auto-end`, which floating-ui only supports via the `autoPlacement` middleware (and Popover *defaults* to `auto`), so a small internal `getFloatingPlacement` util maps those values.

Snapshot churn explained: floating-ui applies the offset transform synchronously in jsdom (popper never got that far in tests), and it consumes a `useId` internally which shifts subsequent generated ids. No positional values changed.

## Screenshots/Screen Recordings

Positioning parity was measured on the docs site with headless Chromium via `getBoundingClientRect`:

<!-- linear:table-colwidths:400,400 -->
| Scenario | Result |
| -- | -- |
| Dropdown open | 4px gap below trigger, `bottom-start` aligned (`leftDelta: 0`) |
| Dropdown, window scrolled 120px while open | menu tracks anchor, gap stays 4px |
| Dropdown near viewport bottom | flips above with 4px gap |
| Select open + viewport resize while open | position holds |
| MultiSelect with no room below | flips above input |
| Popover (`placement="auto"` default) | picks roomiest side, 4px distance |

## Testing/Proof

* `pnpm run lint`, `pnpm run typecheck`, `pnpm run test` all green (1152 tests; 17 snapshot updates reviewed, all id/transform churn as described above).
* Manual parity pass against `pnpm run start` docs in headless Chromium: opened each of the 4 components, measured gaps/alignment, scrolled and resized while open, and forced flip near viewport edges (numbers in the table above). Esc and outside-click close behavior on Popover re-verified. Zero browser console errors.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)