### PR TITLE
fix: TRAC-1396 migrate remaining tag-target styled components to transient props

### DIFF
--- a/.changeset/transient-props-flex-grid-typography-worksheet.md
+++ b/.changeset/transient-props-flex-grid-typography-worksheet.md
@@ -1,0 +1,21 @@
+---
+"@bigcommerce/big-design": patch
+---
+
+Finish migrating tag-target styled components to transient (`$`-prefixed) props ahead of styled-components 6 (LTRAC-1454, catches misses from LTRAC-1396). SC5's automatic `is-prop-valid` filtering hid all of these — they only surface under v6's stricter tag-target handling.
+
+Components fixed:
+
+- **Flex** — `withFlexedContainer()` now reads `$`-prefixed fields; `StyledFlex.defaultProps` updated; `Flex.tsx` destructures all eight container props and hands them off via `toTransientFlexedContainerProps()`. Fixes the highest-volume leak (~70 DOM attribute hits per render).
+- **Grid** — same pattern for `withGridedContainer()` / `withGridedItems()`; `Grid.tsx` and `Grid/Item/Item.tsx` use `toTransientGridedContainerProps()` / `toTransientGridedItemProps()`.
+- **Table/Actions and TableNext/Actions** — `StyledFlex` in each actions bar now takes `$alignItems`, `$flexDirection`, `$justifyContent`, `$stickyHeader`.
+- **Typography** — `commonTextStyles` and `textModifiers` helpers read `$ellipsis` / `$bold` / `$capitalize` / `$italic` / `$lowercase` / `$strikethrough` / `$underline` / `$uppercase`; `Text`, `Small`, and `H0`–`H4` destructure the public modifiers and spread them via a local `toTransientTextProps()`.
+- **AccordionPanel** — `$isExpanded` and `$iconLeft` on `StyledAccordionButton` / `StyledAccordionContent`.
+- **ButtonGroup** — `$borderRadius` and `$isVisible` on dropdown and item wrappers.
+- **Collapse/CollapseTrigger** — `$isOpen`.
+- **Lozenge** — `$hasTooltip`.
+- **PillTabs** — `$isActive` on `StyledPillTab`; `$isVisible` on `StyledFlexItem` / `StyledGroupSeparator`.
+- **Textarea** — `$resize`.
+- **Worksheet** — `$minWidth`, `$hasStaticWidth`, `$hasExpandableRows` on the table; `$columnType`, `$columnWidth` on headers; `$containerHeight` on the scroll box; full `StyledCell` props (`$isFirstSelected`, `$isLastSelected`, `$isChild`, `$isLastChild`, `$isEdited`, `$isSelected`, `$isValid`, `$isNextCellValid`, `$type`) and `$isVisible` on `AutoFillHandler`.
+
+Public prop interfaces and CSS output are unchanged; all 1152 tests pass with zero snapshot diffs on v5.

--- a/packages/big-design/src/components/AccordionPanel/Accordion/Accordion.tsx
+++ b/packages/big-design/src/components/AccordionPanel/Accordion/Accordion.tsx
@@ -20,12 +20,13 @@ export const Accordion: React.FC<AccordionProps> = memo(
     return (
       <>
         <StyledAccordionButton
+          $iconLeft={iconLeft}
+          $isExpanded={isExpanded}
           aria-controls={accordionItemId}
           aria-expanded={isExpanded}
           iconLeft={iconLeft}
           iconRight={<ExpandMoreIcon className="collapse-icon" color="secondary70" />}
           id={accordionId}
-          isExpanded={isExpanded}
           onClick={onClick}
           type="button"
           variant="subtle"
@@ -33,10 +34,10 @@ export const Accordion: React.FC<AccordionProps> = memo(
           {header}
         </StyledAccordionButton>
         <StyledAccordionContent
+          $iconLeft={iconLeft}
           aria-labelledby={accordionId}
           display={isExpanded ? 'block' : 'none'}
           hidden={!isExpanded}
-          iconLeft={iconLeft}
           id={accordionItemId}
           role="region"
         >

--- a/packages/big-design/src/components/AccordionPanel/Accordion/styled.tsx
+++ b/packages/big-design/src/components/AccordionPanel/Accordion/styled.tsx
@@ -6,11 +6,12 @@ import { Box } from '../../Box';
 import { StyleableButton } from '../../Button/private';
 
 interface StyledAccordionButtonProps {
-  isExpanded: boolean;
+  $isExpanded: boolean;
+  $iconLeft?: React.ReactNode;
 }
 
 interface StyledAccordionContentProps {
-  iconLeft: React.ReactNode;
+  $iconLeft?: React.ReactNode;
 }
 
 export const StyledAccordionButton = styled(StyleableButton)<StyledAccordionButtonProps>`
@@ -22,14 +23,14 @@ export const StyledAccordionButton = styled(StyleableButton)<StyledAccordionButt
   span {
     width: 100%;
     color: ${({ theme }) => theme.colors.secondary70};
-    grid-template-columns: ${({ iconLeft, theme }) =>
-      iconLeft
+    grid-template-columns: ${({ $iconLeft, theme }) =>
+      $iconLeft
         ? `${theme.spacing.xLarge} 1fr ${theme.spacing.medium}`
         : `1fr ${theme.spacing.medium}`};
   }
 
-  ${({ isExpanded }) =>
-    isExpanded &&
+  ${({ $isExpanded }) =>
+    $isExpanded &&
     css`
       border-bottom: ${({ theme }) => theme.border.box};
     `}
@@ -41,8 +42,8 @@ export const StyledAccordionButton = styled(StyleableButton)<StyledAccordionButt
   .collapse-icon {
     ${withTransition(['transform'])}
 
-    ${({ isExpanded }) =>
-      isExpanded &&
+    ${({ $isExpanded }) =>
+      $isExpanded &&
       css`
         transform: rotate(-180deg);
       `}
@@ -51,7 +52,7 @@ export const StyledAccordionButton = styled(StyleableButton)<StyledAccordionButt
 
 export const StyledAccordionContent = styled(Box)<StyledAccordionContentProps>`
   padding: ${({ theme }) => theme.spacing.xLarge}};
-  padding-left: ${({ iconLeft, theme }) => (iconLeft ? remCalc(60) : theme.spacing.xLarge)};
+  padding-left: ${({ $iconLeft, theme }) => ($iconLeft ? remCalc(60) : theme.spacing.xLarge)};
 `;
 
 StyledAccordionButton.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -104,8 +104,8 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
     const renderedDropdown = useMemo(
       () => (
         <StyledFlexItem
+          $isVisible={isMenuVisible}
           data-testid="buttongroup-dropdown"
-          isVisible={isMenuVisible}
           ref={dropdownRef}
           role="listitem"
         >
@@ -127,7 +127,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
             placement="bottom-end"
             toggle={
               <StyledButton
-                borderRadius={actionsState.every(({ isVisible }) => !isVisible)}
+                $borderRadius={actionsState.every(({ isVisible }) => !isVisible)}
                 iconOnly={<MoreHorizIcon title={localization.more} />}
                 type="button"
                 variant="secondary"
@@ -149,8 +149,8 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = memo(
 
             return (
               <StyledFlexItem
+                $isVisible={isVisible}
                 data-testid="buttongroup-item"
-                isVisible={isVisible}
                 key={key}
                 ref={ref}
                 role="listitem"

--- a/packages/big-design/src/components/ButtonGroup/styled.tsx
+++ b/packages/big-design/src/components/ButtonGroup/styled.tsx
@@ -5,16 +5,16 @@ import { StyleableButton } from '../Button/private';
 import { FlexItem } from '../Flex';
 
 interface StyledButtonProps {
-  borderRadius?: boolean;
+  $borderRadius?: boolean;
 }
 
 interface StyledFlexItemProps {
-  isVisible: boolean;
+  $isVisible: boolean;
 }
 
 export const StyledButton = styled(StyleableButton)<StyledButtonProps>`
-  ${({ borderRadius, theme }) =>
-    borderRadius
+  ${({ $borderRadius, theme }) =>
+    $borderRadius
       ? css`
           border-radius: ${theme.borderRadius.normal};
         `
@@ -44,8 +44,8 @@ export const StyledFlexItem = styled(FlexItem)<StyledFlexItemProps>`
     border-top-right-radius: ${({ theme }) => theme.borderRadius.normal};
   }
 
-  ${({ isVisible }) =>
-    !isVisible &&
+  ${({ $isVisible }) =>
+    !$isVisible &&
     css`
       position: absolute;
       visibility: hidden;

--- a/packages/big-design/src/components/Collapse/CollapseTrigger/CollapseTrigger.tsx
+++ b/packages/big-design/src/components/Collapse/CollapseTrigger/CollapseTrigger.tsx
@@ -19,12 +19,12 @@ export const CollapseTrigger: React.FC<CollapseTriggerProps> = ({
 
   return (
     <StyledButton
+      $isOpen={isOpen}
       aria-controls={panelId}
       aria-expanded={isOpen}
       disabled={disabled}
       iconRight={<ExpandMoreIcon title={title} />}
       id={triggerId}
-      isOpen={isOpen}
       marginVertical={marginVertical}
       onClick={toggle}
       type="button"

--- a/packages/big-design/src/components/Collapse/CollapseTrigger/styled.tsx
+++ b/packages/big-design/src/components/Collapse/CollapseTrigger/styled.tsx
@@ -6,7 +6,7 @@ import { ButtonProps } from '../../Button';
 import { StyleableButton } from '../../Button/private';
 
 interface StyledButtonProps extends ButtonProps {
-  isOpen?: boolean;
+  $isOpen?: boolean;
 }
 
 export const StyledButton = styled(StyleableButton)<StyledButtonProps>`
@@ -30,8 +30,8 @@ export const StyledButton = styled(StyleableButton)<StyledButtonProps>`
   svg {
     ${withTransition(['transform'])}
 
-    ${({ isOpen }) =>
-      isOpen &&
+    ${({ $isOpen }) =>
+      $isOpen &&
       css`
         transform: rotate(-180deg);
       `}

--- a/packages/big-design/src/components/FeatureSet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/FeatureSet/__snapshots__/spec.tsx.snap
@@ -18,12 +18,6 @@ exports[`render feature set 1`] = `
 .c2 {
   color: currentColor;
   margin: 0 0 1rem;
-  display: inline-block;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  word-wrap: normal;
   color: currentColor;
   font-size: 0.875rem;
   font-weight: 400;

--- a/packages/big-design/src/components/Flex/Flex.tsx
+++ b/packages/big-design/src/components/Flex/Flex.tsx
@@ -4,6 +4,7 @@ import { BoxProps } from '../Box';
 
 import { StyledFlex } from './styled';
 import { FlexedProps } from './types';
+import { toTransientFlexedContainerProps } from './withFlex';
 
 export type FlexProps = BoxProps & FlexedProps;
 
@@ -15,9 +16,33 @@ interface PrivateProps {
 // a tag), so `display` also needs to reach Box's own internal $-prefixed handling
 // untouched (its public contract), while `$display` feeds StyledFlex's own separate
 // withDisplay() call on its outer layer.
-const RawFlex: React.FC<FlexProps & PrivateProps> = ({ as, display, forwardedRef, ...rest }) => (
-  <StyledFlex $display={display} display={display} forwardedAs={as} ref={forwardedRef} {...rest} />
-);
+const RawFlex: React.FC<FlexProps & PrivateProps> = (props) => {
+  const {
+    as,
+    display,
+    forwardedRef,
+    alignContent,
+    alignItems,
+    flexColumnGap,
+    flexDirection,
+    flexGap,
+    flexRowGap,
+    flexWrap,
+    justifyContent,
+    ...domProps
+  } = props;
+
+  return (
+    <StyledFlex
+      $display={display}
+      display={display}
+      forwardedAs={as}
+      ref={forwardedRef}
+      {...domProps}
+      {...toTransientFlexedContainerProps(props)}
+    />
+  );
+};
 
 export const Flex = forwardRef<HTMLDivElement, FlexProps>((props, ref) => (
   <RawFlex {...props} forwardedRef={ref} />

--- a/packages/big-design/src/components/Flex/styled.tsx
+++ b/packages/big-design/src/components/Flex/styled.tsx
@@ -1,17 +1,20 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import React from 'react';
 import styled from 'styled-components';
 
 import { withDisplay } from '../../helpers';
 import { TransientDisplayProps } from '../../helpers/display/types';
 import { Box } from '../Box';
 
-import { FlexProps } from './Flex';
+import { TransientFlexedProps } from './types';
 import { withFlexedContainer } from './withFlex';
 
+interface StyledFlexProps extends TransientFlexedProps, TransientDisplayProps {
+  forwardedAs?: React.ElementType;
+}
+
 // TODO: Remove the `forwardedAs` manual prop definition when @types get updated
-export const StyledFlex = styled(Box)<
-  FlexProps & TransientDisplayProps & { forwardedAs?: FlexProps['as'] }
->`
+export const StyledFlex = styled(Box)<StyledFlexProps>`
   ${withFlexedContainer()}
 
   display: flex;
@@ -20,10 +23,10 @@ export const StyledFlex = styled(Box)<
 `;
 
 StyledFlex.defaultProps = {
-  alignContent: 'stretch',
-  alignItems: 'stretch',
-  flexDirection: { mobile: 'column', tablet: 'row' },
-  flexWrap: 'nowrap',
-  justifyContent: 'flex-start',
+  $alignContent: 'stretch',
+  $alignItems: 'stretch',
+  $flexDirection: { mobile: 'column', tablet: 'row' },
+  $flexWrap: 'nowrap',
+  $justifyContent: 'flex-start',
   theme: defaultTheme,
 };

--- a/packages/big-design/src/components/Flex/types.ts
+++ b/packages/big-design/src/components/Flex/types.ts
@@ -89,6 +89,17 @@ export type FlexedProps = Partial<{
   justifyContent: JustifyContent;
 }>;
 
+export type TransientFlexedProps = Partial<{
+  $alignContent: AlignContent;
+  $alignItems: AlignItems;
+  $flexColumnGap: FlexColumnGap;
+  $flexDirection: FlexDirection;
+  $flexGap: FlexGap;
+  $flexRowGap: FlexRowGap;
+  $flexWrap: FlexWrap;
+  $justifyContent: JustifyContent;
+}>;
+
 export type FlexedItemProps = Partial<{
   alignSelf: AlignSelf;
   flexBasis: FlexBasis;

--- a/packages/big-design/src/components/Flex/withFlex.ts
+++ b/packages/big-design/src/components/Flex/withFlex.ts
@@ -6,21 +6,27 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { FlexedItemProps, FlexedOverload, FlexedProps, TransientFlexedItemProps } from './types';
+import {
+  FlexedItemProps,
+  FlexedOverload,
+  FlexedProps,
+  TransientFlexedItemProps,
+  TransientFlexedProps,
+} from './types';
 
-export const withFlexedContainer = () => css<FlexedProps>`
-  ${({ alignContent, theme }) =>
-    alignContent && getFlexedStyles(alignContent, theme, 'align-content')};
-  ${({ alignItems, theme }) => alignItems && getFlexedStyles(alignItems, theme, 'align-items')};
-  ${({ flexDirection, theme }) =>
-    flexDirection && getFlexedStyles(flexDirection, theme, 'flex-direction')};
-  ${({ flexGap, theme }) => flexGap && getFlexedStyles(flexGap, theme, 'gap')};
-  ${({ flexColumnGap, theme }) =>
-    flexColumnGap && getFlexedStyles(flexColumnGap, theme, 'column-gap')};
-  ${({ flexRowGap, theme }) => flexRowGap && getFlexedStyles(flexRowGap, theme, 'row-gap')};
-  ${({ flexWrap, theme }) => flexWrap && getFlexedStyles(flexWrap, theme, 'flex-wrap')};
-  ${({ justifyContent, theme }) =>
-    justifyContent && getFlexedStyles(justifyContent, theme, 'justify-content')};
+export const withFlexedContainer = () => css<TransientFlexedProps>`
+  ${({ $alignContent, theme }) =>
+    $alignContent && getFlexedStyles($alignContent, theme, 'align-content')};
+  ${({ $alignItems, theme }) => $alignItems && getFlexedStyles($alignItems, theme, 'align-items')};
+  ${({ $flexDirection, theme }) =>
+    $flexDirection && getFlexedStyles($flexDirection, theme, 'flex-direction')};
+  ${({ $flexGap, theme }) => $flexGap && getFlexedStyles($flexGap, theme, 'gap')};
+  ${({ $flexColumnGap, theme }) =>
+    $flexColumnGap && getFlexedStyles($flexColumnGap, theme, 'column-gap')};
+  ${({ $flexRowGap, theme }) => $flexRowGap && getFlexedStyles($flexRowGap, theme, 'row-gap')};
+  ${({ $flexWrap, theme }) => $flexWrap && getFlexedStyles($flexWrap, theme, 'flex-wrap')};
+  ${({ $justifyContent, theme }) =>
+    $justifyContent && getFlexedStyles($justifyContent, theme, 'justify-content')};
 `;
 
 export const withFlexedItems = () => css<TransientFlexedItemProps>`
@@ -33,6 +39,30 @@ export const withFlexedItems = () => css<TransientFlexedItemProps>`
   ${({ $flexShrink, theme }) =>
     typeof $flexShrink !== 'undefined' && getFlexedStyles($flexShrink, theme, 'flex-shrink')};
 `;
+
+export function toTransientFlexedContainerProps(props: FlexedProps): TransientFlexedProps {
+  const {
+    alignContent,
+    alignItems,
+    flexColumnGap,
+    flexDirection,
+    flexGap,
+    flexRowGap,
+    flexWrap,
+    justifyContent,
+  } = props;
+
+  return {
+    $alignContent: alignContent,
+    $alignItems: alignItems,
+    $flexColumnGap: flexColumnGap,
+    $flexDirection: flexDirection,
+    $flexGap: flexGap,
+    $flexRowGap: flexRowGap,
+    $flexWrap: flexWrap,
+    $justifyContent: justifyContent,
+  };
+}
 
 // Rename-and-keep helper: maps FlexedItemProps' public fields to their transient
 // ($-prefixed) names for hand-off to a tag-target styled component. withFlexedItems()

--- a/packages/big-design/src/components/Grid/Grid.tsx
+++ b/packages/big-design/src/components/Grid/Grid.tsx
@@ -4,6 +4,7 @@ import { BoxProps } from '../Box';
 
 import { StyledGrid } from './styled';
 import { GridedProps } from './types';
+import { toTransientGridedContainerProps } from './withGrid';
 
 export type GridProps = BoxProps & GridedProps;
 
@@ -15,9 +16,35 @@ interface PrivateProps {
 // a tag), so `display` also needs to reach Box's own internal $-prefixed handling
 // untouched (its public contract), while `$display` feeds StyledGrid's own separate
 // withDisplay() call on its outer layer.
-const RawGrid: React.FC<GridProps & PrivateProps> = ({ as, display, forwardedRef, ...rest }) => (
-  <StyledGrid $display={display} display={display} forwardedAs={as} ref={forwardedRef} {...rest} />
-);
+const RawGrid: React.FC<GridProps & PrivateProps> = (props) => {
+  const {
+    as,
+    display,
+    forwardedRef,
+    gridAreas,
+    gridAutoColumns,
+    gridAutoFlow,
+    gridAutoRows,
+    gridColumns,
+    gridColumnGap,
+    gridGap,
+    gridRows,
+    gridRowGap,
+    gridTemplate,
+    ...domProps
+  } = props;
+
+  return (
+    <StyledGrid
+      $display={display}
+      display={display}
+      forwardedAs={as}
+      ref={forwardedRef}
+      {...domProps}
+      {...toTransientGridedContainerProps(props)}
+    />
+  );
+};
 
 export const Grid = forwardRef<HTMLDivElement, GridProps>((props, ref) => (
   <RawGrid {...props} forwardedRef={ref} />

--- a/packages/big-design/src/components/Grid/Item/Item.tsx
+++ b/packages/big-design/src/components/Grid/Item/Item.tsx
@@ -2,11 +2,24 @@ import React from 'react';
 
 import { BoxProps } from '../../Box';
 import { GridedItemProps } from '../types';
+import { toTransientGridedItemProps } from '../withGrid';
 
 import { StyledGridItem } from './styled';
 
 export type GridItemProps = BoxProps & GridedItemProps;
 
-export const GridItem: React.FC<GridItemProps> = ({ as, ...rest }) => (
-  <StyledGridItem forwardedAs={as} {...rest} />
-);
+export const GridItem: React.FC<GridItemProps> = (props) => {
+  const {
+    as,
+    gridArea,
+    gridColumn,
+    gridColumnEnd,
+    gridColumnStart,
+    gridRow,
+    gridRowEnd,
+    gridRowStart,
+    ...domProps
+  } = props;
+
+  return <StyledGridItem forwardedAs={as} {...domProps} {...toTransientGridedItemProps(props)} />;
+};

--- a/packages/big-design/src/components/Grid/Item/styled.tsx
+++ b/packages/big-design/src/components/Grid/Item/styled.tsx
@@ -2,11 +2,10 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { Box } from '../../Box';
+import { TransientGridedItemProps } from '../types';
 import { withGridedItems } from '../withGrid';
 
-import { GridItemProps } from './Item';
-
-export const StyledGridItem = styled(Box)<GridItemProps>`
+export const StyledGridItem = styled(Box)<TransientGridedItemProps>`
   ${withGridedItems()}
 `;
 

--- a/packages/big-design/src/components/Grid/styled.tsx
+++ b/packages/big-design/src/components/Grid/styled.tsx
@@ -1,17 +1,20 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import React from 'react';
 import styled from 'styled-components';
 
 import { withDisplay } from '../../helpers';
 import { TransientDisplayProps } from '../../helpers/display/types';
 import { Box } from '../Box';
 
-import { GridProps } from './Grid';
+import { TransientGridedProps } from './types';
 import { withGridedContainer } from './withGrid';
 
+interface StyledGridProps extends TransientGridedProps, TransientDisplayProps {
+  forwardedAs?: React.ElementType;
+}
+
 // TODO: Remove the `forwardedAs` manual prop definition when @types get updated
-export const StyledGrid = styled(Box)<
-  GridProps & TransientDisplayProps & { forwardedAs?: GridProps['as'] }
->`
+export const StyledGrid = styled(Box)<StyledGridProps>`
   ${withGridedContainer()}
 
   display: grid;
@@ -19,4 +22,4 @@ export const StyledGrid = styled(Box)<
   ${withDisplay()}
 `;
 
-StyledGrid.defaultProps = { theme: defaultTheme, gridGap: defaultTheme.spacing.medium };
+StyledGrid.defaultProps = { theme: defaultTheme, $gridGap: defaultTheme.spacing.medium };

--- a/packages/big-design/src/components/Grid/types.ts
+++ b/packages/big-design/src/components/Grid/types.ts
@@ -51,6 +51,19 @@ export type GridedProps = Partial<{
   gridTemplate: GridTemplate;
 }>;
 
+export type TransientGridedProps = Partial<{
+  $gridAreas: GridAreas;
+  $gridAutoColumns: GridAutoColumns;
+  $gridAutoFlow: GridAutoFlow;
+  $gridAutoRows: GridAutoRows;
+  $gridColumns: GridColumns;
+  $gridColumnGap: GridColumnGap;
+  $gridGap: GridGap;
+  $gridRows: GridRows;
+  $gridRowGap: GridRowGap;
+  $gridTemplate: GridTemplate;
+}>;
+
 export type GridedItemProps = Partial<{
   gridArea: GridArea;
   gridColumn: GridColumn;
@@ -59,6 +72,16 @@ export type GridedItemProps = Partial<{
   gridRow: GridRow;
   gridRowEnd: GridRowEnd;
   gridRowStart: GridRowStart;
+}>;
+
+export type TransientGridedItemProps = Partial<{
+  $gridArea: GridArea;
+  $gridColumn: GridColumn;
+  $gridColumnEnd: GridColumnEnd;
+  $gridColumnStart: GridColumnStart;
+  $gridRow: GridRow;
+  $gridRowEnd: GridRowEnd;
+  $gridRowStart: GridRowStart;
 }>;
 
 export interface GridedOverload {

--- a/packages/big-design/src/components/Grid/withGrid.ts
+++ b/packages/big-design/src/components/Grid/withGrid.ts
@@ -6,40 +6,96 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { GridedItemProps, GridedOverload, GridedProps } from './types';
+import {
+  GridedItemProps,
+  GridedOverload,
+  GridedProps,
+  TransientGridedItemProps,
+  TransientGridedProps,
+} from './types';
 
-export const withGridedContainer = () => css<GridedProps>`
-  ${({ gridAreas, theme }) =>
-    gridAreas && getGridedStyles(gridAreas, theme, 'grid-template-areas')};
-  ${({ gridAutoColumns, theme }) =>
-    gridAutoColumns && getGridedStyles(gridAutoColumns, theme, 'grid-auto-columns')};
-  ${({ gridAutoFlow, theme }) =>
-    gridAutoFlow && getGridedStyles(gridAutoFlow, theme, 'grid-auto-flow')};
-  ${({ gridAutoRows, theme }) =>
-    gridAutoRows && getGridedStyles(gridAutoRows, theme, 'grid-auto-rows')};
-  ${({ gridColumns, theme }) =>
-    gridColumns && getGridedStyles(gridColumns, theme, 'grid-template-columns')};
-  ${({ gridGap, theme }) => gridGap && getGridedStyles(gridGap, theme, 'gap')};
-  ${({ gridColumnGap, theme }) =>
-    gridColumnGap && getGridedStyles(gridColumnGap, theme, 'column-gap')};
-  ${({ gridRows, theme }) => gridRows && getGridedStyles(gridRows, theme, 'grid-template-rows')};
-  ${({ gridRowGap, theme }) => gridRowGap && getGridedStyles(gridRowGap, theme, 'row-gap')};
-  ${({ gridTemplate, theme }) =>
-    gridTemplate && getGridedStyles(gridTemplate, theme, 'grid-template')};
+export const withGridedContainer = () => css<TransientGridedProps>`
+  ${({ $gridAreas, theme }) =>
+    $gridAreas && getGridedStyles($gridAreas, theme, 'grid-template-areas')};
+  ${({ $gridAutoColumns, theme }) =>
+    $gridAutoColumns && getGridedStyles($gridAutoColumns, theme, 'grid-auto-columns')};
+  ${({ $gridAutoFlow, theme }) =>
+    $gridAutoFlow && getGridedStyles($gridAutoFlow, theme, 'grid-auto-flow')};
+  ${({ $gridAutoRows, theme }) =>
+    $gridAutoRows && getGridedStyles($gridAutoRows, theme, 'grid-auto-rows')};
+  ${({ $gridColumns, theme }) =>
+    $gridColumns && getGridedStyles($gridColumns, theme, 'grid-template-columns')};
+  ${({ $gridGap, theme }) => $gridGap && getGridedStyles($gridGap, theme, 'gap')};
+  ${({ $gridColumnGap, theme }) =>
+    $gridColumnGap && getGridedStyles($gridColumnGap, theme, 'column-gap')};
+  ${({ $gridRows, theme }) => $gridRows && getGridedStyles($gridRows, theme, 'grid-template-rows')};
+  ${({ $gridRowGap, theme }) => $gridRowGap && getGridedStyles($gridRowGap, theme, 'row-gap')};
+  ${({ $gridTemplate, theme }) =>
+    $gridTemplate && getGridedStyles($gridTemplate, theme, 'grid-template')};
 `;
 
-export const withGridedItems = () => css<GridedItemProps>`
-  ${({ gridArea, theme }) => gridArea && getGridedStyles(gridArea, theme, 'grid-area')};
-  ${({ gridColumn, theme }) => gridColumn && getGridedStyles(gridColumn, theme, 'grid-column')};
-  ${({ gridColumnEnd, theme }) =>
-    gridColumnEnd && getGridedStyles(gridColumnEnd, theme, 'grid-column-end')};
-  ${({ gridColumnStart, theme }) =>
-    gridColumnStart && getGridedStyles(gridColumnStart, theme, 'grid-column-start')};
-  ${({ gridRow, theme }) => gridRow && getGridedStyles(gridRow, theme, 'grid-row')};
-  ${({ gridRowEnd, theme }) => gridRowEnd && getGridedStyles(gridRowEnd, theme, 'grid-row-end')};
-  ${({ gridRowStart, theme }) =>
-    gridRowStart && getGridedStyles(gridRowStart, theme, 'grid-row-start')};
+export const withGridedItems = () => css<TransientGridedItemProps>`
+  ${({ $gridArea, theme }) => $gridArea && getGridedStyles($gridArea, theme, 'grid-area')};
+  ${({ $gridColumn, theme }) => $gridColumn && getGridedStyles($gridColumn, theme, 'grid-column')};
+  ${({ $gridColumnEnd, theme }) =>
+    $gridColumnEnd && getGridedStyles($gridColumnEnd, theme, 'grid-column-end')};
+  ${({ $gridColumnStart, theme }) =>
+    $gridColumnStart && getGridedStyles($gridColumnStart, theme, 'grid-column-start')};
+  ${({ $gridRow, theme }) => $gridRow && getGridedStyles($gridRow, theme, 'grid-row')};
+  ${({ $gridRowEnd, theme }) => $gridRowEnd && getGridedStyles($gridRowEnd, theme, 'grid-row-end')};
+  ${({ $gridRowStart, theme }) =>
+    $gridRowStart && getGridedStyles($gridRowStart, theme, 'grid-row-start')};
 `;
+
+export function toTransientGridedContainerProps(props: GridedProps): TransientGridedProps {
+  const {
+    gridAreas,
+    gridAutoColumns,
+    gridAutoFlow,
+    gridAutoRows,
+    gridColumns,
+    gridColumnGap,
+    gridGap,
+    gridRows,
+    gridRowGap,
+    gridTemplate,
+  } = props;
+
+  return {
+    $gridAreas: gridAreas,
+    $gridAutoColumns: gridAutoColumns,
+    $gridAutoFlow: gridAutoFlow,
+    $gridAutoRows: gridAutoRows,
+    $gridColumns: gridColumns,
+    $gridColumnGap: gridColumnGap,
+    $gridGap: gridGap,
+    $gridRows: gridRows,
+    $gridRowGap: gridRowGap,
+    $gridTemplate: gridTemplate,
+  };
+}
+
+export function toTransientGridedItemProps(props: GridedItemProps): TransientGridedItemProps {
+  const {
+    gridArea,
+    gridColumn,
+    gridColumnEnd,
+    gridColumnStart,
+    gridRow,
+    gridRowEnd,
+    gridRowStart,
+  } = props;
+
+  return {
+    $gridArea: gridArea,
+    $gridColumn: gridColumn,
+    $gridColumnEnd: gridColumnEnd,
+    $gridColumnStart: gridColumnStart,
+    $gridRow: gridRow,
+    $gridRowEnd: gridRowEnd,
+    $gridRowStart: gridRowStart,
+  };
+}
 
 const getGridedStyles: GridedOverload = (
   gridedProp: any,

--- a/packages/big-design/src/components/Lozenge/Lozenge.tsx
+++ b/packages/big-design/src/components/Lozenge/Lozenge.tsx
@@ -99,7 +99,7 @@ export const Lozenge = forwardRef<HTMLDivElement | HTMLButtonElement, LozengePro
         <Tooltip
           placement="auto"
           trigger={
-            <StyledLozenge hasTooltip ref={(node) => setForwardedRef(ref, node)} variant={variant}>
+            <StyledLozenge $hasTooltip ref={(node) => setForwardedRef(ref, node)} variant={variant}>
               <VariantIcon aria-hidden="true" size="large" />
               {label}
               <InfoIcon aria-hidden="true" size="large" />

--- a/packages/big-design/src/components/Lozenge/spec.tsx
+++ b/packages/big-design/src/components/Lozenge/spec.tsx
@@ -123,7 +123,7 @@ test('StyledLozenge adjusts end padding when hasTooltip is true/false', () => {
   // defaultProps has hasTooltip=false
   expect(container.firstChild).toHaveStyleRule('padding-inline-end', theme.spacing.small);
 
-  rerender(<StyledLozenge hasTooltip>Pad</StyledLozenge>);
+  rerender(<StyledLozenge $hasTooltip>Pad</StyledLozenge>);
 
   expect(container.firstChild).toHaveStyleRule('padding-inline-end', theme.spacing.xxSmall);
 });

--- a/packages/big-design/src/components/Lozenge/styled.tsx
+++ b/packages/big-design/src/components/Lozenge/styled.tsx
@@ -6,7 +6,7 @@ import { Box } from '../Box';
 import { LozengeProps } from './Lozenge';
 
 interface StyledLozengeProps extends Omit<LozengeProps, 'label' | 'tooltipContent'> {
-  hasTooltip?: boolean;
+  $hasTooltip?: boolean;
 }
 
 const sharedLozengeStyles = css`
@@ -102,8 +102,8 @@ const variantStyles = {
 
 export const StyledLozenge = styled(Box)<StyledLozengeProps>`
   ${sharedLozengeStyles}
-  padding-inline-end: ${({ theme, hasTooltip }) =>
-    hasTooltip ? theme.spacing.xxSmall : theme.spacing.small};
+  padding-inline-end: ${({ theme, $hasTooltip }) =>
+    $hasTooltip ? theme.spacing.xxSmall : theme.spacing.small};
   ${({ variant = 'new' }) => variantStyles[variant].idle};
 `;
 
@@ -137,7 +137,7 @@ export const StyledLozengeButton = styled.button<StyledLozengeProps>`
 
 StyledLozenge.defaultProps = {
   theme: defaultTheme,
-  hasTooltip: false,
+  $hasTooltip: false,
 };
 
 StyledLozengeButton.defaultProps = {

--- a/packages/big-design/src/components/PillTabs/PillTabs.tsx
+++ b/packages/big-design/src/components/PillTabs/PillTabs.tsx
@@ -200,15 +200,15 @@ export const PillTabs: React.FC<PillTabsProps> = ({
           <Fragment key={id}>
             {showSeparator && (
               <StyledGroupSeparator
+                $isVisible={separatorVisible}
                 aria-orientation="vertical"
-                isVisible={separatorVisible}
                 role="separator"
               />
             )}
-            <StyledFlexItem isVisible={isVisible} ref={setPillRef(index)} role="listitem">
+            <StyledFlexItem $isVisible={isVisible} ref={setPillRef(index)} role="listitem">
               <StyledPillTab
+                $isActive={isActive}
                 disabled={!isVisible}
-                isActive={isActive}
                 marginRight="xSmall"
                 onClick={onClick}
                 type="button"
@@ -220,7 +220,11 @@ export const PillTabs: React.FC<PillTabsProps> = ({
           </Fragment>
         );
       })}
-      <StyledFlexItem isVisible={dropdownItemGroups.length > 0} ref={refs.dropdown} role="listitem">
+      <StyledFlexItem
+        $isVisible={dropdownItemGroups.length > 0}
+        ref={refs.dropdown}
+        role="listitem"
+      >
         <Dropdown
           items={dropdownItemGroups}
           maxWidth={dropdownMaxWidth}

--- a/packages/big-design/src/components/PillTabs/styled.tsx
+++ b/packages/big-design/src/components/PillTabs/styled.tsx
@@ -5,16 +5,16 @@ import { StyleableButton } from '../Button/private';
 import { FlexItem } from '../Flex';
 
 interface StyledPillTabProps {
-  isActive: boolean;
+  $isActive: boolean;
 }
 
 interface StyledFlexItemProps {
-  isVisible: boolean;
+  $isVisible: boolean;
 }
 
 export const StyledPillTab = styled(StyleableButton)<StyledPillTabProps>`
   ${(props) =>
-    props.isActive &&
+    props.$isActive &&
     css`
       background-color: ${({ theme }) => theme.colors.primary20};
     `}
@@ -22,7 +22,7 @@ export const StyledPillTab = styled(StyleableButton)<StyledPillTabProps>`
 
 export const StyledFlexItem = styled(FlexItem)<StyledFlexItemProps>`
   ${(props) =>
-    !props.isVisible &&
+    !props.$isVisible &&
     css`
       position: absolute;
       visibility: hidden;
@@ -39,7 +39,7 @@ export const StyledGroupSeparator = styled.div<StyledFlexItemProps>`
     `${theme.spacing.xxSmall} ${theme.spacing.xSmall} ${theme.spacing.xxSmall} 0`};
 
   ${(props) =>
-    !props.isVisible &&
+    !props.$isVisible &&
     css`
       position: absolute;
       visibility: hidden;

--- a/packages/big-design/src/components/Table/Actions/Actions.tsx
+++ b/packages/big-design/src/components/Table/Actions/Actions.tsx
@@ -57,14 +57,14 @@ const InternalActions = <T extends TableItem>({
 
   return (
     <StyledFlex
-      alignItems="center"
+      $alignItems="center"
+      $flexDirection="row"
+      $justifyContent="stretch"
+      $stickyHeader={stickyHeader}
       aria-controls={tableId}
       aria-label="Table Controls"
-      flexDirection="row"
-      justifyContent="stretch"
       ref={forwardedRef}
       role="toolbar"
-      stickyHeader={stickyHeader}
       {...props}
     >
       <SelectAll

--- a/packages/big-design/src/components/Table/Actions/styled.tsx
+++ b/packages/big-design/src/components/Table/Actions/styled.tsx
@@ -1,18 +1,22 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { FlexProps } from '../../Flex';
+import { TransientFlexedProps } from '../../Flex/types';
 import { withFlexedContainer } from '../../Flex/withFlex';
 
-export const StyledFlex = styled.div<FlexProps & { stickyHeader?: boolean }>`
+interface StyledFlexProps extends TransientFlexedProps {
+  $stickyHeader?: boolean;
+}
+
+export const StyledFlex = styled.div<StyledFlexProps>`
   ${withFlexedContainer()}
 
   background-color: ${({ theme }) => theme.colors.white};
   display: flex;
   padding: ${({ theme }) => `${theme.spacing.small} ${theme.spacing.xLarge}`};
 
-  ${({ theme, stickyHeader }) =>
-    stickyHeader &&
+  ${({ theme, $stickyHeader }) =>
+    $stickyHeader &&
     css`
       ${theme.breakpoints.tablet} {
         position: sticky;

--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -73,14 +73,14 @@ const InternalActions = <T extends TableItem>({
 
   return (
     <StyledFlex
-      alignItems="center"
+      $alignItems="center"
+      $flexDirection="row"
+      $justifyContent="stretch"
+      $stickyHeader={stickyHeader}
       aria-controls={tableId}
       aria-label="Table Controls"
-      flexDirection="row"
-      justifyContent="stretch"
       ref={forwardedRef}
       role="toolbar"
-      stickyHeader={stickyHeader}
       {...props}
     >
       {isSelectable && (

--- a/packages/big-design/src/components/TableNext/Actions/styled.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/styled.tsx
@@ -1,18 +1,22 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { FlexProps } from '../../Flex';
+import { TransientFlexedProps } from '../../Flex/types';
 import { withFlexedContainer } from '../../Flex/withFlex';
 
-export const StyledFlex = styled.div<FlexProps & { stickyHeader?: boolean }>`
+interface StyledFlexProps extends TransientFlexedProps {
+  $stickyHeader?: boolean;
+}
+
+export const StyledFlex = styled.div<StyledFlexProps>`
   ${withFlexedContainer()}
 
   background-color: ${({ theme }) => theme.colors.white};
   display: flex;
   padding: ${({ theme }) => `${theme.spacing.small} ${theme.spacing.xLarge}`};
 
-  ${({ theme, stickyHeader }) =>
-    stickyHeader &&
+  ${({ theme, $stickyHeader }) =>
+    $stickyHeader &&
     css`
       ${theme.breakpoints.tablet} {
         position: sticky;

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -94,10 +94,10 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
       <StyledTextareaWrapper>
         <StyledTextarea
           {...props}
+          $resize={resize}
           error={errors}
           id={id}
           ref={forwardedRef}
-          resize={resize}
           rows={numOfRows}
         />
       </StyledTextareaWrapper>

--- a/packages/big-design/src/components/Textarea/styled.tsx
+++ b/packages/big-design/src/components/Textarea/styled.tsx
@@ -1,17 +1,21 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
+import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { withTransition } from '../../helpers/transitions';
 
-import { TextareaProps } from './Textarea';
+interface StyledTextareaProps {
+  $resize?: boolean;
+  error?: React.ReactNode | React.ReactNode[];
+}
 
-export const StyledTextareaWrapper = styled.span<TextareaProps>`
+export const StyledTextareaWrapper = styled.span`
   align-items: center;
   display: flex;
   position: relative;
 `;
 
-export const StyledTextarea = styled.textarea<TextareaProps>`
+export const StyledTextarea = styled.textarea<StyledTextareaProps>`
   ${withTransition(['border', 'box-shadow'])}
 
   background-color: ${({ theme }) => theme.colors.white};
@@ -23,8 +27,8 @@ export const StyledTextarea = styled.textarea<TextareaProps>`
   padding: ${({ theme }) => `${theme.spacing.xxSmall} ${theme.spacing.small}`};
   width: 100%;
 
-  ${({ resize }) =>
-    resize
+  ${({ $resize }) =>
+    $resize
       ? css`
           resize: vertical;
         `

--- a/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
@@ -88,12 +88,6 @@ exports[`renders simple tree 1`] = `
 .c12 {
   color: #313440;
   margin: 0 0 1rem;
-  display: inline-block;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  word-wrap: normal;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5rem;

--- a/packages/big-design/src/components/Typography/Typography.tsx
+++ b/packages/big-design/src/components/Typography/Typography.tsx
@@ -12,7 +12,27 @@ import {
   StyledSmall,
   StyledText,
 } from './styled';
-import { HeadingProps, HeadingTag, HRProps, TextProps } from './types';
+import {
+  HeadingProps,
+  HeadingTag,
+  HRProps,
+  TextModifiers,
+  TextProps,
+  TypographyProps,
+} from './types';
+
+function toTransientTextProps(props: TypographyProps & TextModifiers) {
+  return {
+    $ellipsis: props.ellipsis,
+    $bold: props.bold,
+    $capitalize: props.capitalize,
+    $italic: props.italic,
+    $lowercase: props.lowercase,
+    $strikethrough: props.strikethrough,
+    $underline: props.underline,
+    $uppercase: props.uppercase,
+  };
+}
 
 const validHeadingTags = new Set<HeadingTag>(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
@@ -38,10 +58,24 @@ export const Text: React.FC<TextProps> = memo((props) => {
     marginLeft,
     marginVertical,
     marginHorizontal,
+    ellipsis,
+    bold,
+    capitalize,
+    italic,
+    lowercase,
+    strikethrough,
+    underline,
+    uppercase,
     ...domProps
   } = props;
 
-  return <StyleableText {...domProps} {...toTransientMarginProps(props)} />;
+  return (
+    <StyleableText
+      {...domProps}
+      {...toTransientMarginProps(props)}
+      {...toTransientTextProps(props)}
+    />
+  );
 });
 
 export const Small: React.FC<TextProps> = memo((props) => {
@@ -55,10 +89,24 @@ export const Small: React.FC<TextProps> = memo((props) => {
     marginLeft,
     marginVertical,
     marginHorizontal,
+    ellipsis,
+    bold,
+    capitalize,
+    italic,
+    lowercase,
+    strikethrough,
+    underline,
+    uppercase,
     ...domProps
   } = props;
 
-  return <StyleableSmall {...domProps} {...toTransientMarginProps(props)} />;
+  return (
+    <StyleableSmall
+      {...domProps}
+      {...toTransientMarginProps(props)}
+      {...toTransientTextProps(props)}
+    />
+  );
 });
 
 export const HR: React.FC<HRProps> = memo((props) => {
@@ -90,11 +138,17 @@ export const H0: React.FC<HeadingProps> = memo((props) => {
     marginLeft,
     marginVertical,
     marginHorizontal,
+    ellipsis,
     ...domProps
   } = props;
 
   return (
-    <StyleableH0 as={getHeadingTag('h1', as)} {...domProps} {...toTransientMarginProps(props)} />
+    <StyleableH0
+      as={getHeadingTag('h1', as)}
+      {...domProps}
+      {...toTransientMarginProps(props)}
+      {...toTransientTextProps(props)}
+    />
   );
 });
 
@@ -110,11 +164,17 @@ export const H1: React.FC<HeadingProps> = memo((props) => {
     marginLeft,
     marginVertical,
     marginHorizontal,
+    ellipsis,
     ...domProps
   } = props;
 
   return (
-    <StyleableH1 as={getHeadingTag('h1', as)} {...domProps} {...toTransientMarginProps(props)} />
+    <StyleableH1
+      as={getHeadingTag('h1', as)}
+      {...domProps}
+      {...toTransientMarginProps(props)}
+      {...toTransientTextProps(props)}
+    />
   );
 });
 
@@ -130,11 +190,17 @@ export const H2: React.FC<HeadingProps> = memo((props) => {
     marginLeft,
     marginVertical,
     marginHorizontal,
+    ellipsis,
     ...domProps
   } = props;
 
   return (
-    <StyleableH2 as={getHeadingTag('h2', as)} {...domProps} {...toTransientMarginProps(props)} />
+    <StyleableH2
+      as={getHeadingTag('h2', as)}
+      {...domProps}
+      {...toTransientMarginProps(props)}
+      {...toTransientTextProps(props)}
+    />
   );
 });
 
@@ -150,11 +216,17 @@ export const H3: React.FC<HeadingProps> = memo((props) => {
     marginLeft,
     marginVertical,
     marginHorizontal,
+    ellipsis,
     ...domProps
   } = props;
 
   return (
-    <StyleableH3 as={getHeadingTag('h3', as)} {...domProps} {...toTransientMarginProps(props)} />
+    <StyleableH3
+      as={getHeadingTag('h3', as)}
+      {...domProps}
+      {...toTransientMarginProps(props)}
+      {...toTransientTextProps(props)}
+    />
   );
 });
 
@@ -170,11 +242,17 @@ export const H4: React.FC<HeadingProps> = memo((props) => {
     marginLeft,
     marginVertical,
     marginHorizontal,
+    ellipsis,
     ...domProps
   } = props;
 
   return (
-    <StyleableH4 as={getHeadingTag('h4', as)} {...domProps} {...toTransientMarginProps(props)} />
+    <StyleableH4
+      as={getHeadingTag('h4', as)}
+      {...domProps}
+      {...toTransientMarginProps(props)}
+      {...toTransientTextProps(props)}
+    />
   );
 });
 

--- a/packages/big-design/src/components/Typography/styled.tsx
+++ b/packages/big-design/src/components/Typography/styled.tsx
@@ -5,58 +5,70 @@ import styled, { css } from 'styled-components';
 import { MarginProps, withMargins } from '../../helpers';
 import { TransientMarginProps } from '../../helpers/margins/margins';
 
-import { HeadingProps, HRProps, TextProps, TypographyProps } from './types';
+import {
+  HeadingProps,
+  HRProps,
+  TextProps,
+  TransientTextModifiers,
+  TransientTypographyProps,
+  TypographyProps,
+} from './types';
 
-type StyledHeadingProps = Omit<HeadingProps, keyof MarginProps> & TransientMarginProps;
-type StyledTextProps = Omit<TextProps, keyof MarginProps> & TransientMarginProps;
+type StyledHeadingProps = Omit<HeadingProps, keyof MarginProps> &
+  TransientMarginProps &
+  TransientTypographyProps;
+type StyledTextProps = Omit<TextProps, keyof MarginProps> &
+  TransientMarginProps &
+  TransientTypographyProps &
+  TransientTextModifiers;
 type StyledHRProps = Omit<HRProps, keyof MarginProps> & TransientMarginProps;
 
-const commonTextStyles = (props: TypographyProps) => css`
+const commonTextStyles = (props: TypographyProps & TransientTypographyProps) => css`
   color: ${({ theme }) => (props.color ? theme.colors[props.color] : theme.colors.secondary70)};
   margin: 0 0 ${({ theme }) => theme.spacing.medium};
 
-  ${props.ellipsis && ellipsis()};
+  ${props.$ellipsis && ellipsis()};
 `;
 
-const textModifiers = (props: TextProps) => css`
+const textModifiers = (props: TextProps & TransientTextModifiers) => css`
   ${({ theme }) =>
-    props.bold &&
+    props.$bold &&
     css`
       font-weight: ${theme.typography.fontWeight.semiBold};
     `}
 
   ${() =>
-    props.italic &&
+    props.$italic &&
     css`
       font-style: italic;
     `}
 
   ${() =>
-    props.underline &&
+    props.$underline &&
     css`
       text-decoration: underline;
     `}
 
   ${() =>
-    props.strikethrough &&
+    props.$strikethrough &&
     css`
       text-decoration: line-through;
     `}
 
   ${() =>
-    props.capitalize &&
+    props.$capitalize &&
     css`
       text-transform: capitalize;
     `}
 
   ${() =>
-    props.lowercase &&
+    props.$lowercase &&
     css`
       text-transform: lowercase;
     `}
 
   ${() =>
-    props.uppercase &&
+    props.$uppercase &&
     css`
       text-transform: uppercase;
     `}

--- a/packages/big-design/src/components/Typography/types.ts
+++ b/packages/big-design/src/components/Typography/types.ts
@@ -9,6 +9,10 @@ export interface TypographyProps {
   theme?: ThemeInterface;
 }
 
+export interface TransientTypographyProps {
+  $ellipsis?: boolean;
+}
+
 export interface TextModifiers {
   bold?: boolean;
   capitalize?: boolean;
@@ -17,6 +21,16 @@ export interface TextModifiers {
   strikethrough?: boolean;
   underline?: boolean;
   uppercase?: boolean;
+}
+
+export interface TransientTextModifiers {
+  $bold?: boolean;
+  $capitalize?: boolean;
+  $italic?: boolean;
+  $lowercase?: boolean;
+  $strikethrough?: boolean;
+  $underline?: boolean;
+  $uppercase?: boolean;
 }
 
 export type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';

--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -294,8 +294,8 @@ const InternalCell = <T extends WorksheetItem>({
   const renderedAutoFillHandler = useMemo(() => {
     return isLastSelected ? (
       <AutoFillHandler
+        $isVisible={!isAutoFillActive}
         aria-label="Autofill handler"
-        isVisible={!isAutoFillActive}
         onDoubleClick={handleAutoFilldblClick}
         onMouseDown={(event) => {
           event.stopPropagation();
@@ -317,14 +317,15 @@ const InternalCell = <T extends WorksheetItem>({
 
   return (
     <StyledCell
-      isChild={isChild}
-      isEdited={isEdited}
-      isFirstSelected={isFirstSelected}
-      isLastChild={isLastChild}
-      isLastSelected={isLastSelected}
-      isNextCellValid={isNextCellValid}
-      isSelected={isSelected}
-      isValid={isValid}
+      $isChild={isChild}
+      $isEdited={isEdited}
+      $isFirstSelected={isFirstSelected}
+      $isLastChild={isLastChild}
+      $isLastSelected={isLastSelected}
+      $isNextCellValid={isNextCellValid}
+      $isSelected={isSelected}
+      $isValid={isValid}
+      $type={type}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onMouseDown={() => {
@@ -337,7 +338,6 @@ const InternalCell = <T extends WorksheetItem>({
         setIsMouseDown(false);
         setSelectingActive(false);
       }}
-      type={type}
     >
       {renderedCell}
       {renderedAutoFillHandler}

--- a/packages/big-design/src/components/Worksheet/Cell/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/styled.tsx
@@ -4,15 +4,15 @@ import styled, { css } from 'styled-components';
 import { Cell, WorksheetItem } from '../types';
 
 interface StyledCellProps<Item> {
-  isFirstSelected: boolean;
-  isLastSelected: boolean;
-  isLastChild: boolean;
-  isChild: boolean;
-  isEdited?: boolean;
-  isSelected?: boolean;
-  isValid?: boolean;
-  isNextCellValid: boolean;
-  type: Cell<Item>['type'];
+  $isFirstSelected: boolean;
+  $isLastSelected: boolean;
+  $isLastChild: boolean;
+  $isChild: boolean;
+  $isEdited?: boolean;
+  $isSelected?: boolean;
+  $isValid?: boolean;
+  $isNextCellValid: boolean;
+  $type: Cell<Item>['type'];
 }
 
 export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
@@ -20,12 +20,12 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
   background-color: ${({ theme }) => theme.colors.inherit};
   border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} solid ${theme.colors.secondary30}`};
   box-sizing: border-box;
-  padding: ${({ theme, type }) =>
-    type === 'select' || type === 'toggle'
+  padding: ${({ theme, $type }) =>
+    $type === 'select' || $type === 'toggle'
       ? 0
       : `${theme.helpers.remCalc(6)} ${theme.helpers.remCalc(17)}`};
-  text-align: ${({ type }) => {
-    switch (type) {
+  text-align: ${({ $type }) => {
+    switch ($type) {
       case 'number':
         return 'right';
 
@@ -38,58 +38,60 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
   }};
   user-select: none;
 
-  ${({ type }) =>
-    type === 'toggle' &&
+  ${({ $type }) =>
+    $type === 'toggle' &&
     css`
       position: relative;
       border-color: ${({ theme }) =>
         `${theme.colors.white} ${theme.colors.white} ${theme.colors.white} ${theme.colors.secondary30}`};
     `}
 
-  ${({ type, isChild }) =>
-    type === 'toggle' &&
-    !isChild &&
+  ${({ $type, $isChild }) =>
+    $type === 'toggle' &&
+    !$isChild &&
     css`
       border-color: ${({ theme }) =>
         `${theme.colors.secondary30} ${theme.colors.white} ${theme.colors.secondary30} ${theme.colors.secondary30}`};
     `}
 
 
-    ${({ type, isLastChild }) =>
-    type === 'toggle' &&
-    isLastChild &&
+    ${({ $type, $isLastChild }) =>
+    $type === 'toggle' &&
+    $isLastChild &&
     css`
       border-bottom-color: ${({ theme }) => theme.colors.secondary30};
     `}
 
-  ${({ type, isSelected, isFirstSelected, isLastSelected, isNextCellValid }) =>
-    isSelected &&
-    type !== 'toggle' &&
+  ${({ $type, $isSelected, $isFirstSelected, $isLastSelected, $isNextCellValid }) =>
+    $isSelected &&
+    $type !== 'toggle' &&
     css`
       border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} double ${theme.colors.primary}`};
 
       border-top-color: ${({ theme }) =>
-        isFirstSelected ? theme.colors.primary : theme.colors.secondary30};
+        $isFirstSelected ? theme.colors.primary : theme.colors.secondary30};
       border-bottom-color: ${({ theme }) => {
-        if (!isNextCellValid && !isLastSelected) {
+        if (!$isNextCellValid && !$isLastSelected) {
           return theme.colors.danger;
         }
 
-        return isFirstSelected || isLastSelected ? theme.colors.primary : theme.colors.secondary30;
+        return $isFirstSelected || $isLastSelected
+          ? theme.colors.primary
+          : theme.colors.secondary30;
       }};
       ${AutoFillHandler} {
         display: block;
       }
     `}
 
-  ${({ isValid }) =>
-    !isValid &&
+  ${({ $isValid }) =>
+    !$isValid &&
     css`
       border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} double ${theme.colors.danger}`};
     `}
 
-  ${({ isEdited }) =>
-    isEdited &&
+  ${({ $isEdited }) =>
+    $isEdited &&
     css`
       background-color: ${({ theme }) => theme.colors.warning10};
     `}
@@ -101,15 +103,15 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
     margin: 0;
   }
 
-  ${({ type, isChild, isLastChild }) =>
-    type === 'toggle' &&
-    isChild &&
+  ${({ $type, $isChild, $isLastChild }) =>
+    $type === 'toggle' &&
+    $isChild &&
     css`
       &::before {
         content: '';
         display: block;
         top: 0;
-        height: ${isLastChild ? '50%' : '100%'};
+        height: ${$isLastChild ? '50%' : '100%'};
         left: 50%;
         width: ${({ theme }) => theme.helpers.remCalc(1)};
         position: absolute;
@@ -128,16 +130,16 @@ export const StyledCell = styled.td<StyledCellProps<WorksheetItem>>`
     `}
 `;
 
-export const AutoFillHandler = styled.div<{ isVisible: boolean }>`
+export const AutoFillHandler = styled.div<{ $isVisible: boolean }>`
   position: absolute;
-  border: ${({ theme, isVisible }) =>
+  border: ${({ theme, $isVisible }) =>
     `${theme.helpers.remCalc(1)} solid ${
-      isVisible ? theme.colors.white : theme.colors.transparent
+      $isVisible ? theme.colors.white : theme.colors.transparent
     }`};
   height: ${({ theme }) => theme.helpers.remCalc(6)};
   width: ${({ theme }) => theme.helpers.remCalc(6)};
-  background-color: ${({ theme, isVisible }) =>
-    isVisible ? theme.colors.primary : theme.colors.transparent};
+  background-color: ${({ theme, $isVisible }) =>
+    $isVisible ? theme.colors.primary : theme.colors.transparent};
   right: -${({ theme }) => theme.helpers.remCalc(4)};
   bottom: -${({ theme }) => theme.helpers.remCalc(4)};
   z-index: 100;

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -76,9 +76,9 @@ const InternalTable = ({
 
   return (
     <Table
-      hasExpandableRows={hasExpandableRows}
-      hasStaticWidth={hasStaticWidth}
-      minWidth={minWidth}
+      $hasExpandableRows={hasExpandableRows}
+      $hasStaticWidth={hasStaticWidth}
+      $minWidth={minWidth}
       onKeyDown={onKeyDown}
       onKeyUp={onKeyUp}
       ref={tableRef}
@@ -285,7 +285,7 @@ const InternalWorksheet = typedMemo(
           <tr>
             <Status />
             {expandedColumns.map((column, index) => (
-              <Header columnType={column.type} columnWidth={column.width || 'auto'} key={index}>
+              <Header $columnType={column.type} $columnWidth={column.width || 'auto'} key={index}>
                 {column.header} {getRenderedTooltip(column.tooltip)}
               </Header>
             ))}
@@ -350,7 +350,7 @@ const InternalWorksheet = typedMemo(
 
     return (
       <UpdateItemsProvider items={rows}>
-        <StyledBox containerHeight={isVirtualized ? height : undefined} ref={scrollContainerRef}>
+        <StyledBox $containerHeight={isVirtualized ? height : undefined} ref={scrollContainerRef}>
           <InternalTable
             hasExpandableRows={Boolean(expandableRows)}
             hasStaticWidth={tableHasStaticWidth}

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -656,7 +656,6 @@ exports[`renders worksheet 1`] = `
         />
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -672,7 +671,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c11"
-          type="checkbox"
         >
           <div
             class="c12"
@@ -734,7 +732,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -750,7 +747,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="modal"
         >
           <div
             class="c21 c22"
@@ -783,7 +779,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c29"
-          type="number"
         >
           <p
             class="c9"
@@ -804,7 +799,6 @@ exports[`renders worksheet 1`] = `
         />
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -820,7 +814,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c11"
-          type="checkbox"
         >
           <div
             class="c12"
@@ -882,7 +875,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -898,7 +890,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="modal"
         >
           <div
             class="c21 c22"
@@ -931,7 +922,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c29"
-          type="number"
         >
           <p
             class="c9"
@@ -952,7 +942,6 @@ exports[`renders worksheet 1`] = `
         />
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -968,7 +957,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c11"
-          type="checkbox"
         >
           <div
             class="c12"
@@ -1029,7 +1017,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1043,7 +1030,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="modal"
         >
           <div
             class="c21 c22"
@@ -1076,7 +1062,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c29"
-          type="number"
         >
           <p
             class="c9"
@@ -1097,7 +1082,6 @@ exports[`renders worksheet 1`] = `
         />
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1113,7 +1097,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c11"
-          type="checkbox"
         >
           <div
             class="c12"
@@ -1175,7 +1158,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1191,7 +1173,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="modal"
         >
           <div
             class="c21 c22"
@@ -1224,7 +1205,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c29"
-          type="number"
         >
           <p
             class="c9"
@@ -1245,7 +1225,6 @@ exports[`renders worksheet 1`] = `
         />
         <td
           class="c32"
-          type="text"
         >
           <p
             class="c9"
@@ -1259,7 +1238,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c11"
-          type="checkbox"
         >
           <div
             class="c12"
@@ -1319,7 +1297,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1333,7 +1310,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="modal"
         >
           <div
             class="c21 c22"
@@ -1364,7 +1340,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c33"
-          type="number"
         >
           <p
             class="c9"
@@ -1383,7 +1358,6 @@ exports[`renders worksheet 1`] = `
         />
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1399,7 +1373,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c11"
-          type="checkbox"
         >
           <div
             class="c12"
@@ -1461,7 +1434,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1477,7 +1449,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="modal"
         >
           <div
             class="c21 c22"
@@ -1510,7 +1481,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c29"
-          type="number"
         >
           <p
             class="c9"
@@ -1531,7 +1501,6 @@ exports[`renders worksheet 1`] = `
         />
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1547,7 +1516,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c11"
-          type="checkbox"
         >
           <div
             class="c12"
@@ -1608,7 +1576,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1624,7 +1591,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="modal"
         >
           <div
             class="c21 c22"
@@ -1657,7 +1623,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c33"
-          type="number"
         >
           <p
             class="c9"
@@ -1678,7 +1643,6 @@ exports[`renders worksheet 1`] = `
         />
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1694,7 +1658,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c11"
-          type="checkbox"
         >
           <div
             class="c12"
@@ -1756,7 +1719,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1772,7 +1734,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="modal"
         >
           <div
             class="c21 c22"
@@ -1805,7 +1766,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c29"
-          type="number"
         >
           <p
             class="c9"
@@ -1826,7 +1786,6 @@ exports[`renders worksheet 1`] = `
         />
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1842,7 +1801,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c11"
-          type="checkbox"
         >
           <div
             class="c12"
@@ -1904,7 +1862,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="text"
         >
           <p
             class="c9"
@@ -1920,7 +1877,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c8"
-          type="modal"
         >
           <div
             class="c21 c22"
@@ -1953,7 +1909,6 @@ exports[`renders worksheet 1`] = `
         </td>
         <td
           class="c29"
-          type="number"
         >
           <p
             class="c9"

--- a/packages/big-design/src/components/Worksheet/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/styled.tsx
@@ -4,16 +4,16 @@ import styled, { css } from 'styled-components';
 import { InternalWorksheetColumn } from './types';
 
 export const Table = styled.table<{
-  minWidth?: number;
-  hasStaticWidth: boolean;
-  hasExpandableRows: boolean;
+  $minWidth?: number;
+  $hasStaticWidth: boolean;
+  $hasExpandableRows: boolean;
 }>`
   border-collapse: collapse;
   border-spacing: 0;
-  min-width: ${({ minWidth, hasStaticWidth }) =>
-    minWidth && !hasStaticWidth ? `${minWidth}px` : 'auto'};
+  min-width: ${({ $minWidth, $hasStaticWidth }) =>
+    $minWidth && !$hasStaticWidth ? `${$minWidth}px` : 'auto'};
   table-layout: fixed;
-  width: ${({ hasStaticWidth }) => (hasStaticWidth ? 'auto' : '100%')};
+  width: ${({ $hasStaticWidth }) => ($hasStaticWidth ? 'auto' : '100%')};
 
   &:focus {
     outline: none;
@@ -26,8 +26,8 @@ export const Table = styled.table<{
     background-color: ${({ theme }) => theme.colors.white};
   }
 
-  ${({ hasExpandableRows }) =>
-    hasExpandableRows &&
+  ${({ $hasExpandableRows }) =>
+    $hasExpandableRows &&
     css`
       & > thead > tr {
         & > th:nth-of-type(2) {
@@ -46,40 +46,40 @@ export const Table = styled.table<{
 Table.defaultProps = { theme: defaultTheme };
 
 export const Header = styled.th<{
-  columnType: InternalWorksheetColumn<unknown>['type'];
-  columnWidth: InternalWorksheetColumn<unknown>['width'];
+  $columnType: InternalWorksheetColumn<unknown>['type'];
+  $columnWidth: InternalWorksheetColumn<unknown>['width'];
 }>`
   border: ${({ theme }) => `${theme.helpers.remCalc(0.5)} solid ${theme.colors.secondary30}`};
-  border-right-color: ${({ theme, columnType }) =>
-    columnType === 'toggle' ? theme.colors.white : theme.colors.secondary30};
+  border-right-color: ${({ theme, $columnType }) =>
+    $columnType === 'toggle' ? theme.colors.white : theme.colors.secondary30};
   box-sizing: border-box;
   color: ${({ theme }) => theme.colors.secondary60};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
   height: ${({ theme }) => theme.helpers.remCalc(52)};
   overflow: hidden;
   padding: ${({ theme }) => `0 ${theme.helpers.remCalc(17)}`};
-  text-align: ${({ columnType }) => {
-    if (columnType === 'number') {
+  text-align: ${({ $columnType }) => {
+    if ($columnType === 'number') {
       return 'right';
     }
 
-    if (columnType === 'checkbox') {
+    if ($columnType === 'checkbox') {
       return 'center';
     }
 
     return 'left';
   }};
-  width: ${({ columnWidth }) =>
-    typeof columnWidth === 'string' ? columnWidth : `${columnWidth}px`};
+  width: ${({ $columnWidth }) =>
+    typeof $columnWidth === 'string' ? $columnWidth : `${$columnWidth}px`};
 `;
 
-export const StyledBox = styled.div<{ containerHeight?: number | string }>`
+export const StyledBox = styled.div<{ $containerHeight?: number | string }>`
   overflow-x: auto;
   overflow-y: auto;
-  ${({ containerHeight }) =>
-    containerHeight &&
+  ${({ $containerHeight }) =>
+    $containerHeight &&
     css`
-      height: ${typeof containerHeight === 'number' ? `${containerHeight}px` : containerHeight};
+      height: ${typeof $containerHeight === 'number' ? `${$containerHeight}px` : $containerHeight};
     `}
 `;
 


### PR DESCRIPTION
## What?

Finishes the transient-props migration started in [LTRAC-1396](https://linear.app/commerce/issue/LTRAC-1396/migrate-bigdesign-styled-components-props-to-transient-dollar-prefixed). SC5's automatic `is-prop-valid` prop filtering hid a large set of misses — they only surface under SC6's stricter tag-target handling, where custom props must be `$`-prefixed to avoid leaking as DOM attributes. This was found while running the test suite on the [LTRAC-1367](https://linear.app/commerce/issue/LTRAC-1367/flip-to-styled-components-6-dev-deps-peers) (SC6 flip) branch, where `jest-fail-on-console` acted as the leak detector and produced 149 test failures / 49 failed suites.

Components fixed:

* **Flex** — `withFlexedContainer()` now reads `$`-prefixed fields; `StyledFlex.defaultProps` updated; `Flex.tsx` uses `toTransientFlexedContainerProps()`. Fixes the highest-volume leak (\~70 DOM attribute hits per render, including from `defaultProps`).
* **Grid** — same pattern for container and item helpers; `Grid.tsx` and `Grid/Item/Item.tsx` use dedicated `toTransient*` helpers.
* **Table/Actions and TableNext/Actions** — `$alignItems`, `$flexDirection`, `$justifyContent`, `$stickyHeader` on each actions bar's `StyledFlex`.
* **Typography** — `commonTextStyles` and `textModifiers` helpers read `$`-prefixed modifier fields; `Text`, `Small`, and `H0`–`H4` map public modifiers via a local `toTransientTextProps()`.
* **AccordionPanel** — `$isExpanded`, `$iconLeft`.
* **ButtonGroup** — `$borderRadius`, `$isVisible`.
* **Collapse/CollapseTrigger** — `$isOpen`.
* **Lozenge** — `$hasTooltip`.
* **PillTabs** — `$isActive`, `$isVisible`.
* **Textarea** — `$resize`.
* **Worksheet** — table-level `$minWidth`/`$hasStaticWidth`/`$hasExpandableRows`, header `$columnType`/`$columnWidth`, scroll box `$containerHeight`, full `StyledCell` props, and `AutoFillHandler` `$isVisible`.

Public prop interfaces and CSS output are unchanged throughout.

Refs [LTRAC-1396](https://linear.app/commerce/issue/LTRAC-1396/migrate-bigdesign-styled-components-props-to-transient-dollar-prefixed)

## Why?

Unblocks [LTRAC-1367](https://linear.app/commerce/issue/LTRAC-1367/flip-to-styled-components-6-dev-deps-peers) (SC6 flip). Its snapshots can't be regenerated until these leaks are eliminated — otherwise leaked attributes like `aligncontent="stretch"` and `flexdirection="[object Object]"` get baked into the committed snapshots.

## Screenshots/Screen Recordings

N/A — internal prop plumbing change, no visual output change.

## Testing/Proof

* `pnpm run typecheck` — passes clean
* `pnpm run lint` — passes clean (zero warnings)
* `pnpm -F @bigcommerce/big-design run test` — 1152 tests pass, 182 snapshots pass with zero diffs on v5