### PR TITLE
build: TRAC-1305 flip to styled-components 6 (dev deps + peers)

### DIFF
--- a/.changeset/styled-components-6-peer.md
+++ b/.changeset/styled-components-6-peer.md
@@ -1,0 +1,8 @@
+---
+'@bigcommerce/big-design': major
+'@bigcommerce/big-design-icons': major
+'@bigcommerce/big-design-patterns': major
+'@bigcommerce/big-design-theme': major
+---
+
+Require styled-components 6: the `styled-components` peer dependency range moves from `^5.3.5` to `^6.1.14` across all four packages. Consumers must upgrade to styled-components 6 to use this release (v6 supports both React 18 and, ahead of our upcoming React 19 flip, React 19 — while v5 does not support React 19). Along with the peer bump, the packages now build and test against styled-components `^6.4.0`, `@types/styled-components` is dropped (v6 ships its own types), and `jest-styled-components` moves to `^7.4.0` for v6 support (7.4.0 also fixes `toHaveStyleRule`'s `media` option against stylis v4's spaced media-query output). `createTheme()` now returns `keyframes` as a plain object copy rather than a frozen module-namespace object, since styled-components 6 deep-merges themes when folding `defaultProps` and a getter-only namespace object makes that merge throw; the shape and values of `theme.keyframes` are unchanged.

--- a/packages/big-design-icons/package.json
+++ b/packages/big-design-icons/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "styled-components": "^5.3.5"
+    "styled-components": "^6.1.14"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.3",
@@ -56,7 +56,6 @@
     "@svgr/plugin-svgo": "^8.1.0",
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.23",
-    "@types/styled-components": "^5.1.34",
     "babel-plugin-styled-components": "^2.0.7",
     "camelcase": "^6.3.0",
     "eslint": "^8.33.0",
@@ -70,7 +69,7 @@
     "react-dom": "^18.2.0",
     "react-is": "^19.2.0",
     "rimraf": "^6.1.0",
-    "styled-components": "^5.3.11",
+    "styled-components": "^6.4.0",
     "tiny-async-pool": "^2.0.1",
     "typescript": "^5.9.3"
   }

--- a/packages/big-design-patterns/package.json
+++ b/packages/big-design-patterns/package.json
@@ -41,7 +41,7 @@
     "@bigcommerce/big-design-theme": "workspace:^",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "styled-components": "^5.3.5"
+    "styled-components": "^6.1.14"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.3",
@@ -67,18 +67,17 @@
     "@types/node": "^24.10.4",
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.23",
-    "@types/styled-components": "^5.1.34",
     "babel-jest": "^30.2.0",
     "babel-plugin-styled-components": "^2.0.7",
     "eslint": "^8.33.0",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "jest-fail-on-console": "^3.3.1",
-    "jest-styled-components": "^7.1.1",
+    "jest-styled-components": "^7.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^6.1.0",
-    "styled-components": "^5.3.11",
+    "styled-components": "^6.4.0",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/big-design-theme/package.json
+++ b/packages/big-design-theme/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "styled-components": "^5.3.5"
+    "styled-components": "^6.1.14"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.3",
@@ -55,17 +55,16 @@
     "@swc/jest": "^0.2.39",
     "@swc/plugin-styled-components": "^12.0.1",
     "@types/jest": "^30.0.0",
-    "@types/styled-components": "^5.1.34",
     "babel-jest": "^30.2.0",
     "babel-plugin-styled-components": "^2.0.7",
     "eslint": "^8.33.0",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "jest-fail-on-console": "^3.3.1",
-    "jest-styled-components": "^7.1.1",
+    "jest-styled-components": "^7.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "styled-components": "^5.3.11",
+    "styled-components": "^6.4.0",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/big-design-theme/src/index.ts
+++ b/packages/big-design-theme/src/index.ts
@@ -38,7 +38,9 @@ export const createTheme = (customOptions: Partial<ThemeOptions> = {}): ThemeInt
     breakpoints,
     colors,
     helpers: createHelpers(),
-    keyframes,
+    // Spread into a plain object: styled-components 6 deep-merges themes when folding
+    // defaultProps (mixinDeep), which throws on a getter-only module namespace object.
+    keyframes: { ...keyframes },
     lineHeight: createLineHeight(),
     shadow,
     spacing: createSpacing(),

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "styled-components": "^5.3.5"
+    "styled-components": "^6.1.14"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.3",
@@ -76,17 +76,16 @@
     "@types/node": "^24.10.4",
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.23",
-    "@types/styled-components": "^5.1.34",
     "babel-jest": "^30.2.0",
     "babel-plugin-styled-components": "^2.0.7",
     "eslint": "^8.33.0",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "jest-fail-on-console": "^3.3.1",
-    "jest-styled-components": "^7.1.1",
+    "jest-styled-components": "^7.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "styled-components": "^5.3.11",
+    "styled-components": "^6.4.0",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/big-design/src/components/AccordionPanel/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/AccordionPanel/__snapshots__/spec.tsx.snap
@@ -11,47 +11,12 @@ exports[`it renders accordion panel header 1`] = `
 }
 
 .c1 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c1 ~ .bd-button {
+.c1~.bd-button {
   width: auto;
   margin-top: 0;
-}
-
-@media (min-width:0px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:0px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
 }
 
 <h2

--- a/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
@@ -42,8 +42,7 @@ exports[`render default (success) Alert 1`] = `
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: jBcSpD .5s ease-in-out;
-  animation: jBcSpD .5s ease-in-out;
+  animation: k0 .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -60,6 +59,16 @@ exports[`render default (success) Alert 1`] = `
 .c7 {
   color: #313440;
   vertical-align: middle;
+}
+
+@keyframes k0 {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 <div
@@ -148,8 +157,7 @@ exports[`render error Alert 1`] = `
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: jBcSpD .5s ease-in-out;
-  animation: jBcSpD .5s ease-in-out;
+  animation: k0 .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -166,6 +174,16 @@ exports[`render error Alert 1`] = `
 .c7 {
   color: #313440;
   vertical-align: middle;
+}
+
+@keyframes k0 {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 <div
@@ -250,8 +268,7 @@ exports[`render info Alert 1`] = `
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: jBcSpD .5s ease-in-out;
-  animation: jBcSpD .5s ease-in-out;
+  animation: k0 .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -268,6 +285,16 @@ exports[`render info Alert 1`] = `
 .c7 {
   color: #313440;
   vertical-align: middle;
+}
+
+@keyframes k0 {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 <div
@@ -356,8 +383,7 @@ exports[`render warning Alert 1`] = `
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: jBcSpD .5s ease-in-out;
-  animation: jBcSpD .5s ease-in-out;
+  animation: k0 .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -374,6 +400,16 @@ exports[`render warning Alert 1`] = `
 .c7 {
   color: #313440;
   vertical-align: middle;
+}
+
+@keyframes k0 {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 <div
@@ -435,45 +471,26 @@ exports[`renders close button 1`] = `
 }
 
 .c8 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -492,7 +509,7 @@ exports[`renders close button 1`] = `
   pointer-events: none;
 }
 
-.c8 + .bd-button {
+.c8+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -513,12 +530,7 @@ exports[`renders close button 1`] = `
 }
 
 .c10 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -580,8 +592,7 @@ exports[`renders close button 1`] = `
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: jBcSpD .5s ease-in-out;
-  animation: jBcSpD .5s ease-in-out;
+  animation: k0 .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -600,18 +611,28 @@ exports[`renders close button 1`] = `
   vertical-align: middle;
 }
 
-@media (min-width:720px) {
-  .c8 + .bd-button {
+@media (min-width: 720px) {
+  .c8+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c8 {
     width: auto;
     padding: 0;
     min-width: 2.25rem;
+  }
+}
+
+@keyframes k0 {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
   }
 }
 
@@ -740,8 +761,7 @@ exports[`renders header 1`] = `
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: jBcSpD .5s ease-in-out;
-  animation: jBcSpD .5s ease-in-out;
+  animation: k0 .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -763,6 +783,16 @@ exports[`renders header 1`] = `
 .c9 {
   color: #313440;
   vertical-align: middle;
+}
+
+@keyframes k0 {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 <div
@@ -848,23 +878,14 @@ exports[`renders with external link 1`] = `
 }
 
 .c8 {
-  -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
 }
 
@@ -877,8 +898,6 @@ exports[`renders with external link 1`] = `
 }
 
 .c8 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   margin-left: 0.25rem;
 }
@@ -900,8 +919,7 @@ exports[`renders with external link 1`] = `
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: jBcSpD .5s ease-in-out;
-  animation: jBcSpD .5s ease-in-out;
+  animation: k0 .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -923,6 +941,16 @@ exports[`renders with external link 1`] = `
 .c9 {
   font-size: 0.875rem;
   vertical-align: middle;
+}
+
+@keyframes k0 {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 <div
@@ -1022,15 +1050,12 @@ exports[`renders with link 1`] = `
 }
 
 .c8 {
-  -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -1059,8 +1084,7 @@ exports[`renders with link 1`] = `
 .c2 {
   border-radius: 0.25rem;
   box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
-  -webkit-animation: jBcSpD .5s ease-in-out;
-  animation: jBcSpD .5s ease-in-out;
+  animation: k0 .5s ease-in-out;
   background-color: #FFFFFF;
   grid-gap: 0.75rem;
   max-width: 28.5rem;
@@ -1082,6 +1106,16 @@ exports[`renders with link 1`] = `
 .c9 {
   font-size: 0.875rem;
   vertical-align: middle;
+}
+
+@keyframes k0 {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 <div

--- a/packages/big-design/src/components/AnchorNav/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/AnchorNav/__snapshots__/spec.tsx.snap
@@ -6,92 +6,62 @@ exports[`AnchorNav Component matches the snapshot 1`] = `
 }
 
 .c2 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
   gap: xLarge;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c3 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c1 {
-  position: -webkit-sticky;
   position: sticky;
-  -webkit-inset-block-start: 0;
-  -ms-intb-rlock-start: 0;
   inset-block-start: 0;
   width: 16.625rem;
   float: inline-start;
   display: none;
 }
 
-.c1 > ul {
+.c1>ul {
   list-style-type: none;
   padding: 0;
   margin: 0;
 }
 
-.c1 > ul > li {
+.c1>ul>li {
   display: block;
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
-.c1 > ul > li > a {
+.c1>ul>li>a {
   color: #3C64F4;
-  -webkit-text-decoration: none;
   text-decoration: none;
   display: block;
   padding: 0.75rem 1.25rem;
   border-inline-start: 0.25rem solid transparent;
 }
 
-.c1 > ul > li > a:hover {
+.c1>ul>li>a:hover {
   background-color: #F0F3FF;
 }
 
-.c1 > ul > li > a.active {
+.c1>ul>li>a.active {
   color: #313440;
   border-inline-start: 0.25rem solid #3C64F4;
 }
 
-.c1 > ul > li > a.active:hover {
+.c1>ul>li>a.active:hover {
   background-color: transparent;
 }
 

--- a/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Button/__snapshots__/spec.tsx.snap
@@ -15,16 +15,10 @@ exports[`isLoading render loading button 1`] = `
 .c6 {
   stroke-dasharray: 43.982297150257104 43.982297150257104;
   stroke: #3C64F4;
-  -webkit-transform-origin: 50% 50%;
-  -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: fxwtRW 1s ease-out infinite;
-  animation: fxwtRW 1s ease-out infinite;
+  animation: k0 1s ease-out infinite;
   stroke-dashoffset: 43.982297150257104;
-  -webkit-transform: rotate(-90deg);
-  -ms-transform: rotate(-90deg);
   transform: rotate(-90deg);
-  -webkit-transition: stroke-dashoffset 0.35s;
   transition: stroke-dashoffset 0.35s;
 }
 
@@ -33,66 +27,34 @@ exports[`isLoading render loading button 1`] = `
 }
 
 .c2 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -111,7 +73,7 @@ exports[`isLoading render loading button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -132,12 +94,7 @@ exports[`isLoading render loading button 1`] = `
 }
 
 .c7 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -149,32 +106,44 @@ exports[`isLoading render loading button 1`] = `
   position: absolute;
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c2 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
     flex-direction: column;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c2 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
     flex-direction: row;
   }
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
+  }
+}
+
+@keyframes k0 {
+  0% {
+    stroke-dashoffset: -43.982297150257104;
+    transform: rotate(-90deg);
+  }
+
+  50% {
+    stroke-dashoffset: -27.48893571891069;
+  }
+
+  100% {
+    stroke-dashoffset: -43.982297150257104;
+    transform: rotate(270deg);
   }
 }
 
@@ -213,45 +182,26 @@ exports[`isLoading render loading button 1`] = `
 
 exports[`render default button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -270,7 +220,7 @@ exports[`render default button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -291,26 +241,21 @@ exports[`render default button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -329,45 +274,26 @@ exports[`render default button 1`] = `
 
 exports[`render destructive button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -386,7 +312,7 @@ exports[`render destructive button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -407,26 +333,21 @@ exports[`render destructive button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -445,45 +366,26 @@ exports[`render destructive button 1`] = `
 
 exports[`render destructive disabled button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -502,7 +404,7 @@ exports[`render destructive disabled button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -523,26 +425,21 @@ exports[`render destructive disabled button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -562,45 +459,26 @@ exports[`render destructive disabled button 1`] = `
 
 exports[`render disabled button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -619,7 +497,7 @@ exports[`render disabled button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -640,26 +518,21 @@ exports[`render disabled button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -685,45 +558,26 @@ exports[`render icon left and right button 1`] = `
 }
 
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -744,7 +598,7 @@ exports[`render icon left and right button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -765,26 +619,21 @@ exports[`render icon left and right button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -845,45 +694,26 @@ exports[`render icon left button 1`] = `
 }
 
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -903,7 +733,7 @@ exports[`render icon left button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -924,26 +754,21 @@ exports[`render icon left button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -986,45 +811,26 @@ exports[`render icon only button 1`] = `
 }
 
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1043,7 +849,7 @@ exports[`render icon only button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1064,26 +870,21 @@ exports[`render icon only button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
     padding: 0;
@@ -1127,45 +928,26 @@ exports[`render icon right button 1`] = `
 }
 
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1185,7 +967,7 @@ exports[`render icon right button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1206,26 +988,21 @@ exports[`render icon right button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -1262,45 +1039,26 @@ exports[`render icon right button 1`] = `
 
 exports[`render secondary button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1319,7 +1077,7 @@ exports[`render secondary button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1340,26 +1098,21 @@ exports[`render secondary button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -1378,45 +1131,26 @@ exports[`render secondary button 1`] = `
 
 exports[`render secondary destructive button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1435,7 +1169,7 @@ exports[`render secondary destructive button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1456,26 +1190,21 @@ exports[`render secondary destructive button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -1494,45 +1223,26 @@ exports[`render secondary destructive button 1`] = `
 
 exports[`render secondary destructive disabled button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1551,7 +1261,7 @@ exports[`render secondary destructive disabled button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1572,26 +1282,21 @@ exports[`render secondary destructive disabled button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -1611,45 +1316,26 @@ exports[`render secondary destructive disabled button 1`] = `
 
 exports[`render secondary disabled button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1668,7 +1354,7 @@ exports[`render secondary disabled button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1689,26 +1375,21 @@ exports[`render secondary disabled button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -1728,45 +1409,26 @@ exports[`render secondary disabled button 1`] = `
 
 exports[`render subtle button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1785,7 +1447,7 @@ exports[`render subtle button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1807,26 +1469,21 @@ exports[`render subtle button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -1845,45 +1502,26 @@ exports[`render subtle button 1`] = `
 
 exports[`render subtle destructive button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1902,7 +1540,7 @@ exports[`render subtle destructive button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1924,26 +1562,21 @@ exports[`render subtle destructive button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -1962,45 +1595,26 @@ exports[`render subtle destructive button 1`] = `
 
 exports[`render subtle destructive disabled button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -2019,7 +1633,7 @@ exports[`render subtle destructive disabled button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -2041,26 +1655,21 @@ exports[`render subtle destructive disabled button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -2080,45 +1689,26 @@ exports[`render subtle destructive disabled button 1`] = `
 
 exports[`render subtle disabled button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -2137,7 +1727,7 @@ exports[`render subtle disabled button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -2159,26 +1749,21 @@ exports[`render subtle disabled button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -2198,45 +1783,26 @@ exports[`render subtle disabled button 1`] = `
 
 exports[`render utility button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -2255,7 +1821,7 @@ exports[`render utility button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -2280,26 +1846,21 @@ exports[`render utility button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -2318,45 +1879,26 @@ exports[`render utility button 1`] = `
 
 exports[`render utility destructive button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -2375,7 +1917,7 @@ exports[`render utility destructive button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -2400,26 +1942,21 @@ exports[`render utility destructive button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -2438,45 +1975,26 @@ exports[`render utility destructive button 1`] = `
 
 exports[`render utility destructive disabled button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -2495,7 +2013,7 @@ exports[`render utility destructive disabled button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -2520,26 +2038,21 @@ exports[`render utility destructive disabled button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
@@ -2559,45 +2072,26 @@ exports[`render utility destructive disabled button 1`] = `
 
 exports[`render utility disabled button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -2616,7 +2110,7 @@ exports[`render utility disabled button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -2641,26 +2135,21 @@ exports[`render utility disabled button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }

--- a/packages/big-design/src/components/Button/styled.tsx
+++ b/packages/big-design/src/components/Button/styled.tsx
@@ -92,9 +92,7 @@ export const StyledButton = styled.button<StyledButtonProps>`
   ${(props) => getButtonStyles(props)}
 `;
 
-export const ContentWrapper = styled.span.attrs<Record<string, unknown>, { $isLoading?: boolean }>(
-  {},
-)`
+export const ContentWrapper = styled.span<{ $isLoading?: boolean }>`
   align-content: center;
   align-items: center;
   display: inline-grid;
@@ -116,7 +114,7 @@ export const LoadingSpinnerWrapper = styled(Flex)`
  * These can be generated dynamically but I'm leaning towards being extra
  * explicit and being able to handle corner cases and changes from design easily
  */
-const ButtonPrimary = css<ButtonProps>`
+const ButtonPrimary = css`
   background-color: ${({ theme }) => theme.colors.primary};
   border-color: ${({ theme }) => theme.colors.primary};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
@@ -138,7 +136,7 @@ const ButtonPrimary = css<ButtonProps>`
   }
 `;
 
-const ButtonPrimaryDestructive = css<ButtonProps>`
+const ButtonPrimaryDestructive = css`
   background-color: ${({ theme }) => theme.colors.danger};
   border-color: ${({ theme }) => theme.colors.danger};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};
@@ -160,7 +158,7 @@ const ButtonPrimaryDestructive = css<ButtonProps>`
   }
 `;
 
-const ButtonSecondary = css<ButtonProps>`
+const ButtonSecondary = css`
   background-color: transparent;
   border-color: ${({ theme }) => theme.colors.primary};
   color: ${({ theme }) => theme.colors.primary};
@@ -182,7 +180,7 @@ const ButtonSecondary = css<ButtonProps>`
   }
 `;
 
-const ButtonSecondaryDestructive = css<ButtonProps>`
+const ButtonSecondaryDestructive = css`
   background-color: transparent;
   border-color: ${({ theme }) => theme.colors.danger};
   color: ${({ theme }) => theme.colors.danger};
@@ -204,7 +202,7 @@ const ButtonSecondaryDestructive = css<ButtonProps>`
   }
 `;
 
-const ButtonSubtle = css<ButtonProps>`
+const ButtonSubtle = css`
   background-color: transparent;
   border-color: transparent;
   color: ${({ theme }) => theme.colors.primary};
@@ -227,7 +225,7 @@ const ButtonSubtle = css<ButtonProps>`
   }
 `;
 
-const ButtonSubtleDestructive = css<ButtonProps>`
+const ButtonSubtleDestructive = css`
   background-color: transparent;
   border-color: transparent;
   color: ${({ theme }) => theme.colors.danger};
@@ -250,7 +248,7 @@ const ButtonSubtleDestructive = css<ButtonProps>`
   }
 `;
 
-const ButtonUtility = css<ButtonProps>`
+const ButtonUtility = css`
   background-color: transparent;
   border-color: transparent;
   color: ${({ theme }) => theme.colors.secondary60};
@@ -276,7 +274,7 @@ const ButtonUtility = css<ButtonProps>`
   }
 `;
 
-const ButtonUtilityDestructive = css<ButtonProps>`
+const ButtonUtilityDestructive = css`
   background-color: transparent;
   border-color: transparent;
   color: ${({ theme }) => theme.colors.secondary60};

--- a/packages/big-design/src/components/Checkbox/Label/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/Label/styled.tsx
@@ -4,13 +4,14 @@ import { ComponentPropsWithoutRef } from 'react';
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../../helpers';
+import { TransientMarginProps } from '../../../helpers/margins/margins';
 
 export interface StyledLabelProps extends ComponentPropsWithoutRef<'label'> {
   hidden?: boolean;
   disabled?: boolean;
 }
 
-export const StyledLabel = styled.label<StyledLabelProps>`
+export const StyledLabel = styled.label<StyledLabelProps & TransientMarginProps>`
   color: ${({ theme }) => theme.colors.secondary70};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`render Checkbox checked 1`] = `
-.c5 {
+.c4 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c6 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -16,28 +16,21 @@ exports[`render Checkbox checked 1`] = `
   cursor: pointer;
 }
 
-.c7:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c6 {
+.c5 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -48,14 +41,9 @@ exports[`render Checkbox checked 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #3C64F4;
   box-sizing: border-box;
@@ -64,33 +52,24 @@ exports[`render Checkbox checked 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c4:hover {
+.c3:hover {
   border-color: #3C64F4;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c3 svg {
   opacity: 1;
 }
 
@@ -107,12 +86,12 @@ exports[`render Checkbox checked 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     for=":r0:"
   >
     <svg
       aria-hidden="true"
-      class="c5"
+      class="c4"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -130,10 +109,10 @@ exports[`render Checkbox checked 1`] = `
     </svg>
   </label>
   <div
-    class="c6"
+    class="c5"
   >
     <label
-      class="c7"
+      class="c6"
       for=":r0:"
       id=":r1:"
     >
@@ -144,13 +123,13 @@ exports[`render Checkbox checked 1`] = `
 `;
 
 exports[`render Checkbox disabled checked 1`] = `
-.c5 {
+.c4 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c6 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -160,28 +139,21 @@ exports[`render Checkbox disabled checked 1`] = `
   cursor: not-allowed;
 }
 
-.c7:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c6 {
+.c5 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -192,14 +164,9 @@ exports[`render Checkbox disabled checked 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #3C64F4;
   box-sizing: border-box;
@@ -208,20 +175,11 @@ exports[`render Checkbox disabled checked 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
   background: #D9DCE9;
@@ -229,11 +187,11 @@ exports[`render Checkbox disabled checked 1`] = `
   cursor: not-allowed;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c3 svg {
   opacity: 1;
 }
 
@@ -251,13 +209,13 @@ exports[`render Checkbox disabled checked 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     disabled=""
     for=":rl:"
   >
     <svg
       aria-hidden="true"
-      class="c5"
+      class="c4"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -275,11 +233,11 @@ exports[`render Checkbox disabled checked 1`] = `
     </svg>
   </label>
   <div
-    class="c6"
+    class="c5"
   >
     <label
       aria-hidden="true"
-      class="c7"
+      class="c6"
       disabled=""
       for=":rl:"
       id=":rm:"
@@ -291,13 +249,13 @@ exports[`render Checkbox disabled checked 1`] = `
 `;
 
 exports[`render Checkbox disabled indeterminate 1`] = `
-.c5 {
+.c4 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c6 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -307,28 +265,21 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   cursor: not-allowed;
 }
 
-.c7:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c6 {
+.c5 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -339,14 +290,9 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #3C64F4;
   box-sizing: border-box;
@@ -355,20 +301,11 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
   background: #D9DCE9;
@@ -376,11 +313,11 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   cursor: not-allowed;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c3 svg {
   opacity: 1;
 }
 
@@ -396,13 +333,13 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     disabled=""
     for=":rr:"
   >
     <svg
       aria-hidden="true"
-      class="c5"
+      class="c4"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -420,11 +357,11 @@ exports[`render Checkbox disabled indeterminate 1`] = `
     </svg>
   </label>
   <div
-    class="c6"
+    class="c5"
   >
     <label
       aria-hidden="true"
-      class="c7"
+      class="c6"
       disabled=""
       for=":rr:"
       id=":rs:"
@@ -436,13 +373,13 @@ exports[`render Checkbox disabled indeterminate 1`] = `
 `;
 
 exports[`render Checkbox disabled unchecked 1`] = `
-.c5 {
+.c4 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c6 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -452,28 +389,21 @@ exports[`render Checkbox disabled unchecked 1`] = `
   cursor: not-allowed;
 }
 
-.c7:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c6 {
+.c5 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -484,14 +414,9 @@ exports[`render Checkbox disabled unchecked 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #FFFFFF;
   box-sizing: border-box;
@@ -500,20 +425,11 @@ exports[`render Checkbox disabled unchecked 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
   background: #F6F7FC;
@@ -521,11 +437,11 @@ exports[`render Checkbox disabled unchecked 1`] = `
   cursor: not-allowed;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c3 svg {
   opacity: 0;
 }
 
@@ -542,13 +458,13 @@ exports[`render Checkbox disabled unchecked 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     disabled=""
     for=":ro:"
   >
     <svg
       aria-hidden="true"
-      class="c5"
+      class="c4"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -566,11 +482,11 @@ exports[`render Checkbox disabled unchecked 1`] = `
     </svg>
   </label>
   <div
-    class="c6"
+    class="c5"
   >
     <label
       aria-hidden="true"
-      class="c7"
+      class="c6"
       disabled=""
       for=":ro:"
       id=":rp:"
@@ -582,13 +498,13 @@ exports[`render Checkbox disabled unchecked 1`] = `
 `;
 
 exports[`render Checkbox indeterminate 1`] = `
-.c5 {
+.c4 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c6 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -597,28 +513,21 @@ exports[`render Checkbox indeterminate 1`] = `
   cursor: pointer;
 }
 
-.c7:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c6 {
+.c5 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -629,14 +538,9 @@ exports[`render Checkbox indeterminate 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #3C64F4;
   box-sizing: border-box;
@@ -645,33 +549,24 @@ exports[`render Checkbox indeterminate 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c4:hover {
+.c3:hover {
   border-color: #3C64F4;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c3 svg {
   opacity: 1;
 }
 
@@ -686,12 +581,12 @@ exports[`render Checkbox indeterminate 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     for=":ri:"
   >
     <svg
       aria-hidden="true"
-      class="c5"
+      class="c4"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -709,10 +604,10 @@ exports[`render Checkbox indeterminate 1`] = `
     </svg>
   </label>
   <div
-    class="c6"
+    class="c5"
   >
     <label
-      class="c7"
+      class="c6"
       for=":ri:"
       id=":rj:"
     >
@@ -723,13 +618,13 @@ exports[`render Checkbox indeterminate 1`] = `
 `;
 
 exports[`render Checkbox unchecked 1`] = `
-.c5 {
+.c4 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c6 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -738,28 +633,21 @@ exports[`render Checkbox unchecked 1`] = `
   cursor: pointer;
 }
 
-.c7:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c6 {
+.c5 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -770,14 +658,9 @@ exports[`render Checkbox unchecked 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #FFFFFF;
   box-sizing: border-box;
@@ -786,33 +669,24 @@ exports[`render Checkbox unchecked 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c4:hover {
+.c3:hover {
   border-color: #B4BAD1;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c3 svg {
   opacity: 0;
 }
 
@@ -828,12 +702,12 @@ exports[`render Checkbox unchecked 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     for=":r3:"
   >
     <svg
       aria-hidden="true"
-      class="c5"
+      class="c4"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -851,10 +725,10 @@ exports[`render Checkbox unchecked 1`] = `
     </svg>
   </label>
   <div
-    class="c6"
+    class="c5"
   >
     <label
-      class="c7"
+      class="c6"
       for=":r3:"
       id=":r4:"
     >
@@ -865,13 +739,13 @@ exports[`render Checkbox unchecked 1`] = `
 `;
 
 exports[`render Checkbox with description object 1`] = `
-.c5 {
+.c4 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c7 {
+.c6 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -880,11 +754,11 @@ exports[`render Checkbox with description object 1`] = `
   cursor: pointer;
 }
 
-.c7:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
+.c7 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -894,53 +768,43 @@ exports[`render Checkbox with description object 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c8:last-child {
+.c7:last-child {
   margin-bottom: 0;
 }
 
-.c9 {
-  -webkit-transition: all 70ms ease-out;
+.c8 {
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c9:active {
+.c8:active {
   color: #0024A6;
 }
 
-.c9:hover:not(:active) {
+.c8:hover:not(:active) {
   color: #0024A6;
 }
 
-.c10 {
+.c9 {
   font-size: 0.875rem;
 }
 
-.c6 {
+.c5 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -951,14 +815,9 @@ exports[`render Checkbox with description object 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #FFFFFF;
   box-sizing: border-box;
@@ -967,33 +826,24 @@ exports[`render Checkbox with description object 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c4:hover {
+.c3:hover {
   border-color: #B4BAD1;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c3 svg {
   opacity: 0;
 }
 
@@ -1010,12 +860,12 @@ exports[`render Checkbox with description object 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     for=":r6:"
   >
     <svg
       aria-hidden="true"
-      class="c5"
+      class="c4"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -1033,22 +883,22 @@ exports[`render Checkbox with description object 1`] = `
     </svg>
   </label>
   <div
-    class="c6"
+    class="c5"
   >
     <label
-      class="c7"
+      class="c6"
       for=":r6:"
       id=":r7:"
     >
       Unchecked
     </label>
     <p
-      class="c8"
+      class="c7"
     >
       description
        
       <a
-        class="c9 c10"
+        class="c8 c9"
         href="bar"
         target="foo"
       >
@@ -1060,7 +910,148 @@ exports[`render Checkbox with description object 1`] = `
 `;
 
 exports[`render Checkbox with description string 1`] = `
+.c4 {
+  vertical-align: middle;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.c6 {
+  color: #313440;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0 0 1rem;
+  cursor: pointer;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
+.c7 {
+  color: #313440;
+  margin: 0 0 1rem;
+  color: #5E637A;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
 .c5 {
+  margin-left: 0.5rem;
+}
+
+.c0 {
+  align-items: flex-start;
+  display: flex;
+}
+
+.c2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c3 {
+  transition: all 150ms ease-out;
+  transition-property: border-color,background,box-shadow,color,opacity;
+  align-items: center;
+  background: #FFFFFF;
+  box-sizing: border-box;
+  border: 1px solid #D9DCE9;
+  border-color: #D9DCE9;
+  border-radius: 0.25rem;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: inline-flex;
+  height: 1.25rem;
+  justify-content: center;
+  margin-bottom: 0.125rem;
+  margin-top: 0.125rem;
+  user-select: none;
+  width: 1.25rem;
+}
+
+.c3:hover {
+  border-color: #B4BAD1;
+}
+
+.c1:focus+.c3 {
+  box-shadow: 0 0 0 0.25rem #DBE3FE;
+}
+
+.c3 svg {
+  opacity: 0;
+}
+
+<div
+  class="c0"
+>
+  <input
+    aria-checked="false"
+    aria-labelledby=":rg:"
+    class="c1 c2"
+    id=":rf:"
+    name="test-group"
+    type="checkbox"
+  />
+  <label
+    aria-hidden="true"
+    class="c3"
+    for=":rf:"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4"
+      fill="currentColor"
+      height="24"
+      stroke="currentColor"
+      stroke-width="0"
+      viewBox="0 0 24 24"
+      width="24"
+    >
+      <path
+        d="M0 0h24v24H0z"
+        fill="none"
+      />
+      <path
+        d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
+      />
+    </svg>
+  </label>
+  <div
+    class="c5"
+  >
+    <label
+      class="c6"
+      for=":rf:"
+      id=":rg:"
+    >
+      Unchecked
+    </label>
+    <p
+      class="c7"
+    >
+      description text
+    </p>
+  </div>
+</div>
+`;
+
+exports[`render Checkbox with img props 1`] = `
+.c4 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -1079,194 +1070,23 @@ exports[`render Checkbox with description string 1`] = `
   margin-bottom: 0;
 }
 
-.c8 {
-  color: #313440;
-  margin: 0 0 1rem;
-  color: #5E637A;
-  font-size: 0.875rem;
-  font-weight: 400;
-  line-height: 1.25rem;
-  margin: 0 0 0.75rem;
-}
-
-.c8:last-child {
-  margin-bottom: 0;
-}
-
 .c6 {
   margin-left: 0.5rem;
 }
 
-.c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c2 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.c4 {
-  -webkit-transition: all 150ms ease-out;
-  transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
-  transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #FFFFFF;
-  box-sizing: border-box;
-  border: 1px solid #D9DCE9;
-  border-color: #D9DCE9;
-  border-radius: 0.25rem;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  margin-bottom: 0.125rem;
-  margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  width: 1.25rem;
-}
-
-.c4:hover {
-  border-color: #B4BAD1;
-}
-
-.c1:focus + .c3 {
-  box-shadow: 0 0 0 0.25rem #DBE3FE;
-}
-
-.c4 svg {
-  opacity: 0;
-}
-
-<div
-  class="c0"
->
-  <input
-    aria-checked="false"
-    aria-labelledby=":rg:"
-    class="c1 c2"
-    id=":rf:"
-    name="test-group"
-    type="checkbox"
-  />
-  <label
-    aria-hidden="true"
-    class="c3 c4"
-    for=":rf:"
-  >
-    <svg
-      aria-hidden="true"
-      class="c5"
-      fill="currentColor"
-      height="24"
-      stroke="currentColor"
-      stroke-width="0"
-      viewBox="0 0 24 24"
-      width="24"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M9 16.17 5.53 12.7a.996.996 0 1 0-1.41 1.41l4.18 4.18c.39.39 1.02.39 1.41 0L20.29 7.71a.996.996 0 1 0-1.41-1.41z"
-      />
-    </svg>
-  </label>
-  <div
-    class="c6"
-  >
-    <label
-      class="c7"
-      for=":rf:"
-      id=":rg:"
-    >
-      Unchecked
-    </label>
-    <p
-      class="c8"
-    >
-      description text
-    </p>
-  </div>
-</div>
-`;
-
-exports[`render Checkbox with img props 1`] = `
 .c5 {
-  vertical-align: middle;
-  height: 1.5rem;
-  width: 1.5rem;
-}
-
-.c8 {
-  color: #313440;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5rem;
-  margin: 0 0 1rem;
-  cursor: pointer;
-}
-
-.c8:last-child {
-  margin-bottom: 0;
-}
-
-.c7 {
-  margin-left: 0.5rem;
-}
-
-.c6 {
   margin-inline-start: 0.5rem;
   object-fit: contain;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -1277,14 +1097,9 @@ exports[`render Checkbox with img props 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #FFFFFF;
   box-sizing: border-box;
@@ -1293,33 +1108,24 @@ exports[`render Checkbox with img props 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c4:hover {
+.c3:hover {
   border-color: #B4BAD1;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4 svg {
+.c3 svg {
   opacity: 0;
 }
 
@@ -1336,12 +1142,12 @@ exports[`render Checkbox with img props 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     for=":rc:"
   >
     <svg
       aria-hidden="true"
-      class="c5"
+      class="c4"
       fill="currentColor"
       height="24"
       stroke="currentColor"
@@ -1360,16 +1166,16 @@ exports[`render Checkbox with img props 1`] = `
   </label>
   <img
     alt="Thumbnail"
-    class="c6"
+    class="c5"
     height="100"
     src="https://example.com/thumbnail.png"
     width="100"
   />
   <div
-    class="c7"
+    class="c6"
   >
     <label
-      class="c8"
+      class="c7"
       for=":rc:"
       id=":rd:"
     >

--- a/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
@@ -31,45 +31,26 @@ exports[`renders with close button if onRemove is present 1`] = `
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -88,7 +69,7 @@ exports[`renders with close button if onRemove is present 1`] = `
   pointer-events: none;
 }
 
-.c3 + .bd-button {
+.c3+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -110,12 +91,7 @@ exports[`renders with close button if onRemove is present 1`] = `
 }
 
 .c5 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -123,17 +99,8 @@ exports[`renders with close button if onRemove is present 1`] = `
 }
 
 .c1 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 
@@ -145,14 +112,14 @@ exports[`renders with close button if onRemove is present 1`] = `
   min-width: auto;
 }
 
-@media (min-width:720px) {
-  .c3 + .bd-button {
+@media (min-width: 720px) {
+  .c3+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     width: auto;
     padding: 0;
@@ -229,17 +196,8 @@ exports[`renders without close button 1`] = `
 }
 
 .c1 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 

--- a/packages/big-design/src/components/Chip/spec.tsx
+++ b/packages/big-design/src/components/Chip/spec.tsx
@@ -64,7 +64,7 @@ test('icon is always constrained to 16px (1rem) regardless of icon size prop', (
 });
 
 test('icon is always constrained to 16px even if size is set to 40px', () => {
-  const { container } = render(<Chip icon={<AddIcon size="40px" />} label="Large icon" />);
+  const { container } = render(<Chip icon={<AddIcon size={40} />} label="Large icon" />);
 
   const chip = container.firstChild;
   const iconWrapper = chip?.firstChild;

--- a/packages/big-design/src/components/FeatureSet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/FeatureSet/__snapshots__/spec.tsx.snap
@@ -5,12 +5,7 @@ exports[`render feature set 1`] = `
   list-style-type: none;
   margin: 0;
   padding: 0;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   gap: 0.75rem;
 }
@@ -37,33 +32,20 @@ exports[`render feature set 1`] = `
 }
 
 .c1 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background-color: #ECEEF5;
   border-radius: 0.25rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   color: #5E637A;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
   gap: 0.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   padding-block: 0.125rem;
   padding-inline: 0.5rem;
 }
 
-.c1 > svg {
+.c1>svg {
   height: 1rem;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   width: 1rem;
 }

--- a/packages/big-design/src/components/Flex/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Flex/__snapshots__/spec.tsx.snap
@@ -6,38 +6,21 @@ exports[`render flex 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c1 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
     flex-direction: column;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
     flex-direction: row;
   }
 }

--- a/packages/big-design/src/components/Form/Description/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/Description/__snapshots__/spec.tsx.snap
@@ -38,15 +38,12 @@ exports[`renders description with link 1`] = `
 }
 
 .c1 {
-  -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -2,10 +2,11 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withMargins } from '../../../helpers';
+import { TransientMarginProps } from '../../../helpers/margins/margins';
 
 import { type FormControlLabelProps } from './Label';
 
-export const StyledLabel = styled.label<FormControlLabelProps>`
+export const StyledLabel = styled.label<FormControlLabelProps & TransientMarginProps>`
   color: ${({ theme }) => theme.colors.secondary70};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   font-weight: ${({ theme }) => theme.typography.fontWeight.semiBold};

--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -39,20 +39,12 @@ exports[`simple form render 1`] = `
 }
 
 .c6 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: border,box-shadow;
   transition-property: border,box-shadow;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background-color: #FFFFFF;
   border-radius: 0.25rem;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   min-height: 2.25rem;
   overflow: hidden;
@@ -74,8 +66,6 @@ exports[`simple form render 1`] = `
   border: 0;
   box-sizing: border-box;
   color: #313440;
-  -webkit-flex: 1 1 40%;
-  -ms-flex: 1 1 40%;
   flex: 1 1 40%;
   height: 100%;
   padding: 0;
@@ -88,28 +78,13 @@ exports[`simple form render 1`] = `
   outline: none;
 }
 
-.c8::-webkit-input-placeholder {
-  color: #B4BAD1;
-  font-size: 1rem;
-}
-
-.c8::-moz-placeholder {
-  color: #B4BAD1;
-  font-size: 1rem;
-}
-
-.c8:-ms-input-placeholder {
-  color: #B4BAD1;
-  font-size: 1rem;
-}
-
 .c8::placeholder {
   color: #B4BAD1;
   font-size: 1rem;
 }
 
 .c8:-webkit-autofill {
-  background-color: #F0F3FF !important;
+  background-color: #F0F3FF!important;
   -webkit-box-shadow: 0 0 0px 1000px #F0F3FF inset;
 }
 
@@ -119,20 +94,10 @@ exports[`simple form render 1`] = `
 }
 
 .c7 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
   flex: 1;
   height: 100%;
 }
@@ -156,14 +121,6 @@ exports[`simple form render 1`] = `
   cursor: pointer;
   display: inline-block;
   margin-bottom: 0.25rem;
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
 }
 
 <form

--- a/packages/big-design/src/components/GlobalStyles/GlobalStyles.tsx
+++ b/packages/big-design/src/components/GlobalStyles/GlobalStyles.tsx
@@ -10,4 +10,6 @@ export const GlobalStyles = createGlobalStyle`
   }
 `;
 
-GlobalStyles.defaultProps = { theme: defaultTheme };
+// styled-components 6 types createGlobalStyle's return without `defaultProps`, but the
+// runtime still reads it as the theme fallback (determineTheme), so assign it untyped.
+Object.assign(GlobalStyles, { defaultProps: { theme: defaultTheme } });

--- a/packages/big-design/src/components/Grid/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Grid/__snapshots__/spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`render Grid 1`] = `
 
 .c1 {
   gap: 1rem;
-  grid-template: "head head" 80px "nav  main" 1fr "nav  foot" 10% / 120px 1fr;
+  grid-template: "head head" 80px "nav  main" 1fr "nav  foot" 10%/120px 1fr;
   display: grid;
 }
 

--- a/packages/big-design/src/components/InfoCard/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InfoCard/__snapshots__/spec.tsx.snap
@@ -21,23 +21,10 @@ exports[`matches snapshot 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -71,23 +58,17 @@ exports[`matches snapshot 1`] = `
 .c2 {
   margin-inline-end: 0.5rem;
   object-fit: contain;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c1 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
     flex-direction: column;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
     flex-direction: row;
   }
 }

--- a/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
@@ -431,69 +431,35 @@ exports[`renders actions 1`] = `
 }
 
 .c10 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c12 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -518,7 +484,7 @@ exports[`renders actions 1`] = `
   pointer-events: none;
 }
 
-.c12 + .bd-button {
+.c12+.bd-button {
   margin-left: 0.5rem;
 }
 
@@ -539,12 +505,7 @@ exports[`renders actions 1`] = `
 }
 
 .c13 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -600,14 +561,14 @@ exports[`renders actions 1`] = `
   margin-right: -0.25rem;
 }
 
-@media (min-width:720px) {
-  .c12 + .bd-button {
+@media (min-width: 720px) {
+  .c12+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c12 {
     width: auto;
   }
@@ -703,45 +664,26 @@ exports[`renders close button 1`] = `
 }
 
 .c9 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -760,7 +702,7 @@ exports[`renders close button 1`] = `
   pointer-events: none;
 }
 
-.c9 + .bd-button {
+.c9+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -781,12 +723,7 @@ exports[`renders close button 1`] = `
 }
 
 .c11 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -861,14 +798,14 @@ exports[`renders close button 1`] = `
   vertical-align: middle;
 }
 
-@media (min-width:720px) {
-  .c9 + .bd-button {
+@media (min-width: 720px) {
+  .c9+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c9 {
     width: auto;
     padding: 0;
@@ -1116,23 +1053,14 @@ exports[`renders with external link 1`] = `
 }
 
 .c9 {
-  -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
 }
 
@@ -1145,8 +1073,6 @@ exports[`renders with external link 1`] = `
 }
 
 .c9 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   margin-left: 0.25rem;
 }
@@ -1288,15 +1214,12 @@ exports[`renders with link 1`] = `
 }
 
 .c9 {
-  -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -22,20 +22,12 @@ exports[`renders all together 1`] = `
 }
 
 .c2 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: border,box-shadow;
   transition-property: border,box-shadow;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background-color: #FFFFFF;
   border-radius: 0.25rem;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   min-height: 2.25rem;
   overflow: hidden;
@@ -57,8 +49,6 @@ exports[`renders all together 1`] = `
   border: 0;
   box-sizing: border-box;
   color: #313440;
-  -webkit-flex: 1 1 40%;
-  -ms-flex: 1 1 40%;
   flex: 1 1 40%;
   height: 100%;
   padding: 0;
@@ -73,28 +63,13 @@ exports[`renders all together 1`] = `
   outline: none;
 }
 
-.c6::-webkit-input-placeholder {
-  color: #B4BAD1;
-  font-size: 1rem;
-}
-
-.c6::-moz-placeholder {
-  color: #B4BAD1;
-  font-size: 1rem;
-}
-
-.c6:-ms-input-placeholder {
-  color: #B4BAD1;
-  font-size: 1rem;
-}
-
 .c6::placeholder {
   color: #B4BAD1;
   font-size: 1rem;
 }
 
 .c6:-webkit-autofill {
-  background-color: #F0F3FF !important;
+  background-color: #F0F3FF!important;
   -webkit-box-shadow: 0 0 0px 1000px #F0F3FF inset;
 }
 
@@ -104,14 +79,8 @@ exports[`renders all together 1`] = `
 }
 
 .c3 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   color: #5E637A;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 100%;
   position: absolute;
@@ -122,14 +91,8 @@ exports[`renders all together 1`] = `
 }
 
 .c7 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   color: #5E637A;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 100%;
   position: absolute;
@@ -140,20 +103,10 @@ exports[`renders all together 1`] = `
 }
 
 .c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
   flex: 1;
   height: 100%;
 }

--- a/packages/big-design/src/components/Link/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Link/__snapshots__/spec.tsx.snap
@@ -2,15 +2,12 @@
 
 exports[`render link 1`] = `
 .c0 {
-  -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
@@ -38,23 +35,14 @@ exports[`renders with external icon 1`] = `
 }
 
 .c0 {
-  -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
 }
 
@@ -67,8 +55,6 @@ exports[`renders with external icon 1`] = `
 }
 
 .c0 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   margin-left: 0.25rem;
 }

--- a/packages/big-design/src/components/Lozenge/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Lozenge/__snapshots__/spec.tsx.snap
@@ -3,9 +3,6 @@
 exports[`Lozenge (button) applies expanded styles when isOpen is true 1`] = `
 .c0 {
   border-radius: 1rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
   gap: 0.25rem;
@@ -16,9 +13,6 @@ exports[`Lozenge (button) applies expanded styles when isOpen is true 1`] = `
   padding-inline-start: 0.5rem;
   white-space: nowrap;
   padding-inline-end: 0.25rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   cursor: pointer;
   border: none;
@@ -27,17 +21,11 @@ exports[`Lozenge (button) applies expanded styles when isOpen is true 1`] = `
 }
 
 .c0 svg:last-child {
-  -webkit-transition: -webkit-transform 0.3s ease;
-  -webkit-transition: transform 0.3s ease;
   transition: transform 0.3s ease;
 }
 
 .c0[aria-expanded='true'] svg:last-child {
-  -webkit-transform: rotate(-180deg);
-  -ms-transform: rotate(-180deg);
   transform: rotate(-180deg);
-  -webkit-transition: -webkit-transform 0.3s ease;
-  -webkit-transition: transform 0.3s ease;
   transition: transform 0.3s ease;
 }
 
@@ -110,9 +98,6 @@ exports[`Lozenge (button) applies expanded styles when isOpen is true 1`] = `
 exports[`render Lozenge as button (popover variant) 1`] = `
 .c0 {
   border-radius: 1rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
   gap: 0.25rem;
@@ -123,9 +108,6 @@ exports[`render Lozenge as button (popover variant) 1`] = `
   padding-inline-start: 0.5rem;
   white-space: nowrap;
   padding-inline-end: 0.25rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   cursor: pointer;
   border: none;
@@ -134,17 +116,11 @@ exports[`render Lozenge as button (popover variant) 1`] = `
 }
 
 .c0 svg:last-child {
-  -webkit-transition: -webkit-transform 0.3s ease;
-  -webkit-transition: transform 0.3s ease;
   transition: transform 0.3s ease;
 }
 
 .c0[aria-expanded='true'] svg:last-child {
-  -webkit-transform: rotate(-180deg);
-  -ms-transform: rotate(-180deg);
   transform: rotate(-180deg);
-  -webkit-transition: -webkit-transform 0.3s ease;
-  -webkit-transition: transform 0.3s ease;
   transition: transform 0.3s ease;
 }
 
@@ -221,9 +197,6 @@ exports[`render alpha Lozenge 1`] = `
 
 .c1 {
   border-radius: 1rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
   gap: 0.25rem;
@@ -280,9 +253,6 @@ exports[`render beta Lozenge 1`] = `
 
 .c1 {
   border-radius: 1rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
   gap: 0.25rem;
@@ -335,9 +305,6 @@ exports[`render default Lozenge 1`] = `
 
 .c1 {
   border-radius: 1rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
   gap: 0.25rem;
@@ -396,9 +363,6 @@ exports[`render deprecated Lozenge 1`] = `
 
 .c1 {
   border-radius: 1rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
   gap: 0.25rem;
@@ -451,9 +415,6 @@ exports[`render legacy Lozenge 1`] = `
 
 .c1 {
   border-radius: 1rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
   gap: 0.25rem;
@@ -506,9 +467,6 @@ exports[`render new Lozenge 1`] = `
 
 .c1 {
   border-radius: 1rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
   gap: 0.25rem;

--- a/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
@@ -427,69 +427,35 @@ exports[`renders actions 1`] = `
 }
 
 .c10 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c12 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -514,7 +480,7 @@ exports[`renders actions 1`] = `
   pointer-events: none;
 }
 
-.c12 + .bd-button {
+.c12+.bd-button {
   margin-left: 0.5rem;
 }
 
@@ -535,12 +501,7 @@ exports[`renders actions 1`] = `
 }
 
 .c13 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -595,14 +556,14 @@ exports[`renders actions 1`] = `
   margin-right: -0.25rem;
 }
 
-@media (min-width:720px) {
-  .c12 + .bd-button {
+@media (min-width: 720px) {
+  .c12+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c12 {
     width: auto;
   }
@@ -698,45 +659,26 @@ exports[`renders close button 1`] = `
 }
 
 .c9 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -755,7 +697,7 @@ exports[`renders close button 1`] = `
   pointer-events: none;
 }
 
-.c9 + .bd-button {
+.c9+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -776,12 +718,7 @@ exports[`renders close button 1`] = `
 }
 
 .c11 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -855,14 +792,14 @@ exports[`renders close button 1`] = `
   vertical-align: middle;
 }
 
-@media (min-width:720px) {
-  .c9 + .bd-button {
+@media (min-width: 720px) {
+  .c9+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c9 {
     width: auto;
     padding: 0;
@@ -1108,23 +1045,14 @@ exports[`renders with external link 1`] = `
 }
 
 .c9 {
-  -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
 }
 
@@ -1137,8 +1065,6 @@ exports[`renders with external link 1`] = `
 }
 
 .c9 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   margin-left: 0.25rem;
 }
@@ -1279,15 +1205,12 @@ exports[`renders with link 1`] = `
 }
 
 .c9 {
-  -webkit-transition: all 70ms ease-out;
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 

--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -21,69 +21,35 @@ exports[`render open modal 1`] = `
 }
 
 .c2 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c5 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -102,7 +68,7 @@ exports[`render open modal 1`] = `
   pointer-events: none;
 }
 
-.c5 + .bd-button {
+.c5+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -123,12 +89,7 @@ exports[`render open modal 1`] = `
 }
 
 .c7 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -161,18 +122,9 @@ exports[`render open modal 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 100%;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   left: 0;
   position: fixed;
@@ -198,22 +150,19 @@ exports[`render open modal 1`] = `
 }
 
 .c9 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
   flex-grow: 1;
   padding: 0 1rem;
   overflow-y: auto;
 }
 
-@media (min-width:720px) {
-  .c5 + .bd-button {
+@media (min-width: 720px) {
+  .c5+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c5 {
     width: auto;
     padding: 0;
@@ -221,7 +170,7 @@ exports[`render open modal 1`] = `
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     border-radius: 0.25rem;
     box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
@@ -231,19 +180,19 @@ exports[`render open modal 1`] = `
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c3 {
     max-height: 80vh;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c4 {
     display: none;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c9 {
     padding: 0 1.5rem;
   }
@@ -322,69 +271,35 @@ exports[`render open modal without backdrop 1`] = `
 }
 
 .c2 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c5 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -403,7 +318,7 @@ exports[`render open modal without backdrop 1`] = `
   pointer-events: none;
 }
 
-.c5 + .bd-button {
+.c5+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -424,12 +339,7 @@ exports[`render open modal without backdrop 1`] = `
 }
 
 .c7 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -462,18 +372,9 @@ exports[`render open modal without backdrop 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 100%;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   left: 0;
   position: fixed;
@@ -498,22 +399,19 @@ exports[`render open modal without backdrop 1`] = `
 }
 
 .c9 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
   flex-grow: 1;
   padding: 0 1rem;
   overflow-y: auto;
 }
 
-@media (min-width:720px) {
-  .c5 + .bd-button {
+@media (min-width: 720px) {
+  .c5+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c5 {
     width: auto;
     padding: 0;
@@ -521,7 +419,7 @@ exports[`render open modal without backdrop 1`] = `
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     border-radius: 0.25rem;
     box-shadow: 0px 2px 12px rgba(49,52,64,0.2);
@@ -531,19 +429,19 @@ exports[`render open modal without backdrop 1`] = `
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c3 {
     max-height: 80vh;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c4 {
     display: none;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c9 {
     padding: 0 1.5rem;
   }
@@ -612,45 +510,26 @@ exports[`render open modal without backdrop 1`] = `
 
 exports[`renders destructive action button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -669,7 +548,7 @@ exports[`renders destructive action button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -690,65 +569,24 @@ exports[`renders destructive action button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:0px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:1025px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
 }
 
 <button
@@ -764,45 +602,26 @@ exports[`renders destructive action button 1`] = `
 
 exports[`renders secondary action button 1`] = `
 .c0 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -821,7 +640,7 @@ exports[`renders secondary action button 1`] = `
   pointer-events: none;
 }
 
-.c0 + .bd-button {
+.c0+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -842,65 +661,24 @@ exports[`renders secondary action button 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-@media (min-width:0px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-  .c0 + .bd-button {
+@media (min-width: 720px) {
+  .c0+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     width: auto;
   }
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:1025px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
 }
 
 <button

--- a/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
@@ -24,88 +24,43 @@ exports[`render offset pagination component 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c4 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -125,7 +80,7 @@ exports[`render offset pagination component 1`] = `
   pointer-events: none;
 }
 
-.c4 + .bd-button {
+.c4+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -147,45 +102,26 @@ exports[`render offset pagination component 1`] = `
 }
 
 .c11 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -204,7 +140,7 @@ exports[`render offset pagination component 1`] = `
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c11+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -226,12 +162,7 @@ exports[`render offset pagination component 1`] = `
 }
 
 .c6 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -268,27 +199,27 @@ exports[`render offset pagination component 1`] = `
   width: auto;
 }
 
-@media (min-width:720px) {
-  .c4 + .bd-button {
+@media (min-width: 720px) {
+  .c4+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c4 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c11 + .bd-button {
+@media (min-width: 720px) {
+  .c11+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c11 {
     width: auto;
     padding: 0;
@@ -455,88 +386,43 @@ exports[`render offset pagination component with invalid page info 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c4 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -556,7 +442,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
   pointer-events: none;
 }
 
-.c4 + .bd-button {
+.c4+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -578,45 +464,26 @@ exports[`render offset pagination component with invalid page info 1`] = `
 }
 
 .c11 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -635,7 +502,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c11+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -657,12 +524,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
 }
 
 .c6 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -699,27 +561,27 @@ exports[`render offset pagination component with invalid page info 1`] = `
   width: auto;
 }
 
-@media (min-width:720px) {
-  .c4 + .bd-button {
+@media (min-width: 720px) {
+  .c4+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c4 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c11 + .bd-button {
+@media (min-width: 720px) {
+  .c11+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c11 {
     width: auto;
     padding: 0;
@@ -886,88 +748,43 @@ exports[`render offset pagination component with invalid range info 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c4 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -987,7 +804,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
   pointer-events: none;
 }
 
-.c4 + .bd-button {
+.c4+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1009,45 +826,26 @@ exports[`render offset pagination component with invalid range info 1`] = `
 }
 
 .c11 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1066,7 +864,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c11+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1088,12 +886,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
 }
 
 .c6 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -1130,27 +923,27 @@ exports[`render offset pagination component with invalid range info 1`] = `
   width: auto;
 }
 
-@media (min-width:720px) {
-  .c4 + .bd-button {
+@media (min-width: 720px) {
+  .c4+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c4 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c11 + .bd-button {
+@media (min-width: 720px) {
+  .c11+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c11 {
     width: auto;
     padding: 0;
@@ -1318,88 +1111,43 @@ exports[`render offset pagination component with no items 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c4 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1419,7 +1167,7 @@ exports[`render offset pagination component with no items 1`] = `
   pointer-events: none;
 }
 
-.c4 + .bd-button {
+.c4+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1441,45 +1189,26 @@ exports[`render offset pagination component with no items 1`] = `
 }
 
 .c11 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1498,7 +1227,7 @@ exports[`render offset pagination component with no items 1`] = `
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c11+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1520,12 +1249,7 @@ exports[`render offset pagination component with no items 1`] = `
 }
 
 .c6 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -1562,27 +1286,27 @@ exports[`render offset pagination component with no items 1`] = `
   width: auto;
 }
 
-@media (min-width:720px) {
-  .c4 + .bd-button {
+@media (min-width: 720px) {
+  .c4+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c4 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c11 + .bd-button {
+@media (min-width: 720px) {
+  .c11+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c11 {
     width: auto;
     padding: 0;

--- a/packages/big-design/src/components/Panel/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Panel/__snapshots__/spec.tsx.snap
@@ -18,19 +18,19 @@ exports[`render panel 1`] = `
   border-radius: 0;
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     padding: 1rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     padding: 1.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c1 {
     border-radius: 0.25rem;
   }
@@ -70,26 +70,11 @@ exports[`render panel with only a heading and no content 1`] = `
 }
 
 .c3 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -98,30 +83,27 @@ exports[`render panel with only a heading and no content 1`] = `
 }
 
 .c5 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c5 ~ .bd-button {
+.c5~.bd-button {
   width: auto;
   margin-top: 0;
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     padding: 1rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     padding: 1.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c1 {
     border-radius: 0.25rem;
   }

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -18,88 +18,43 @@ exports[`dropdown is not visible if items fit 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -122,7 +77,7 @@ exports[`dropdown is not visible if items fit 1`] = `
   pointer-events: none;
 }
 
-.c3 + .bd-button {
+.c3+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -144,45 +99,26 @@ exports[`dropdown is not visible if items fit 1`] = `
 }
 
 .c7 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -201,7 +137,7 @@ exports[`dropdown is not visible if items fit 1`] = `
   pointer-events: none;
 }
 
-.c7 + .bd-button {
+.c7+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -223,12 +159,7 @@ exports[`dropdown is not visible if items fit 1`] = `
 }
 
 .c4 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -266,27 +197,27 @@ exports[`dropdown is not visible if items fit 1`] = `
   z-index: -1070;
 }
 
-@media (min-width:720px) {
-  .c3 + .bd-button {
+@media (min-width: 720px) {
+  .c3+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c7 + .bd-button {
+@media (min-width: 720px) {
+  .c7+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c7 {
     width: auto;
     padding: 0;
@@ -397,88 +328,43 @@ exports[`it renders the given tabs 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -501,7 +387,7 @@ exports[`it renders the given tabs 1`] = `
   pointer-events: none;
 }
 
-.c3 + .bd-button {
+.c3+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -523,45 +409,26 @@ exports[`it renders the given tabs 1`] = `
 }
 
 .c7 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -580,7 +447,7 @@ exports[`it renders the given tabs 1`] = `
   pointer-events: none;
 }
 
-.c7 + .bd-button {
+.c7+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -602,12 +469,7 @@ exports[`it renders the given tabs 1`] = `
 }
 
 .c4 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -645,27 +507,27 @@ exports[`it renders the given tabs 1`] = `
   z-index: -1070;
 }
 
-@media (min-width:720px) {
-  .c3 + .bd-button {
+@media (min-width: 720px) {
+  .c3+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c7 + .bd-button {
+@media (min-width: 720px) {
+  .c7+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c7 {
     width: auto;
     padding: 0;
@@ -776,88 +638,43 @@ exports[`only the pills that fit are visible 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -880,7 +697,7 @@ exports[`only the pills that fit are visible 1`] = `
   pointer-events: none;
 }
 
-.c3 + .bd-button {
+.c3+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -902,45 +719,26 @@ exports[`only the pills that fit are visible 1`] = `
 }
 
 .c7 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -959,7 +757,7 @@ exports[`only the pills that fit are visible 1`] = `
   pointer-events: none;
 }
 
-.c7 + .bd-button {
+.c7+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -981,12 +779,7 @@ exports[`only the pills that fit are visible 1`] = `
 }
 
 .c4 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -1024,27 +817,27 @@ exports[`only the pills that fit are visible 1`] = `
   z-index: -1070;
 }
 
-@media (min-width:720px) {
-  .c3 + .bd-button {
+@media (min-width: 720px) {
+  .c3+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c7 + .bd-button {
+@media (min-width: 720px) {
+  .c7+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c7 {
     width: auto;
     padding: 0;
@@ -1187,88 +980,43 @@ exports[`only the pills that fit are visible 2 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1291,7 +1039,7 @@ exports[`only the pills that fit are visible 2 1`] = `
   pointer-events: none;
 }
 
-.c3 + .bd-button {
+.c3+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1313,45 +1061,26 @@ exports[`only the pills that fit are visible 2 1`] = `
 }
 
 .c7 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1370,7 +1099,7 @@ exports[`only the pills that fit are visible 2 1`] = `
   pointer-events: none;
 }
 
-.c7 + .bd-button {
+.c7+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1392,12 +1121,7 @@ exports[`only the pills that fit are visible 2 1`] = `
 }
 
 .c4 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -1435,27 +1159,27 @@ exports[`only the pills that fit are visible 2 1`] = `
   z-index: -1070;
 }
 
-@media (min-width:720px) {
-  .c3 + .bd-button {
+@media (min-width: 720px) {
+  .c3+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c7 + .bd-button {
+@media (min-width: 720px) {
+  .c7+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c7 {
     width: auto;
     padding: 0;
@@ -1597,88 +1321,43 @@ exports[`renders all the filters if they fit 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1701,7 +1380,7 @@ exports[`renders all the filters if they fit 1`] = `
   pointer-events: none;
 }
 
-.c3 + .bd-button {
+.c3+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1723,45 +1402,26 @@ exports[`renders all the filters if they fit 1`] = `
 }
 
 .c7 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -1780,7 +1440,7 @@ exports[`renders all the filters if they fit 1`] = `
   pointer-events: none;
 }
 
-.c7 + .bd-button {
+.c7+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -1802,12 +1462,7 @@ exports[`renders all the filters if they fit 1`] = `
 }
 
 .c4 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -1845,27 +1500,27 @@ exports[`renders all the filters if they fit 1`] = `
   z-index: -1070;
 }
 
-@media (min-width:720px) {
-  .c3 + .bd-button {
+@media (min-width: 720px) {
+  .c3+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c7 + .bd-button {
+@media (min-width: 720px) {
+  .c7+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c7 {
     width: auto;
     padding: 0;
@@ -2006,88 +1661,43 @@ exports[`renders dropdown if items do not fit 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -2110,7 +1720,7 @@ exports[`renders dropdown if items do not fit 1`] = `
   pointer-events: none;
 }
 
-.c3 + .bd-button {
+.c3+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -2132,45 +1742,26 @@ exports[`renders dropdown if items do not fit 1`] = `
 }
 
 .c7 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -2189,7 +1780,7 @@ exports[`renders dropdown if items do not fit 1`] = `
   pointer-events: none;
 }
 
-.c7 + .bd-button {
+.c7+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -2211,12 +1802,7 @@ exports[`renders dropdown if items do not fit 1`] = `
 }
 
 .c4 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -2254,27 +1840,27 @@ exports[`renders dropdown if items do not fit 1`] = `
   z-index: -1070;
 }
 
-@media (min-width:720px) {
-  .c3 + .bd-button {
+@media (min-width: 720px) {
+  .c3+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c7 + .bd-button {
+@media (min-width: 720px) {
+  .c7+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c7 {
     width: auto;
     padding: 0;

--- a/packages/big-design/src/components/ProgressBar/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/ProgressBar/__snapshots__/spec.tsx.snap
@@ -12,9 +12,7 @@ exports[`render determinant progress bar 1`] = `
   background-color: #3C64F4;
   height: 100%;
   overflow: hidden;
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: width,background-color,height;
   transition-property: width,background-color,height;
   width: 50%;
 }
@@ -46,10 +44,23 @@ exports[`render indeterminant progress bar 1`] = `
   background-color: #3C64F4;
   height: 100%;
   overflow: hidden;
-  -webkit-animation: cdRApH 2s ease-in-out infinite;
-  animation: cdRApH 2s ease-in-out infinite;
+  animation: k0 2s ease-in-out infinite;
   position: relative;
   width: 6.25%;
+}
+
+@keyframes k0 {
+  from {
+    left: -10%;
+  }
+
+  25% {
+    width: 50%;
+  }
+
+  to {
+    left: 100%;
+  }
 }
 
 <div>

--- a/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/ProgressCircle/__snapshots__/spec.tsx.snap
@@ -49,14 +49,9 @@ exports[`render determinant progress circle 1`] = `
 .c2 {
   stroke-dasharray: 138.23007675795088 138.23007675795088;
   stroke: #3C64F4;
-  -webkit-transform-origin: 50% 50%;
-  -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
   stroke-dashoffset: 69.11503837897544;
-  -webkit-transform: rotate(-90deg);
-  -ms-transform: rotate(-90deg);
   transform: rotate(-90deg);
-  -webkit-transition: stroke-dashoffset 0.35s;
   transition: stroke-dashoffset 0.35s;
 }
 
@@ -145,17 +140,27 @@ exports[`render indeterminant progress bar 1`] = `
 .c2 {
   stroke-dasharray: 138.23007675795088 138.23007675795088;
   stroke: #3C64F4;
-  -webkit-transform-origin: 50% 50%;
-  -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: dfVSSu 1s ease-out infinite;
-  animation: dfVSSu 1s ease-out infinite;
+  animation: k0 1s ease-out infinite;
   stroke-dashoffset: 138.23007675795088;
-  -webkit-transform: rotate(-90deg);
-  -ms-transform: rotate(-90deg);
   transform: rotate(-90deg);
-  -webkit-transition: stroke-dashoffset 0.35s;
   transition: stroke-dashoffset 0.35s;
+}
+
+@keyframes k0 {
+  0% {
+    stroke-dashoffset: -138.23007675795088;
+    transform: rotate(-90deg);
+  }
+
+  50% {
+    stroke-dashoffset: -86.3937979737193;
+  }
+
+  100% {
+    stroke-dashoffset: -138.23007675795088;
+    transform: rotate(270deg);
+  }
 }
 
 <div>
@@ -194,17 +199,27 @@ exports[`render large progress circle 1`] = `
 .c2 {
   stroke-dasharray: 226.1946710584651 226.1946710584651;
   stroke: #3C64F4;
-  -webkit-transform-origin: 50% 50%;
-  -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: krEchf 1s ease-out infinite;
-  animation: krEchf 1s ease-out infinite;
+  animation: k0 1s ease-out infinite;
   stroke-dashoffset: 226.1946710584651;
-  -webkit-transform: rotate(-90deg);
-  -ms-transform: rotate(-90deg);
   transform: rotate(-90deg);
-  -webkit-transition: stroke-dashoffset 0.35s;
   transition: stroke-dashoffset 0.35s;
+}
+
+@keyframes k0 {
+  0% {
+    stroke-dashoffset: -226.1946710584651;
+    transform: rotate(-90deg);
+  }
+
+  50% {
+    stroke-dashoffset: -141.3716694115407;
+  }
+
+  100% {
+    stroke-dashoffset: -226.1946710584651;
+    transform: rotate(270deg);
+  }
 }
 
 <div>
@@ -243,17 +258,27 @@ exports[`render medium progress circle 1`] = `
 .c2 {
   stroke-dasharray: 138.23007675795088 138.23007675795088;
   stroke: #3C64F4;
-  -webkit-transform-origin: 50% 50%;
-  -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: dfVSSu 1s ease-out infinite;
-  animation: dfVSSu 1s ease-out infinite;
+  animation: k0 1s ease-out infinite;
   stroke-dashoffset: 138.23007675795088;
-  -webkit-transform: rotate(-90deg);
-  -ms-transform: rotate(-90deg);
   transform: rotate(-90deg);
-  -webkit-transition: stroke-dashoffset 0.35s;
   transition: stroke-dashoffset 0.35s;
+}
+
+@keyframes k0 {
+  0% {
+    stroke-dashoffset: -138.23007675795088;
+    transform: rotate(-90deg);
+  }
+
+  50% {
+    stroke-dashoffset: -86.3937979737193;
+  }
+
+  100% {
+    stroke-dashoffset: -138.23007675795088;
+    transform: rotate(270deg);
+  }
 }
 
 <div>
@@ -292,17 +317,27 @@ exports[`render small progress circle 1`] = `
 .c2 {
   stroke-dasharray: 87.96459430051421 87.96459430051421;
   stroke: #3C64F4;
-  -webkit-transform-origin: 50% 50%;
-  -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: kpuuIv 1s ease-out infinite;
-  animation: kpuuIv 1s ease-out infinite;
+  animation: k0 1s ease-out infinite;
   stroke-dashoffset: 87.96459430051421;
-  -webkit-transform: rotate(-90deg);
-  -ms-transform: rotate(-90deg);
   transform: rotate(-90deg);
-  -webkit-transition: stroke-dashoffset 0.35s;
   transition: stroke-dashoffset 0.35s;
+}
+
+@keyframes k0 {
+  0% {
+    stroke-dashoffset: -87.96459430051421;
+    transform: rotate(-90deg);
+  }
+
+  50% {
+    stroke-dashoffset: -54.97787143782138;
+  }
+
+  100% {
+    stroke-dashoffset: -87.96459430051421;
+    transform: rotate(270deg);
+  }
 }
 
 <div>
@@ -341,17 +376,27 @@ exports[`render xSmall progress circle 1`] = `
 .c2 {
   stroke-dasharray: 65.97344572538566 65.97344572538566;
   stroke: #3C64F4;
-  -webkit-transform-origin: 50% 50%;
-  -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: hiqbsE 1s ease-out infinite;
-  animation: hiqbsE 1s ease-out infinite;
+  animation: k0 1s ease-out infinite;
   stroke-dashoffset: 65.97344572538566;
-  -webkit-transform: rotate(-90deg);
-  -ms-transform: rotate(-90deg);
   transform: rotate(-90deg);
-  -webkit-transition: stroke-dashoffset 0.35s;
   transition: stroke-dashoffset 0.35s;
+}
+
+@keyframes k0 {
+  0% {
+    stroke-dashoffset: -65.97344572538566;
+    transform: rotate(-90deg);
+  }
+
+  50% {
+    stroke-dashoffset: -41.23340357836604;
+  }
+
+  100% {
+    stroke-dashoffset: -65.97344572538566;
+    transform: rotate(270deg);
+  }
 }
 
 <div>
@@ -390,17 +435,27 @@ exports[`render xSmall progress circle 2`] = `
 .c2 {
   stroke-dasharray: 43.982297150257104 43.982297150257104;
   stroke: #3C64F4;
-  -webkit-transform-origin: 50% 50%;
-  -ms-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
-  -webkit-animation: fxwtRW 1s ease-out infinite;
-  animation: fxwtRW 1s ease-out infinite;
+  animation: k0 1s ease-out infinite;
   stroke-dashoffset: 43.982297150257104;
-  -webkit-transform: rotate(-90deg);
-  -ms-transform: rotate(-90deg);
   transform: rotate(-90deg);
-  -webkit-transition: stroke-dashoffset 0.35s;
   transition: stroke-dashoffset 0.35s;
+}
+
+@keyframes k0 {
+  0% {
+    stroke-dashoffset: -43.982297150257104;
+    transform: rotate(-90deg);
+  }
+
+  50% {
+    stroke-dashoffset: -27.48893571891069;
+  }
+
+  100% {
+    stroke-dashoffset: -43.982297150257104;
+    transform: rotate(270deg);
+  }
 }
 
 <div>

--- a/packages/big-design/src/components/Radio/Label/styled.tsx
+++ b/packages/big-design/src/components/Radio/Label/styled.tsx
@@ -3,12 +3,13 @@ import { ComponentPropsWithoutRef } from 'react';
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../../helpers';
+import { TransientMarginProps } from '../../../helpers/margins/margins';
 
 export interface StyledLabelProps extends ComponentPropsWithoutRef<'label'> {
   disabled?: boolean;
 }
 
-export const StyledLabel = styled.label<StyledLabelProps>`
+export const StyledLabel = styled.label<StyledLabelProps & TransientMarginProps>`
   color: ${({ theme }) => theme.colors.secondary70};
   font-size: ${({ theme }) => theme.typography.fontSize.medium};
   font-weight: ${({ theme }) => theme.typography.fontWeight.regular};

--- a/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`render Radio (checked + disabled) 1`] = `
-.c6 {
+.c5 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -11,28 +11,21 @@ exports[`render Radio (checked + disabled) 1`] = `
   cursor: not-allowed;
 }
 
-.c6:last-child {
+.c5:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c4 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -43,10 +36,8 @@ exports[`render Radio (checked + disabled) 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,box-shadow;
   transition-property: border-color,box-shadow;
   background-color: #F6F7FC;
   border: 1px solid #D9DCE9;
@@ -55,28 +46,21 @@ exports[`render Radio (checked + disabled) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   height: 1.25rem;
   position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
   cursor: not-allowed;
   border-color: #D9DCE9;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4:after {
-  -webkit-transition: all 150ms ease-out;
+.c3:after {
   transition: all 150ms ease-out;
-  -webkit-transition-property: opacity;
   transition-property: opacity;
   background-color: #B4BAD1;
   border-radius: 50%;
@@ -86,13 +70,11 @@ exports[`render Radio (checked + disabled) 1`] = `
   opacity: 0;
   position: absolute;
   top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
   width: 0.75rem;
 }
 
-.c4:after {
+.c3:after {
   opacity: 1;
 }
 
@@ -110,16 +92,16 @@ exports[`render Radio (checked + disabled) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     disabled=""
     for=":r8:"
   />
   <div
-    class="c5"
+    class="c4"
   >
     <label
       aria-hidden="true"
-      class="c6"
+      class="c5"
       disabled=""
       for=":r8:"
       id=":r9:"
@@ -131,7 +113,7 @@ exports[`render Radio (checked + disabled) 1`] = `
 `;
 
 exports[`render Radio (checked) 1`] = `
-.c6 {
+.c5 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -140,28 +122,21 @@ exports[`render Radio (checked) 1`] = `
   cursor: pointer;
 }
 
-.c6:last-child {
+.c5:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c4 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -172,10 +147,8 @@ exports[`render Radio (checked) 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,box-shadow;
   transition-property: border-color,box-shadow;
   background-color: #FFFFFF;
   border: 1px solid #D9DCE9;
@@ -184,30 +157,23 @@ exports[`render Radio (checked) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   height: 1.25rem;
   position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c4:hover {
+.c3:hover {
   border-color: #2852EB;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4:after {
-  -webkit-transition: all 150ms ease-out;
+.c3:after {
   transition: all 150ms ease-out;
-  -webkit-transition-property: opacity;
   transition-property: opacity;
   background-color: #3C64F4;
   border-radius: 50%;
@@ -217,13 +183,11 @@ exports[`render Radio (checked) 1`] = `
   opacity: 0;
   position: absolute;
   top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
   width: 0.75rem;
 }
 
-.c4:after {
+.c3:after {
   opacity: 1;
 }
 
@@ -240,14 +204,14 @@ exports[`render Radio (checked) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     for=":r0:"
   />
   <div
-    class="c5"
+    class="c4"
   >
     <label
-      class="c6"
+      class="c5"
       for=":r0:"
       id=":r1:"
     >
@@ -258,7 +222,7 @@ exports[`render Radio (checked) 1`] = `
 `;
 
 exports[`render Radio (unchecked + description object) 1`] = `
-.c7 {
+.c6 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -268,36 +232,33 @@ exports[`render Radio (unchecked + description object) 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c7:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c8 {
-  -webkit-transition: all 70ms ease-out;
+.c7 {
   transition: all 70ms ease-out;
-  -webkit-transition-property: color;
   transition-property: color;
   color: #3C64F4;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
-  -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c8:active {
+.c7:active {
   color: #0024A6;
 }
 
-.c8:hover:not(:active) {
+.c7:hover:not(:active) {
   color: #0024A6;
 }
 
-.c9 {
+.c8 {
   font-size: 0.875rem;
 }
 
-.c6 {
+.c5 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -306,28 +267,21 @@ exports[`render Radio (unchecked + description object) 1`] = `
   cursor: pointer;
 }
 
-.c6:last-child {
+.c5:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c4 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -338,10 +292,8 @@ exports[`render Radio (unchecked + description object) 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,box-shadow;
   transition-property: border-color,box-shadow;
   background-color: #FFFFFF;
   border: 1px solid #D9DCE9;
@@ -350,30 +302,23 @@ exports[`render Radio (unchecked + description object) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   height: 1.25rem;
   position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c4:hover {
+.c3:hover {
   border-color: #B4BAD1;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4:after {
-  -webkit-transition: all 150ms ease-out;
+.c3:after {
   transition: all 150ms ease-out;
-  -webkit-transition-property: opacity;
   transition-property: opacity;
   background-color: #3C64F4;
   border-radius: 50%;
@@ -383,8 +328,6 @@ exports[`render Radio (unchecked + description object) 1`] = `
   opacity: 0;
   position: absolute;
   top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
   width: 0.75rem;
 }
@@ -401,26 +344,26 @@ exports[`render Radio (unchecked + description object) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     for=":r4:"
   />
   <div
-    class="c5"
+    class="c4"
   >
     <label
-      class="c6"
+      class="c5"
       for=":r4:"
       id=":r5:"
     >
       Unchecked
     </label>
     <p
-      class="c7"
+      class="c6"
     >
       description
        
       <a
-        class="c8 c9"
+        class="c7 c8"
         href="bar"
         target="foo"
       >
@@ -432,7 +375,7 @@ exports[`render Radio (unchecked + description object) 1`] = `
 `;
 
 exports[`render Radio (unchecked + description text) 1`] = `
-.c7 {
+.c6 {
   color: #313440;
   margin: 0 0 1rem;
   color: #5E637A;
@@ -442,11 +385,11 @@ exports[`render Radio (unchecked + description text) 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.c7:last-child {
+.c6:last-child {
   margin-bottom: 0;
 }
 
-.c6 {
+.c5 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -455,28 +398,21 @@ exports[`render Radio (unchecked + description text) 1`] = `
   cursor: pointer;
 }
 
-.c6:last-child {
+.c5:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c4 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -487,10 +423,8 @@ exports[`render Radio (unchecked + description text) 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,box-shadow;
   transition-property: border-color,box-shadow;
   background-color: #FFFFFF;
   border: 1px solid #D9DCE9;
@@ -499,30 +433,23 @@ exports[`render Radio (unchecked + description text) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   height: 1.25rem;
   position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c4:hover {
+.c3:hover {
   border-color: #B4BAD1;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4:after {
-  -webkit-transition: all 150ms ease-out;
+.c3:after {
   transition: all 150ms ease-out;
-  -webkit-transition-property: opacity;
   transition-property: opacity;
   background-color: #3C64F4;
   border-radius: 50%;
@@ -532,8 +459,6 @@ exports[`render Radio (unchecked + description text) 1`] = `
   opacity: 0;
   position: absolute;
   top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
   width: 0.75rem;
 }
@@ -550,21 +475,21 @@ exports[`render Radio (unchecked + description text) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     for=":r6:"
   />
   <div
-    class="c5"
+    class="c4"
   >
     <label
-      class="c6"
+      class="c5"
       for=":r6:"
       id=":r7:"
     >
       Unchecked
     </label>
     <p
-      class="c7"
+      class="c6"
     >
       description
     </p>
@@ -573,7 +498,7 @@ exports[`render Radio (unchecked + description text) 1`] = `
 `;
 
 exports[`render Radio (unchecked + disabled) 1`] = `
-.c6 {
+.c5 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -583,28 +508,21 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   cursor: not-allowed;
 }
 
-.c6:last-child {
+.c5:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c4 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -615,10 +533,8 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,box-shadow;
   transition-property: border-color,box-shadow;
   background-color: #F6F7FC;
   border: 1px solid #D9DCE9;
@@ -627,28 +543,21 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   height: 1.25rem;
   position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
   cursor: not-allowed;
   border-color: #D9DCE9;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4:after {
-  -webkit-transition: all 150ms ease-out;
+.c3:after {
   transition: all 150ms ease-out;
-  -webkit-transition-property: opacity;
   transition-property: opacity;
   background-color: #B4BAD1;
   border-radius: 50%;
@@ -658,8 +567,6 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   opacity: 0;
   position: absolute;
   top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
   width: 0.75rem;
 }
@@ -677,16 +584,16 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     disabled=""
     for=":ra:"
   />
   <div
-    class="c5"
+    class="c4"
   >
     <label
       aria-hidden="true"
-      class="c6"
+      class="c5"
       disabled=""
       for=":ra:"
       id=":rb:"
@@ -698,7 +605,7 @@ exports[`render Radio (unchecked + disabled) 1`] = `
 `;
 
 exports[`render Radio (unchecked) 1`] = `
-.c6 {
+.c5 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -707,28 +614,21 @@ exports[`render Radio (unchecked) 1`] = `
   cursor: pointer;
 }
 
-.c6:last-child {
+.c5:last-child {
   margin-bottom: 0;
 }
 
-.c5 {
+.c4 {
   margin-left: 0.5rem;
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -739,10 +639,8 @@ exports[`render Radio (unchecked) 1`] = `
   width: 1px;
 }
 
-.c4 {
-  -webkit-transition: all 150ms ease-out;
+.c3 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,box-shadow;
   transition-property: border-color,box-shadow;
   background-color: #FFFFFF;
   border: 1px solid #D9DCE9;
@@ -751,30 +649,23 @@ exports[`render Radio (unchecked) 1`] = `
   color: #FFFFFF;
   cursor: pointer;
   display: inline-block;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
   height: 1.25rem;
   position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c4:hover {
+.c3:hover {
   border-color: #B4BAD1;
 }
 
-.c1:focus + .c3 {
+.c1:focus+.c3 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c4:after {
-  -webkit-transition: all 150ms ease-out;
+.c3:after {
   transition: all 150ms ease-out;
-  -webkit-transition-property: opacity;
   transition-property: opacity;
   background-color: #3C64F4;
   border-radius: 50%;
@@ -784,8 +675,6 @@ exports[`render Radio (unchecked) 1`] = `
   opacity: 0;
   position: absolute;
   top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
   width: 0.75rem;
 }
@@ -802,14 +691,14 @@ exports[`render Radio (unchecked) 1`] = `
   />
   <label
     aria-hidden="true"
-    class="c3 c4"
+    class="c3"
     for=":r2:"
   />
   <div
-    class="c5"
+    class="c4"
   >
     <label
-      class="c6"
+      class="c5"
       for=":r2:"
       id=":r3:"
     >

--- a/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
@@ -24,88 +24,43 @@ exports[`render Stateless pagination component 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c4 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -125,7 +80,7 @@ exports[`render Stateless pagination component 1`] = `
   pointer-events: none;
 }
 
-.c4 + .bd-button {
+.c4+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -147,45 +102,26 @@ exports[`render Stateless pagination component 1`] = `
 }
 
 .c11 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -204,7 +140,7 @@ exports[`render Stateless pagination component 1`] = `
   pointer-events: none;
 }
 
-.c11 + .bd-button {
+.c11+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -226,12 +162,7 @@ exports[`render Stateless pagination component 1`] = `
 }
 
 .c6 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -268,27 +199,27 @@ exports[`render Stateless pagination component 1`] = `
   width: auto;
 }
 
-@media (min-width:720px) {
-  .c4 + .bd-button {
+@media (min-width: 720px) {
+  .c4+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c4 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c11 + .bd-button {
+@media (min-width: 720px) {
+  .c11+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c11 {
     width: auto;
     padding: 0;

--- a/packages/big-design/src/components/StatusMessage/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/StatusMessage/__snapshots__/spec.tsx.snap
@@ -8,27 +8,12 @@ exports[`renders with the "404" variant 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
   gap: 1rem;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -46,20 +31,9 @@ exports[`renders with the "404" variant 1`] = `
 }
 
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
 }
@@ -71,7 +45,7 @@ exports[`renders with the "404" variant 1`] = `
   position: relative;
   overflow: hidden;
   margin: 0;
-  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M45%2079V41h20.261L75%2050.738V79H45ZM64.127%2051.76V43.27H47.269v33.462h25.462V51.76h-8.604Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22122%22%20height%3D%22129%22%20fill%3D%22none%22%3E%3Cpath%20stroke%3D%22url(%23a)%22%20d%3D%22M1%2090.868%2061%201l60%2089.868%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M121%2038.132%2061%20128%201%2038.132%22%20opacity%3D%22.5%22%20%2F%3E%3Cdefs%3E%3CradialGradient%20id%3D%22a%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20292.218%20-240.194%200%2061%20-19.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20-292.218%20240.194%200%2061%20148.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top,#72d8db 0%,#d9f9fa 100%);
+  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M45%2079V41h20.261L75%2050.738V79H45ZM64.127%2051.76V43.27H47.269v33.462h25.462V51.76h-8.604Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22122%22%20height%3D%22129%22%20fill%3D%22none%22%3E%3Cpath%20stroke%3D%22url(%23a)%22%20d%3D%22M1%2090.868%2061%201l60%2089.868%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M121%2038.132%2061%20128%201%2038.132%22%20opacity%3D%22.5%22%20%2F%3E%3Cdefs%3E%3CradialGradient%20id%3D%22a%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20292.218%20-240.194%200%2061%20-19.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20-292.218%20240.194%200%2061%20148.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top, #72d8db 0%, #d9f9fa 100%);
   content: '';
 }
 
@@ -102,27 +76,12 @@ exports[`renders with the "error" variant 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
   gap: 1rem;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -140,20 +99,9 @@ exports[`renders with the "error" variant 1`] = `
 }
 
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
 }
@@ -165,7 +113,7 @@ exports[`renders with the "error" variant 1`] = `
   position: relative;
   overflow: hidden;
   margin: 0;
-  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M61.023%2050.5h-2.269V62h2.269V50.5Zm-1.022%2014.7c-.384%200-.707.126-.97.378-.261.252-.392.57-.392.953%200%20.398.13.73.392.994.262.265.584.398.968.398.397%200%20.723-.133.979-.398s.383-.596.383-.995c0-.382-.13-.7-.392-.952a1.342%201.342%200%200%200-.968-.378ZM59.984%2041c2.631%200%205.096.499%207.394%201.496a19.347%2019.347%200%200%201%206.038%204.085%2019.333%2019.333%200%200%201%204.088%206.04C78.5%2054.92%2079%2057.386%2079%2060.02c0%202.623-.499%205.087-1.496%207.394-.997%202.307-2.36%204.316-4.086%206.026-1.726%201.71-3.739%203.064-6.039%204.063C65.08%2078.5%2062.613%2079%2059.98%2079c-2.623%200-5.087-.499-7.394-1.496-2.307-.997-4.316-2.35-6.026-4.06-1.71-1.71-3.064-3.72-4.063-6.032C41.5%2065.101%2041%2062.635%2041%2060.016c0-2.631.499-5.096%201.496-7.394s2.35-4.308%204.06-6.029c1.71-1.72%203.72-3.083%206.032-4.087C54.899%2041.502%2057.364%2041%2059.983%2041Zm-.009%202.27c-4.64%200-8.584%201.629-11.833%204.887-3.248%203.26-4.873%207.215-4.873%2011.868%200%204.64%201.622%208.584%204.864%2011.833C51.375%2075.106%2055.331%2076.73%2060%2076.73c4.636%200%208.584-1.622%2011.843-4.864C75.1%2068.625%2076.73%2064.669%2076.73%2060c0-4.636-1.63-8.584-4.888-11.843-3.26-3.258-7.215-4.887-11.868-4.887Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22120%22%20height%3D%22120%22%20fill%3D%22none%22%3E%3Cg%20clip-path%3D%22url(%23a)%22%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M30.727%200%2060%2029.273%2089.272%200%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23c)%22%20d%3D%22M120%2030.727%2090.727%2060%20120%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23d)%22%20d%3D%22M0%2030.727%2029.273%2060%200%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23e)%22%20d%3D%22M89.272%20120%2060%2090.727%2030.727%20120%22%20opacity%3D%22.5%22%20%2F%3E%3C%2Fg%3E%3Cdefs%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(-87.474%2061.379%20-.174)%20scale(104.574%2074.3313)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22c%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(2.409%20-1361.019%201419.477)%20scale(118.789%2084.4351)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22d%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(-117.91637%20-11.90682%208.46332%20-83.81448%2058.463%2058.464)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22e%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(69.856%20-14.194%2071.776)%20scale(164.114%20116.652)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CclipPath%20id%3D%22a%22%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M0%200h120v120H0z%22%20%2F%3E%3C%2FclipPath%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top,#ebb2ca 0%,#eee8fa 100%);
+  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M61.023%2050.5h-2.269V62h2.269V50.5Zm-1.022%2014.7c-.384%200-.707.126-.97.378-.261.252-.392.57-.392.953%200%20.398.13.73.392.994.262.265.584.398.968.398.397%200%20.723-.133.979-.398s.383-.596.383-.995c0-.382-.13-.7-.392-.952a1.342%201.342%200%200%200-.968-.378ZM59.984%2041c2.631%200%205.096.499%207.394%201.496a19.347%2019.347%200%200%201%206.038%204.085%2019.333%2019.333%200%200%201%204.088%206.04C78.5%2054.92%2079%2057.386%2079%2060.02c0%202.623-.499%205.087-1.496%207.394-.997%202.307-2.36%204.316-4.086%206.026-1.726%201.71-3.739%203.064-6.039%204.063C65.08%2078.5%2062.613%2079%2059.98%2079c-2.623%200-5.087-.499-7.394-1.496-2.307-.997-4.316-2.35-6.026-4.06-1.71-1.71-3.064-3.72-4.063-6.032C41.5%2065.101%2041%2062.635%2041%2060.016c0-2.631.499-5.096%201.496-7.394s2.35-4.308%204.06-6.029c1.71-1.72%203.72-3.083%206.032-4.087C54.899%2041.502%2057.364%2041%2059.983%2041Zm-.009%202.27c-4.64%200-8.584%201.629-11.833%204.887-3.248%203.26-4.873%207.215-4.873%2011.868%200%204.64%201.622%208.584%204.864%2011.833C51.375%2075.106%2055.331%2076.73%2060%2076.73c4.636%200%208.584-1.622%2011.843-4.864C75.1%2068.625%2076.73%2064.669%2076.73%2060c0-4.636-1.63-8.584-4.888-11.843-3.26-3.258-7.215-4.887-11.868-4.887Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22120%22%20height%3D%22120%22%20fill%3D%22none%22%3E%3Cg%20clip-path%3D%22url(%23a)%22%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M30.727%200%2060%2029.273%2089.272%200%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23c)%22%20d%3D%22M120%2030.727%2090.727%2060%20120%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23d)%22%20d%3D%22M0%2030.727%2029.273%2060%200%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23e)%22%20d%3D%22M89.272%20120%2060%2090.727%2030.727%20120%22%20opacity%3D%22.5%22%20%2F%3E%3C%2Fg%3E%3Cdefs%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(-87.474%2061.379%20-.174)%20scale(104.574%2074.3313)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22c%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(2.409%20-1361.019%201419.477)%20scale(118.789%2084.4351)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22d%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(-117.91637%20-11.90682%208.46332%20-83.81448%2058.463%2058.464)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22e%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(69.856%20-14.194%2071.776)%20scale(164.114%20116.652)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CclipPath%20id%3D%22a%22%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M0%200h120v120H0z%22%20%2F%3E%3C%2FclipPath%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top, #ebb2ca 0%, #eee8fa 100%);
   content: '';
 }
 
@@ -196,27 +144,12 @@ exports[`renders with the "info" variant 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
   gap: 1rem;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -234,20 +167,9 @@ exports[`renders with the "info" variant 1`] = `
 }
 
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
 }
@@ -259,7 +181,7 @@ exports[`renders with the "info" variant 1`] = `
   position: relative;
   overflow: hidden;
   margin: 0;
-  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M58.977%2069.5h2.269V58h-2.269v11.5Zm1.022-14.7c.384%200%20.707-.126.97-.378.261-.252.392-.57.392-.953%200-.398-.13-.73-.392-.995a1.307%201.307%200%200%200-.968-.397c-.397%200-.723.133-.979.398-.256.264-.383.596-.383.994%200%20.383.13.7.392.953.262.252.584.378.968.378Zm.017%2024.2c-2.631%200-5.096-.499-7.394-1.496a19.347%2019.347%200%200%201-6.038-4.086%2019.333%2019.333%200%200%201-4.088-6.039C41.5%2065.08%2041%2062.613%2041%2059.98c0-2.623.499-5.087%201.496-7.394.997-2.307%202.36-4.316%204.085-6.026%201.727-1.71%203.74-3.064%206.04-4.063C54.92%2041.5%2057.386%2041%2060.02%2041c2.623%200%205.087.499%207.394%201.496%202.307.997%204.316%202.35%206.026%204.06%201.71%201.71%203.064%203.72%204.063%206.032C78.5%2054.899%2079%2057.364%2079%2059.983c0%202.632-.499%205.097-1.496%207.395-.997%202.298-2.35%204.308-4.06%206.028-1.71%201.721-3.72%203.084-6.032%204.088C65.101%2078.498%2062.635%2079%2060.016%2079Zm.009-2.27c4.64%200%208.584-1.629%2011.833-4.888%203.248-3.258%204.873-7.214%204.873-11.867%200-4.64-1.622-8.584-4.864-11.833C68.625%2044.895%2064.669%2043.27%2060%2043.27c-4.636%200-8.584%201.622-11.843%204.864C44.9%2051.375%2043.27%2055.331%2043.27%2060c0%204.636%201.629%208.584%204.887%2011.843%203.26%203.258%207.215%204.888%2011.868%204.888Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22122%22%20height%3D%22129%22%20fill%3D%22none%22%3E%3Cpath%20stroke%3D%22url(%23a)%22%20d%3D%22M1%2090.868%2061%201l60%2089.868%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M121%2038.132%2061%20128%201%2038.132%22%20opacity%3D%22.5%22%20%2F%3E%3Cdefs%3E%3CradialGradient%20id%3D%22a%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20292.218%20-240.194%200%2061%20-19.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20-292.218%20240.194%200%2061%20148.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top,#72d8db 0%,#d9f9fa 100%);
+  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M58.977%2069.5h2.269V58h-2.269v11.5Zm1.022-14.7c.384%200%20.707-.126.97-.378.261-.252.392-.57.392-.953%200-.398-.13-.73-.392-.995a1.307%201.307%200%200%200-.968-.397c-.397%200-.723.133-.979.398-.256.264-.383.596-.383.994%200%20.383.13.7.392.953.262.252.584.378.968.378Zm.017%2024.2c-2.631%200-5.096-.499-7.394-1.496a19.347%2019.347%200%200%201-6.038-4.086%2019.333%2019.333%200%200%201-4.088-6.039C41.5%2065.08%2041%2062.613%2041%2059.98c0-2.623.499-5.087%201.496-7.394.997-2.307%202.36-4.316%204.085-6.026%201.727-1.71%203.74-3.064%206.04-4.063C54.92%2041.5%2057.386%2041%2060.02%2041c2.623%200%205.087.499%207.394%201.496%202.307.997%204.316%202.35%206.026%204.06%201.71%201.71%203.064%203.72%204.063%206.032C78.5%2054.899%2079%2057.364%2079%2059.983c0%202.632-.499%205.097-1.496%207.395-.997%202.298-2.35%204.308-4.06%206.028-1.71%201.721-3.72%203.084-6.032%204.088C65.101%2078.498%2062.635%2079%2060.016%2079Zm.009-2.27c4.64%200%208.584-1.629%2011.833-4.888%203.248-3.258%204.873-7.214%204.873-11.867%200-4.64-1.622-8.584-4.864-11.833C68.625%2044.895%2064.669%2043.27%2060%2043.27c-4.636%200-8.584%201.622-11.843%204.864C44.9%2051.375%2043.27%2055.331%2043.27%2060c0%204.636%201.629%208.584%204.887%2011.843%203.26%203.258%207.215%204.888%2011.868%204.888Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22122%22%20height%3D%22129%22%20fill%3D%22none%22%3E%3Cpath%20stroke%3D%22url(%23a)%22%20d%3D%22M1%2090.868%2061%201l60%2089.868%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M121%2038.132%2061%20128%201%2038.132%22%20opacity%3D%22.5%22%20%2F%3E%3Cdefs%3E%3CradialGradient%20id%3D%22a%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20292.218%20-240.194%200%2061%20-19.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20-292.218%20240.194%200%2061%20148.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top, #72d8db 0%, #d9f9fa 100%);
   content: '';
 }
 
@@ -290,27 +212,12 @@ exports[`renders with the "search" variant 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
   gap: 1rem;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -328,20 +235,9 @@ exports[`renders with the "search" variant 1`] = `
 }
 
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
 }
@@ -353,7 +249,7 @@ exports[`renders with the "search" variant 1`] = `
   position: relative;
   overflow: hidden;
   margin: 0;
-  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M75.53%2077.192%2062.555%2064.215c-.995.88-2.155%201.56-3.48%202.036a12.076%2012.076%200%200%201-4.116.714c-3.396%200-6.27-1.175-8.622-3.526-2.352-2.35-3.528-5.2-3.528-8.55%200-3.349%201.175-6.2%203.525-8.553%202.35-2.352%205.205-3.528%208.561-3.528%203.357%200%206.212%201.175%208.563%203.526%202.352%202.351%203.527%205.202%203.527%208.553%200%201.4-.24%202.765-.719%204.092a11.743%2011.743%200%200%201-2.08%203.605l13.007%2012.927-1.661%201.681ZM54.928%2064.696c2.732%200%205.046-.952%206.943-2.856%201.897-1.904%202.845-4.222%202.845-6.954%200-2.732-.948-5.05-2.845-6.953-1.897-1.904-4.211-2.856-6.943-2.856-2.749%200-5.078.952-6.987%202.856-1.909%201.903-2.863%204.221-2.863%206.953s.954%205.05%202.863%206.954c1.91%201.904%204.238%202.856%206.987%202.856Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22122%22%20height%3D%22129%22%20fill%3D%22none%22%3E%3Cpath%20stroke%3D%22url(%23a)%22%20d%3D%22M1%2090.868%2061%201l60%2089.868%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M121%2038.132%2061%20128%201%2038.132%22%20opacity%3D%22.5%22%20%2F%3E%3Cdefs%3E%3CradialGradient%20id%3D%22a%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20292.218%20-240.194%200%2061%20-19.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20-292.218%20240.194%200%2061%20148.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top,#72d8db 0%,#d9f9fa 100%);
+  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M75.53%2077.192%2062.555%2064.215c-.995.88-2.155%201.56-3.48%202.036a12.076%2012.076%200%200%201-4.116.714c-3.396%200-6.27-1.175-8.622-3.526-2.352-2.35-3.528-5.2-3.528-8.55%200-3.349%201.175-6.2%203.525-8.553%202.35-2.352%205.205-3.528%208.561-3.528%203.357%200%206.212%201.175%208.563%203.526%202.352%202.351%203.527%205.202%203.527%208.553%200%201.4-.24%202.765-.719%204.092a11.743%2011.743%200%200%201-2.08%203.605l13.007%2012.927-1.661%201.681ZM54.928%2064.696c2.732%200%205.046-.952%206.943-2.856%201.897-1.904%202.845-4.222%202.845-6.954%200-2.732-.948-5.05-2.845-6.953-1.897-1.904-4.211-2.856-6.943-2.856-2.749%200-5.078.952-6.987%202.856-1.909%201.903-2.863%204.221-2.863%206.953s.954%205.05%202.863%206.954c1.91%201.904%204.238%202.856%206.987%202.856Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22122%22%20height%3D%22129%22%20fill%3D%22none%22%3E%3Cpath%20stroke%3D%22url(%23a)%22%20d%3D%22M1%2090.868%2061%201l60%2089.868%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M121%2038.132%2061%20128%201%2038.132%22%20opacity%3D%22.5%22%20%2F%3E%3Cdefs%3E%3CradialGradient%20id%3D%22a%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20292.218%20-240.194%200%2061%20-19.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20-292.218%20240.194%200%2061%20148.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top, #72d8db 0%, #d9f9fa 100%);
   content: '';
 }
 
@@ -384,27 +280,12 @@ exports[`renders with the "server-error" variant 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
   gap: 1rem;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -422,20 +303,9 @@ exports[`renders with the "server-error" variant 1`] = `
 }
 
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
 }
@@ -447,7 +317,7 @@ exports[`renders with the "server-error" variant 1`] = `
   position: relative;
   overflow: hidden;
   margin: 0;
-  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M50.518%2048.212c-.594%200-1.098.208-1.51.624-.413.416-.62.92-.62%201.515%200%20.594.209%201.098.625%201.51.415.413.92.62%201.515.62.594%200%201.098-.208%201.51-.624.413-.416.62-.921.62-1.515%200-.595-.208-1.098-.624-1.511a2.071%202.071%200%200%200-1.516-.62Zm0%2019.276c-.594%200-1.098.208-1.51.624-.413.416-.62.922-.62%201.516s.209%201.098.625%201.51c.415.413.92.62%201.515.62.594%200%201.098-.208%201.51-.624.413-.416.62-.921.62-1.516%200-.594-.208-1.097-.624-1.51a2.07%202.07%200%200%200-1.516-.62ZM43%2058.092V42.631h34v15.461H43ZM45.27%2044.9v10.923h29.46V44.9H45.27ZM43%2077.37V61.876h34v15.492H43Zm2.27-13.224V75.1h29.46V64.146H45.27Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22120%22%20height%3D%22120%22%20fill%3D%22none%22%3E%3Cg%20clip-path%3D%22url(%23a)%22%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M30.727%200%2060%2029.273%2089.272%200%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23c)%22%20d%3D%22M120%2030.727%2090.727%2060%20120%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23d)%22%20d%3D%22M0%2030.727%2029.273%2060%200%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23e)%22%20d%3D%22M89.272%20120%2060%2090.727%2030.727%20120%22%20opacity%3D%22.5%22%20%2F%3E%3C%2Fg%3E%3Cdefs%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(-87.474%2061.379%20-.174)%20scale(104.574%2074.3313)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22c%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(2.409%20-1361.019%201419.477)%20scale(118.789%2084.4351)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22d%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(-117.91637%20-11.90682%208.46332%20-83.81448%2058.463%2058.464)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22e%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(69.856%20-14.194%2071.776)%20scale(164.114%20116.652)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CclipPath%20id%3D%22a%22%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M0%200h120v120H0z%22%20%2F%3E%3C%2FclipPath%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top,#ebb2ca 0%,#eee8fa 100%);
+  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M50.518%2048.212c-.594%200-1.098.208-1.51.624-.413.416-.62.92-.62%201.515%200%20.594.209%201.098.625%201.51.415.413.92.62%201.515.62.594%200%201.098-.208%201.51-.624.413-.416.62-.921.62-1.515%200-.595-.208-1.098-.624-1.511a2.071%202.071%200%200%200-1.516-.62Zm0%2019.276c-.594%200-1.098.208-1.51.624-.413.416-.62.922-.62%201.516s.209%201.098.625%201.51c.415.413.92.62%201.515.62.594%200%201.098-.208%201.51-.624.413-.416.62-.921.62-1.516%200-.594-.208-1.097-.624-1.51a2.07%202.07%200%200%200-1.516-.62ZM43%2058.092V42.631h34v15.461H43ZM45.27%2044.9v10.923h29.46V44.9H45.27ZM43%2077.37V61.876h34v15.492H43Zm2.27-13.224V75.1h29.46V64.146H45.27Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22120%22%20height%3D%22120%22%20fill%3D%22none%22%3E%3Cg%20clip-path%3D%22url(%23a)%22%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M30.727%200%2060%2029.273%2089.272%200%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23c)%22%20d%3D%22M120%2030.727%2090.727%2060%20120%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23d)%22%20d%3D%22M0%2030.727%2029.273%2060%200%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23e)%22%20d%3D%22M89.272%20120%2060%2090.727%2030.727%20120%22%20opacity%3D%22.5%22%20%2F%3E%3C%2Fg%3E%3Cdefs%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(-87.474%2061.379%20-.174)%20scale(104.574%2074.3313)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22c%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(2.409%20-1361.019%201419.477)%20scale(118.789%2084.4351)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22d%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(-117.91637%20-11.90682%208.46332%20-83.81448%2058.463%2058.464)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22e%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(69.856%20-14.194%2071.776)%20scale(164.114%20116.652)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CclipPath%20id%3D%22a%22%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M0%200h120v120H0z%22%20%2F%3E%3C%2FclipPath%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top, #ebb2ca 0%, #eee8fa 100%);
   content: '';
 }
 
@@ -478,27 +348,12 @@ exports[`renders with the "success" variant 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
   gap: 1rem;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -516,20 +371,9 @@ exports[`renders with the "success" variant 1`] = `
 }
 
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
 }
@@ -541,7 +385,7 @@ exports[`renders with the "success" variant 1`] = `
   position: relative;
   overflow: hidden;
   margin: 0;
-  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M50.338%2071.125%2039.792%2060.598l1.631-1.63%208.915%208.895.693-.692%201.63%201.63-2.323%202.324Zm9.25%200L49.062%2060.598l1.63-1.63%208.896%208.895%2018.989-18.969%201.63%201.612-20.619%2020.619Zm-.692-8.558-1.63-1.63%2012.06-12.062%201.632%201.63-12.062%2012.062Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22122%22%20height%3D%22129%22%20fill%3D%22none%22%3E%3Cpath%20stroke%3D%22url(%23a)%22%20d%3D%22M1%2090.868%2061%201l60%2089.868%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M121%2038.132%2061%20128%201%2038.132%22%20opacity%3D%22.5%22%20%2F%3E%3Cdefs%3E%3CradialGradient%20id%3D%22a%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20292.218%20-240.194%200%2061%20-19.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20-292.218%20240.194%200%2061%20148.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top,#78e4a3 0%,#f3fdec 100%);
+  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M50.338%2071.125%2039.792%2060.598l1.631-1.63%208.915%208.895.693-.692%201.63%201.63-2.323%202.324Zm9.25%200L49.062%2060.598l1.63-1.63%208.896%208.895%2018.989-18.969%201.63%201.612-20.619%2020.619Zm-.692-8.558-1.63-1.63%2012.06-12.062%201.632%201.63-12.062%2012.062Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22122%22%20height%3D%22129%22%20fill%3D%22none%22%3E%3Cpath%20stroke%3D%22url(%23a)%22%20d%3D%22M1%2090.868%2061%201l60%2089.868%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M121%2038.132%2061%20128%201%2038.132%22%20opacity%3D%22.5%22%20%2F%3E%3Cdefs%3E%3CradialGradient%20id%3D%22a%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20292.218%20-240.194%200%2061%20-19.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20-292.218%20240.194%200%2061%20148.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top, #78e4a3 0%, #f3fdec 100%);
   content: '';
 }
 
@@ -572,27 +416,12 @@ exports[`renders with the "unauthorized" variant 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
   gap: 1rem;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -610,20 +439,9 @@ exports[`renders with the "unauthorized" variant 1`] = `
 }
 
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
 }
@@ -635,7 +453,7 @@ exports[`renders with the "unauthorized" variant 1`] = `
   position: relative;
   overflow: hidden;
   margin: 0;
-  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M57.815%2065.511h4.37l-1.193-6.903a3.443%203.443%200%200%200%201.533-1.172c.394-.532.59-1.128.59-1.79%200-.864-.303-1.6-.91-2.206A3.003%203.003%200%200%200%2060%2052.53c-.864%200-1.6.304-2.206.91a3.004%203.004%200%200%200-.91%202.206c0%20.662.197%201.258.591%201.79.394.532.904.923%201.533%201.172l-1.193%206.903ZM60%2078.942c-4.346-1.192-7.933-3.779-10.76-7.76-2.827-3.98-4.24-8.389-4.24-13.224V46.672l15-5.615%2015%205.615v11.285c0%204.835-1.414%209.244-4.24%2013.225-2.827%203.98-6.414%206.567-10.76%207.76Zm0-2.37c3.73-1.215%206.785-3.552%209.163-7.01%202.379-3.46%203.568-7.328%203.568-11.604v-9.704L60%2043.469l-12.73%204.785v9.704c0%204.276%201.188%208.144%203.566%2011.603%202.379%203.46%205.433%205.796%209.164%207.012Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22120%22%20height%3D%22120%22%20fill%3D%22none%22%3E%3Cg%20clip-path%3D%22url(%23a)%22%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M30.727%200%2060%2029.273%2089.272%200%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23c)%22%20d%3D%22M120%2030.727%2090.727%2060%20120%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23d)%22%20d%3D%22M0%2030.727%2029.273%2060%200%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23e)%22%20d%3D%22M89.272%20120%2060%2090.727%2030.727%20120%22%20opacity%3D%22.5%22%20%2F%3E%3C%2Fg%3E%3Cdefs%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(-87.474%2061.379%20-.174)%20scale(104.574%2074.3313)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22c%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(2.409%20-1361.019%201419.477)%20scale(118.789%2084.4351)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22d%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(-117.91637%20-11.90682%208.46332%20-83.81448%2058.463%2058.464)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22e%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(69.856%20-14.194%2071.776)%20scale(164.114%20116.652)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CclipPath%20id%3D%22a%22%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M0%200h120v120H0z%22%20%2F%3E%3C%2FclipPath%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top,#efc879 0%,#fefbf2 100%);
+  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M57.815%2065.511h4.37l-1.193-6.903a3.443%203.443%200%200%200%201.533-1.172c.394-.532.59-1.128.59-1.79%200-.864-.303-1.6-.91-2.206A3.003%203.003%200%200%200%2060%2052.53c-.864%200-1.6.304-2.206.91a3.004%203.004%200%200%200-.91%202.206c0%20.662.197%201.258.591%201.79.394.532.904.923%201.533%201.172l-1.193%206.903ZM60%2078.942c-4.346-1.192-7.933-3.779-10.76-7.76-2.827-3.98-4.24-8.389-4.24-13.224V46.672l15-5.615%2015%205.615v11.285c0%204.835-1.414%209.244-4.24%2013.225-2.827%203.98-6.414%206.567-10.76%207.76Zm0-2.37c3.73-1.215%206.785-3.552%209.163-7.01%202.379-3.46%203.568-7.328%203.568-11.604v-9.704L60%2043.469l-12.73%204.785v9.704c0%204.276%201.188%208.144%203.566%2011.603%202.379%203.46%205.433%205.796%209.164%207.012Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22120%22%20height%3D%22120%22%20fill%3D%22none%22%3E%3Cg%20clip-path%3D%22url(%23a)%22%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M30.727%200%2060%2029.273%2089.272%200%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23c)%22%20d%3D%22M120%2030.727%2090.727%2060%20120%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23d)%22%20d%3D%22M0%2030.727%2029.273%2060%200%2089.273%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23e)%22%20d%3D%22M89.272%20120%2060%2090.727%2030.727%20120%22%20opacity%3D%22.5%22%20%2F%3E%3C%2Fg%3E%3Cdefs%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(-87.474%2061.379%20-.174)%20scale(104.574%2074.3313)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22c%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(2.409%20-1361.019%201419.477)%20scale(118.789%2084.4351)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22d%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(-117.91637%20-11.90682%208.46332%20-83.81448%2058.463%2058.464)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22e%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22rotate(69.856%20-14.194%2071.776)%20scale(164.114%20116.652)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CclipPath%20id%3D%22a%22%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M0%200h120v120H0z%22%20%2F%3E%3C%2FclipPath%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top, #efc879 0%, #fefbf2 100%);
   content: '';
 }
 
@@ -666,27 +484,12 @@ exports[`renders with the "warning" variant 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
   gap: 1rem;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -704,20 +507,9 @@ exports[`renders with the "warning" variant 1`] = `
 }
 
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
 }
@@ -729,7 +521,7 @@ exports[`renders with the "warning" variant 1`] = `
   position: relative;
   overflow: hidden;
   margin: 0;
-  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M58.865%2062.077h2.27V51.019h-2.27v11.058ZM60%2067.038c.342%200%20.636-.123.882-.368.245-.246.368-.54.368-.882%200-.342-.123-.636-.368-.881a1.203%201.203%200%200%200-.882-.369c-.342%200-.636.123-.882.369-.245.245-.368.539-.368.881%200%20.343.123.636.368.882.246.245.54.368.882.368Zm0%2013.058L39.904%2060%2060%2039.904%2080.096%2060%2060%2080.096Zm0-3.223L76.873%2060%2060%2043.127%2043.127%2060%2060%2076.873Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22122%22%20height%3D%22129%22%20fill%3D%22none%22%3E%3Cpath%20stroke%3D%22url(%23a)%22%20d%3D%22M1%2090.868%2061%201l60%2089.868%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M121%2038.132%2061%20128%201%2038.132%22%20opacity%3D%22.5%22%20%2F%3E%3Cdefs%3E%3CradialGradient%20id%3D%22a%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20292.218%20-240.194%200%2061%20-19.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20-292.218%20240.194%200%2061%20148.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top,#efc879 0%,#fefbf2 100%);
+  background-image: url("data:image/svg+xml,%3Csvg%20fill%3D%22none%22%20height%3D%22120%22%20role%3D%22img%22%20width%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M58.865%2062.077h2.27V51.019h-2.27v11.058ZM60%2067.038c.342%200%20.636-.123.882-.368.245-.246.368-.54.368-.882%200-.342-.123-.636-.368-.881a1.203%201.203%200%200%200-.882-.369c-.342%200-.636.123-.882.369-.245.245-.368.539-.368.881%200%20.343.123.636.368.882.246.245.54.368.882.368Zm0%2013.058L39.904%2060%2060%2039.904%2080.096%2060%2060%2080.096Zm0-3.223L76.873%2060%2060%2043.127%2043.127%2060%2060%2076.873Z%22%20fill%3D%22%23fff%22%20%2F%3E%3C%2Fsvg%3E"),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22122%22%20height%3D%22129%22%20fill%3D%22none%22%3E%3Cpath%20stroke%3D%22url(%23a)%22%20d%3D%22M1%2090.868%2061%201l60%2089.868%22%20opacity%3D%22.5%22%20%2F%3E%3Cpath%20stroke%3D%22url(%23b)%22%20d%3D%22M121%2038.132%2061%20128%201%2038.132%22%20opacity%3D%22.5%22%20%2F%3E%3Cdefs%3E%3CradialGradient%20id%3D%22a%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20292.218%20-240.194%200%2061%20-19.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3CradialGradient%20id%3D%22b%22%20cx%3D%220%22%20cy%3D%220%22%20r%3D%221%22%20gradientTransform%3D%22matrix(0%20-292.218%20240.194%200%2061%20148.095)%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%3Cstop%20stop-color%3D%22%23fff%22%20%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23fff%22%20stop-opacity%3D%220%22%20%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3C%2Fsvg%3E"),radial-gradient(circle at center top, #efc879 0%, #fefbf2 100%);
   content: '';
 }
 

--- a/packages/big-design/src/components/Stepper/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Stepper/__snapshots__/spec.tsx.snap
@@ -42,50 +42,20 @@ exports[`renders Stepper 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c6 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -131,8 +101,6 @@ exports[`renders Stepper 1`] = `
 }
 
 .c4 {
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
   gap: 0.5rem;
   grid-template-areas: 'light dash' 'text text';
@@ -143,15 +111,10 @@ exports[`renders Stepper 1`] = `
   border-radius: 1rem;
   color: #FFFFFF;
   grid-area: light;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 
 .c10 {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
   align-self: center;
   height: 0.125rem;
   grid-area: dash;
@@ -162,159 +125,159 @@ exports[`renders Stepper 1`] = `
   grid-area: text;
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c2 {
     display: none;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c2 {
     display: grid;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c2 {
     margin-right: 0.5rem;
   }
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c5 {
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c5 {
     padding-top: 0;
     padding-bottom: 0;
   }
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c5 {
     padding-left: 0.5rem;
     padding-right: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c5 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c9 {
     display: none;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c9 {
     display: block;
   }
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c13 {
     display: grid;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c13 {
     display: grid;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c13 {
     margin-right: 0.5rem;
   }
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c16 {
     display: none;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c16 {
     display: block;
   }
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c17 {
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c17 {
     padding-top: 0;
     padding-bottom: 0;
   }
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c17 {
     padding-left: 0.5rem;
     padding-right: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c17 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c18 {
     display: none;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c18 {
     display: none;
   }
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c3 {
     display: none;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     display: grid;
   }
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c14 {
     display: grid;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c14 {
     display: grid;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c4 {
     grid-template-columns: 1.5rem 1fr;
     grid-template-rows: 1.5rem 1fr;
@@ -323,10 +286,9 @@ exports[`renders Stepper 1`] = `
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c15 {
     border: 0;
-    -webkit-clip: rect(0 0 0 0);
     clip: rect(0 0 0 0);
     height: 1px;
     margin: -1px;
@@ -338,7 +300,7 @@ exports[`renders Stepper 1`] = `
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c7 {
     border-radius: 50%;
     font-size: 1rem;

--- a/packages/big-design/src/components/Switch/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Switch/__snapshots__/spec.tsx.snap
@@ -6,29 +6,15 @@ exports[`render Switch checked 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -39,14 +25,12 @@ exports[`render Switch checked 1`] = `
   width: 1px;
 }
 
-.c2:focus + label::before {
+.c2:focus+label::before {
   box-shadow: 0px 0px 0px 4px rgba(60,100,244,0.2);
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background,border-color;
   transition-property: background,border-color;
   background: #9EB3FC;
   border-color: #9EB3FC;
@@ -66,10 +50,7 @@ exports[`render Switch checked 1`] = `
 }
 
 .c3::before {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background,-webkit-transform;
-  -webkit-transition-property: background,transform;
   transition-property: background,transform;
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -83,18 +64,14 @@ exports[`render Switch checked 1`] = `
   width: 1.5rem;
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c1 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
     flex-direction: column;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
     flex-direction: row;
   }
 }
@@ -122,29 +99,15 @@ exports[`render Switch disabled checked 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -155,14 +118,12 @@ exports[`render Switch disabled checked 1`] = `
   width: 1px;
 }
 
-.c2:focus + label::before {
+.c2:focus+label::before {
   box-shadow: 0px 0px 0px 4px rgba(60,100,244,0.2);
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background,border-color;
   transition-property: background,border-color;
   background: #9EB3FC;
   border-color: #9EB3FC;
@@ -190,10 +151,7 @@ exports[`render Switch disabled checked 1`] = `
 }
 
 .c3::before {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background,-webkit-transform;
-  -webkit-transition-property: background,transform;
   transition-property: background,transform;
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -209,18 +167,14 @@ exports[`render Switch disabled checked 1`] = `
   cursor: not-allowed;
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c1 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
     flex-direction: column;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
     flex-direction: row;
   }
 }
@@ -250,29 +204,15 @@ exports[`render Switch disabled unchecked 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -283,14 +223,12 @@ exports[`render Switch disabled unchecked 1`] = `
   width: 1px;
 }
 
-.c2:focus + label::before {
+.c2:focus+label::before {
   box-shadow: 0px 0px 0px 4px rgba(60,100,244,0.2);
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background,border-color;
   transition-property: background,border-color;
   background: #D9DCE9;
   border-color: #D9DCE9;
@@ -318,10 +256,7 @@ exports[`render Switch disabled unchecked 1`] = `
 }
 
 .c3::before {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background,-webkit-transform;
-  -webkit-transition-property: background,transform;
   transition-property: background,transform;
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -335,23 +270,17 @@ exports[`render Switch disabled unchecked 1`] = `
   width: 1.5rem;
   background: #F6F7FC;
   cursor: not-allowed;
-  -webkit-transform: translateX(-100%);
-  -ms-transform: translateX(-100%);
   transform: translateX(-100%);
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c1 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
     flex-direction: column;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
     flex-direction: row;
   }
 }
@@ -380,29 +309,15 @@ exports[`render Switch unchecked 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -413,14 +328,12 @@ exports[`render Switch unchecked 1`] = `
   width: 1px;
 }
 
-.c2:focus + label::before {
+.c2:focus+label::before {
   box-shadow: 0px 0px 0px 4px rgba(60,100,244,0.2);
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background,border-color;
   transition-property: background,border-color;
   background: #D9DCE9;
   border-color: #D9DCE9;
@@ -440,10 +353,7 @@ exports[`render Switch unchecked 1`] = `
 }
 
 .c3::before {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background,-webkit-transform;
-  -webkit-transition-property: background,transform;
   transition-property: background,transform;
   border-radius: 0.25rem;
   box-shadow: 0px 1px 6px rgba(49,52,64,0.2);
@@ -455,23 +365,17 @@ exports[`render Switch unchecked 1`] = `
   position: absolute;
   top: -0.3125rem;
   width: 1.5rem;
-  -webkit-transform: translateX(-100%);
-  -ms-transform: translateX(-100%);
   transform: translateX(-100%);
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c1 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
     flex-direction: column;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
     flex-direction: row;
   }
 }

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -24,107 +24,51 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 .c4 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
 .c5 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c7 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -144,7 +88,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   pointer-events: none;
 }
 
-.c7 + .bd-button {
+.c7+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -166,45 +110,26 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 .c14 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -223,7 +148,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   pointer-events: none;
 }
 
-.c14 + .bd-button {
+.c14+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -245,12 +170,7 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 .c9 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -292,46 +212,35 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: stretch;
-  -webkit-justify-content: stretch;
-  -ms-flex-pack: stretch;
   justify-content: stretch;
   background-color: #FFFFFF;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
 }
 
-@media (min-width:720px) {
-  .c7 + .bd-button {
+@media (min-width: 720px) {
+  .c7+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c7 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c14 + .bd-button {
+@media (min-width: 720px) {
+  .c14+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c14 {
     width: auto;
     padding: 0;
@@ -491,26 +400,11 @@ exports[`renders a simple table 1`] = `
 }
 
 .c3 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -534,9 +428,6 @@ exports[`renders a simple table 1`] = `
 }
 
 .c4 {
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -558,9 +449,7 @@ exports[`renders a simple table 1`] = `
 }
 
 .c5 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color;
   transition-property: background-color;
   display: table-row;
   background-color: transparent;
@@ -732,7 +621,7 @@ exports[`renders a table figure 1`] = `
   white-space: nowrap;
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     white-space: normal;
   }
@@ -744,7 +633,7 @@ exports[`renders a table figure 1`] = `
 `;
 
 exports[`selectable renders selectable actions and checkboxes 1`] = `
-.c10 {
+.c9 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -759,55 +648,29 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   box-sizing: border-box;
 }
 
-.c14 {
+.c13 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
 
 .c4 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c13 {
+.c12 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -816,11 +679,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin-left: 0.75rem;
 }
 
-.c13:last-child {
+.c12:last-child {
   margin-bottom: 0;
 }
 
-.c15 {
+.c14 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -829,11 +692,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0;
 }
 
-.c15:last-child {
+.c14:last-child {
   margin-bottom: 0;
 }
 
-.c12 {
+.c11 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -841,7 +704,6 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0 0 1rem;
   cursor: pointer;
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -852,28 +714,21 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   width: 1px;
 }
 
-.c12:last-child {
+.c11:last-child {
   margin-bottom: 0;
 }
 
-.c11 {
+.c10 {
   margin-left: 0.5rem;
 }
 
 .c5 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c7 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -884,14 +739,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   width: 1px;
 }
 
-.c9 {
-  -webkit-transition: all 150ms ease-out;
+.c8 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #FFFFFF;
   box-sizing: border-box;
@@ -900,52 +750,32 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c9:hover {
+.c8:hover {
   border-color: #B4BAD1;
 }
 
-.c6:focus + .c8 {
+.c6:focus+.c8 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9 svg {
+.c8 svg {
   opacity: 0;
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: stretch;
-  -webkit-justify-content: stretch;
-  -ms-flex-pack: stretch;
   justify-content: stretch;
   background-color: #FFFFFF;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
 }
@@ -974,12 +804,12 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         />
         <label
           aria-hidden="true"
-          class="c8 c9"
+          class="c8"
           for=":r3d:"
         >
           <svg
             aria-hidden="true"
-            class="c10"
+            class="c9"
             fill="currentColor"
             height="24"
             stroke="currentColor"
@@ -997,10 +827,10 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
           </svg>
         </label>
         <div
-          class="c11"
+          class="c10"
         >
           <label
-            class="c12"
+            class="c11"
             for=":r3d:"
             hidden=""
             id=":r3e:"
@@ -1010,17 +840,17 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         </div>
       </div>
       <p
-        class="c13"
+        class="c12"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c14 c2"
+    class="c13 c2"
   >
     <p
-      class="c15"
+      class="c14"
     >
       Product
     </p>

--- a/packages/big-design/src/components/Table/helpers/display/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/helpers/display/__snapshots__/spec.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`responsive display 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     display: none;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     display: table-cell;
   }

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -24,107 +24,51 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 .c4 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
 .c5 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
 .c7 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -144,7 +88,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   pointer-events: none;
 }
 
-.c7 + .bd-button {
+.c7+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -166,45 +110,26 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 .c14 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -223,7 +148,7 @@ exports[`offset pagination renders a pagination component 1`] = `
   pointer-events: none;
 }
 
-.c14 + .bd-button {
+.c14+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -245,12 +170,7 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 .c9 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -292,46 +212,35 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: stretch;
-  -webkit-justify-content: stretch;
-  -ms-flex-pack: stretch;
   justify-content: stretch;
   background-color: #FFFFFF;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
 }
 
-@media (min-width:720px) {
-  .c7 + .bd-button {
+@media (min-width: 720px) {
+  .c7+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c7 {
     width: auto;
   }
 }
 
-@media (min-width:720px) {
-  .c14 + .bd-button {
+@media (min-width: 720px) {
+  .c14+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c14 {
     width: auto;
     padding: 0;
@@ -491,26 +400,11 @@ exports[`renders a simple table 1`] = `
 }
 
 .c3 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -534,9 +428,6 @@ exports[`renders a simple table 1`] = `
 }
 
 .c4 {
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -558,9 +449,7 @@ exports[`renders a simple table 1`] = `
 }
 
 .c5 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color;
   transition-property: background-color;
   display: table-row;
   background-color: transparent;
@@ -792,7 +681,7 @@ exports[`renders a table figure 1`] = `
   white-space: nowrap;
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     white-space: normal;
   }
@@ -804,7 +693,7 @@ exports[`renders a table figure 1`] = `
 `;
 
 exports[`selectable renders selectable actions and checkboxes 1`] = `
-.c10 {
+.c9 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -819,55 +708,29 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   box-sizing: border-box;
 }
 
-.c14 {
+.c13 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
 
 .c4 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c13 {
+.c12 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -876,11 +739,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin-left: 0.75rem;
 }
 
-.c13:last-child {
+.c12:last-child {
   margin-bottom: 0;
 }
 
-.c15 {
+.c14 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -889,11 +752,11 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0;
 }
 
-.c15:last-child {
+.c14:last-child {
   margin-bottom: 0;
 }
 
-.c12 {
+.c11 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -901,7 +764,6 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   margin: 0 0 1rem;
   cursor: pointer;
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -912,28 +774,21 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   width: 1px;
 }
 
-.c12:last-child {
+.c11:last-child {
   margin-bottom: 0;
 }
 
-.c11 {
+.c10 {
   margin-left: 0.5rem;
 }
 
 .c5 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c7 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -944,14 +799,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   width: 1px;
 }
 
-.c9 {
-  -webkit-transition: all 150ms ease-out;
+.c8 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #FFFFFF;
   box-sizing: border-box;
@@ -960,52 +810,32 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c9:hover {
+.c8:hover {
   border-color: #B4BAD1;
 }
 
-.c6:focus + .c8 {
+.c6:focus+.c8 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9 svg {
+.c8 svg {
   opacity: 0;
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: stretch;
-  -webkit-justify-content: stretch;
-  -ms-flex-pack: stretch;
   justify-content: stretch;
   background-color: #FFFFFF;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
 }
@@ -1034,12 +864,12 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         />
         <label
           aria-hidden="true"
-          class="c8 c9"
+          class="c8"
           for=":r92:"
         >
           <svg
             aria-hidden="true"
-            class="c10"
+            class="c9"
             fill="currentColor"
             height="24"
             stroke="currentColor"
@@ -1057,10 +887,10 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
           </svg>
         </label>
         <div
-          class="c11"
+          class="c10"
         >
           <label
-            class="c12"
+            class="c11"
             for=":r92:"
             hidden=""
             id=":r93:"
@@ -1070,17 +900,17 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         </div>
       </div>
       <p
-        class="c13"
+        class="c12"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c14 c2"
+    class="c13 c2"
   >
     <p
-      class="c15"
+      class="c14"
     >
       Product
     </p>
@@ -1089,7 +919,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 `;
 
 exports[`selectable selectable by default (isChildrenRowsSelectable prop is not used or is set to false) when isChildrenRowsSelectable prop is not used or is set to false, as default renders checkboxes just for parent rows 1`] = `
-.c10 {
+.c9 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -1104,55 +934,29 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   box-sizing: border-box;
 }
 
-.c14 {
+.c13 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
 
 .c4 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c13 {
+.c12 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1161,11 +965,11 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   margin-left: 0.75rem;
 }
 
-.c13:last-child {
+.c12:last-child {
   margin-bottom: 0;
 }
 
-.c15 {
+.c14 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1174,11 +978,11 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   margin: 0;
 }
 
-.c15:last-child {
+.c14:last-child {
   margin-bottom: 0;
 }
 
-.c12 {
+.c11 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -1186,7 +990,6 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   margin: 0 0 1rem;
   cursor: pointer;
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -1197,28 +1000,21 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   width: 1px;
 }
 
-.c12:last-child {
+.c11:last-child {
   margin-bottom: 0;
 }
 
-.c11 {
+.c10 {
   margin-left: 0.5rem;
 }
 
 .c5 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c7 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -1229,14 +1025,9 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   width: 1px;
 }
 
-.c9 {
-  -webkit-transition: all 150ms ease-out;
+.c8 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #FFFFFF;
   box-sizing: border-box;
@@ -1245,62 +1036,34 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c9:hover {
+.c8:hover {
   border-color: #B4BAD1;
 }
 
-.c6:focus + .c8 {
+.c6:focus+.c8 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9 svg {
+.c8 svg {
   opacity: 0;
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: stretch;
-  -webkit-justify-content: stretch;
-  -ms-flex-pack: stretch;
   justify-content: stretch;
   background-color: #FFFFFF;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
 }
 
 <div
@@ -1327,12 +1090,12 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
         />
         <label
           aria-hidden="true"
-          class="c8 c9"
+          class="c8"
           for=":r9o:"
         >
           <svg
             aria-hidden="true"
-            class="c10"
+            class="c9"
             fill="currentColor"
             height="24"
             stroke="currentColor"
@@ -1350,10 +1113,10 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
           </svg>
         </label>
         <div
-          class="c11"
+          class="c10"
         >
           <label
-            class="c12"
+            class="c11"
             for=":r9o:"
             hidden=""
             id=":r9p:"
@@ -1363,17 +1126,17 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
         </div>
       </div>
       <p
-        class="c13"
+        class="c12"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c14 c2"
+    class="c13 c2"
   >
     <p
-      class="c15"
+      class="c14"
     >
       Product
     </p>
@@ -1382,7 +1145,7 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
 `;
 
 exports[`selectable selectable by not default (isChildrenRowsSelectable prop is used and it is set to true renders checkboxes for parent rows and children rows) 1`] = `
-.c10 {
+.c9 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
@@ -1397,55 +1160,29 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   box-sizing: border-box;
 }
 
-.c14 {
+.c13 {
   margin-right: 1rem;
   box-sizing: border-box;
 }
 
 .c4 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c2 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c13 {
+.c12 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1454,11 +1191,11 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   margin-left: 0.75rem;
 }
 
-.c13:last-child {
+.c12:last-child {
   margin-bottom: 0;
 }
 
-.c15 {
+.c14 {
   color: #313440;
   margin: 0 0 1rem;
   font-size: 1rem;
@@ -1467,11 +1204,11 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   margin: 0;
 }
 
-.c15:last-child {
+.c14:last-child {
   margin-bottom: 0;
 }
 
-.c12 {
+.c11 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -1479,7 +1216,6 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   margin: 0 0 1rem;
   cursor: pointer;
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -1490,28 +1226,21 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   width: 1px;
 }
 
-.c12:last-child {
+.c11:last-child {
   margin-bottom: 0;
 }
 
-.c11 {
+.c10 {
   margin-left: 0.5rem;
 }
 
 .c5 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c7 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -1522,14 +1251,9 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   width: 1px;
 }
 
-.c9 {
-  -webkit-transition: all 150ms ease-out;
+.c8 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #FFFFFF;
   box-sizing: border-box;
@@ -1538,62 +1262,34 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c9:hover {
+.c8:hover {
   border-color: #B4BAD1;
 }
 
-.c6:focus + .c8 {
+.c6:focus+.c8 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c9 svg {
+.c8 svg {
   opacity: 0;
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: stretch;
-  -webkit-justify-content: stretch;
-  -ms-flex-pack: stretch;
   justify-content: stretch;
   background-color: #FFFFFF;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 0.75rem 1.5rem;
-}
-
-@media (min-width:720px) {
-
-}
-
-@media (min-width:720px) {
-
 }
 
 <div
@@ -1620,12 +1316,12 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
         />
         <label
           aria-hidden="true"
-          class="c8 c9"
+          class="c8"
           for=":rdf:"
         >
           <svg
             aria-hidden="true"
-            class="c10"
+            class="c9"
             fill="currentColor"
             height="24"
             stroke="currentColor"
@@ -1643,10 +1339,10 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
           </svg>
         </label>
         <div
-          class="c11"
+          class="c10"
         >
           <label
-            class="c12"
+            class="c11"
             for=":rdf:"
             hidden=""
             id=":rdg:"
@@ -1656,17 +1352,17 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
         </div>
       </div>
       <p
-        class="c13"
+        class="c12"
       >
         5
       </p>
     </div>
   </div>
   <div
-    class="c14 c2"
+    class="c13 c2"
   >
     <p
-      class="c15"
+      class="c14"
     >
       Product
     </p>

--- a/packages/big-design/src/components/TableNext/helpers/display/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/helpers/display/__snapshots__/spec.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`responsive display 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     display: none;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     display: table-cell;
   }

--- a/packages/big-design/src/components/Tabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tabs/__snapshots__/spec.tsx.snap
@@ -6,69 +6,35 @@ exports[`render Tabs 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -87,7 +53,7 @@ exports[`render Tabs 1`] = `
   pointer-events: none;
 }
 
-.c3 + .bd-button {
+.c3+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -109,12 +75,7 @@ exports[`render Tabs 1`] = `
 }
 
 .c5 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -135,14 +96,14 @@ exports[`render Tabs 1`] = `
   width: auto;
 }
 
-@media (min-width:720px) {
-  .c3 + .bd-button {
+@media (min-width: 720px) {
+  .c3+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     width: auto;
   }
@@ -189,69 +150,35 @@ exports[`render Tabs with disabled item 1`] = `
 }
 
 .c1 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -270,7 +197,7 @@ exports[`render Tabs with disabled item 1`] = `
   pointer-events: none;
 }
 
-.c3 + .bd-button {
+.c3+.bd-button {
   margin-top: 0.5rem;
 }
 
@@ -292,12 +219,7 @@ exports[`render Tabs with disabled item 1`] = `
 }
 
 .c5 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
@@ -318,14 +240,14 @@ exports[`render Tabs with disabled item 1`] = `
   width: auto;
 }
 
-@media (min-width:720px) {
-  .c3 + .bd-button {
+@media (min-width: 720px) {
+  .c3+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c3 {
     width: auto;
   }

--- a/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
@@ -16,21 +16,13 @@ exports[`renders all together 1`] = `
 }
 
 .c2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   position: relative;
 }
 
 .c3 {
-  -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
-  -webkit-transition-property: border,box-shadow;
   transition-property: border,box-shadow;
   background-color: #FFFFFF;
   border-radius: 0.25rem;
@@ -55,24 +47,6 @@ exports[`renders all together 1`] = `
 
 .c3[disabled] {
   background-color: #ECEEF5;
-}
-
-.c3::-webkit-input-placeholder {
-  color: #B4BAD1;
-  line-height: 1.5rem;
-  font-size: 1rem;
-}
-
-.c3::-moz-placeholder {
-  color: #B4BAD1;
-  line-height: 1.5rem;
-  font-size: 1rem;
-}
-
-.c3:-ms-input-placeholder {
-  color: #B4BAD1;
-  line-height: 1.5rem;
-  font-size: 1rem;
 }
 
 .c3::placeholder {

--- a/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Tree/__snapshots__/spec.tsx.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders simple tree 1`] = `
-.c8 {
+.c7 {
   vertical-align: middle;
   color: #5E637A;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c11 {
+.c10 {
   vertical-align: middle;
   color: #9EB3FC;
   height: 1.5rem;
@@ -19,73 +19,44 @@ exports[`renders simple tree 1`] = `
   list-style-type: none;
   margin: 0;
   padding: 0;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 
-.c0 > li > ul {
+.c0 >li>ul {
   padding-left: 1.75rem;
 }
 
 .c0.c0[role='tree'] {
-  overflow: hidden !important;
+  overflow: hidden!important;
 }
 
 .c2 {
   box-sizing: border-box;
 }
 
-.c9 {
+.c8 {
   margin-left: 0.25rem;
   box-sizing: border-box;
 }
 
 .c3 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
-.c6 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
+.c5 {
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c12 {
+.c11 {
   color: #313440;
   margin: 0 0 1rem;
   display: inline-block;
@@ -100,7 +71,7 @@ exports[`renders simple tree 1`] = `
   margin-left: 0.25rem;
 }
 
-.c12:last-child {
+.c11:last-child {
   margin-bottom: 0;
 }
 
@@ -108,18 +79,18 @@ exports[`renders simple tree 1`] = `
   outline: 0;
 }
 
-.c7 {
+.c6 {
   z-index: 1;
 }
 
-.c5 {
+.c4 {
   cursor: pointer;
   min-height: 2.5rem;
   position: relative;
 }
 
-li:focus > .c4::after,
-.c5:hover::after {
+li:focus>.c4::after,
+.c4:hover::after {
   bottom: 0;
   content: '';
   left: -1000px;
@@ -130,24 +101,22 @@ li:focus > .c4::after,
   background-color: #F6F7FC;
 }
 
-.c5 label,
-.c5 svg {
+.c4 label,
+.c4 svg {
   vertical-align: middle;
 }
 
-.c10 {
+.c9 {
   z-index: 1;
 }
 
-.c14 {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
+.c13 {
   flex-shrink: 0;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c13 {
+.c12 {
   z-index: 1;
 }
 
@@ -166,14 +135,14 @@ li:focus > .c4::after,
     tabindex="-1"
   >
     <div
-      class="c2 c3 c4 c5"
+      class="c2 c3 c4"
     >
       <div
-        class="c2 c6 c7"
+        class="c2 c5 c6"
       >
         <svg
           aria-hidden="true"
-          class="c8"
+          class="c7"
           fill="currentColor"
           focusable="false"
           height="24"
@@ -192,11 +161,11 @@ li:focus > .c4::after,
         </svg>
       </div>
       <div
-        class="c9 c6 c10"
+        class="c8 c5 c9"
       >
         <svg
           aria-hidden="true"
-          class="c11"
+          class="c10"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -214,7 +183,7 @@ li:focus > .c4::after,
         </svg>
       </div>
       <span
-        class="c12 c13"
+        class="c11 c12"
         color="secondary70"
       >
         Test Node 0
@@ -231,14 +200,14 @@ li:focus > .c4::after,
     tabindex="-1"
   >
     <div
-      class="c2 c3 c4 c5"
+      class="c2 c3 c4"
     >
       <div
-        class="c2 c6 c7"
+        class="c2 c5 c6"
       >
         <svg
           aria-hidden="true"
-          class="c8"
+          class="c7"
           fill="currentColor"
           focusable="false"
           height="24"
@@ -257,11 +226,11 @@ li:focus > .c4::after,
         </svg>
       </div>
       <div
-        class="c9 c6 c10"
+        class="c8 c5 c9"
       >
         <svg
           aria-hidden="true"
-          class="c11"
+          class="c10"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -279,7 +248,7 @@ li:focus > .c4::after,
         </svg>
       </div>
       <span
-        class="c12 c13"
+        class="c11 c12"
         color="secondary70"
       >
         Test Node 1
@@ -296,17 +265,17 @@ li:focus > .c4::after,
     tabindex="-1"
   >
     <div
-      class="c2 c3 c4 c5"
+      class="c2 c3 c4"
     >
       <div
-        class="c14"
+        class="c13"
       />
       <div
-        class="c9 c6 c10"
+        class="c8 c5 c9"
       >
         <svg
           aria-hidden="true"
-          class="c11"
+          class="c10"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -324,7 +293,7 @@ li:focus > .c4::after,
         </svg>
       </div>
       <span
-        class="c12 c13"
+        class="c11 c12"
         color="secondary70"
       >
         Category
@@ -341,14 +310,14 @@ li:focus > .c4::after,
     tabindex="-1"
   >
     <div
-      class="c2 c3 c4 c5"
+      class="c2 c3 c4"
     >
       <div
-        class="c2 c6 c7"
+        class="c2 c5 c6"
       >
         <svg
           aria-hidden="true"
-          class="c8"
+          class="c7"
           fill="currentColor"
           focusable="false"
           height="24"
@@ -367,11 +336,11 @@ li:focus > .c4::after,
         </svg>
       </div>
       <div
-        class="c9 c6 c10"
+        class="c8 c5 c9"
       >
         <svg
           aria-hidden="true"
-          class="c11"
+          class="c10"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -389,7 +358,7 @@ li:focus > .c4::after,
         </svg>
       </div>
       <span
-        class="c12 c13"
+        class="c11 c12"
         color="secondary70"
       >
         Test Node 3
@@ -406,14 +375,14 @@ li:focus > .c4::after,
     tabindex="-1"
   >
     <div
-      class="c2 c3 c4 c5"
+      class="c2 c3 c4"
     >
       <div
-        class="c2 c6 c7"
+        class="c2 c5 c6"
       >
         <svg
           aria-hidden="true"
-          class="c8"
+          class="c7"
           fill="currentColor"
           focusable="false"
           height="24"
@@ -432,11 +401,11 @@ li:focus > .c4::after,
         </svg>
       </div>
       <div
-        class="c9 c6 c10"
+        class="c8 c5 c9"
       >
         <svg
           aria-hidden="true"
-          class="c11"
+          class="c10"
           fill="currentColor"
           height="24"
           stroke="currentColor"
@@ -454,7 +423,7 @@ li:focus > .c4::after,
         </svg>
       </div>
       <span
-        class="c12 c13"
+        class="c11 c12"
         color="secondary70"
       >
         Test Node 4

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -7,30 +7,23 @@ exports[`renders worksheet 1`] = `
   width: 1rem;
 }
 
-.c18 {
+.c17 {
   vertical-align: middle;
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c19 {
+.c18 {
   margin-left: 0.5rem;
 }
 
 .c13 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c15 {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -41,14 +34,9 @@ exports[`renders worksheet 1`] = `
   width: 1px;
 }
 
-.c17 {
-  -webkit-transition: all 150ms ease-out;
+.c16 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #3C64F4;
   box-sizing: border-box;
@@ -57,44 +45,30 @@ exports[`renders worksheet 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c17:hover {
+.c16:hover {
   border-color: #3C64F4;
 }
 
-.c14:focus + .c16 {
+.c14:focus+.c16 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c17 svg {
+.c16 svg {
   opacity: 1;
 }
 
-.c30 {
-  -webkit-transition: all 150ms ease-out;
+.c29 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: border-color,background,box-shadow,color,opacity;
   transition-property: border-color,background,box-shadow,color,opacity;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   background: #FFFFFF;
   box-sizing: border-box;
@@ -103,33 +77,24 @@ exports[`renders worksheet 1`] = `
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   margin-bottom: 0.125rem;
   margin-top: 0.125rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   width: 1.25rem;
 }
 
-.c30:hover {
+.c29:hover {
   border-color: #B4BAD1;
 }
 
-.c14:focus + .c16 {
+.c14:focus+.c29 {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c30 svg {
+.c29 svg {
   opacity: 0;
 }
 
@@ -138,52 +103,28 @@ exports[`renders worksheet 1`] = `
   box-sizing: border-box;
 }
 
-.c21 {
-  box-sizing: border-box;
-}
-
-.c23 {
-  padding-right: 0.75rem;
+.c20 {
   box-sizing: border-box;
 }
 
 .c22 {
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
+  padding-right: 0.75rem;
+  box-sizing: border-box;
+}
+
+.c21 {
   align-content: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
-.c24 {
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
+.c23 {
   align-self: auto;
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
   order: 0;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
   flex-shrink: 1;
 }
 
@@ -207,46 +148,27 @@ exports[`renders worksheet 1`] = `
   margin-bottom: 0;
 }
 
-.c26 {
-  -webkit-transition: all 150ms ease-out;
+.c25 {
   transition: all 150ms ease-out;
-  -webkit-transition-property: background-color,border-color,box-shadow,color;
   transition-property: background-color,border-color,box-shadow,color;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: 1px solid #D9DCE9;
   border-radius: 0.25rem;
   color: #FFFFFF;
   cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-flex: none;
-  -ms-flex: none;
   flex: none;
   font-size: 1rem;
   font-weight: 400;
   height: 2.25rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   line-height: 2rem;
   outline: none;
   padding: 0 1rem;
   position: relative;
   text-align: center;
-  -webkit-text-decoration: none;
   text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -256,50 +178,45 @@ exports[`renders worksheet 1`] = `
   color: #3C64F4;
 }
 
-.c26:focus {
+.c25:focus {
   outline: none;
 }
 
-.c26[disabled] {
+.c25[disabled] {
   border-color: #D9DCE9;
   pointer-events: none;
 }
 
-.c26 + .bd-button {
+.c25+.bd-button {
   margin-top: 0.5rem;
 }
 
-.c26:active {
+.c25:active {
   background-color: #DBE3FE;
 }
 
-.c26:focus {
+.c25:focus {
   box-shadow: 0 0 0 0.25rem #DBE3FE;
 }
 
-.c26:hover:not(:active) {
+.c25:hover:not(:active) {
   background-color: #F0F3FF;
 }
 
-.c26[disabled] {
+.c25[disabled] {
   border-color: transparent;
   color: #D9DCE9;
 }
 
-.c28 {
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
+.c27 {
   align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
 }
 
-.c20 {
+.c19 {
   color: #313440;
   font-size: 1rem;
   font-weight: 400;
@@ -307,7 +224,6 @@ exports[`renders worksheet 1`] = `
   margin: 0 0 1rem;
   cursor: pointer;
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -318,34 +234,31 @@ exports[`renders worksheet 1`] = `
   width: 1px;
 }
 
-.c20:last-child {
+.c19:last-child {
   margin-bottom: 0;
 }
 
-.c12 > div {
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
+.c12>div {
   justify-content: center;
 }
 
-.c27 {
+.c26 {
   font-size: 0.875rem;
   height: auto;
   line-height: 1.25rem;
   padding: 0;
 }
 
-.c27:hover:not(:active) {
+.c26:hover:not(:active) {
   background-color: inherit;
   color: #0024A6;
 }
 
-.c27:active {
+.c26:active {
   background-color: inherit;
 }
 
-.c25 {
+.c24 {
   overflow: hidden;
 }
 
@@ -356,9 +269,6 @@ exports[`renders worksheet 1`] = `
   box-sizing: border-box;
   padding: 0.375rem 1.0625rem;
   text-align: left;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 
@@ -376,9 +286,6 @@ exports[`renders worksheet 1`] = `
   box-sizing: border-box;
   padding: 0.375rem 1.0625rem;
   text-align: center;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 
@@ -389,20 +296,35 @@ exports[`renders worksheet 1`] = `
   margin: 0;
 }
 
-.c29 {
+.c28 {
   position: relative;
   background-color: inherit;
   border: 0.03125rem solid #D9DCE9;
   box-sizing: border-box;
   padding: 0.375rem 1.0625rem;
   text-align: right;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 
-.c29 p {
+.c28 p {
+  display: block;
+  white-space: inherit;
+  word-break: break-word;
+  margin: 0;
+}
+
+.c31 {
+  position: relative;
+  background-color: inherit;
+  border: 0.03125rem solid #D9DCE9;
+  box-sizing: border-box;
+  padding: 0.375rem 1.0625rem;
+  text-align: left;
+  user-select: none;
+  border: 0.03125rem double #DB3643;
+}
+
+.c31 p {
   display: block;
   white-space: inherit;
   word-break: break-word;
@@ -415,36 +337,12 @@ exports[`renders worksheet 1`] = `
   border: 0.03125rem solid #D9DCE9;
   box-sizing: border-box;
   padding: 0.375rem 1.0625rem;
-  text-align: left;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
+  text-align: right;
   user-select: none;
   border: 0.03125rem double #DB3643;
 }
 
 .c32 p {
-  display: block;
-  white-space: inherit;
-  word-break: break-word;
-  margin: 0;
-}
-
-.c33 {
-  position: relative;
-  background-color: inherit;
-  border: 0.03125rem solid #D9DCE9;
-  box-sizing: border-box;
-  padding: 0.375rem 1.0625rem;
-  text-align: right;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  border: 0.03125rem double #DB3643;
-}
-
-.c33 p {
   display: block;
   white-space: inherit;
   word-break: break-word;
@@ -473,7 +371,7 @@ exports[`renders worksheet 1`] = `
   width: 0.25rem;
 }
 
-.c31 {
+.c30 {
   background-color: #D9DCE9;
   border-top: 0.03125rem solid #D9DCE9;
   box-sizing: border-box;
@@ -496,8 +394,7 @@ exports[`renders worksheet 1`] = `
   outline: none;
 }
 
-.c1 > thead {
-  position: -webkit-sticky;
+.c1>thead {
   position: sticky;
   top: 0;
   z-index: 1;
@@ -548,31 +445,27 @@ exports[`renders worksheet 1`] = `
   overflow-y: auto;
 }
 
-@media (min-width:0px) {
-  .c22 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
+@media (min-width: 0px) {
+  .c21 {
     flex-direction: column;
   }
 }
 
-@media (min-width:720px) {
-  .c22 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
+@media (min-width: 720px) {
+  .c21 {
     flex-direction: row;
   }
 }
 
-@media (min-width:720px) {
-  .c26 + .bd-button {
+@media (min-width: 720px) {
+  .c25+.bd-button {
     margin-top: 0;
     margin-left: 0.5rem;
   }
 }
 
-@media (min-width:720px) {
-  .c26 {
+@media (min-width: 720px) {
+  .c25 {
     width: auto;
   }
 }
@@ -688,12 +581,12 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c17"
+                class="c16"
                 for=":r5:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c18"
+                  class="c17"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -711,11 +604,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c19"
+                class="c18"
               >
                 <label
                   aria-hidden="false"
-                  class="c20"
+                  class="c19"
                   for=":r5:"
                   hidden=""
                   id=":r6:"
@@ -749,10 +642,10 @@ exports[`renders worksheet 1`] = `
           class="c8"
         >
           <div
-            class="c21 c22"
+            class="c20 c21"
           >
             <div
-              class="c23 c24 c25"
+              class="c22 c23 c24"
             >
               <p
                 class="c9"
@@ -763,10 +656,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c26 c27"
+              class="c25 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Edit
               </span>
@@ -778,7 +671,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c29"
+          class="c28"
         >
           <p
             class="c9"
@@ -831,12 +724,12 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c17"
+                class="c16"
                 for=":rd:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c18"
+                  class="c17"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -854,11 +747,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c19"
+                class="c18"
               >
                 <label
                   aria-hidden="false"
-                  class="c20"
+                  class="c19"
                   for=":rd:"
                   hidden=""
                   id=":re:"
@@ -892,10 +785,10 @@ exports[`renders worksheet 1`] = `
           class="c8"
         >
           <div
-            class="c21 c22"
+            class="c20 c21"
           >
             <div
-              class="c23 c24 c25"
+              class="c22 c23 c24"
             >
               <p
                 class="c9"
@@ -906,10 +799,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c26 c27"
+              class="c25 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Edit
               </span>
@@ -921,7 +814,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c29"
+          class="c28"
         >
           <p
             class="c9"
@@ -973,12 +866,12 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c30"
+                class="c29"
                 for=":rl:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c18"
+                  class="c17"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -996,11 +889,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c19"
+                class="c18"
               >
                 <label
                   aria-hidden="false"
-                  class="c20"
+                  class="c19"
                   for=":rl:"
                   hidden=""
                   id=":rm:"
@@ -1032,10 +925,10 @@ exports[`renders worksheet 1`] = `
           class="c8"
         >
           <div
-            class="c21 c22"
+            class="c20 c21"
           >
             <div
-              class="c23 c24 c25"
+              class="c22 c23 c24"
             >
               <p
                 class="c9"
@@ -1046,10 +939,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c26 c27"
+              class="c25 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Edit
               </span>
@@ -1061,7 +954,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c29"
+          class="c28"
         >
           <p
             class="c9"
@@ -1114,12 +1007,12 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c17"
+                class="c16"
                 for=":rt:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c18"
+                  class="c17"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1137,11 +1030,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c19"
+                class="c18"
               >
                 <label
                   aria-hidden="false"
-                  class="c20"
+                  class="c19"
                   for=":rt:"
                   hidden=""
                   id=":ru:"
@@ -1175,10 +1068,10 @@ exports[`renders worksheet 1`] = `
           class="c8"
         >
           <div
-            class="c21 c22"
+            class="c20 c21"
           >
             <div
-              class="c23 c24 c25"
+              class="c22 c23 c24"
             >
               <p
                 class="c9"
@@ -1189,10 +1082,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c26 c27"
+              class="c25 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Edit
               </span>
@@ -1204,7 +1097,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c29"
+          class="c28"
         >
           <p
             class="c9"
@@ -1221,10 +1114,10 @@ exports[`renders worksheet 1`] = `
       </tr>
       <tr>
         <td
-          class="c31"
+          class="c30"
         />
         <td
-          class="c32"
+          class="c31"
         >
           <p
             class="c9"
@@ -1253,12 +1146,12 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c30"
+                class="c29"
                 for=":r15:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c18"
+                  class="c17"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1276,11 +1169,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c19"
+                class="c18"
               >
                 <label
                   aria-hidden="false"
-                  class="c20"
+                  class="c19"
                   for=":r15:"
                   hidden=""
                   id=":r16:"
@@ -1312,10 +1205,10 @@ exports[`renders worksheet 1`] = `
           class="c8"
         >
           <div
-            class="c21 c22"
+            class="c20 c21"
           >
             <div
-              class="c23 c24 c25"
+              class="c22 c23 c24"
             >
               <p
                 class="c9"
@@ -1324,10 +1217,10 @@ exports[`renders worksheet 1`] = `
               />
             </div>
             <button
-              class="c26 c27"
+              class="c25 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Edit
               </span>
@@ -1339,7 +1232,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c33"
+          class="c32"
         >
           <p
             class="c9"
@@ -1390,12 +1283,12 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c17"
+                class="c16"
                 for=":r1d:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c18"
+                  class="c17"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1413,11 +1306,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c19"
+                class="c18"
               >
                 <label
                   aria-hidden="false"
-                  class="c20"
+                  class="c19"
                   for=":r1d:"
                   hidden=""
                   id=":r1e:"
@@ -1451,10 +1344,10 @@ exports[`renders worksheet 1`] = `
           class="c8"
         >
           <div
-            class="c21 c22"
+            class="c20 c21"
           >
             <div
-              class="c23 c24 c25"
+              class="c22 c23 c24"
             >
               <p
                 class="c9"
@@ -1465,10 +1358,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c26 c27"
+              class="c25 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Edit
               </span>
@@ -1480,7 +1373,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c29"
+          class="c28"
         >
           <p
             class="c9"
@@ -1497,7 +1390,7 @@ exports[`renders worksheet 1`] = `
       </tr>
       <tr>
         <td
-          class="c31"
+          class="c30"
         />
         <td
           class="c8"
@@ -1532,12 +1425,12 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c30"
+                class="c29"
                 for=":r1l:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c18"
+                  class="c17"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1555,11 +1448,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c19"
+                class="c18"
               >
                 <label
                   aria-hidden="false"
-                  class="c20"
+                  class="c19"
                   for=":r1l:"
                   hidden=""
                   id=":r1m:"
@@ -1593,10 +1486,10 @@ exports[`renders worksheet 1`] = `
           class="c8"
         >
           <div
-            class="c21 c22"
+            class="c20 c21"
           >
             <div
-              class="c23 c24 c25"
+              class="c22 c23 c24"
             >
               <p
                 class="c9"
@@ -1607,10 +1500,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c26 c27"
+              class="c25 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Edit
               </span>
@@ -1622,7 +1515,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c33"
+          class="c32"
         >
           <p
             class="c9"
@@ -1675,12 +1568,12 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c17"
+                class="c16"
                 for=":r1t:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c18"
+                  class="c17"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1698,11 +1591,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c19"
+                class="c18"
               >
                 <label
                   aria-hidden="false"
-                  class="c20"
+                  class="c19"
                   for=":r1t:"
                   hidden=""
                   id=":r1u:"
@@ -1736,10 +1629,10 @@ exports[`renders worksheet 1`] = `
           class="c8"
         >
           <div
-            class="c21 c22"
+            class="c20 c21"
           >
             <div
-              class="c23 c24 c25"
+              class="c22 c23 c24"
             >
               <p
                 class="c9"
@@ -1750,10 +1643,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c26 c27"
+              class="c25 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Edit
               </span>
@@ -1765,7 +1658,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c29"
+          class="c28"
         >
           <p
             class="c9"
@@ -1818,12 +1711,12 @@ exports[`renders worksheet 1`] = `
               />
               <label
                 aria-hidden="true"
-                class="c16 c17"
+                class="c16"
                 for=":r25:"
               >
                 <svg
                   aria-hidden="true"
-                  class="c18"
+                  class="c17"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -1841,11 +1734,11 @@ exports[`renders worksheet 1`] = `
                 </svg>
               </label>
               <div
-                class="c19"
+                class="c18"
               >
                 <label
                   aria-hidden="false"
-                  class="c20"
+                  class="c19"
                   for=":r25:"
                   hidden=""
                   id=":r26:"
@@ -1879,10 +1772,10 @@ exports[`renders worksheet 1`] = `
           class="c8"
         >
           <div
-            class="c21 c22"
+            class="c20 c21"
           >
             <div
-              class="c23 c24 c25"
+              class="c22 c23 c24"
             >
               <p
                 class="c9"
@@ -1893,10 +1786,10 @@ exports[`renders worksheet 1`] = `
               </p>
             </div>
             <button
-              class="c26 c27"
+              class="c25 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Edit
               </span>
@@ -1908,7 +1801,7 @@ exports[`renders worksheet 1`] = `
           />
         </td>
         <td
-          class="c29"
+          class="c28"
         >
           <p
             class="c9"

--- a/packages/big-design/src/helpers/display/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/helpers/display/__snapshots__/spec.tsx.snap
@@ -1,17 +1,14 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`responsive display 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     display: none;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
     display: flex;
   }
 }

--- a/packages/big-design/src/helpers/margins/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/helpers/margins/__snapshots__/spec.tsx.snap
@@ -6,19 +6,19 @@ exports[`responsive and non responsive combination 1`] = `
   margin-bottom: 1rem;
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     margin-left: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     margin-left: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     margin-left: 1rem;
   }
@@ -30,19 +30,19 @@ exports[`responsive and non responsive combination 1`] = `
 `;
 
 exports[`responsive margin 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     margin: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     margin: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     margin: 1rem;
   }
@@ -54,19 +54,19 @@ exports[`responsive margin 1`] = `
 `;
 
 exports[`responsive marginBottom 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     margin-bottom: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     margin-bottom: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     margin-bottom: 1rem;
   }
@@ -78,21 +78,21 @@ exports[`responsive marginBottom 1`] = `
 `;
 
 exports[`responsive marginHorizontal 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     margin-left: 0;
     margin-right: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     margin-left: 0.75rem;
     margin-right: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     margin-left: 1rem;
     margin-right: 1rem;
@@ -105,19 +105,19 @@ exports[`responsive marginHorizontal 1`] = `
 `;
 
 exports[`responsive marginLeft 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     margin-left: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     margin-left: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     margin-left: 1rem;
   }
@@ -129,19 +129,19 @@ exports[`responsive marginLeft 1`] = `
 `;
 
 exports[`responsive marginRight 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     margin-right: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     margin-right: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     margin-right: 1rem;
   }
@@ -153,19 +153,19 @@ exports[`responsive marginRight 1`] = `
 `;
 
 exports[`responsive marginTop 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     margin-top: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     margin-top: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     margin-top: 1rem;
   }
@@ -177,21 +177,21 @@ exports[`responsive marginTop 1`] = `
 `;
 
 exports[`responsive marginVertical 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     margin-top: 0;
     margin-bottom: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     margin-top: 0.75rem;
     margin-bottom: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     margin-top: 1rem;
     margin-bottom: 1rem;

--- a/packages/big-design/src/helpers/paddings/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/helpers/paddings/__snapshots__/spec.tsx.snap
@@ -6,19 +6,19 @@ exports[`responsive and non responsive combination 1`] = `
   padding-bottom: 1rem;
 }
 
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     padding-left: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     padding-left: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     padding-left: 1rem;
   }
@@ -30,19 +30,19 @@ exports[`responsive and non responsive combination 1`] = `
 `;
 
 exports[`responsive padding 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     padding: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     padding: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     padding: 1rem;
   }
@@ -54,19 +54,19 @@ exports[`responsive padding 1`] = `
 `;
 
 exports[`responsive paddingBottom 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     padding-bottom: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     padding-bottom: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     padding-bottom: 1rem;
   }
@@ -78,21 +78,21 @@ exports[`responsive paddingBottom 1`] = `
 `;
 
 exports[`responsive paddingHorizontal 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     padding-left: 0.75rem;
     padding-right: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     padding-left: 1rem;
     padding-right: 1rem;
@@ -105,19 +105,19 @@ exports[`responsive paddingHorizontal 1`] = `
 `;
 
 exports[`responsive paddingLeft 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     padding-left: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     padding-left: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     padding-left: 1rem;
   }
@@ -129,19 +129,19 @@ exports[`responsive paddingLeft 1`] = `
 `;
 
 exports[`responsive paddingRight 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     padding-right: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     padding-right: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     padding-right: 1rem;
   }
@@ -153,19 +153,19 @@ exports[`responsive paddingRight 1`] = `
 `;
 
 exports[`responsive paddingTop 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     padding-top: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     padding-top: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     padding-top: 1rem;
   }
@@ -177,21 +177,21 @@ exports[`responsive paddingTop 1`] = `
 `;
 
 exports[`responsive paddingVertical 1`] = `
-@media (min-width:0px) {
+@media (min-width: 0px) {
   .c0 {
     padding-top: 0;
     padding-bottom: 0;
   }
 }
 
-@media (min-width:720px) {
+@media (min-width: 720px) {
   .c0 {
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
   }
 }
 
-@media (min-width:1025px) {
+@media (min-width: 1025px) {
   .c0 {
     padding-top: 1rem;
     padding-bottom: 1rem;

--- a/packages/configs/eslint/base.js
+++ b/packages/configs/eslint/base.js
@@ -40,6 +40,9 @@ module.exports = {
     '@typescript-eslint/prefer-nullish-coalescing': 'off',
     'func-names': 'off',
     'import/no-dynamic-require': 'off',
+    // styled-components 6 also exports `styled` by name, so the conventional
+    // `import styled from 'styled-components'` now trips this rule repo-wide.
+    'import/no-named-as-default': 'off',
     'import/no-named-default': 'off',
     'import/no-extraneous-dependencies': 'off',
     'import/dynamic-import-chunkname': 'off',

--- a/packages/docs/components/List/styled.tsx
+++ b/packages/docs/components/List/styled.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
 
 import { ListProps } from './List';
 
@@ -23,7 +23,12 @@ const SharedListStyles = css<StyledListProps>`
   ${({ $reset, theme }) =>
     $reset &&
     css`
-      ${theme.helpers.listReset};
+      ${
+        // Temporary until docs flips to styled-components 6: the theme dist now types
+        // CSSRules as v6's RuleSet, which v5's css typings can't accept.
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        theme.helpers.listReset as unknown as FlattenSimpleInterpolation
+      };
     `}
 `;
 

--- a/packages/docs/components/MethodBadge/styled.ts
+++ b/packages/docs/components/MethodBadge/styled.ts
@@ -1,5 +1,5 @@
 import { MarginProps, withMargins } from '@bigcommerce/big-design';
-import styled from 'styled-components';
+import styled, { FlattenSimpleInterpolation } from 'styled-components';
 
 import { MethodBadgeProps } from './MethodBadge';
 
@@ -14,7 +14,12 @@ interface StyledMethodBadgeProps extends Omit<MethodBadgeProps, 'label' | keyof 
 }
 
 export const StyledMethodBadge = styled.span<StyledMethodBadgeProps>`
-  ${withMargins()};
+  ${
+    // Temporary until docs flips to styled-components 6: big-design's dist now types
+    // withMargins() as v6's RuleSet, which v5's css typings can't accept.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    withMargins() as unknown as FlattenSimpleInterpolation
+  };
 
   background-color: ${({ theme }) => theme.colors.secondary70};
   border-radius: ${({ theme }) => theme.borderRadius.normal};

--- a/packages/docs/components/SideNav/SideNavMenu/styled.tsx
+++ b/packages/docs/components/SideNav/SideNavMenu/styled.tsx
@@ -1,5 +1,5 @@
 import { FlexItem } from '@bigcommerce/big-design';
-import styled from 'styled-components';
+import styled, { FlattenSimpleInterpolation } from 'styled-components';
 
 export const StyledMenu = styled(FlexItem)`
   ${({ theme }) => theme.breakpoints.tablet} {
@@ -12,12 +12,20 @@ interface Navigation {
 }
 
 export const StyledNavigation = styled(FlexItem)<Navigation>`
-  ${({ theme }) => theme.shadow.floating};
+  ${({ theme }) =>
+    // Temporary until docs flips to styled-components 6: the theme dist now types
+    // CSSRules as v6's RuleSet, which v5's css typings can't accept.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    theme.shadow.floating as unknown as FlattenSimpleInterpolation};
 
   background-color: ${({ theme }) => theme.colors.white};
-  border-bottom: ${({ theme }) => theme.border.box};
+  border-bottom: ${({ theme }) =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    theme.border.box as unknown as FlattenSimpleInterpolation};
   border-radius: 0;
-  border-top: ${({ theme }) => theme.border.box};
+  border-top: ${({ theme }) =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    theme.border.box as unknown as FlattenSimpleInterpolation};
   display: ${({ isExpanded }) => (isExpanded ? 'block' : 'none')};
   height: 16rem;
   left: 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,15 +155,12 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.23
         version: 18.2.23
-      '@types/styled-components':
-        specifier: ^5.1.34
-        version: 5.1.34
       babel-jest:
         specifier: ^30.2.0
         version: 30.2.0(@babel/core@7.28.0)
       babel-plugin-styled-components:
         specifier: ^2.0.7
-        version: 2.1.4(@babel/core@7.28.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))(supports-color@5.5.0)
+        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       eslint:
         specifier: ^8.33.0
         version: 8.57.0
@@ -177,8 +174,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       jest-styled-components:
-        specifier: ^7.1.1
-        version: 7.2.0(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))
+        specifier: ^7.4.0
+        version: 7.4.0(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -186,8 +183,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0)
+        specifier: ^6.4.0
+        version: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -243,12 +240,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.23
         version: 18.2.23
-      '@types/styled-components':
-        specifier: ^5.1.34
-        version: 5.1.34
       babel-plugin-styled-components:
         specifier: ^2.0.7
-        version: 2.1.4(@babel/core@7.28.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))(supports-color@5.5.0)
+        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       camelcase:
         specifier: ^6.3.0
         version: 6.3.0
@@ -286,8 +280,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0
       styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0)
+        specifier: ^6.4.0
+        version: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tiny-async-pool:
         specifier: ^2.0.1
         version: 2.1.0
@@ -370,15 +364,12 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.23
         version: 18.2.23
-      '@types/styled-components':
-        specifier: ^5.1.34
-        version: 5.1.34
       babel-jest:
         specifier: ^30.2.0
         version: 30.2.0(@babel/core@7.28.0)
       babel-plugin-styled-components:
         specifier: ^2.0.7
-        version: 2.1.4(@babel/core@7.28.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))(supports-color@5.5.0)
+        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       eslint:
         specifier: ^8.33.0
         version: 8.57.0
@@ -392,8 +383,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       jest-styled-components:
-        specifier: ^7.1.1
-        version: 7.2.0(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))
+        specifier: ^7.4.0
+        version: 7.4.0(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -404,8 +395,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0
       styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0)
+        specifier: ^6.4.0
+        version: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -458,15 +449,12 @@ importers:
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
-      '@types/styled-components':
-        specifier: ^5.1.34
-        version: 5.1.34
       babel-jest:
         specifier: ^30.2.0
         version: 30.2.0(@babel/core@7.28.0)
       babel-plugin-styled-components:
         specifier: ^2.0.7
-        version: 2.1.4(@babel/core@7.28.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))(supports-color@5.5.0)
+        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       eslint:
         specifier: ^8.33.0
         version: 8.57.0
@@ -480,8 +468,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       jest-styled-components:
-        specifier: ^7.1.1
-        version: 7.2.0(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))
+        specifier: ^7.4.0
+        version: 7.4.0(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -489,8 +477,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0)
+        specifier: ^6.4.0
+        version: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -657,9 +645,6 @@ packages:
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
-
-  '@adobe/css-tools@4.3.3':
-    resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
@@ -1695,8 +1680,14 @@ packages:
   '@emotion/is-prop-valid@1.1.2':
     resolution: {integrity: sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==}
 
+  '@emotion/is-prop-valid@1.4.0':
+    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
+
   '@emotion/memoize@0.7.5':
     resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
 
   '@emotion/stylis@0.8.5':
     resolution: {integrity: sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==}
@@ -3587,6 +3578,9 @@ packages:
   csstype@3.0.10:
     resolution: {integrity: sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -4812,8 +4806,8 @@ packages:
     resolution: {integrity: sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-styled-components@7.2.0:
-    resolution: {integrity: sha512-gwyyveNjvuRA0pyhbQoydXZllLZESs2VuL5fXCabzh0buHPAOUfANtW7n5YMPmdC0sH3VB7h2eUGZ23+tjvaBA==}
+  jest-styled-components@7.4.0:
+    resolution: {integrity: sha512-VUkStCEG3ewwBTADMT9VyrZ5Pi5oPAzufcafyK6zREFeMv0fcU2LdYFpM5RZm78IrU+Fi6DhD+NVeiurVe3LKQ==}
     engines: {node: '>= 12'}
     peerDependencies:
       styled-components: '>= 5'
@@ -5871,6 +5865,22 @@ packages:
       react-dom: '>= 16.8.0'
       react-is: '>= 16.8.0'
 
+  styled-components@6.5.0:
+    resolution: {integrity: sha512-WLnTRAIRJsmCQfPXoEDDd1YMML+ImxQ8YGVVg60FALxsn/rpWiQWSJCZDNfu/buAcBFnTUr8ev6CBR8rb7xLiQ==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      css-to-react-native: '>= 3.2.0'
+      react: '>= 16.8.0'
+      react-dom: '>= 16.8.0'
+      react-native: '>= 0.68.0'
+    peerDependenciesMeta:
+      css-to-react-native:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -5883,6 +5893,9 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  stylis@4.3.6:
+    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -6415,8 +6428,6 @@ packages:
 snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
-
-  '@adobe/css-tools@4.3.3': {}
 
   '@adobe/css-tools@4.4.4': {}
 
@@ -7916,7 +7927,13 @@ snapshots:
     dependencies:
       '@emotion/memoize': 0.7.5
 
+  '@emotion/is-prop-valid@1.4.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+
   '@emotion/memoize@0.7.5': {}
+
+  '@emotion/memoize@0.9.0': {}
 
   '@emotion/stylis@0.8.5': {}
 
@@ -9552,6 +9569,18 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  babel-plugin-styled-components@2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.28.0)
+      lodash: 4.17.21
+      picomatch: 2.3.1
+      styled-components: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.0):
     dependencies:
       '@babel/core': 7.28.0
@@ -9874,6 +9903,8 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.0.10: {}
+
+  csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
 
@@ -11591,10 +11622,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-styled-components@7.2.0(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0)):
+  jest-styled-components@7.4.0(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)):
     dependencies:
-      '@adobe/css-tools': 4.3.3
-      styled-components: 5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0)
+      '@adobe/css-tools': 4.4.4
+      styled-components: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
   jest-util@30.2.0:
     dependencies:
@@ -12770,12 +12801,23 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
+  styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@emotion/is-prop-valid': 1.4.0
+      csstype: 3.2.3
+      react: 18.2.0
+      stylis: 4.3.6
+    optionalDependencies:
+      react-dom: 18.2.0(react@18.2.0)
+
   styled-jsx@5.1.6(@babel/core@7.28.0)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
       '@babel/core': 7.28.0
+
+  stylis@4.3.6: {}
 
   sucrase@3.35.0:
     dependencies:


### PR DESCRIPTION
Jira: [TRAC-1305](<https://bigcommercecloud.atlassian.net/browse/TRAC-1305>)

## What?

Flips the repo and the published peer ranges from styled-components 5 to 6:

* All four published packages: dev dep `styled-components@^6.4.0`, peer `^6.1.14`, `@types/styled-components` dropped (v6 ships its own types), `jest-styled-components@^7.4.0`.
* `major` changeset for all four packages (peer requirement change).
* Residual SC6 fallout: theme's `createTheme()` returns `keyframes` as a plain object copy (SC6's `mixinDeep` defaultProps folding throws on the getter-only module-namespace object), `createGlobalStyle` keeps its `defaultProps` theme fallback via `Object.assign` (v6 runtime still reads it, the type just no longer declares it), Button/label styled typing fixes, and `import/no-named-as-default` disabled in the shared eslint config (SC6 also exports `styled` by name, flagging \~96 conventional default imports).
* Snapshot regeneration for stylis v4 output (vendor prefixes dropped, spaced media queries, generated keyframe names).

## Why?

SC6 works on React 18 while React 19 does not work on SC5, so this lands before the React 19 flip ([LTRAC-1368](https://linear.app/commerce/issue/LTRAC-1368/flip-to-react-19-dev-deps-types-peers)). Notes for review:

* **Stacked on** bigcommerce/big-design#1900 (the lowercase prop-leak fixes, split out of this PR); rebase onto `main` once that merges. Those fixes gate this PR's snapshot regen — without them the leaked attributes get baked into the committed snapshots.
* `jest-styled-components` ended at `^7.4.0`, not the planned `^7.2.0`: 7.2.0's `toHaveStyleRule` `media` matcher strips `: ` from the expected value only, so it can never match stylis v4's spaced media queries; 7.4.0 normalizes both sides.
* Docs deliberately stays on SC5 (own ticket): three interpolation sites consuming the now-SC6-typed dists carry temporary `FlattenSimpleInterpolation` casts. One workspace quirk worth knowing: docs now runs two SC instances at runtime (its v5 + the packages' v6), so big-design components fall back to their `defaultProps` theme instead of docs' v5 `ThemeProvider` context. Invisible today since docs uses the default theme; goes away when docs flips.
* Snapshot churn is the expected stylis v4 formatting change only. Beyond eyeballing samples per package, I script-diffed the before/after DOM attribute set of every changed snapshot against main to confirm no junk attributes were added.

## Screenshots/Screen Recordings

No visual changes intended; snapshot CSS diffs are prefix/formatting churn only.

## Testing/Proof

`pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run build` all green across all packages (1152 big-design tests, 182 snapshots, zero console-error failures; docs site builds and prerenders every page). Theme injection without a `ThemeProvider` verified under `jest-fail-on-console` for both styled `defaultProps` (Box) and `createGlobalStyle` (GlobalStyles resolves `Source Sans Pro` from the default theme). The swc plugin transform still emits `withConfig({ displayName, componentId })` + `/*#__PURE__*/` against the v6 runtime.

Refs [LTRAC-1305](https://linear.app/commerce/issue/LTRAC-1305/terraform-cloudflare-remove-lightstep-traces-workers-observability)

[TRAC-1305]: https://bigcommercecloud.atlassian.net/browse/TRAC-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ