### PR TITLE
feat(component): TRAC-1304 migrate Tooltip to @floating-ui/react, remove react-popper (breaking)

### DIFF
--- a/.changeset/tooltip-floating-ui-migration.md
+++ b/.changeset/tooltip-floating-ui-migration.md
@@ -1,0 +1,81 @@
+---
+"@bigcommerce/big-design": major
+---
+
+Migrate `Tooltip` positioning from `react-popper` to `@floating-ui/react`, removing `react-popper` from `@bigcommerce/big-design`.
+
+**Breaking changes:**
+
+- `TooltipProps.modifiers` (typed as `PopperProps['modifiers']`) is replaced by `middleware?: Middleware[]` from `@floating-ui/react`. The default behavior (4px offset, shift to stay in viewport) is unchanged when no `middleware` prop is passed.
+- `TooltipProps.placement` now accepts `@floating-ui/react`'s `Placement` values plus `"auto"`, `"auto-start"`, and `"auto-end"`. Explicit placements use `flip()` to reposition on overflow; `"auto*"` values use `autoPlacement()` to pick the side with the most space.
+
+**Migration guide:**
+
+The `middleware` prop replaces `modifiers`. Common popper modifier equivalents:
+
+| Popper modifier | Floating UI middleware |
+|---|---|
+| `{ name: 'offset', options: { offset: [0, N] } }` | `offset(N)` |
+| `{ name: 'preventOverflow' }` | `shift()` |
+| `{ name: 'flip' }` | `flip()` (included in defaults) |
+
+The `middleware` prop replaces the entire default stack, so include everything you need:
+
+```tsx
+import { offset, shift } from '@floating-ui/react';
+
+// Before — increase offset, prevent overflow
+<Tooltip
+  placement="left"
+  modifiers={[
+    { name: 'offset', options: { offset: [0, 20] } },
+    { name: 'preventOverflow' },
+  ]}
+  trigger={<button>Hover me</button>}
+>
+  Content
+</Tooltip>
+
+// After
+<Tooltip
+  placement="left"
+  middleware={[offset(20), shift()]}
+  trigger={<button>Hover me</button>}
+>
+  Content
+</Tooltip>
+```
+
+```tsx
+// Before — custom skidding (cross-axis offset) and distance
+<Tooltip
+  placement="bottom"
+  modifiers={[{ name: 'offset', options: { offset: [12, 8] } }]}
+  trigger={<button>Hover me</button>}
+>
+  Content
+</Tooltip>
+
+// After — floating-ui offset takes { mainAxis, crossAxis }
+import { offset } from '@floating-ui/react';
+
+<Tooltip
+  placement="bottom"
+  middleware={[offset({ mainAxis: 8, crossAxis: 12 })]}
+  trigger={<button>Hover me</button>}
+>
+  Content
+</Tooltip>
+```
+
+```tsx
+// Before — auto placement
+<Tooltip placement="auto" trigger={<button>Hover me</button>}>
+  Content
+</Tooltip>
+
+// After — "auto" is now the default, placement can be omitted entirely
+<Tooltip trigger={<button>Hover me</button>}>
+  Content
+</Tooltip>
+```

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -47,7 +47,6 @@
     "polished": "^4.3.1",
     "react-datepicker": "^7.6.0",
     "react-intersection-observer": "^10.0.0",
-    "react-popper": "^2.3.0",
     "@tanstack/react-virtual": "^3.13.0",
     "zustand": "^5.0.11"
   },

--- a/packages/big-design/src/components/List/Item/Content.tsx
+++ b/packages/big-design/src/components/List/Item/Content.tsx
@@ -1,4 +1,5 @@
 import { IconProps } from '@bigcommerce/big-design-icons';
+import { offset, shift } from '@floating-ui/react';
 import React, { cloneElement, isValidElement, memo, useCallback, useMemo } from 'react';
 
 import { DropdownItem, DropdownLinkItem } from '../../Dropdown';
@@ -54,11 +55,7 @@ export const Content = memo(({ item, isHighlighted, wrapText = false }: ContentP
 
   const wrapInTooltip = useCallback(
     (tooltip: string, tooltipTrigger: React.ReactElement) => (
-      <Tooltip
-        modifiers={[{ name: 'preventOverflow' }, { name: 'offset', options: { offset: [0, 20] } }]}
-        placement="left"
-        trigger={tooltipTrigger}
-      >
+      <Tooltip middleware={[offset(20), shift()]} placement="left" trigger={tooltipTrigger}>
         {tooltip}
       </Tooltip>
     ),

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -340,7 +340,7 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 <div
-  aria-controls=":r12:"
+  aria-controls=":r14:"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -361,11 +361,11 @@ exports[`offset pagination renders a pagination component 1`] = `
         >
           <button
             aria-activedescendant=""
-            aria-controls=":r13:-menu"
+            aria-controls=":r15:-menu"
             aria-expanded="false"
             aria-haspopup="menu"
             class="c7 c8"
-            id=":r13:-toggle-button"
+            id=":r15:-toggle-button"
             role="button"
             tabindex="0"
             type="button"
@@ -402,9 +402,9 @@ exports[`offset pagination renders a pagination component 1`] = `
               class="c12"
             >
               <ul
-                aria-labelledby=":r13:-label"
+                aria-labelledby=":r15:-label"
                 class="c13"
-                id=":r13:-menu"
+                id=":r15:-menu"
                 role="menu"
               />
             </div>
@@ -423,7 +423,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r17:"
+              aria-labelledby=":r19:"
               class="c15"
               fill="currentColor"
               height="24"
@@ -433,7 +433,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r17:"
+                id=":r19:"
               >
                 Previous page
               </title>
@@ -455,7 +455,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r18:"
+              aria-labelledby=":r1a:"
               class="c15"
               fill="currentColor"
               height="24"
@@ -465,7 +465,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r18:"
+                id=":r1a:"
               >
                 Next page
               </title>
@@ -951,7 +951,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls=":r3a:"
+  aria-controls=":r3c:"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -967,15 +967,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r3c:"
+          aria-labelledby=":r3e:"
           class="c6 c7"
-          id=":r3b:"
+          id=":r3d:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r3b:"
+          for=":r3d:"
         >
           <svg
             aria-hidden="true"
@@ -1001,9 +1001,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c12"
-            for=":r3b:"
+            for=":r3d:"
             hidden=""
-            id=":r3c:"
+            id=":r3e:"
           >
             Select All
           </label>

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -340,7 +340,7 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 <div
-  aria-controls=":r12:"
+  aria-controls=":r14:"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -361,11 +361,11 @@ exports[`offset pagination renders a pagination component 1`] = `
         >
           <button
             aria-activedescendant=""
-            aria-controls=":r13:-menu"
+            aria-controls=":r15:-menu"
             aria-expanded="false"
             aria-haspopup="menu"
             class="c7 c8"
-            id=":r13:-toggle-button"
+            id=":r15:-toggle-button"
             role="button"
             tabindex="0"
             type="button"
@@ -402,9 +402,9 @@ exports[`offset pagination renders a pagination component 1`] = `
               class="c12"
             >
               <ul
-                aria-labelledby=":r13:-label"
+                aria-labelledby=":r15:-label"
                 class="c13"
-                id=":r13:-menu"
+                id=":r15:-menu"
                 role="menu"
               />
             </div>
@@ -423,7 +423,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r17:"
+              aria-labelledby=":r19:"
               class="c15"
               fill="currentColor"
               height="24"
@@ -433,7 +433,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r17:"
+                id=":r19:"
               >
                 Previous page
               </title>
@@ -455,7 +455,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r18:"
+              aria-labelledby=":r1a:"
               class="c15"
               fill="currentColor"
               height="24"
@@ -465,7 +465,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r18:"
+                id=":r1a:"
               >
                 Next page
               </title>
@@ -1011,7 +1011,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls=":r8v:"
+  aria-controls=":r91:"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -1027,15 +1027,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r91:"
+          aria-labelledby=":r93:"
           class="c6 c7"
-          id=":r90:"
+          id=":r92:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r90:"
+          for=":r92:"
         >
           <svg
             aria-hidden="true"
@@ -1061,9 +1061,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c12"
-            for=":r90:"
+            for=":r92:"
             hidden=""
-            id=":r91:"
+            id=":r93:"
           >
             Select All
           </label>
@@ -1304,7 +1304,7 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
 }
 
 <div
-  aria-controls=":r9l:"
+  aria-controls=":r9n:"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -1320,15 +1320,15 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r9n:"
+          aria-labelledby=":r9p:"
           class="c6 c7"
-          id=":r9m:"
+          id=":r9o:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":r9m:"
+          for=":r9o:"
         >
           <svg
             aria-hidden="true"
@@ -1354,9 +1354,9 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
         >
           <label
             class="c12"
-            for=":r9m:"
+            for=":r9o:"
             hidden=""
-            id=":r9n:"
+            id=":r9p:"
           >
             Select All
           </label>
@@ -1597,7 +1597,7 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
 }
 
 <div
-  aria-controls=":rdc:"
+  aria-controls=":rde:"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -1613,15 +1613,15 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
       >
         <input
           aria-checked="false"
-          aria-labelledby=":rde:"
+          aria-labelledby=":rdg:"
           class="c6 c7"
-          id=":rdd:"
+          id=":rdf:"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8 c9"
-          for=":rdd:"
+          for=":rdf:"
         >
           <svg
             aria-hidden="true"
@@ -1647,9 +1647,9 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
         >
           <label
             class="c12"
-            for=":rdd:"
+            for=":rdf:"
             hidden=""
-            id=":rde:"
+            id=":rdg:"
           >
             Select All
           </label>

--- a/packages/big-design/src/components/Tooltip/Tooltip.tsx
+++ b/packages/big-design/src/components/Tooltip/Tooltip.tsx
@@ -1,66 +1,51 @@
-import { Placement } from '@popperjs/core';
-import React, {
-  cloneElement,
-  ComponentPropsWithoutRef,
-  memo,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { autoUpdate, Middleware, offset, Placement, shift, useFloating } from '@floating-ui/react';
+import React, { cloneElement, ComponentPropsWithoutRef, memo, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Manager, Popper, PopperProps, Reference } from 'react-popper';
 
+import { getFloatingPlacement } from '../../utils/floatingPlacement';
 import { Small } from '../Typography';
 
 import { StyledTooltip } from './styled';
 
+type TooltipPlacement = Placement | 'auto' | 'auto-start' | 'auto-end';
+
 export interface TooltipProps extends ComponentPropsWithoutRef<'div'> {
   children?: React.ReactNode;
-  placement: Placement;
+  placement?: TooltipPlacement;
   trigger: React.ReactElement;
-  modifiers?: PopperProps<any>['modifiers'];
+  middleware?: Middleware[];
 }
 
 export const Tooltip: React.FC<TooltipProps> = memo(
-  ({ children, modifiers, trigger, id, ...props }) => {
+  ({ children, middleware, trigger, id, placement = 'auto' }) => {
     const [isVisible, setIsVisible] = useState(false);
-    const [tooltipContainer, setTooltipContainer] = useState<HTMLDivElement | null>(null);
-    const tooltipModifiers = useMemo(() => {
-      const mods = modifiers || [];
 
-      return [
-        { name: 'eventListeners', options: { scroll: isVisible, resize: isVisible } },
-        { name: 'offset', options: { offset: [0, 4] } },
-        ...mods,
-      ];
-    }, [isVisible, modifiers]);
+    const { middleware: placementMiddleware, placement: floatingPlacement } =
+      getFloatingPlacement(placement);
 
+    const {
+      floatingStyles,
+      refs,
+      update,
+      placement: resolvedPlacement,
+    } = useFloating({
+      middleware: middleware ?? [offset(4), placementMiddleware, shift()],
+      placement: floatingPlacement,
+    });
+
+    // Only run autoUpdate while visible — matches popper's eventListeners { scroll, resize } behavior
     useEffect(() => {
-      const container = document.createElement('div');
-
-      document.body.appendChild(container);
-      setTooltipContainer(container);
-    }, []);
-
-    useEffect(() => {
-      return () => {
-        if (tooltipContainer) {
-          document.body.removeChild(tooltipContainer);
-        }
-      };
-    }, [tooltipContainer]);
+      if (isVisible && refs.reference.current && refs.floating.current) {
+        return autoUpdate(refs.reference.current, refs.floating.current, update);
+      }
+    }, [isVisible, refs.reference, refs.floating, update]);
 
     const renderContent = () => {
       return typeof children === 'string' ? <Small color="white">{children}</Small> : children;
     };
 
-    const hideTooltip = () => {
-      setIsVisible(false);
-    };
-
-    const showTooltip = () => {
-      setIsVisible(true);
-    };
+    const hideTooltip = () => setIsVisible(false);
+    const showTooltip = () => setIsVisible(true);
 
     const onKeyDown = (event: React.KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -69,34 +54,29 @@ export const Tooltip: React.FC<TooltipProps> = memo(
     };
 
     return (
-      <Manager>
-        <Reference>
-          {({ ref }) =>
-            cloneElement(trigger, {
-              ref,
-              onBlur: hideTooltip,
-              onFocus: showTooltip,
-              onKeyDown,
-              onMouseEnter: showTooltip,
-              onMouseLeave: hideTooltip,
-            })
-          }
-        </Reference>
-        {tooltipContainer
-          ? createPortal(
-              <Popper modifiers={tooltipModifiers} placement={props.placement || 'top'}>
-                {({ placement, ref, style }) =>
-                  isVisible && (
-                    <StyledTooltip data-placement={placement} id={id} ref={ref} style={style}>
-                      {renderContent()}
-                    </StyledTooltip>
-                  )
-                }
-              </Popper>,
-              tooltipContainer,
-            )
-          : null}
-      </Manager>
+      <>
+        {cloneElement(trigger, {
+          ref: refs.setReference,
+          onBlur: hideTooltip,
+          onFocus: showTooltip,
+          onKeyDown,
+          onMouseEnter: showTooltip,
+          onMouseLeave: hideTooltip,
+        })}
+        {createPortal(
+          isVisible && (
+            <StyledTooltip
+              data-placement={resolvedPlacement}
+              id={id}
+              ref={refs.setFloating}
+              style={floatingStyles}
+            >
+              {renderContent()}
+            </StyledTooltip>
+          ),
+          document.body,
+        )}
+      </>
     );
   },
 );

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -623,7 +623,7 @@ exports[`renders worksheet 1`] = `
           >
             <svg
               aria-describedby=":r0:"
-              aria-labelledby=":r1:"
+              aria-labelledby=":r2:"
               class="c7"
               fill="currentColor"
               height="24"
@@ -633,7 +633,7 @@ exports[`renders worksheet 1`] = `
               width="24"
             >
               <title
-                id=":r1:"
+                id=":r2:"
               >
                 Hover or focus for additional context.
               </title>
@@ -682,16 +682,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r5:"
+                aria-labelledby=":r6:"
                 checked=""
                 class="c14 c15"
-                id=":r4:"
+                id=":r5:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16 c17"
-                for=":r4:"
+                for=":r5:"
               >
                 <svg
                   aria-hidden="true"
@@ -718,9 +718,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c20"
-                  for=":r4:"
+                  for=":r5:"
                   hidden=""
-                  id=":r5:"
+                  id=":r6:"
                 >
                   Checked
                 </label>
@@ -830,16 +830,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":rd:"
+                aria-labelledby=":re:"
                 checked=""
                 class="c14 c15"
-                id=":rc:"
+                id=":rd:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16 c17"
-                for=":rc:"
+                for=":rd:"
               >
                 <svg
                   aria-hidden="true"
@@ -866,9 +866,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c20"
-                  for=":rc:"
+                  for=":rd:"
                   hidden=""
-                  id=":rd:"
+                  id=":re:"
                 >
                   Checked
                 </label>
@@ -978,15 +978,15 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="false"
-                aria-labelledby=":rl:"
+                aria-labelledby=":rm:"
                 class="c14 c15"
-                id=":rk:"
+                id=":rl:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16 c30"
-                for=":rk:"
+                for=":rl:"
               >
                 <svg
                   aria-hidden="true"
@@ -1013,9 +1013,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c20"
-                  for=":rk:"
+                  for=":rl:"
                   hidden=""
-                  id=":rl:"
+                  id=":rm:"
                 >
                   Unchecked
                 </label>
@@ -1123,16 +1123,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":rt:"
+                aria-labelledby=":ru:"
                 checked=""
                 class="c14 c15"
-                id=":rs:"
+                id=":rt:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16 c17"
-                for=":rs:"
+                for=":rt:"
               >
                 <svg
                   aria-hidden="true"
@@ -1159,9 +1159,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c20"
-                  for=":rs:"
+                  for=":rt:"
                   hidden=""
-                  id=":rt:"
+                  id=":ru:"
                 >
                   Checked
                 </label>
@@ -1268,15 +1268,15 @@ exports[`renders worksheet 1`] = `
               class="c13"
             >
               <input
-                aria-labelledby=":r15:"
+                aria-labelledby=":r16:"
                 class="c14 c15"
-                id=":r14:"
+                id=":r15:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16 c30"
-                for=":r14:"
+                for=":r15:"
               >
                 <svg
                   aria-hidden="true"
@@ -1303,9 +1303,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c20"
-                  for=":r14:"
+                  for=":r15:"
                   hidden=""
-                  id=":r15:"
+                  id=":r16:"
                 >
                   Unchecked
                 </label>
@@ -1409,16 +1409,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r1d:"
+                aria-labelledby=":r1e:"
                 checked=""
                 class="c14 c15"
-                id=":r1c:"
+                id=":r1d:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16 c17"
-                for=":r1c:"
+                for=":r1d:"
               >
                 <svg
                   aria-hidden="true"
@@ -1445,9 +1445,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c20"
-                  for=":r1c:"
+                  for=":r1d:"
                   hidden=""
-                  id=":r1d:"
+                  id=":r1e:"
                 >
                   Checked
                 </label>
@@ -1557,15 +1557,15 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="false"
-                aria-labelledby=":r1l:"
+                aria-labelledby=":r1m:"
                 class="c14 c15"
-                id=":r1k:"
+                id=":r1l:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16 c30"
-                for=":r1k:"
+                for=":r1l:"
               >
                 <svg
                   aria-hidden="true"
@@ -1592,9 +1592,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c20"
-                  for=":r1k:"
+                  for=":r1l:"
                   hidden=""
-                  id=":r1l:"
+                  id=":r1m:"
                 >
                   Unchecked
                 </label>
@@ -1704,16 +1704,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r1t:"
+                aria-labelledby=":r1u:"
                 checked=""
                 class="c14 c15"
-                id=":r1s:"
+                id=":r1t:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16 c17"
-                for=":r1s:"
+                for=":r1t:"
               >
                 <svg
                   aria-hidden="true"
@@ -1740,9 +1740,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c20"
-                  for=":r1s:"
+                  for=":r1t:"
                   hidden=""
-                  id=":r1t:"
+                  id=":r1u:"
                 >
                   Checked
                 </label>
@@ -1852,16 +1852,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r25:"
+                aria-labelledby=":r26:"
                 checked=""
                 class="c14 c15"
-                id=":r24:"
+                id=":r25:"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16 c17"
-                for=":r24:"
+                for=":r25:"
               >
                 <svg
                   aria-hidden="true"
@@ -1888,9 +1888,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c20"
-                  for=":r24:"
+                  for=":r25:"
                   hidden=""
-                  id=":r25:"
+                  id=":r26:"
                 >
                   Checked
                 </label>

--- a/packages/docs/PropTables/TooltipPropTable.tsx
+++ b/packages/docs/PropTables/TooltipPropTable.tsx
@@ -11,7 +11,6 @@ const tooltipProps: Prop[] = [
   },
   {
     name: 'placement',
-    defaultValue: 'top',
     types: [
       'auto',
       'auto-end',
@@ -29,7 +28,15 @@ const tooltipProps: Prop[] = [
       'top-end',
       'top-start',
     ],
-    description: 'Sets the position of the Tooltip.',
+    defaultValue: 'auto',
+    description:
+      'Sets the preferred position of the Tooltip. Explicit placements flip to the opposite side when there is not enough space. Auto placements pick whichever side has the most available space.',
+  },
+  {
+    name: 'middleware',
+    types: 'Middleware[]',
+    description:
+      'Floating UI middleware to customize positioning. Replaces the default middleware stack (offset(4), flip/autoPlacement, shift). Import middleware from @floating-ui/react.',
   },
 ];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,9 +91,6 @@ importers:
       react-intersection-observer:
         specifier: ^10.0.0
         version: 10.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react-popper:
-        specifier: ^2.3.0
-        version: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@18.2.73)(react@18.2.0)(use-sync-external-store@1.4.0(react@18.2.0))


### PR DESCRIPTION
## Summary

- Rewrites \`Tooltip\` off the \`Manager\`/\`Reference\`/\`Popper\` render-prop API onto \`useFloating\` from \`@floating-ui/react\`
- Removes \`react-popper\` from \`packages/big-design/package.json\` (the last direct consumer)
- Replaces \`TooltipProps.modifiers: PopperProps['modifiers']\` with \`middleware?: Middleware[]\` from \`@floating-ui/react\`
- \`TooltipProps.placement\` is now optional (defaults to \`"auto"\`) and accepts all explicit placements plus \`"auto"\`, \`"auto-start"\`, \`"auto-end"\`. Explicit placements use \`flip()\`; auto placements use \`autoPlacement()\` to pick the side with the most space
- Updates the internal \`List/Item/Content.tsx\` caller to use floating-ui middleware (\`offset(20)\`, \`shift()\`)
- Updates docs prop table for \`Tooltip\` (new \`middleware\` prop, \`placement\` now optional with \`"auto"\` default)

## Breaking changes

\`TooltipProps.modifiers\` → \`middleware?: Middleware[]\`. Common popper modifier equivalents:

| Popper modifier | Floating UI middleware |
|---|---|
| `{ name: 'offset', options: { offset: [0, N] } }` | `offset(N)` |
| `{ name: 'preventOverflow' }` | `shift()` |
| `{ name: 'flip' }` | built into defaults, no change needed |

```tsx
// Before
<Tooltip
  placement="left"
  modifiers={[{ name: 'offset', options: { offset: [0, 20] } }, { name: 'preventOverflow' }]}
  trigger={btn}
>
  Content
</Tooltip>

// After
import { offset, shift } from '@floating-ui/react';
<Tooltip placement="left" middleware={[offset(20), shift()]} trigger={btn}>
  Content
</Tooltip>

// "auto" placement is still valid, and is now the default — can be omitted
<Tooltip trigger={btn}>Content</Tooltip>
```

## Test plan

- [x] CI: lint, typecheck, build all pass
- [x] All 1152 tests pass (3 snapshot suites updated for \`useId\` counter shift caused by new import in \`Content.tsx\`)
- [ ] Manual: tooltip placement on all sides, show/hide on hover/focus, Escape closes, edge-of-viewport repositioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)