### PR TITLE
build: TRAC-1306 flip to React 19 dev deps, types, and peers

### DIFF
--- a/.changeset/react-19-peer-deps.md
+++ b/.changeset/react-19-peer-deps.md
@@ -1,0 +1,15 @@
+---
+"@bigcommerce/big-design": major
+"@bigcommerce/big-design-icons": major
+"@bigcommerce/big-design-patterns": major
+"@bigcommerce/big-design-theme": major
+---
+
+Bump peer dependencies to React 19. All packages now require `react` and `react-dom` `^19.0.0`. `@types/react` and `@types/react-dom` are updated to `^19.0.0` as well.
+
+Breaking changes driven by React 19 type updates:
+
+- `TableColumn.render` type narrowed from `ComponentType<T> | ((props: T) => ReactNode)` to `(props: T, context?: any) => ReactNode` — class-component render references are no longer typed (they remain callable at runtime via their call signature).
+- `RefObject<T>` is now `RefObject<T | null>` throughout the public prop API, matching React 19's revised `createRef`/`useRef` signatures.
+- `MutableRefObject` removed from public types; use `RefObject` instead.
+- `FormEvent` replaced with `SubmitEvent` for `onSubmit` handlers, matching React 19's new `SubmitEventHandler` type.

--- a/packages/big-design-icons/package.json
+++ b/packages/big-design-icons/package.json
@@ -37,8 +37,8 @@
     "@bigcommerce/big-design-theme": "workspace:^"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "styled-components": "^6.1.14"
   },
   "devDependencies": {
@@ -54,8 +54,8 @@
     "@svgr/plugin-jsx": "^8.1.0",
     "@svgr/plugin-prettier": "^8.1.0",
     "@svgr/plugin-svgo": "^8.1.0",
-    "@types/react": "^18.2.73",
-    "@types/react-dom": "^18.2.23",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "babel-plugin-styled-components": "^2.0.7",
     "camelcase": "^6.3.0",
     "eslint": "^8.33.0",
@@ -65,8 +65,8 @@
     "inquirer": "^8.2.7",
     "inquirer-autocomplete-prompt": "^2.0.1",
     "prettier": "^2.4.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-is": "^19.2.0",
     "rimraf": "^6.1.0",
     "styled-components": "^6.4.0",

--- a/packages/big-design-icons/src/flags/base/index.tsx
+++ b/packages/big-design-icons/src/flags/base/index.tsx
@@ -21,16 +21,12 @@ export function createStyledFlagIcon(
   >,
 ) {
   const StyledFlagIcon = styled(FlagIcon)`
-    ${({ size, theme }) =>
-      size && {
-        width: typeof size === 'number' ? theme.helpers.remCalc(size) : theme.spacing[size],
-      }}
+    ${({ size = 'xLarge', theme }) => ({
+      width: typeof size === 'number' ? theme.helpers.remCalc(size) : theme.spacing[size],
+    })}
   `;
 
-  StyledFlagIcon.defaultProps = {
-    size: 'xLarge',
-    theme: defaultTheme,
-  };
+  StyledFlagIcon.defaultProps = { theme: defaultTheme };
 
   return StyledFlagIcon;
 }

--- a/packages/big-design-patterns/package.json
+++ b/packages/big-design-patterns/package.json
@@ -39,8 +39,8 @@
     "@bigcommerce/big-design": "workspace:^",
     "@bigcommerce/big-design-icons": "workspace:^",
     "@bigcommerce/big-design-theme": "workspace:^",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "styled-components": "^6.1.14"
   },
   "devDependencies": {
@@ -65,8 +65,8 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.4",
-    "@types/react": "^18.2.73",
-    "@types/react-dom": "^18.2.23",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "babel-jest": "^30.2.0",
     "babel-plugin-styled-components": "^2.0.7",
     "eslint": "^8.33.0",
@@ -74,8 +74,8 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-fail-on-console": "^3.3.1",
     "jest-styled-components": "^7.4.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "rimraf": "^6.1.0",
     "styled-components": "^6.4.0",
     "typescript": "^5.9.3"

--- a/packages/big-design-theme/package.json
+++ b/packages/big-design-theme/package.json
@@ -37,8 +37,8 @@
     "polished": "^4.3.1"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "styled-components": "^6.1.14"
   },
   "devDependencies": {
@@ -62,8 +62,8 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-fail-on-console": "^3.3.1",
     "jest-styled-components": "^7.4.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "styled-components": "^6.4.0",
     "typescript": "^5.9.3"
   }

--- a/packages/big-design/jest.config.js
+++ b/packages/big-design/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
       // excluded via `istanbul ignore`; these floors reflect the remaining reachable code.
       statements: 97.05,
       branches: 88.69,
-      functions: 97.95,
+      functions: 97.87,
       lines: 97.45,
     },
   },

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -51,8 +51,8 @@
     "zustand": "^5.0.11"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "styled-components": "^6.1.14"
   },
   "devDependencies": {
@@ -74,8 +74,8 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.4",
-    "@types/react": "^18.2.73",
-    "@types/react-dom": "^18.2.23",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "babel-jest": "^30.2.0",
     "babel-plugin-styled-components": "^2.0.7",
     "eslint": "^8.33.0",
@@ -83,8 +83,8 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-fail-on-console": "^3.3.1",
     "jest-styled-components": "^7.4.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "styled-components": "^6.4.0",
     "typescript": "^5.9.3"
   }

--- a/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Alert/__snapshots__/spec.tsx.snap
@@ -796,7 +796,7 @@ exports[`renders header 1`] = `
 }
 
 <div
-  aria-labelledby=":rd:"
+  aria-labelledby="_r_d_"
   class="c0 c1 c2"
   role="alert"
   type="success"
@@ -828,7 +828,7 @@ exports[`renders header 1`] = `
   >
     <h4
       class="c6 c7"
-      id=":rd:"
+      id="_r_d_"
     >
       Header
     </h4>

--- a/packages/big-design/src/components/AnchorNav/AnchorNav.tsx
+++ b/packages/big-design/src/components/AnchorNav/AnchorNav.tsx
@@ -19,7 +19,7 @@ export interface AnchorNavProps {
 const useAnchorObserver = (
   id: string,
   setActiveId: React.Dispatch<React.SetStateAction<string | null>>,
-  suspendObserverRef: React.MutableRefObject<boolean>,
+  suspendObserverRef: React.RefObject<boolean>,
 ): React.RefCallback<HTMLElement> => {
   const { ref, inView } = useInView({
     threshold: 0.1,
@@ -39,7 +39,7 @@ interface AnchorSectionProps {
   id: string;
   children: React.ReactNode;
   setActiveId: React.Dispatch<React.SetStateAction<string | null>>;
-  suspendObserverRef: React.MutableRefObject<boolean>;
+  suspendObserverRef: React.RefObject<boolean>;
   registerSection: (id: string, el: HTMLElement | null) => void;
 }
 

--- a/packages/big-design/src/components/Badge/Badge.tsx
+++ b/packages/big-design/src/components/Badge/Badge.tsx
@@ -27,7 +27,7 @@ export const Badge: React.FC<BadgeProps> = memo((props) => {
   } = props;
 
   return typeof label === 'string' ? (
-    <StyledBadge {...domProps} {...toTransientMarginProps(props)} $variant={variant}>
+    <StyledBadge {...domProps} {...toTransientMarginProps(props)} $variant={variant ?? 'secondary'}>
       {label}
     </StyledBadge>
   ) : null;

--- a/packages/big-design/src/components/Badge/styled.tsx
+++ b/packages/big-design/src/components/Badge/styled.tsx
@@ -58,5 +58,4 @@ export const StyledBadge = styled.span<StyledBadgeProps>`
 
 StyledBadge.defaultProps = {
   theme: defaultTheme,
-  $variant: 'secondary',
 };

--- a/packages/big-design/src/components/Button/styled.tsx
+++ b/packages/big-design/src/components/Button/styled.tsx
@@ -70,24 +70,27 @@ export const StyledButton = styled.button<StyledButtonProps>`
     width: auto;
 
     ${({ $iconOnly, theme }) =>
-      $iconOnly &&
-      css`
-        padding: 0;
-        min-width: ${addValues(theme.spacing.xxLarge, theme.spacing.xxSmall)};
-      `};
+      $iconOnly
+        ? css`
+            padding: 0;
+            min-width: ${addValues(theme.spacing.xxLarge, theme.spacing.xxSmall)};
+          `
+        : undefined};
   }
 
   ${({ $iconLeft, theme }) =>
-    $iconLeft &&
-    css`
-      padding-left: ${theme.spacing.xSmall};
-    `};
+    $iconLeft
+      ? css`
+          padding-left: ${theme.spacing.xSmall};
+        `
+      : undefined};
 
   ${({ $iconRight, theme }) =>
-    $iconRight &&
-    css`
-      padding-right: ${theme.spacing.xSmall};
-    `};
+    $iconRight
+      ? css`
+          padding-right: ${theme.spacing.xSmall};
+        `
+      : undefined};
 
   ${(props) => getButtonStyles(props)}
 `;
@@ -100,10 +103,11 @@ export const ContentWrapper = styled.span<{ $isLoading?: boolean }>`
   grid-gap: ${({ theme }) => theme.spacing.xSmall};
 
   ${({ $isLoading }) =>
-    $isLoading &&
-    css`
-      visibility: hidden;
-    `};
+    $isLoading
+      ? css`
+          visibility: hidden;
+        `
+      : undefined};
 `;
 
 export const LoadingSpinnerWrapper = styled(Flex)`

--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -40,7 +40,7 @@ export interface ButtonGroupProps extends ComponentPropsWithoutRef<'div'>, Margi
 interface ActionsState {
   isVisible: boolean;
   action: ButtonGroupAction;
-  ref: React.RefObject<HTMLDivElement>;
+  ref: React.RefObject<HTMLDivElement | null>;
 }
 
 const excludeIconProps = ({

--- a/packages/big-design/src/components/Checkbox/Checkbox.tsx
+++ b/packages/big-design/src/components/Checkbox/Checkbox.tsx
@@ -123,10 +123,6 @@ const RawCheckbox: React.FC<CheckboxProps & PrivateProps> = ({
             if (typeof forwardedRef === 'function') {
               forwardedRef(checkbox);
             } else {
-              // RefObject.current is readonly in DefinitelyTyped
-              // but in practice you can still write to it.
-              // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
-              // @ts-expect-error TODO look into useImperativeHandle
               forwardedRef.current = checkbox;
             }
           }

--- a/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Checkbox/__snapshots__/spec.tsx.snap
@@ -78,16 +78,16 @@ exports[`render Checkbox checked 1`] = `
 >
   <input
     aria-checked="true"
-    aria-labelledby=":r1:"
+    aria-labelledby="_r_1_"
     checked=""
     class="c1 c2"
-    id=":r0:"
+    id="_r_0_"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":r0:"
+    for="_r_0_"
   >
     <svg
       aria-hidden="true"
@@ -113,8 +113,8 @@ exports[`render Checkbox checked 1`] = `
   >
     <label
       class="c6"
-      for=":r0:"
-      id=":r1:"
+      for="_r_0_"
+      id="_r_1_"
     >
       Checked
     </label>
@@ -200,18 +200,18 @@ exports[`render Checkbox disabled checked 1`] = `
 >
   <input
     aria-checked="true"
-    aria-labelledby=":rm:"
+    aria-labelledby="_r_m_"
     checked=""
     class="c1 c2"
     disabled=""
-    id=":rl:"
+    id="_r_l_"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
     disabled=""
-    for=":rl:"
+    for="_r_l_"
   >
     <svg
       aria-hidden="true"
@@ -239,8 +239,8 @@ exports[`render Checkbox disabled checked 1`] = `
       aria-hidden="true"
       class="c6"
       disabled=""
-      for=":rl:"
-      id=":rm:"
+      for="_r_l_"
+      id="_r_m_"
     >
       Checked
     </label>
@@ -325,17 +325,17 @@ exports[`render Checkbox disabled indeterminate 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby=":rs:"
+    aria-labelledby="_r_s_"
     class="c1 c2"
     disabled=""
-    id=":rr:"
+    id="_r_r_"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
     disabled=""
-    for=":rr:"
+    for="_r_r_"
   >
     <svg
       aria-hidden="true"
@@ -363,8 +363,8 @@ exports[`render Checkbox disabled indeterminate 1`] = `
       aria-hidden="true"
       class="c6"
       disabled=""
-      for=":rr:"
-      id=":rs:"
+      for="_r_r_"
+      id="_r_s_"
     >
       Unchecked
     </label>
@@ -450,17 +450,17 @@ exports[`render Checkbox disabled unchecked 1`] = `
 >
   <input
     aria-checked="false"
-    aria-labelledby=":rp:"
+    aria-labelledby="_r_p_"
     class="c1 c2"
     disabled=""
-    id=":ro:"
+    id="_r_o_"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
     disabled=""
-    for=":ro:"
+    for="_r_o_"
   >
     <svg
       aria-hidden="true"
@@ -488,8 +488,8 @@ exports[`render Checkbox disabled unchecked 1`] = `
       aria-hidden="true"
       class="c6"
       disabled=""
-      for=":ro:"
-      id=":rp:"
+      for="_r_o_"
+      id="_r_p_"
     >
       Checked
     </label>
@@ -574,15 +574,15 @@ exports[`render Checkbox indeterminate 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby=":rj:"
+    aria-labelledby="_r_j_"
     class="c1 c2"
-    id=":ri:"
+    id="_r_i_"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":ri:"
+    for="_r_i_"
   >
     <svg
       aria-hidden="true"
@@ -608,8 +608,8 @@ exports[`render Checkbox indeterminate 1`] = `
   >
     <label
       class="c6"
-      for=":ri:"
-      id=":rj:"
+      for="_r_i_"
+      id="_r_j_"
     >
       Unchecked
     </label>
@@ -695,15 +695,15 @@ exports[`render Checkbox unchecked 1`] = `
 >
   <input
     aria-checked="false"
-    aria-labelledby=":r4:"
+    aria-labelledby="_r_4_"
     class="c1 c2"
-    id=":r3:"
+    id="_r_3_"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":r3:"
+    for="_r_3_"
   >
     <svg
       aria-hidden="true"
@@ -729,8 +729,8 @@ exports[`render Checkbox unchecked 1`] = `
   >
     <label
       class="c6"
-      for=":r3:"
-      id=":r4:"
+      for="_r_3_"
+      id="_r_4_"
     >
       Unchecked
     </label>
@@ -852,16 +852,16 @@ exports[`render Checkbox with description object 1`] = `
 >
   <input
     aria-checked="false"
-    aria-labelledby=":r7:"
+    aria-labelledby="_r_7_"
     class="c1 c2"
-    id=":r6:"
+    id="_r_6_"
     name="test-group"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":r6:"
+    for="_r_6_"
   >
     <svg
       aria-hidden="true"
@@ -887,8 +887,8 @@ exports[`render Checkbox with description object 1`] = `
   >
     <label
       class="c6"
-      for=":r6:"
-      id=":r7:"
+      for="_r_6_"
+      id="_r_7_"
     >
       Unchecked
     </label>
@@ -1001,16 +1001,16 @@ exports[`render Checkbox with description string 1`] = `
 >
   <input
     aria-checked="false"
-    aria-labelledby=":rg:"
+    aria-labelledby="_r_g_"
     class="c1 c2"
-    id=":rf:"
+    id="_r_f_"
     name="test-group"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":rf:"
+    for="_r_f_"
   >
     <svg
       aria-hidden="true"
@@ -1036,8 +1036,8 @@ exports[`render Checkbox with description string 1`] = `
   >
     <label
       class="c6"
-      for=":rf:"
-      id=":rg:"
+      for="_r_f_"
+      id="_r_g_"
     >
       Unchecked
     </label>
@@ -1134,16 +1134,16 @@ exports[`render Checkbox with img props 1`] = `
 >
   <input
     aria-checked="false"
-    aria-labelledby=":rd:"
+    aria-labelledby="_r_d_"
     class="c1 c2"
-    id=":rc:"
+    id="_r_c_"
     name="test-group"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":rc:"
+    for="_r_c_"
   >
     <svg
       aria-hidden="true"
@@ -1176,8 +1176,8 @@ exports[`render Checkbox with img props 1`] = `
   >
     <label
       class="c7"
-      for=":rc:"
-      id=":rd:"
+      for="_r_c_"
+      id="_r_d_"
     >
       Unchecked
     </label>

--- a/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Chip/__snapshots__/spec.tsx.snap
@@ -144,7 +144,7 @@ exports[`renders with close button if onRemove is present 1`] = `
       class="c5"
     >
       <svg
-        aria-labelledby=":r0:"
+        aria-labelledby="_r_0_"
         class="c6"
         fill="currentColor"
         height="24"
@@ -154,7 +154,7 @@ exports[`renders with close button if onRemove is present 1`] = `
         width="24"
       >
         <title
-          id=":r0:"
+          id="_r_0_"
         >
           Delete
         </title>

--- a/packages/big-design/src/components/Counter/spec.tsx
+++ b/packages/big-design/src/components/Counter/spec.tsx
@@ -386,7 +386,7 @@ test('error shows when an array of Errors', () => {
 });
 
 test('input counter value does not change when using it inside a form', async () => {
-  const handleOnSubmit = jest.fn((e: React.FormEvent) => {
+  const handleOnSubmit = jest.fn((e: React.SubmitEvent) => {
     e.preventDefault();
   });
 

--- a/packages/big-design/src/components/FeatureSet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/FeatureSet/__snapshots__/spec.tsx.snap
@@ -54,25 +54,25 @@ exports[`render feature set 1`] = `
   class="c0"
 >
   <li
-    aria-labelledby=":r0:"
+    aria-labelledby="_r_0_"
     class="c1"
   >
     <span
       class="c2"
       color="currentColor"
-      id=":r0:"
+      id="_r_0_"
     >
       Feature 1
     </span>
   </li>
   <li
-    aria-labelledby=":r1:"
+    aria-labelledby="_r_1_"
     class="c1"
   >
     <span
       class="c2"
       color="currentColor"
-      id=":r1:"
+      id="_r_1_"
     >
       Feature 2
     </span>

--- a/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Form/__snapshots__/spec.tsx.snap
@@ -145,7 +145,7 @@ exports[`simple form render 1`] = `
       <div>
         <label
           class="c5"
-          for=":r0:"
+          for="_r_0_"
         >
           First Name
         </label>
@@ -162,7 +162,7 @@ exports[`simple form render 1`] = `
           >
             <input
               class="c8"
-              id=":r0:"
+              id="_r_0_"
               placeholder="Placeholder text"
             />
           </div>
@@ -175,7 +175,7 @@ exports[`simple form render 1`] = `
       <div>
         <label
           class="c5"
-          for=":r1:"
+          for="_r_1_"
         >
           Middle Name
         </label>
@@ -192,7 +192,7 @@ exports[`simple form render 1`] = `
           >
             <input
               class="c8"
-              id=":r1:"
+              id="_r_1_"
               placeholder="Placeholder text"
             />
           </div>

--- a/packages/big-design/src/components/GlobalStyles/GlobalStyles.tsx
+++ b/packages/big-design/src/components/GlobalStyles/GlobalStyles.tsx
@@ -1,15 +1,19 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { normalize } from 'polished';
-import { createGlobalStyle } from 'styled-components';
+import React, { useContext } from 'react';
+import { createGlobalStyle, ThemeContext } from 'styled-components';
 
-export const GlobalStyles = createGlobalStyle`
+const BaseGlobalStyles = createGlobalStyle<{ $fontFamily: string }>`
   ${normalize()}
 
   body {
-    font-family: ${({ theme }) => theme.typography.fontFamily};
+    font-family: ${({ $fontFamily }) => $fontFamily};
   }
 `;
 
-// styled-components 6 types createGlobalStyle's return without `defaultProps`, but the
-// runtime still reads it as the theme fallback (determineTheme), so assign it untyped.
-Object.assign(GlobalStyles, { defaultProps: { theme: defaultTheme } });
+export const GlobalStyles: React.FC = () => {
+  // ThemeContext returns undefined when no ThemeProvider is present; fall back to defaultTheme
+  const theme = useContext(ThemeContext) ?? defaultTheme;
+
+  return <BaseGlobalStyles $fontFamily={theme.typography.fontFamily} />;
+};

--- a/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/InlineMessage/__snapshots__/spec.tsx.snap
@@ -864,7 +864,7 @@ exports[`renders close button 1`] = `
         class="c11"
       >
         <svg
-          aria-labelledby=":ra:"
+          aria-labelledby="_r_a_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -874,7 +874,7 @@ exports[`renders close button 1`] = `
           width="24"
         >
           <title
-            id=":ra:"
+            id="_r_a_"
           >
             Close
           </title>

--- a/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Input/__snapshots__/spec.tsx.snap
@@ -125,7 +125,7 @@ exports[`renders all together 1`] = `
 <div>
   <label
     class="c0"
-    for=":rp:"
+    for="_r_p_"
   >
     This is a label
   </label>
@@ -165,7 +165,7 @@ exports[`renders all together 1`] = `
     >
       <input
         class="c6"
-        id=":rp:"
+        id="_r_p_"
       />
     </div>
     <div

--- a/packages/big-design/src/components/Input/styled.tsx
+++ b/packages/big-design/src/components/Input/styled.tsx
@@ -42,11 +42,12 @@ export const StyledInputWrapper = styled.span<StyledInputWrapperProps>`
   }
 
   ${({ $error, $focus, theme }) =>
-    $focus &&
-    css`
-      outline: none;
-      box-shadow: 0 0 0 4px ${$error ? theme.colors.danger20 : theme.colors.primary20};
-    `};
+    $focus
+      ? css`
+          outline: none;
+          box-shadow: 0 0 0 4px ${$error ? theme.colors.danger20 : theme.colors.primary20};
+        `
+      : undefined};
 
   &[disabled] {
     background-color: ${({ theme }) => theme.colors.secondary20};
@@ -87,36 +88,41 @@ export const StyledInput = styled.input<StyledInputProps>`
   }
 
   ${({ $iconRight, theme }) =>
-    $iconRight &&
-    css`
-      padding-right: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
-    `};
+    $iconRight
+      ? css`
+          padding-right: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
+        `
+      : undefined};
 
   ${({ $iconLeft, theme }) =>
-    $iconLeft &&
-    css`
-      padding-left: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
-    `};
+    $iconLeft
+      ? css`
+          padding-left: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
+        `
+      : undefined};
 
   ${({ $chips, theme }) =>
-    $chips &&
-    css`
-      min-height: ${theme.spacing.xLarge};
-      padding-left: ${theme.spacing.xxSmall};
-      padding-right: ${theme.spacing.none};
-    `};
+    $chips
+      ? css`
+          min-height: ${theme.spacing.xLarge};
+          padding-left: ${theme.spacing.xxSmall};
+          padding-right: ${theme.spacing.none};
+        `
+      : undefined};
 
   ${({ $chips, theme }) =>
-    $chips?.length &&
-    css`
-      margin-top: ${theme.spacing.xxSmall};
-    `};
+    $chips?.length
+      ? css`
+          margin-top: ${theme.spacing.xxSmall};
+        `
+      : undefined};
 
   ${({ $chips }) =>
-    !$chips &&
-    css`
-      min-height: ${remCalc(34)};
-    `};
+    !$chips
+      ? css`
+          min-height: ${remCalc(34)};
+        `
+      : undefined};
 
   &[disabled] {
     background-color: ${({ theme }) => theme.colors.secondary20};
@@ -135,16 +141,18 @@ export const StyledIconWrapper = styled.div<TransientPaddingProps>`
   ${withPaddings()}
 
   ${({ $paddingLeft }) =>
-    $paddingLeft === 'xSmall' &&
-    css`
-      left: 0;
-    `}
+    $paddingLeft === 'xSmall'
+      ? css`
+          left: 0;
+        `
+      : undefined}
 
   ${({ $paddingRight }) =>
-    $paddingRight === 'xSmall' &&
-    css`
-      right: 0;
-    `}
+    $paddingRight === 'xSmall'
+      ? css`
+          right: 0;
+        `
+      : undefined}
 `;
 
 interface StyledInputContentProps {
@@ -160,17 +168,19 @@ export const StyledInputContent = styled.div<StyledInputContentProps>`
   height: 100%;
 
   ${({ $chips, theme }) =>
-    $chips &&
-    css`
-      margin-left: ${theme.spacing.xxSmall};
-      padding-right: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
-    `};
+    $chips
+      ? css`
+          margin-left: ${theme.spacing.xxSmall};
+          padding-right: ${addValues(theme.spacing.xxSmall, theme.spacing.xxLarge)};
+        `
+      : undefined};
 
   ${({ $chips, theme }) =>
-    $chips?.length &&
-    css`
-      margin-bottom: ${theme.spacing.xxSmall};
-    `};
+    $chips?.length
+      ? css`
+          margin-bottom: ${theme.spacing.xxSmall};
+        `
+      : undefined};
 `;
 
 StyledInput.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Lozenge/Lozenge.tsx
+++ b/packages/big-design/src/components/Lozenge/Lozenge.tsx
@@ -55,7 +55,7 @@ const iconMap = {
 };
 
 // Ref helper: narrows to a ref object whose `current` is T | null
-function isRefObject<T>(r: React.ForwardedRef<T>): r is React.MutableRefObject<T | null> {
+function isRefObject<T>(r: React.ForwardedRef<T>): r is React.RefObject<T | null> {
   return r !== null && typeof r === 'object' && 'current' in r;
 }
 
@@ -99,11 +99,7 @@ export const Lozenge = forwardRef<HTMLDivElement | HTMLButtonElement, LozengePro
         <Tooltip
           placement="auto"
           trigger={
-            <StyledLozenge
-              $hasTooltip
-              $variant={variant}
-              ref={(node) => setForwardedRef(ref, node)}
-            >
+            <StyledLozenge $hasTooltip $variant={variant}>
               <VariantIcon aria-hidden="true" size="large" />
               {label}
               <InfoIcon aria-hidden="true" size="large" />

--- a/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Message/__snapshots__/spec.tsx.snap
@@ -858,7 +858,7 @@ exports[`renders close button 1`] = `
         class="c11"
       >
         <svg
-          aria-labelledby=":ra:"
+          aria-labelledby="_r_a_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -868,7 +868,7 @@ exports[`renders close button 1`] = `
           width="24"
         >
           <title
-            id=":ra:"
+            id="_r_a_"
           >
             Close
           </title>

--- a/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Modal/__snapshots__/spec.tsx.snap
@@ -210,7 +210,7 @@ exports[`render open modal 1`] = `
       tabindex="-1"
     >
       <div
-        aria-labelledby=":r0:"
+        aria-labelledby="_r_0_"
         class="c1 c2 c3"
       >
         <div
@@ -223,7 +223,7 @@ exports[`render open modal 1`] = `
               class="c7"
             >
               <svg
-                aria-labelledby=":r1:"
+                aria-labelledby="_r_1_"
                 class="c8"
                 fill="currentColor"
                 height="24"
@@ -233,7 +233,7 @@ exports[`render open modal 1`] = `
                 width="24"
               >
                 <title
-                  id=":r1:"
+                  id="_r_1_"
                 >
                   Close
                 </title>
@@ -459,7 +459,7 @@ exports[`render open modal without backdrop 1`] = `
       tabindex="-1"
     >
       <div
-        aria-labelledby=":r2:"
+        aria-labelledby="_r_2_"
         class="c1 c2 c3"
       >
         <div
@@ -472,7 +472,7 @@ exports[`render open modal without backdrop 1`] = `
               class="c7"
             >
               <svg
-                aria-labelledby=":r3:"
+                aria-labelledby="_r_3_"
                 class="c8"
                 fill="currentColor"
                 height="24"
@@ -482,7 +482,7 @@ exports[`render open modal without backdrop 1`] = `
                 width="24"
               >
                 <title
-                  id=":r3:"
+                  id="_r_3_"
                 >
                   Close
                 </title>

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -59,7 +59,7 @@ export const MultiSelect = typedMemo(
     value,
     ...props
   }: MultiSelectProps<T>): ReturnType<React.FC<MultiSelectProps<T>>> => {
-    const defaultRef: RefObject<HTMLInputElement> = createRef();
+    const defaultRef: RefObject<HTMLInputElement | null> = createRef();
     const multiSelectUniqueId = useId();
 
     const [inputValue, setInputValue] = useState('');

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -767,7 +767,9 @@ test('should use the passed in ref object if provided', async () => {
 
 test('should call the provided refSetter if any', async () => {
   let inputRef: HTMLInputElement | null = null;
-  const refSetter = (ref: HTMLInputElement) => (inputRef = ref);
+  const refSetter = (ref: HTMLInputElement) => {
+    inputRef = ref;
+  };
 
   render(
     <MultiSelect

--- a/packages/big-design/src/components/MultiSelect/types.ts
+++ b/packages/big-design/src/components/MultiSelect/types.ts
@@ -13,7 +13,7 @@ interface BaseSelect extends Omit<ComponentPropsWithoutRef<'input'>, 'children' 
   disabled?: boolean;
   error?: InputProps['error'];
   filterable?: boolean;
-  inputRef?: RefObject<HTMLInputElement> | React.Ref<HTMLInputElement>;
+  inputRef?: RefObject<HTMLInputElement | null> | React.Ref<HTMLInputElement>;
   label?: React.ReactNode;
   labelId?: string;
   maxHeight?: number;

--- a/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/OffsetPagination/__snapshots__/spec.tsx.snap
@@ -240,11 +240,11 @@ exports[`render offset pagination component 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":r0:-menu"
+        aria-controls="_r_0_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
-        id=":r0:-toggle-button"
+        id="_r_0_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -281,9 +281,9 @@ exports[`render offset pagination component 1`] = `
           class="c9"
         >
           <ul
-            aria-labelledby=":r0:-label"
+            aria-labelledby="_r_0_-label"
             class="c10"
-            id=":r0:-menu"
+            id="_r_0_-menu"
             role="menu"
           />
         </div>
@@ -302,7 +302,7 @@ exports[`render offset pagination component 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":r4:"
+          aria-labelledby="_r_4_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -312,7 +312,7 @@ exports[`render offset pagination component 1`] = `
           width="24"
         >
           <title
-            id=":r4:"
+            id="_r_4_"
           >
             Previous page
           </title>
@@ -334,7 +334,7 @@ exports[`render offset pagination component 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":r5:"
+          aria-labelledby="_r_5_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -344,7 +344,7 @@ exports[`render offset pagination component 1`] = `
           width="24"
         >
           <title
-            id=":r5:"
+            id="_r_5_"
           >
             Next page
           </title>
@@ -602,11 +602,11 @@ exports[`render offset pagination component with invalid page info 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":r6:-menu"
+        aria-controls="_r_6_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
-        id=":r6:-toggle-button"
+        id="_r_6_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -643,9 +643,9 @@ exports[`render offset pagination component with invalid page info 1`] = `
           class="c9"
         >
           <ul
-            aria-labelledby=":r6:-label"
+            aria-labelledby="_r_6_-label"
             class="c10"
-            id=":r6:-menu"
+            id="_r_6_-menu"
             role="menu"
           />
         </div>
@@ -664,7 +664,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":ra:"
+          aria-labelledby="_r_a_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -674,7 +674,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
           width="24"
         >
           <title
-            id=":ra:"
+            id="_r_a_"
           >
             Previous page
           </title>
@@ -696,7 +696,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":rb:"
+          aria-labelledby="_r_b_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -706,7 +706,7 @@ exports[`render offset pagination component with invalid page info 1`] = `
           width="24"
         >
           <title
-            id=":rb:"
+            id="_r_b_"
           >
             Next page
           </title>
@@ -964,11 +964,11 @@ exports[`render offset pagination component with invalid range info 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":rc:-menu"
+        aria-controls="_r_c_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
-        id=":rc:-toggle-button"
+        id="_r_c_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -1005,9 +1005,9 @@ exports[`render offset pagination component with invalid range info 1`] = `
           class="c9"
         >
           <ul
-            aria-labelledby=":rc:-label"
+            aria-labelledby="_r_c_-label"
             class="c10"
-            id=":rc:-menu"
+            id="_r_c_-menu"
             role="menu"
           />
         </div>
@@ -1026,7 +1026,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":rg:"
+          aria-labelledby="_r_g_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -1036,7 +1036,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
           width="24"
         >
           <title
-            id=":rg:"
+            id="_r_g_"
           >
             Previous page
           </title>
@@ -1059,7 +1059,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":rh:"
+          aria-labelledby="_r_h_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -1069,7 +1069,7 @@ exports[`render offset pagination component with invalid range info 1`] = `
           width="24"
         >
           <title
-            id=":rh:"
+            id="_r_h_"
           >
             Next page
           </title>
@@ -1327,11 +1327,11 @@ exports[`render offset pagination component with no items 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":ri:-menu"
+        aria-controls="_r_i_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
-        id=":ri:-toggle-button"
+        id="_r_i_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -1368,9 +1368,9 @@ exports[`render offset pagination component with no items 1`] = `
           class="c9"
         >
           <ul
-            aria-labelledby=":ri:-label"
+            aria-labelledby="_r_i_-label"
             class="c10"
-            id=":ri:-menu"
+            id="_r_i_-menu"
             role="menu"
           />
         </div>
@@ -1389,7 +1389,7 @@ exports[`render offset pagination component with no items 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":rm:"
+          aria-labelledby="_r_m_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -1399,7 +1399,7 @@ exports[`render offset pagination component with no items 1`] = `
           width="24"
         >
           <title
-            id=":rm:"
+            id="_r_m_"
           >
             Previous page
           </title>
@@ -1422,7 +1422,7 @@ exports[`render offset pagination component with no items 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":rn:"
+          aria-labelledby="_r_n_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -1432,7 +1432,7 @@ exports[`render offset pagination component with no items 1`] = `
           width="24"
         >
           <title
-            id=":rn:"
+            id="_r_n_"
           >
             Next page
           </title>

--- a/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/PillTabs/__snapshots__/spec.tsx.snap
@@ -253,11 +253,11 @@ exports[`dropdown is not visible if items fit 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":r4:-menu"
+        aria-controls="_r_4_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":r4:-toggle-button"
+        id="_r_4_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -266,7 +266,7 @@ exports[`dropdown is not visible if items fit 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":r7:"
+            aria-labelledby="_r_7_"
             class="c8"
             fill="currentColor"
             height="24"
@@ -276,7 +276,7 @@ exports[`dropdown is not visible if items fit 1`] = `
             width="24"
           >
             <title
-              id=":r7:"
+              id="_r_7_"
             >
               add
             </title>
@@ -298,9 +298,9 @@ exports[`dropdown is not visible if items fit 1`] = `
           class="c10"
         >
           <ul
-            aria-labelledby=":r4:-label"
+            aria-labelledby="_r_4_-label"
             class="c11"
-            id=":r4:-menu"
+            id="_r_4_-menu"
             role="menu"
           />
         </div>
@@ -563,11 +563,11 @@ exports[`it renders the given tabs 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":r0:-menu"
+        aria-controls="_r_0_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":r0:-toggle-button"
+        id="_r_0_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -576,7 +576,7 @@ exports[`it renders the given tabs 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":r3:"
+            aria-labelledby="_r_3_"
             class="c8"
             fill="currentColor"
             height="24"
@@ -586,7 +586,7 @@ exports[`it renders the given tabs 1`] = `
             width="24"
           >
             <title
-              id=":r3:"
+              id="_r_3_"
             >
               add
             </title>
@@ -608,9 +608,9 @@ exports[`it renders the given tabs 1`] = `
           class="c10"
         >
           <ul
-            aria-labelledby=":r0:-label"
+            aria-labelledby="_r_0_-label"
             class="c11"
-            id=":r0:-menu"
+            id="_r_0_-menu"
             role="menu"
           />
         </div>
@@ -905,11 +905,11 @@ exports[`only the pills that fit are visible 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":rg:-menu"
+        aria-controls="_r_g_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":rg:-toggle-button"
+        id="_r_g_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -918,7 +918,7 @@ exports[`only the pills that fit are visible 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":rj:"
+            aria-labelledby="_r_j_"
             class="c8"
             fill="currentColor"
             height="24"
@@ -928,7 +928,7 @@ exports[`only the pills that fit are visible 1`] = `
             width="24"
           >
             <title
-              id=":rj:"
+              id="_r_j_"
             >
               add
             </title>
@@ -950,9 +950,9 @@ exports[`only the pills that fit are visible 1`] = `
           class="c10"
         >
           <ul
-            aria-labelledby=":rg:-label"
+            aria-labelledby="_r_g_-label"
             class="c11"
-            id=":rg:-menu"
+            id="_r_g_-menu"
             role="menu"
           />
         </div>
@@ -1246,11 +1246,11 @@ exports[`only the pills that fit are visible 2 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":rk:-menu"
+        aria-controls="_r_k_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":rk:-toggle-button"
+        id="_r_k_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -1259,7 +1259,7 @@ exports[`only the pills that fit are visible 2 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":rn:"
+            aria-labelledby="_r_n_"
             class="c8"
             fill="currentColor"
             height="24"
@@ -1269,7 +1269,7 @@ exports[`only the pills that fit are visible 2 1`] = `
             width="24"
           >
             <title
-              id=":rn:"
+              id="_r_n_"
             >
               add
             </title>
@@ -1291,9 +1291,9 @@ exports[`only the pills that fit are visible 2 1`] = `
           class="c10"
         >
           <ul
-            aria-labelledby=":rk:-label"
+            aria-labelledby="_r_k_-label"
             class="c11"
-            id=":rk:-menu"
+            id="_r_k_-menu"
             role="menu"
           />
         </div>
@@ -1586,11 +1586,11 @@ exports[`renders all the filters if they fit 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":rc:-menu"
+        aria-controls="_r_c_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":rc:-toggle-button"
+        id="_r_c_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -1599,7 +1599,7 @@ exports[`renders all the filters if they fit 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":rf:"
+            aria-labelledby="_r_f_"
             class="c8"
             fill="currentColor"
             height="24"
@@ -1609,7 +1609,7 @@ exports[`renders all the filters if they fit 1`] = `
             width="24"
           >
             <title
-              id=":rf:"
+              id="_r_f_"
             >
               add
             </title>
@@ -1631,9 +1631,9 @@ exports[`renders all the filters if they fit 1`] = `
           class="c10"
         >
           <ul
-            aria-labelledby=":rc:-label"
+            aria-labelledby="_r_c_-label"
             class="c11"
-            id=":rc:-menu"
+            id="_r_c_-menu"
             role="menu"
           />
         </div>
@@ -1912,11 +1912,11 @@ exports[`renders dropdown if items do not fit 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":r8:-menu"
+        aria-controls="_r_8_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c7 bd-button"
-        id=":r8:-toggle-button"
+        id="_r_8_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -1925,7 +1925,7 @@ exports[`renders dropdown if items do not fit 1`] = `
           class="c4"
         >
           <svg
-            aria-labelledby=":rb:"
+            aria-labelledby="_r_b_"
             class="c8"
             fill="currentColor"
             height="24"
@@ -1935,7 +1935,7 @@ exports[`renders dropdown if items do not fit 1`] = `
             width="24"
           >
             <title
-              id=":rb:"
+              id="_r_b_"
             >
               add
             </title>
@@ -1957,9 +1957,9 @@ exports[`renders dropdown if items do not fit 1`] = `
           class="c10"
         >
           <ul
-            aria-labelledby=":r8:-label"
+            aria-labelledby="_r_8_-label"
             class="c11"
-            id=":r8:-menu"
+            id="_r_8_-menu"
             role="menu"
           />
         </div>

--- a/packages/big-design/src/components/PillTabs/useAvailableWidth.tsx
+++ b/packages/big-design/src/components/PillTabs/useAvailableWidth.tsx
@@ -3,8 +3,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { useWindowResizeListener } from '../../hooks';
 
 interface Refs {
-  parent: React.RefObject<HTMLElement>;
-  dropdown: React.RefObject<HTMLElement>;
+  parent: React.RefObject<HTMLElement | null>;
+  dropdown: React.RefObject<HTMLElement | null>;
 }
 
 export const useAvailableWidth = ({ parent, dropdown }: Refs) => {

--- a/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Radio/__snapshots__/spec.tsx.snap
@@ -82,11 +82,11 @@ exports[`render Radio (checked + disabled) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby=":r9:"
+    aria-labelledby="_r_9_"
     checked=""
     class="c1 c2"
     disabled=""
-    id=":r8:"
+    id="_r_8_"
     name="test-group"
     type="radio"
   />
@@ -94,7 +94,7 @@ exports[`render Radio (checked + disabled) 1`] = `
     aria-hidden="true"
     class="c3"
     disabled=""
-    for=":r8:"
+    for="_r_8_"
   />
   <div
     class="c4"
@@ -103,8 +103,8 @@ exports[`render Radio (checked + disabled) 1`] = `
       aria-hidden="true"
       class="c5"
       disabled=""
-      for=":r8:"
-      id=":r9:"
+      for="_r_8_"
+      id="_r_9_"
     >
       Checked
     </label>
@@ -195,25 +195,25 @@ exports[`render Radio (checked) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby=":r1:"
+    aria-labelledby="_r_1_"
     checked=""
     class="c1 c2"
-    id=":r0:"
+    id="_r_0_"
     name="test-group"
     type="radio"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":r0:"
+    for="_r_0_"
   />
   <div
     class="c4"
   >
     <label
       class="c5"
-      for=":r0:"
-      id=":r1:"
+      for="_r_0_"
+      id="_r_1_"
     >
       Checked
     </label>
@@ -336,24 +336,24 @@ exports[`render Radio (unchecked + description object) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby=":r5:"
+    aria-labelledby="_r_5_"
     class="c1 c2"
-    id=":r4:"
+    id="_r_4_"
     name="test-group"
     type="radio"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":r4:"
+    for="_r_4_"
   />
   <div
     class="c4"
   >
     <label
       class="c5"
-      for=":r4:"
-      id=":r5:"
+      for="_r_4_"
+      id="_r_5_"
     >
       Unchecked
     </label>
@@ -467,24 +467,24 @@ exports[`render Radio (unchecked + description text) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby=":r7:"
+    aria-labelledby="_r_7_"
     class="c1 c2"
-    id=":r6:"
+    id="_r_6_"
     name="test-group"
     type="radio"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":r6:"
+    for="_r_6_"
   />
   <div
     class="c4"
   >
     <label
       class="c5"
-      for=":r6:"
-      id=":r7:"
+      for="_r_6_"
+      id="_r_7_"
     >
       Unchecked
     </label>
@@ -575,10 +575,10 @@ exports[`render Radio (unchecked + disabled) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby=":rb:"
+    aria-labelledby="_r_b_"
     class="c1 c2"
     disabled=""
-    id=":ra:"
+    id="_r_a_"
     name="test-group"
     type="radio"
   />
@@ -586,7 +586,7 @@ exports[`render Radio (unchecked + disabled) 1`] = `
     aria-hidden="true"
     class="c3"
     disabled=""
-    for=":ra:"
+    for="_r_a_"
   />
   <div
     class="c4"
@@ -595,8 +595,8 @@ exports[`render Radio (unchecked + disabled) 1`] = `
       aria-hidden="true"
       class="c5"
       disabled=""
-      for=":ra:"
-      id=":rb:"
+      for="_r_a_"
+      id="_r_b_"
     >
       Unchecked
     </label>
@@ -683,24 +683,24 @@ exports[`render Radio (unchecked) 1`] = `
   class="c0"
 >
   <input
-    aria-labelledby=":r3:"
+    aria-labelledby="_r_3_"
     class="c1 c2"
-    id=":r2:"
+    id="_r_2_"
     name="test-group"
     type="radio"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":r2:"
+    for="_r_2_"
   />
   <div
     class="c4"
   >
     <label
       class="c5"
-      for=":r2:"
-      id=":r3:"
+      for="_r_2_"
+      id="_r_3_"
     >
       Unchecked
     </label>

--- a/packages/big-design/src/components/Search/Search.tsx
+++ b/packages/big-design/src/components/Search/Search.tsx
@@ -1,5 +1,5 @@
 import { SearchIcon } from '@bigcommerce/big-design-icons';
-import React, { FormEvent } from 'react';
+import React from 'react';
 
 import { Button } from '../Button';
 import { Flex, FlexItem } from '../Flex';
@@ -22,7 +22,7 @@ export const Search: React.FC<SearchProps> = ({
   autoComplete = 'off',
   ...props
 }) => {
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: React.SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     event.stopPropagation();
 

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -47,7 +47,7 @@ export const Select = typedMemo(
     value,
     ...props
   }: SelectProps<T>): ReturnType<React.FC<SelectProps<T>>> => {
-    const defaultRef: RefObject<HTMLInputElement> = createRef();
+    const defaultRef: RefObject<HTMLInputElement | null> = createRef();
     const selectUniqueId = useId();
 
     // aria-labelledby takes presedence over aria-label so we need to strip it out if there is no label

--- a/packages/big-design/src/components/Select/spec.tsx
+++ b/packages/big-design/src/components/Select/spec.tsx
@@ -841,7 +841,9 @@ test('should use the passed in ref object if provided', async () => {
 
 test('should call the provided refSetter if any', async () => {
   let inputRef: HTMLInputElement | null = null;
-  const refSetter = (ref: HTMLInputElement) => (inputRef = ref);
+  const refSetter = (ref: HTMLInputElement) => {
+    inputRef = ref;
+  };
 
   render(
     <Select

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -11,7 +11,7 @@ interface BaseSelect extends Omit<ComponentPropsWithoutRef<'input'>, 'children' 
   disabled?: boolean;
   error?: InputProps['error'];
   filterable?: boolean;
-  inputRef?: RefObject<HTMLInputElement> | React.Ref<HTMLInputElement>;
+  inputRef?: RefObject<HTMLInputElement | null> | React.Ref<HTMLInputElement>;
   label?: React.ReactNode;
   labelId?: string;
   maxHeight?: number;

--- a/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/StatelessPagination/__snapshots__/spec.tsx.snap
@@ -240,11 +240,11 @@ exports[`render Stateless pagination component 1`] = `
     >
       <button
         aria-activedescendant=""
-        aria-controls=":r0:-menu"
+        aria-controls="_r_0_-menu"
         aria-expanded="false"
         aria-haspopup="menu"
         class="c4 c5"
-        id=":r0:-toggle-button"
+        id="_r_0_-toggle-button"
         role="button"
         tabindex="0"
         type="button"
@@ -281,9 +281,9 @@ exports[`render Stateless pagination component 1`] = `
           class="c9"
         >
           <ul
-            aria-labelledby=":r0:-label"
+            aria-labelledby="_r_0_-label"
             class="c10"
-            id=":r0:-menu"
+            id="_r_0_-menu"
             role="menu"
           />
         </div>
@@ -301,7 +301,7 @@ exports[`render Stateless pagination component 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":r4:"
+          aria-labelledby="_r_4_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -311,7 +311,7 @@ exports[`render Stateless pagination component 1`] = `
           width="24"
         >
           <title
-            id=":r4:"
+            id="_r_4_"
           >
             Previous page
           </title>
@@ -333,7 +333,7 @@ exports[`render Stateless pagination component 1`] = `
         class="c6"
       >
         <svg
-          aria-labelledby=":r5:"
+          aria-labelledby="_r_5_"
           class="c12"
           fill="currentColor"
           height="24"
@@ -343,7 +343,7 @@ exports[`render Stateless pagination component 1`] = `
           width="24"
         >
           <title
-            id=":r5:"
+            id="_r_5_"
           >
             Next page
           </title>

--- a/packages/big-design/src/components/Switch/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Switch/__snapshots__/spec.tsx.snap
@@ -82,13 +82,13 @@ exports[`render Switch checked 1`] = `
   <input
     checked=""
     class="c2"
-    id=":r0:"
+    id="_r_0_"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":r0:"
+    for="_r_0_"
   />
 </div>
 `;
@@ -186,14 +186,14 @@ exports[`render Switch disabled checked 1`] = `
     checked=""
     class="c2"
     disabled=""
-    id=":r2:"
+    id="_r_2_"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
     disabled=""
-    for=":r2:"
+    for="_r_2_"
   />
 </div>
 `;
@@ -291,14 +291,14 @@ exports[`render Switch disabled unchecked 1`] = `
   <input
     class="c2"
     disabled=""
-    id=":r3:"
+    id="_r_3_"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
     disabled=""
-    for=":r3:"
+    for="_r_3_"
   />
 </div>
 `;
@@ -385,13 +385,13 @@ exports[`render Switch unchecked 1`] = `
 >
   <input
     class="c2"
-    id=":r1:"
+    id="_r_1_"
     type="checkbox"
   />
   <label
     aria-hidden="true"
     class="c3"
-    for=":r1:"
+    for="_r_1_"
   />
 </div>
 `;

--- a/packages/big-design/src/components/Table/Actions/Actions.tsx
+++ b/packages/big-design/src/components/Table/Actions/Actions.tsx
@@ -11,7 +11,7 @@ import { StyledFlex } from './styled';
 
 export interface ActionsProps<T> {
   customActions?: React.ReactNode;
-  forwardedRef: RefObject<HTMLDivElement>;
+  forwardedRef: RefObject<HTMLDivElement | null>;
   itemName?: string;
   items: T[];
   pagination?: DiscriminatedTablePaginationProps;

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -22,7 +22,7 @@ interface Localization {
 export interface HeaderCellProps<T>
   extends ComponentPropsWithoutRef<'th'>,
     TableColumnDisplayProps {
-  actionsRef: RefObject<HTMLDivElement>;
+  actionsRef: RefObject<HTMLDivElement | null>;
   children?: React.ReactNode;
   column: TableColumn<T>;
   id: string;
@@ -35,12 +35,12 @@ export interface HeaderCellProps<T>
 }
 
 export interface HeaderCheckboxCellProps {
-  actionsRef: RefObject<HTMLDivElement>;
+  actionsRef: RefObject<HTMLDivElement | null>;
   stickyHeader?: boolean;
 }
 
 export interface DragIconCellProps {
-  actionsRef: RefObject<HTMLDivElement>;
+  actionsRef: RefObject<HTMLDivElement | null>;
 }
 
 const InternalHeaderCell = <T extends TableItem>({

--- a/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Table/__snapshots__/spec.tsx.snap
@@ -249,7 +249,7 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 <div
-  aria-controls=":r14:"
+  aria-controls="_r_14_"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -270,11 +270,11 @@ exports[`offset pagination renders a pagination component 1`] = `
         >
           <button
             aria-activedescendant=""
-            aria-controls=":r15:-menu"
+            aria-controls="_r_15_-menu"
             aria-expanded="false"
             aria-haspopup="menu"
             class="c7 c8"
-            id=":r15:-toggle-button"
+            id="_r_15_-toggle-button"
             role="button"
             tabindex="0"
             type="button"
@@ -311,9 +311,9 @@ exports[`offset pagination renders a pagination component 1`] = `
               class="c12"
             >
               <ul
-                aria-labelledby=":r15:-label"
+                aria-labelledby="_r_15_-label"
                 class="c13"
-                id=":r15:-menu"
+                id="_r_15_-menu"
                 role="menu"
               />
             </div>
@@ -332,7 +332,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r19:"
+              aria-labelledby="_r_19_"
               class="c15"
               fill="currentColor"
               height="24"
@@ -342,7 +342,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r19:"
+                id="_r_19_"
               >
                 Previous page
               </title>
@@ -364,7 +364,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r1a:"
+              aria-labelledby="_r_1a_"
               class="c15"
               fill="currentColor"
               height="24"
@@ -374,7 +374,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r1a:"
+                id="_r_1a_"
               >
                 Next page
               </title>
@@ -473,7 +473,7 @@ exports[`renders a simple table 1`] = `
 
 <table
   class="c0"
-  id=":r0:"
+  id="_r_0_"
 >
   <thead
     class=""
@@ -781,7 +781,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls=":r3c:"
+  aria-controls="_r_3c_"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -797,15 +797,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r3e:"
+          aria-labelledby="_r_3e_"
           class="c6 c7"
-          id=":r3d:"
+          id="_r_3d_"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8"
-          for=":r3d:"
+          for="_r_3d_"
         >
           <svg
             aria-hidden="true"
@@ -831,9 +831,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c11"
-            for=":r3d:"
+            for="_r_3d_"
             hidden=""
-            id=":r3e:"
+            id="_r_3e_"
           >
             Select All
           </label>

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -31,9 +31,7 @@ export interface TableColumn<T> extends TableColumnDisplayProps {
   tooltip?: string;
   hideHeader?: boolean;
   isSortable?: boolean;
-  render:
-    | React.ComponentType<T & { children?: ReactNode }>
-    | ((props: T & { children?: ReactNode }, context?: any) => string | number);
+  render: (props: T, context?: any) => ReactNode;
   verticalAlign?: 'top' | 'middle';
   width?: number | string;
   withPadding?: boolean;

--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -17,7 +17,7 @@ import { StyledFlex } from './styled';
 
 export interface ActionsProps<T> {
   customActions?: React.ReactNode;
-  forwardedRef: RefObject<HTMLDivElement>;
+  forwardedRef: RefObject<HTMLDivElement | null>;
   itemName?: string;
   items: T[];
   pagination?: DiscriminatedTablePaginationProps;

--- a/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
@@ -22,7 +22,7 @@ interface Localization {
 export interface HeaderCellProps<T>
   extends ComponentPropsWithoutRef<'th'>,
     TableColumnDisplayProps {
-  actionsRef: RefObject<HTMLDivElement>;
+  actionsRef: RefObject<HTMLDivElement | null>;
   children?: React.ReactNode;
   column: TableColumn<T>;
   id: string;
@@ -35,12 +35,12 @@ export interface HeaderCellProps<T>
 }
 
 export interface HeaderCheckboxCellProps {
-  actionsRef: RefObject<HTMLDivElement>;
+  actionsRef: RefObject<HTMLDivElement | null>;
   stickyHeader?: boolean;
 }
 
 export interface DragIconCellProps {
-  actionsRef: RefObject<HTMLDivElement>;
+  actionsRef: RefObject<HTMLDivElement | null>;
 }
 
 const InternalHeaderCell = <T extends TableItem>({

--- a/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/TableNext/__snapshots__/spec.tsx.snap
@@ -249,7 +249,7 @@ exports[`offset pagination renders a pagination component 1`] = `
 }
 
 <div
-  aria-controls=":r14:"
+  aria-controls="_r_14_"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -270,11 +270,11 @@ exports[`offset pagination renders a pagination component 1`] = `
         >
           <button
             aria-activedescendant=""
-            aria-controls=":r15:-menu"
+            aria-controls="_r_15_-menu"
             aria-expanded="false"
             aria-haspopup="menu"
             class="c7 c8"
-            id=":r15:-toggle-button"
+            id="_r_15_-toggle-button"
             role="button"
             tabindex="0"
             type="button"
@@ -311,9 +311,9 @@ exports[`offset pagination renders a pagination component 1`] = `
               class="c12"
             >
               <ul
-                aria-labelledby=":r15:-label"
+                aria-labelledby="_r_15_-label"
                 class="c13"
-                id=":r15:-menu"
+                id="_r_15_-menu"
                 role="menu"
               />
             </div>
@@ -332,7 +332,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r19:"
+              aria-labelledby="_r_19_"
               class="c15"
               fill="currentColor"
               height="24"
@@ -342,7 +342,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r19:"
+                id="_r_19_"
               >
                 Previous page
               </title>
@@ -364,7 +364,7 @@ exports[`offset pagination renders a pagination component 1`] = `
             class="c9"
           >
             <svg
-              aria-labelledby=":r1a:"
+              aria-labelledby="_r_1a_"
               class="c15"
               fill="currentColor"
               height="24"
@@ -374,7 +374,7 @@ exports[`offset pagination renders a pagination component 1`] = `
               width="24"
             >
               <title
-                id=":r1a:"
+                id="_r_1a_"
               >
                 Next page
               </title>
@@ -473,7 +473,7 @@ exports[`renders a simple table 1`] = `
 
 <table
   class="c0"
-  id=":r0:"
+  id="_r_0_"
 >
   <thead
     class=""
@@ -841,7 +841,7 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
 }
 
 <div
-  aria-controls=":r91:"
+  aria-controls="_r_91_"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -857,15 +857,15 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r93:"
+          aria-labelledby="_r_93_"
           class="c6 c7"
-          id=":r92:"
+          id="_r_92_"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8"
-          for=":r92:"
+          for="_r_92_"
         >
           <svg
             aria-hidden="true"
@@ -891,9 +891,9 @@ exports[`selectable renders selectable actions and checkboxes 1`] = `
         >
           <label
             class="c11"
-            for=":r92:"
+            for="_r_92_"
             hidden=""
-            id=":r93:"
+            id="_r_93_"
           >
             Select All
           </label>
@@ -1067,7 +1067,7 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
 }
 
 <div
-  aria-controls=":r9n:"
+  aria-controls="_r_9n_"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -1083,15 +1083,15 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
       >
         <input
           aria-checked="false"
-          aria-labelledby=":r9p:"
+          aria-labelledby="_r_9p_"
           class="c6 c7"
-          id=":r9o:"
+          id="_r_9o_"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8"
-          for=":r9o:"
+          for="_r_9o_"
         >
           <svg
             aria-hidden="true"
@@ -1117,9 +1117,9 @@ exports[`selectable selectable by default (isChildrenRowsSelectable prop is not 
         >
           <label
             class="c11"
-            for=":r9o:"
+            for="_r_9o_"
             hidden=""
-            id=":r9p:"
+            id="_r_9p_"
           >
             Select All
           </label>
@@ -1293,7 +1293,7 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
 }
 
 <div
-  aria-controls=":rde:"
+  aria-controls="_r_de_"
   aria-label="Table Controls"
   class="c0"
   role="toolbar"
@@ -1309,15 +1309,15 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
       >
         <input
           aria-checked="false"
-          aria-labelledby=":rdg:"
+          aria-labelledby="_r_dg_"
           class="c6 c7"
-          id=":rdf:"
+          id="_r_df_"
           type="checkbox"
         />
         <label
           aria-hidden="true"
           class="c8"
-          for=":rdf:"
+          for="_r_df_"
         >
           <svg
             aria-hidden="true"
@@ -1343,9 +1343,9 @@ exports[`selectable selectable by not default (isChildrenRowsSelectable prop is 
         >
           <label
             class="c11"
-            for=":rdf:"
+            for="_r_df_"
             hidden=""
-            id=":rdg:"
+            id="_r_dg_"
           >
             Select All
           </label>

--- a/packages/big-design/src/components/TableNext/types.ts
+++ b/packages/big-design/src/components/TableNext/types.ts
@@ -47,9 +47,7 @@ export interface TableColumn<T> extends TableColumnDisplayProps {
   tooltip?: string;
   hideHeader?: boolean;
   isSortable?: boolean;
-  render:
-    | React.ComponentType<T & { children?: ReactNode }>
-    | ((props: T & { children?: ReactNode }, context?: any) => string | number);
+  render: (props: T, context?: any) => ReactNode;
   verticalAlign?: 'top' | 'middle';
   width?: number | string;
   withPadding?: boolean;

--- a/packages/big-design/src/components/Tabs/Tabs.tsx
+++ b/packages/big-design/src/components/Tabs/Tabs.tsx
@@ -54,6 +54,7 @@ export const Tabs: React.FC<TabsProps> = memo(
             onClick={handleOnTabClick}
             role="tab"
             tabIndex={id === activeTab ? -1 : 0}
+            variant="subtle"
           >
             {title}
           </StyledTab>

--- a/packages/big-design/src/components/Tabs/styled.tsx
+++ b/packages/big-design/src/components/Tabs/styled.tsx
@@ -35,9 +35,6 @@ export const StyledTab = styled(StyleableButton)<TabProps>`
     `}
 `;
 
-StyledTab.defaultProps = {
-  theme: defaultTheme,
-  variant: 'subtle',
-};
+StyledTab.defaultProps = { theme: defaultTheme };
 
 StyledTabs.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Textarea/Textarea.tsx
+++ b/packages/big-design/src/components/Textarea/Textarea.tsx
@@ -94,8 +94,8 @@ const StyleableTextarea: React.FC<TextareaProps & PrivateProps> = ({
       <StyledTextareaWrapper>
         <StyledTextarea
           {...props}
+          $error={errors}
           $resize={resize}
-          error={errors}
           id={id}
           ref={forwardedRef}
           rows={numOfRows}

--- a/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Textarea/__snapshots__/spec.tsx.snap
@@ -69,7 +69,7 @@ exports[`renders all together 1`] = `
 <div>
   <label
     class="c0"
-    for=":rp:"
+    for="_r_p_"
   >
     This is a label
   </label>
@@ -83,7 +83,7 @@ exports[`renders all together 1`] = `
   >
     <textarea
       class="c3"
-      id=":rp:"
+      id="_r_p_"
       rows="3"
     />
   </span>

--- a/packages/big-design/src/components/Textarea/styled.tsx
+++ b/packages/big-design/src/components/Textarea/styled.tsx
@@ -6,7 +6,7 @@ import { withTransition } from '../../helpers/transitions';
 
 interface StyledTextareaProps {
   $resize?: boolean;
-  error?: React.ReactNode | React.ReactNode[];
+  $error?: React.ReactNode | React.ReactNode[];
 }
 
 export const StyledTextareaWrapper = styled.span`
@@ -36,13 +36,13 @@ export const StyledTextarea = styled.textarea<StyledTextareaProps>`
           resize: none;
         `};
 
-  ${({ error, theme }) => css`
-    border: ${error ? theme.border.boxError : theme.border.box};
+  ${({ $error, theme }) => css`
+    border: ${$error ? theme.border.boxError : theme.border.box};
   `};
 
   &:hover:not([disabled]) {
-    ${({ error, theme }) =>
-      error
+    ${({ $error, theme }) =>
+      $error
         ? css`
             border: ${theme.border.boxError};
           `
@@ -54,7 +54,7 @@ export const StyledTextarea = styled.textarea<StyledTextareaProps>`
   &:focus {
     outline: none;
     box-shadow: 0 0 0 4px
-      ${(props) => (props.error ? props.theme.colors.danger20 : props.theme.colors.primary20)};
+      ${(props) => (props.$error ? props.theme.colors.danger20 : props.theme.colors.primary20)};
   }
 
   &[disabled] {

--- a/packages/big-design/src/components/Tooltip/Tooltip.tsx
+++ b/packages/big-design/src/components/Tooltip/Tooltip.tsx
@@ -53,16 +53,19 @@ export const Tooltip: React.FC<TooltipProps> = memo(
       }
     };
 
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const triggerWithRef = cloneElement(trigger as React.ReactElement<any>, {
+      ref: refs.setReference,
+      onBlur: hideTooltip,
+      onFocus: showTooltip,
+      onKeyDown,
+      onMouseEnter: showTooltip,
+      onMouseLeave: hideTooltip,
+    });
+
     return (
       <>
-        {cloneElement(trigger, {
-          ref: refs.setReference,
-          onBlur: hideTooltip,
-          onFocus: showTooltip,
-          onKeyDown,
-          onMouseEnter: showTooltip,
-          onMouseLeave: hideTooltip,
-        })}
+        {triggerWithRef}
         {createPortal(
           isVisible && (
             <StyledTooltip

--- a/packages/big-design/src/components/Tree/Tree.tsx
+++ b/packages/big-design/src/components/Tree/Tree.tsx
@@ -41,7 +41,7 @@ export const Tree = <T,>({
   virtualization,
 }: TreeProps<T>): React.ReactElement<TreeProps<T>> => {
   const treeRef = useRef<HTMLUListElement>(null);
-  const pendingFocusNodeRef = useRef<TreeNodeId>();
+  const pendingFocusNodeRef = useRef<TreeNodeId | undefined>(undefined);
   const focusedNodeRef = useRef(focusable.focusedNode);
 
   focusedNodeRef.current = focusable.focusedNode;

--- a/packages/big-design/src/components/Tree/hooks/spec.ts
+++ b/packages/big-design/src/components/Tree/hooks/spec.ts
@@ -430,7 +430,7 @@ describe('useTreeVirtualizer', () => {
   const toFlatNodes = (nodes: Array<TreeNodeProps<number>>): Array<FlatTreeNode<number>> =>
     nodes.map((node, index) => ({ node, depth: 0, posinset: index + 1, setsize: nodes.length }));
 
-  const nullScrollRef = { current: null } as RefObject<HTMLUListElement>;
+  const nullScrollRef = { current: null } as RefObject<HTMLUListElement | null>;
 
   test('does not scroll or reassign focus while disabled', () => {
     const onFocus = jest.fn();

--- a/packages/big-design/src/components/Tree/hooks/useTreeVirtualizer.ts
+++ b/packages/big-design/src/components/Tree/hooks/useTreeVirtualizer.ts
@@ -1,5 +1,5 @@
 import { Rect, useVirtualizer, Virtualizer } from '@tanstack/react-virtual';
-import { MutableRefObject, RefObject, useEffect, useMemo, useRef } from 'react';
+import { RefObject, useEffect, useMemo, useRef } from 'react';
 
 import { useEventCallback } from '../../../hooks';
 import { TreeNodeId, TreeNodeProps } from '../types';
@@ -19,7 +19,7 @@ interface UseTreeVirtualizerProps<T> {
   maxHeight?: number;
   nodes: Array<TreeNodeProps<T>>;
   onFocus?: (nodeId: TreeNodeId) => void;
-  scrollRef: RefObject<HTMLUListElement>;
+  scrollRef: RefObject<HTMLUListElement | null>;
 }
 
 // Checks the full (unfiltered-by-expansion) tree, not just the flattened/visible
@@ -32,7 +32,7 @@ const nodeExistsInTree = <T>(nodes: Array<TreeNodeProps<T>>, id: TreeNodeId): bo
   );
 
 const createObserveElementRect =
-  (fallbackHeightRef: MutableRefObject<number>) =>
+  (fallbackHeightRef: RefObject<number>) =>
   <T extends Element>(instance: Virtualizer<T, Element>, cb: (rect: Rect) => void) => {
     const element = instance.scrollElement;
 

--- a/packages/big-design/src/components/Tree/types.ts
+++ b/packages/big-design/src/components/Tree/types.ts
@@ -76,7 +76,7 @@ export interface TreeContextState<T> {
   onKeyDown: TreeOnKeyDown<T>;
   onNodeClick?: TreeOnNodeClick;
   onNodeRefChange(nodeId: TreeNodeId, node: HTMLLIElement | null, wasFocused?: boolean): void;
-  treeRef: RefObject<HTMLUListElement>;
+  treeRef: RefObject<HTMLUListElement | null>;
   disabledNodesSet: Set<TreeNodeId>;
   expandedNodesSet: Set<TreeNodeId>;
   selectedNodesSet: Set<TreeNodeId>;

--- a/packages/big-design/src/components/Worksheet/Row/styled.ts
+++ b/packages/big-design/src/components/Worksheet/Row/styled.ts
@@ -1,8 +1,8 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
-export const StyledTableRow = styled.tr<{ isExpanded: boolean }>`
-  display: ${({ isExpanded }) => (isExpanded ? 'table-row' : 'none')};
+export const StyledTableRow = styled.tr<{ $isExpanded: boolean }>`
+  display: ${({ $isExpanded }) => ($isExpanded ? 'table-row' : 'none')};
 `;
 
 StyledTableRow.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
+++ b/packages/big-design/src/components/Worksheet/__snapshots__/spec.tsx.snap
@@ -515,8 +515,8 @@ exports[`renders worksheet 1`] = `
             class="c6"
           >
             <svg
-              aria-describedby=":r0:"
-              aria-labelledby=":r2:"
+              aria-describedby="_r_0_"
+              aria-labelledby="_r_2_"
               class="c7"
               fill="currentColor"
               height="24"
@@ -526,7 +526,7 @@ exports[`renders worksheet 1`] = `
               width="24"
             >
               <title
-                id=":r2:"
+                id="_r_2_"
               >
                 Hover or focus for additional context.
               </title>
@@ -573,16 +573,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r6:"
+                aria-labelledby="_r_6_"
                 checked=""
                 class="c14 c15"
-                id=":r5:"
+                id="_r_5_"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16"
-                for=":r5:"
+                for="_r_5_"
               >
                 <svg
                   aria-hidden="true"
@@ -609,9 +609,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c19"
-                  for=":r5:"
+                  for="_r_5_"
                   hidden=""
-                  id=":r6:"
+                  id="_r_6_"
                 >
                   Checked
                 </label>
@@ -716,16 +716,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":re:"
+                aria-labelledby="_r_e_"
                 checked=""
                 class="c14 c15"
-                id=":rd:"
+                id="_r_d_"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16"
-                for=":rd:"
+                for="_r_d_"
               >
                 <svg
                   aria-hidden="true"
@@ -752,9 +752,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c19"
-                  for=":rd:"
+                  for="_r_d_"
                   hidden=""
-                  id=":re:"
+                  id="_r_e_"
                 >
                   Checked
                 </label>
@@ -859,15 +859,15 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="false"
-                aria-labelledby=":rm:"
+                aria-labelledby="_r_m_"
                 class="c14 c15"
-                id=":rl:"
+                id="_r_l_"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c29"
-                for=":rl:"
+                for="_r_l_"
               >
                 <svg
                   aria-hidden="true"
@@ -894,9 +894,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c19"
-                  for=":rl:"
+                  for="_r_l_"
                   hidden=""
-                  id=":rm:"
+                  id="_r_m_"
                 >
                   Unchecked
                 </label>
@@ -999,16 +999,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":ru:"
+                aria-labelledby="_r_u_"
                 checked=""
                 class="c14 c15"
-                id=":rt:"
+                id="_r_t_"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16"
-                for=":rt:"
+                for="_r_t_"
               >
                 <svg
                   aria-hidden="true"
@@ -1035,9 +1035,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c19"
-                  for=":rt:"
+                  for="_r_t_"
                   hidden=""
-                  id=":ru:"
+                  id="_r_u_"
                 >
                   Checked
                 </label>
@@ -1139,15 +1139,15 @@ exports[`renders worksheet 1`] = `
               class="c13"
             >
               <input
-                aria-labelledby=":r16:"
+                aria-labelledby="_r_16_"
                 class="c14 c15"
-                id=":r15:"
+                id="_r_15_"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c29"
-                for=":r15:"
+                for="_r_15_"
               >
                 <svg
                   aria-hidden="true"
@@ -1174,9 +1174,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c19"
-                  for=":r15:"
+                  for="_r_15_"
                   hidden=""
-                  id=":r16:"
+                  id="_r_16_"
                 >
                   Unchecked
                 </label>
@@ -1275,16 +1275,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r1e:"
+                aria-labelledby="_r_1e_"
                 checked=""
                 class="c14 c15"
-                id=":r1d:"
+                id="_r_1d_"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16"
-                for=":r1d:"
+                for="_r_1d_"
               >
                 <svg
                   aria-hidden="true"
@@ -1311,9 +1311,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c19"
-                  for=":r1d:"
+                  for="_r_1d_"
                   hidden=""
-                  id=":r1e:"
+                  id="_r_1e_"
                 >
                   Checked
                 </label>
@@ -1418,15 +1418,15 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="false"
-                aria-labelledby=":r1m:"
+                aria-labelledby="_r_1m_"
                 class="c14 c15"
-                id=":r1l:"
+                id="_r_1l_"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c29"
-                for=":r1l:"
+                for="_r_1l_"
               >
                 <svg
                   aria-hidden="true"
@@ -1453,9 +1453,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c19"
-                  for=":r1l:"
+                  for="_r_1l_"
                   hidden=""
-                  id=":r1m:"
+                  id="_r_1m_"
                 >
                   Unchecked
                 </label>
@@ -1560,16 +1560,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r1u:"
+                aria-labelledby="_r_1u_"
                 checked=""
                 class="c14 c15"
-                id=":r1t:"
+                id="_r_1t_"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16"
-                for=":r1t:"
+                for="_r_1t_"
               >
                 <svg
                   aria-hidden="true"
@@ -1596,9 +1596,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c19"
-                  for=":r1t:"
+                  for="_r_1t_"
                   hidden=""
-                  id=":r1u:"
+                  id="_r_1u_"
                 >
                   Checked
                 </label>
@@ -1703,16 +1703,16 @@ exports[`renders worksheet 1`] = `
             >
               <input
                 aria-checked="true"
-                aria-labelledby=":r26:"
+                aria-labelledby="_r_26_"
                 checked=""
                 class="c14 c15"
-                id=":r25:"
+                id="_r_25_"
                 type="checkbox"
               />
               <label
                 aria-hidden="true"
                 class="c16"
-                for=":r25:"
+                for="_r_25_"
               >
                 <svg
                   aria-hidden="true"
@@ -1739,9 +1739,9 @@ exports[`renders worksheet 1`] = `
                 <label
                   aria-hidden="false"
                   class="c19"
-                  for=":r25:"
+                  for="_r_25_"
                   hidden=""
-                  id=":r26:"
+                  id="_r_26_"
                 >
                   Checked
                 </label>

--- a/packages/big-design/src/components/Worksheet/editors/TextEditor/TextEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/TextEditor/TextEditor.tsx
@@ -33,7 +33,7 @@ const InternalTextEditor = <T extends WorksheetItem>({
   const [isMetaKeyValue, setIsMetaKeyValue] = useState(isMetaKey);
   const [isControlValue, setIsControlKeyValue] = useState(isControlKey);
 
-  const blurEventRef = useRef<React.FocusEvent<HTMLInputElement>>();
+  const blurEventRef = useRef<React.FocusEvent<HTMLInputElement> | undefined>(undefined);
   // const actionButtonRef = useRef<HTMLButtonElement | null>(null);
   const actionButtonId = useId();
 

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -119,7 +119,7 @@ export interface InternalTableInterface {
   minWidth?: number;
   onKeyDown?: KeyboardEventHandler | undefined;
   onKeyUp?: ReactEventHandler | undefined;
-  tableRef: RefObject<HTMLTableElement>;
+  tableRef: RefObject<HTMLTableElement | null>;
 }
 
 export type WorksheetItem = Record<string, any>;

--- a/packages/big-design/src/hooks/useComponentSize.ts
+++ b/packages/big-design/src/hooks/useComponentSize.ts
@@ -7,12 +7,12 @@ interface ComponentSize {
   width: HTMLElement['offsetWidth'];
 }
 
-const getSize = <T extends HTMLElement>(element: RefObject<T>['current']): ComponentSize => ({
+const getSize = (element: RefObject<HTMLElement | null>['current']): ComponentSize => ({
   height: element ? element.offsetHeight : 0,
   width: element ? element.offsetWidth : 0,
 });
 
-export const useComponentSize = <T extends HTMLElement>(ref: RefObject<T>): ComponentSize => {
+export const useComponentSize = (ref: RefObject<HTMLElement | null>): ComponentSize => {
   const [size, setSize] = useRafState(getSize(ref.current));
 
   const handleResize = useCallback(() => {

--- a/packages/big-design/src/managers/alerts/AlertsManager.tsx
+++ b/packages/big-design/src/managers/alerts/AlertsManager.tsx
@@ -18,8 +18,12 @@ export const AlertsManager: React.FC<AlertsManagerProps> = ({ manager }) => {
   }
 
   // autoDismiss is consumed by the manager and must not reach the DOM via SC6's prop forwarding.
+  // key must be passed explicitly in React 19; the manager stores it on the alert object.
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  const { autoDismiss, ...alertProps } = alert as AlertProps & { autoDismiss?: boolean };
+  const { key, autoDismiss, ...alertProps } = alert as AlertProps & {
+    key?: string;
+    autoDismiss?: boolean;
+  };
 
-  return <Alert {...alertProps} />;
+  return <Alert key={key} {...alertProps} />;
 };

--- a/packages/docs/components/Code/Code.tsx
+++ b/packages/docs/components/Code/Code.tsx
@@ -8,8 +8,6 @@ export interface CodeProps {
   highlight?: boolean;
 }
 
-export const Code: React.FC<CodeProps> = ({ highlight, primary, ...domProps }) => (
+export const Code: React.FC<CodeProps> = ({ highlight = true, primary, ...domProps }) => (
   <StyledCode $highlight={highlight} $primary={primary} {...domProps} />
 );
-
-Code.defaultProps = { highlight: true };

--- a/packages/docs/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/docs/components/CodeSnippet/CodeSnippet.tsx
@@ -74,8 +74,3 @@ export const CodeSnippet: React.FC<EditorProps> = (props) => {
     </Box>
   );
 };
-
-CodeSnippet.defaultProps = {
-  language: 'tsx',
-  showControls: true,
-};

--- a/packages/docs/components/ColorCards/ColorCard.tsx
+++ b/packages/docs/components/ColorCards/ColorCard.tsx
@@ -1,4 +1,5 @@
 import { Flex, Link, Small, Text } from '@bigcommerce/big-design';
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import React, { useContext } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 
@@ -15,7 +16,7 @@ interface ColorCardProps {
 }
 
 const ColorCard: React.FC<ColorCardProps> = ({ colorCard }) => {
-  const { colors } = useContext(ThemeContext);
+  const { colors } = useContext(ThemeContext) ?? defaultTheme;
   const { description } = colorCard;
   const colorValue = colors[colorCard.name];
   const hasHexColor = colorValue.startsWith('#');

--- a/packages/docs/components/List/styled.tsx
+++ b/packages/docs/components/List/styled.tsx
@@ -1,4 +1,4 @@
-import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { ListProps } from './List';
 
@@ -23,12 +23,7 @@ const SharedListStyles = css<StyledListProps>`
   ${({ $reset, theme }) =>
     $reset &&
     css`
-      ${
-        // Temporary until docs flips to styled-components 6: the theme dist now types
-        // CSSRules as v6's RuleSet, which v5's css typings can't accept.
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        theme.helpers.listReset as unknown as FlattenSimpleInterpolation
-      };
+      ${theme.helpers.listReset};
     `}
 `;
 

--- a/packages/docs/components/MethodBadge/styled.ts
+++ b/packages/docs/components/MethodBadge/styled.ts
@@ -1,5 +1,5 @@
 import { MarginProps, withMargins } from '@bigcommerce/big-design';
-import styled, { FlattenSimpleInterpolation } from 'styled-components';
+import styled from 'styled-components';
 
 import { MethodBadgeProps } from './MethodBadge';
 
@@ -14,12 +14,7 @@ interface StyledMethodBadgeProps extends Omit<MethodBadgeProps, 'label' | keyof 
 }
 
 export const StyledMethodBadge = styled.span<StyledMethodBadgeProps>`
-  ${
-    // Temporary until docs flips to styled-components 6: big-design's dist now types
-    // withMargins() as v6's RuleSet, which v5's css typings can't accept.
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    withMargins() as unknown as FlattenSimpleInterpolation
-  };
+  ${withMargins()};
 
   background-color: ${({ theme }) => theme.colors.secondary70};
   border-radius: ${({ theme }) => theme.borderRadius.normal};

--- a/packages/docs/components/SideNav/SideNavMenu/SideNavMenu.tsx
+++ b/packages/docs/components/SideNav/SideNavMenu/SideNavMenu.tsx
@@ -22,9 +22,9 @@ export const SideNavMenu: React.FC<{ children?: React.ReactNode }> = ({ children
           />
         </StyledMenu>
         <StyledNavigation
+          $isExpanded={isExpanded}
           borderBottom="box"
           borderTop="box"
-          isExpanded={isExpanded}
           shadow="floating"
         >
           {children}

--- a/packages/docs/components/SideNav/SideNavMenu/styled.tsx
+++ b/packages/docs/components/SideNav/SideNavMenu/styled.tsx
@@ -1,5 +1,5 @@
 import { FlexItem } from '@bigcommerce/big-design';
-import styled, { FlattenSimpleInterpolation } from 'styled-components';
+import styled from 'styled-components';
 
 export const StyledMenu = styled(FlexItem)`
   ${({ theme }) => theme.breakpoints.tablet} {
@@ -8,25 +8,17 @@ export const StyledMenu = styled(FlexItem)`
 `;
 
 interface Navigation {
-  isExpanded: boolean;
+  $isExpanded: boolean;
 }
 
 export const StyledNavigation = styled(FlexItem)<Navigation>`
-  ${({ theme }) =>
-    // Temporary until docs flips to styled-components 6: the theme dist now types
-    // CSSRules as v6's RuleSet, which v5's css typings can't accept.
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    theme.shadow.floating as unknown as FlattenSimpleInterpolation};
+  ${({ theme }) => theme.shadow.floating};
 
   background-color: ${({ theme }) => theme.colors.white};
-  border-bottom: ${({ theme }) =>
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    theme.border.box as unknown as FlattenSimpleInterpolation};
+  border-bottom: ${({ theme }) => theme.border.box};
   border-radius: 0;
-  border-top: ${({ theme }) =>
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    theme.border.box as unknown as FlattenSimpleInterpolation};
-  display: ${({ isExpanded }) => (isExpanded ? 'block' : 'none')};
+  border-top: ${({ theme }) => theme.border.box};
+  display: ${({ $isExpanded }) => ($isExpanded ? 'block' : 'none')};
   height: 16rem;
   left: 0;
   overflow: auto;

--- a/packages/docs/components/SnippetControls/SnippetControls.tsx
+++ b/packages/docs/components/SnippetControls/SnippetControls.tsx
@@ -37,7 +37,11 @@ function onCopy(setIsCopying: (copying: boolean) => void, copyToClipboard: () =>
 }
 
 export const SnippetControls: React.FC<SnippetControls> = (props) => {
-  const { copyToClipboard, helperText, resetCode } = props;
+  const {
+    copyToClipboard,
+    helperText = 'Edit the code below to see your changes live!',
+    resetCode,
+  } = props;
   const [isCopying, setIsCopying] = useState(false);
   const { toggleTheme: toggleEditorTheme, setLanguage } = useContext(CodeEditorContext);
 
@@ -87,8 +91,4 @@ export const SnippetControls: React.FC<SnippetControls> = (props) => {
       </FlexItem>
     </StyledFlex>
   );
-};
-
-SnippetControls.defaultProps = {
-  helperText: 'Edit the code below to see your changes live!',
 };

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const bdPkg = require('../big-design/package.json');
 const examplesPkg = require('../examples/package.json');
 
@@ -9,6 +11,7 @@ const EXAMPLES_VERSION = examplesPkg.version;
 /** @type {import('next').NextConfig} */
 module.exports = {
   basePath: isProduction ? URL_PREFIX : '',
+  outputFileTracingRoot: path.join(__dirname, '../../'),
   output: 'export',
   env: {
     CODE_SANDBOX_URL: `https://codesandbox.io/p/devbox/github/bigcommerce/big-design/tree/%40bigcommerce/examples%40${EXAMPLES_VERSION}/packages/examples`,

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -29,10 +29,10 @@
     "clipboard-copy": "^4.0.1",
     "prettier": "^2.4.0",
     "prism-react-renderer": "^2.4.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-live": "^4.1.8",
-    "styled-components": "^5.3.11"
+    "styled-components": "^6.1.14"
   },
   "devDependencies": {
     "@bigcommerce/configs": "workspace:^",
@@ -40,9 +40,8 @@
     "@types/gtag.js": "^0.0.20",
     "@types/node": "^24.10.4",
     "@types/prettier": "^2.0.1",
-    "@types/react": "^18.2.73",
-    "@types/react-dom": "^18.2.23",
-    "@types/styled-components": "^5.1.34",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "eslint": "^8.33.0",
     "jsx-to-string-loader": "^1.2.0",
     "next": "^15.5.21",

--- a/packages/docs/pages/index.tsx
+++ b/packages/docs/pages/index.tsx
@@ -1,4 +1,5 @@
 import { Flex, FlexItem, H3, Link, Panel, Text } from '@bigcommerce/big-design';
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 
@@ -7,7 +8,7 @@ import { Code, CodeSnippet, List } from '../components';
 const CodeSandboxUrl = process.env.CODE_SANDBOX_URL ?? '';
 
 const GettingStartedPage = () => {
-  const { spacing } = useContext(ThemeContext);
+  const { spacing } = useContext(ThemeContext) ?? defaultTheme;
 
   return (
     <Flex flexDirection="column">

--- a/packages/docs/pages/spacing.tsx
+++ b/packages/docs/pages/spacing.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Flex, H1, Panel, Table, Text } from '@bigcommerce/big-design';
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import React, { Fragment, useContext } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 
@@ -29,7 +30,7 @@ const BlueBox = styled(Box)(({ theme }) => ({
 }));
 
 const SpacingPage = () => {
-  const { spacing } = useContext(ThemeContext);
+  const { spacing } = useContext(ThemeContext) ?? defaultTheme;
 
   return (
     <>

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -22,8 +22,8 @@
   "devDependencies": {
     "@bigcommerce/eslint-config": "2.12.0",
     "@types/node": "^24.10.4",
-    "@types/react": "18.2.73",
-    "@types/react-dom": "18.2.23",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "@types/styled-components": "5.1.34",
     "@vitejs/plugin-react": "4.3.4",
     "eslint": "^8.33.0",

--- a/packages/examples/src/ProductList.tsx
+++ b/packages/examples/src/ProductList.tsx
@@ -29,11 +29,11 @@ export const ProductList: React.FC<Props> = ({ onDelete, products }) => {
         <TableFigure>
           <StatefulTable
             columns={[
-              { header: 'Name', hash: 'name', render: ({ name }) => name },
+              { header: 'Name', hash: 'name', render: ({ name }: Product) => name },
               {
                 header: 'Category',
                 hash: 'category',
-                render: ({ category }) => category,
+                render: ({ category }: Product) => category,
               },
               {
                 header: 'Stock',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,19 +66,19 @@ importers:
         version: link:../big-design-theme
       '@floating-ui/react':
         specifier: ^0.27.20
-        version: 0.27.20(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.27.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@popperjs/core':
         specifier: ^2.11.6
         version: 2.11.8
       '@tanstack/react-virtual':
         specifier: ^3.13.0
-        version: 3.13.23(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 3.13.23(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
       downshift:
         specifier: 9.0.10
-        version: 9.0.10(react@18.2.0)
+        version: 9.0.10(react@19.2.8)
       focus-trap:
         specifier: ^7.6.4
         version: 7.6.4
@@ -87,13 +87,13 @@ importers:
         version: 4.3.1
       react-datepicker:
         specifier: ^7.6.0
-        version: 7.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 7.6.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-intersection-observer:
         specifier: ^10.0.0
-        version: 10.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 10.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       zustand:
         specifier: ^5.0.11
-        version: 5.0.11(@types/react@18.2.73)(react@18.2.0)(use-sync-external-store@1.4.0(react@18.2.0))
+        version: 5.0.11(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.4.0(react@19.2.8))
     devDependencies:
       '@babel/cli':
         specifier: ^7.28.3
@@ -139,7 +139,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -150,17 +150,17 @@ importers:
         specifier: ^24.10.4
         version: 24.10.4
       '@types/react':
-        specifier: ^18.2.73
-        version: 18.2.73
+        specifier: ^19.0.0
+        version: 19.2.18
       '@types/react-dom':
-        specifier: ^18.2.23
-        version: 18.2.23
+        specifier: ^19.0.0
+        version: 19.2.4(@types/react@19.2.18)
       babel-jest:
         specifier: ^30.2.0
         version: 30.2.0(@babel/core@7.28.0)
       babel-plugin-styled-components:
         specifier: ^2.0.7
-        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       eslint:
         specifier: ^8.33.0
         version: 8.57.0
@@ -175,16 +175,16 @@ importers:
         version: 3.3.1
       jest-styled-components:
         specifier: ^7.4.0
-        version: 7.4.0(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 7.4.0(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       react:
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: ^19.0.0
+        version: 19.2.8
       react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
+        specifier: ^19.0.0
+        version: 19.2.8(react@19.2.8)
       styled-components:
         specifier: ^6.4.0
-        version: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -235,14 +235,14 @@ importers:
         specifier: ^8.1.0
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
       '@types/react':
-        specifier: ^18.2.73
-        version: 18.2.73
+        specifier: ^19.0.0
+        version: 19.2.18
       '@types/react-dom':
-        specifier: ^18.2.23
-        version: 18.2.23
+        specifier: ^19.0.0
+        version: 19.2.4(@types/react@19.2.18)
       babel-plugin-styled-components:
         specifier: ^2.0.7
-        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       camelcase:
         specifier: ^6.3.0
         version: 6.3.0
@@ -268,11 +268,11 @@ importers:
         specifier: ^2.4.0
         version: 2.8.8
       react:
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: ^19.0.0
+        version: 19.2.8
       react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
+        specifier: ^19.0.0
+        version: 19.2.8(react@19.2.8)
       react-is:
         specifier: ^19.2.0
         version: 19.2.0
@@ -281,7 +281,7 @@ importers:
         version: 6.1.0
       styled-components:
         specifier: ^6.4.0
-        version: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tiny-async-pool:
         specifier: ^2.0.1
         version: 2.1.0
@@ -348,7 +348,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -359,17 +359,17 @@ importers:
         specifier: ^24.10.4
         version: 24.10.4
       '@types/react':
-        specifier: ^18.2.73
-        version: 18.2.73
+        specifier: ^19.0.0
+        version: 19.2.18
       '@types/react-dom':
-        specifier: ^18.2.23
-        version: 18.2.23
+        specifier: ^19.0.0
+        version: 19.2.4(@types/react@19.2.18)
       babel-jest:
         specifier: ^30.2.0
         version: 30.2.0(@babel/core@7.28.0)
       babel-plugin-styled-components:
         specifier: ^2.0.7
-        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       eslint:
         specifier: ^8.33.0
         version: 8.57.0
@@ -384,19 +384,19 @@ importers:
         version: 3.3.1
       jest-styled-components:
         specifier: ^7.4.0
-        version: 7.4.0(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 7.4.0(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       react:
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: ^19.0.0
+        version: 19.2.8
       react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
+        specifier: ^19.0.0
+        version: 19.2.8(react@19.2.8)
       rimraf:
         specifier: ^6.1.0
         version: 6.1.0
       styled-components:
         specifier: ^6.4.0
-        version: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -454,7 +454,7 @@ importers:
         version: 30.2.0(@babel/core@7.28.0)
       babel-plugin-styled-components:
         specifier: ^2.0.7
-        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       eslint:
         specifier: ^8.33.0
         version: 8.57.0
@@ -469,16 +469,16 @@ importers:
         version: 3.3.1
       jest-styled-components:
         specifier: ^7.4.0
-        version: 7.4.0(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 7.4.0(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       react:
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: ^19.0.0
+        version: 19.2.8
       react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
+        specifier: ^19.0.0
+        version: 19.2.8(react@19.2.8)
       styled-components:
         specifier: ^6.4.0
-        version: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -523,7 +523,7 @@ importers:
         version: link:../big-design-theme
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.9
-        version: 1.2.9(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 1.2.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -532,19 +532,19 @@ importers:
         version: 2.8.8
       prism-react-renderer:
         specifier: ^2.4.1
-        version: 2.4.1(react@18.2.0)
+        version: 2.4.1(react@19.2.8)
       react:
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: ^19.0.0
+        version: 19.2.8
       react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
+        specifier: ^19.0.0
+        version: 19.2.8(react@19.2.8)
       react-live:
         specifier: ^4.1.8
-        version: 4.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 4.1.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0)
+        specifier: ^6.1.14
+        version: 6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@bigcommerce/configs':
         specifier: workspace:^
@@ -562,14 +562,11 @@ importers:
         specifier: ^2.0.1
         version: 2.7.3
       '@types/react':
-        specifier: ^18.2.73
-        version: 18.2.73
+        specifier: ^19.0.0
+        version: 19.2.18
       '@types/react-dom':
-        specifier: ^18.2.23
-        version: 18.2.23
-      '@types/styled-components':
-        specifier: ^5.1.34
-        version: 5.1.34
+        specifier: ^19.0.0
+        version: 19.2.4(@types/react@19.2.18)
       eslint:
         specifier: ^8.33.0
         version: 8.57.0
@@ -578,7 +575,7 @@ importers:
         version: 1.2.0
       next:
         specifier: ^15.5.21
-        version: 15.5.21(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 15.5.21(@babel/core@7.28.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -587,7 +584,7 @@ importers:
     dependencies:
       '@bigcommerce/big-design':
         specifier: '*'
-        version: 1.4.1(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))
+        version: 1.4.1(@types/react@19.2.18)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))
       '@bigcommerce/big-design-icons':
         specifier: '*'
         version: 1.0.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))
@@ -617,11 +614,11 @@ importers:
         specifier: ^24.10.4
         version: 24.10.4
       '@types/react':
-        specifier: 18.2.73
-        version: 18.2.73
+        specifier: ^19.0.0
+        version: 19.2.18
       '@types/react-dom':
-        specifier: 18.2.23
-        version: 18.2.23
+        specifier: ^19.0.0
+        version: 19.2.4(@types/react@19.2.18)
       '@types/styled-components':
         specifier: 5.1.34
         version: 5.1.34
@@ -2830,21 +2827,20 @@ packages:
   '@types/prismjs@1.26.5':
     resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
 
-  '@types/prop-types@15.7.4':
-    resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==}
-
   '@types/react-datepicker@7.0.0':
     resolution: {integrity: sha512-4tWwOUq589tozyQPBVEqGNng5DaZkomx5IVNuur868yYdgjH6RaL373/HKiVt1IDoNNXYiTGspm1F7kjrarM8Q==}
     deprecated: This is a stub types definition. react-datepicker provides its own type definitions, so you do not need this installed.
 
-  '@types/react-dom@18.2.23':
-    resolution: {integrity: sha512-ZQ71wgGOTmDYpnav2knkjr3qXdAFu0vsk8Ci5w3pGAIdj7/kKAyn+VsQDhXsmzzzepAiI9leWMmubXz690AI/A==}
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
+    peerDependencies:
+      '@types/react': ^19.2.0
 
   '@types/react-redux@7.1.16':
     resolution: {integrity: sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==}
 
-  '@types/react@18.2.73':
-    resolution: {integrity: sha512-XcGdod0Jjv84HOC7N5ziY3x+qL0AfmubvKOZ9hJjJ2yd5EE+KYjWhdOjt387e9HPheHkdggF9atTifMRtyAaRA==}
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -5436,6 +5432,11 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
   react-fast-compare@2.0.4:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
 
@@ -5498,6 +5499,10 @@ packages:
 
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -5659,6 +5664,9 @@ packages:
 
   scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -7522,7 +7530,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       styled-components: 5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0)
 
-  '@bigcommerce/big-design@1.4.1(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))':
+  '@bigcommerce/big-design@1.4.1(@types/react@19.2.18)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))':
     dependencies:
       '@babel/runtime': 7.26.10
       '@bigcommerce/big-design-icons': 1.0.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0))
@@ -7539,7 +7547,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       styled-components: 5.3.11(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react-is@19.2.0)(react@18.2.0)
-      zustand: 4.5.7(@types/react@18.2.73)(react@18.2.0)
+      zustand: 4.5.7(@types/react@19.2.18)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -8068,12 +8076,26 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   '@floating-ui/react@0.27.20(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/react-dom': 2.1.9(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@floating-ui/utils': 0.2.12
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+      tabbable: 6.2.0
+
+  '@floating-ui/react@0.27.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tabbable: 6.2.0
 
   '@floating-ui/utils@0.2.12': {}
@@ -8522,78 +8544,78 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.2.73)(react@18.2.0)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
-      react: 18.2.0
+      react: 19.2.8
     optionalDependencies:
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-context@1.1.2(@types/react@18.2.73)(react@18.2.0)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
-      react: 18.2.0
+      react: 19.2.8
     optionalDependencies:
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-direction@1.1.1(@types/react@18.2.73)(react@18.2.0)':
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
-      react: 18.2.0
+      react: 19.2.8
     optionalDependencies:
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-presence@1.1.4(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-presence@1.1.4(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.73)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.73)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
-      '@types/react': 18.2.73
-      '@types/react-dom': 18.2.23
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.2.73)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
-      '@types/react': 18.2.73
-      '@types/react-dom': 18.2.23
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-scroll-area@1.2.9(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-scroll-area@1.2.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.73)(react@18.2.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.2.73)(react@18.2.0)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.2.73)(react@18.2.0)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.73)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.73)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
-      '@types/react': 18.2.73
-      '@types/react-dom': 18.2.23
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-slot@1.2.3(@types/react@18.2.73)(react@18.2.0)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.73)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.8)
+      react: 19.2.8
     optionalDependencies:
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.2.73)(react@18.2.0)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
-      react: 18.2.0
+      react: 19.2.8
     optionalDependencies:
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.2.73)(react@18.2.0)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.18)(react@19.2.8)':
     dependencies:
-      react: 18.2.0
+      react: 19.2.8
     optionalDependencies:
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
 
   '@rollup/rollup-android-arm-eabi@4.53.3':
     optional: true
@@ -8886,11 +8908,11 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tanstack/react-virtual@3.13.23(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@tanstack/react-virtual@3.13.23(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/virtual-core': 3.13.23
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   '@tanstack/virtual-core@3.13.23': {}
 
@@ -8914,15 +8936,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.23)(@types/react@18.2.73)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@testing-library/dom': 10.4.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
-      '@types/react': 18.2.73
-      '@types/react-dom': 18.2.23
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -8990,7 +9012,7 @@ snapshots:
 
   '@types/hoist-non-react-statics@3.3.5':
     dependencies:
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
       hoist-non-react-statics: 3.3.2
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -9032,8 +9054,6 @@ snapshots:
 
   '@types/prismjs@1.26.5': {}
 
-  '@types/prop-types@15.7.4': {}
-
   '@types/react-datepicker@7.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       react-datepicker: 7.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -9041,28 +9061,27 @@ snapshots:
       - react
       - react-dom
 
-  '@types/react-dom@18.2.23':
+  '@types/react-dom@19.2.4(@types/react@19.2.18)':
     dependencies:
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
 
   '@types/react-redux@7.1.16':
     dependencies:
       '@types/hoist-non-react-statics': 3.3.5
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
       hoist-non-react-statics: 3.3.2
       redux: 4.1.0
 
-  '@types/react@18.2.73':
+  '@types/react@19.2.18':
     dependencies:
-      '@types/prop-types': 15.7.4
-      csstype: 3.0.10
+      csstype: 3.2.3
 
   '@types/stack-utils@2.0.3': {}
 
   '@types/styled-components@5.1.34':
     dependencies:
       '@types/hoist-non-react-statics': 3.3.5
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
       csstype: 3.0.10
 
   '@types/tough-cookie@4.0.5': {}
@@ -9569,14 +9588,14 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.28.0)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.28.0)
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      styled-components: 6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -10051,12 +10070,12 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
-  downshift@9.0.10(react@18.2.0):
+  downshift@9.0.10(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.28.2
       compute-scroll-into-view: 3.1.1
       prop-types: 15.8.1
-      react: 18.2.0
+      react: 19.2.8
       react-is: 18.2.0
       tslib: 2.8.1
 
@@ -11622,10 +11641,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-styled-components@7.4.0(styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)):
+  jest-styled-components@7.4.0(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
     dependencies:
       '@adobe/css-tools': 4.4.4
-      styled-components: 6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      styled-components: 6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   jest-util@30.2.0:
     dependencies:
@@ -11928,15 +11947,15 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.5.21(@babel/core@7.28.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@15.5.21(@babel/core@7.28.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 15.5.21
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001767
       postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@18.2.0)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.21
       '@next/swc-darwin-x64': 15.5.21
@@ -12207,11 +12226,11 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prism-react-renderer@2.4.1(react@18.2.0):
+  prism-react-renderer@2.4.1(react@19.2.8):
     dependencies:
       '@types/prismjs': 1.26.5
       clsx: 2.1.1
-      react: 18.2.0
+      react: 19.2.8
 
   prop-types@15.8.1:
     dependencies:
@@ -12257,21 +12276,34 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
+  react-datepicker@7.6.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@floating-ui/react': 0.27.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      clsx: 2.1.1
+      date-fns: 3.6.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   react-dom@18.2.0(react@18.2.0):
     dependencies:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
 
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
   react-fast-compare@2.0.4: {}
 
   react-fast-compare@3.2.0: {}
 
-  react-intersection-observer@10.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  react-intersection-observer@10.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      react: 18.2.0
+      react: 19.2.8
     optionalDependencies:
-      react-dom: 18.2.0(react@18.2.0)
+      react-dom: 19.2.8(react@19.2.8)
 
   react-is@16.13.1: {}
 
@@ -12283,13 +12315,13 @@ snapshots:
 
   react-is@19.2.0: {}
 
-  react-live@4.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  react-live@4.1.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      prism-react-renderer: 2.4.1(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      prism-react-renderer: 2.4.1(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       sucrase: 3.35.0
-      use-editable: 2.3.3(react@18.2.0)
+      use-editable: 2.3.3(react@19.2.8)
 
   react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -12316,6 +12348,8 @@ snapshots:
   react@18.2.0:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.2.8: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -12525,6 +12559,8 @@ snapshots:
   scheduler@0.23.0:
     dependencies:
       loose-envify: 1.4.0
+
+  scheduler@0.27.0: {}
 
   semver@5.7.2: {}
 
@@ -12801,19 +12837,19 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
-  styled-components@6.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@emotion/is-prop-valid': 1.4.0
       csstype: 3.2.3
-      react: 18.2.0
+      react: 19.2.8
       stylis: 4.3.6
     optionalDependencies:
-      react-dom: 18.2.0(react@18.2.0)
+      react-dom: 19.2.8(react@19.2.8)
 
-  styled-jsx@5.1.6(@babel/core@7.28.0)(react@18.2.0):
+  styled-jsx@5.1.6(@babel/core@7.28.0)(react@19.2.8):
     dependencies:
       client-only: 0.0.1
-      react: 18.2.0
+      react: 19.2.8
     optionalDependencies:
       '@babel/core': 7.28.0
 
@@ -13131,9 +13167,9 @@ snapshots:
     dependencies:
       punycode: 2.3.0
 
-  use-editable@2.3.3(react@18.2.0):
+  use-editable@2.3.3(react@19.2.8):
     dependencies:
-      react: 18.2.0
+      react: 19.2.8
 
   use-memo-one@1.1.1(react@18.2.0):
     dependencies:
@@ -13142,6 +13178,11 @@ snapshots:
   use-sync-external-store@1.4.0(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  use-sync-external-store@1.4.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+    optional: true
 
   util-deprecate@1.0.2: {}
 
@@ -13331,15 +13372,15 @@ snapshots:
       toposort: 2.0.2
       type-fest: 2.19.0
 
-  zustand@4.5.7(@types/react@18.2.73)(react@18.2.0):
+  zustand@4.5.7(@types/react@19.2.18)(react@18.2.0):
     dependencies:
       use-sync-external-store: 1.4.0(react@18.2.0)
     optionalDependencies:
-      '@types/react': 18.2.73
+      '@types/react': 19.2.18
       react: 18.2.0
 
-  zustand@5.0.11(@types/react@18.2.73)(react@18.2.0)(use-sync-external-store@1.4.0(react@18.2.0)):
+  zustand@5.0.11(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.4.0(react@19.2.8)):
     optionalDependencies:
-      '@types/react': 18.2.73
-      react: 18.2.0
-      use-sync-external-store: 1.4.0(react@18.2.0)
+      '@types/react': 19.2.18
+      react: 19.2.8
+      use-sync-external-store: 1.4.0(react@19.2.8)


### PR DESCRIPTION
Jira: [TRAC-1306](<https://bigcommercecloud.atlassian.net/browse/TRAC-1306>)

## What?

Flips all 4 published packages to React 19: devDependencies (`react`/`react-dom` `^18.2.0` → `^19.0.0`, `@types/react`/`@types/react-dom` `^18.x` → `^19.0.0`) and peerDependencies (`^18.0.0` → `^19.0.0`). Fixes type and runtime fallout required to keep `lint`, `typecheck`, and `test` green.

Key type changes:

* `RefObject<T>` → `RefObject<T | null>` throughout prop interfaces (React 19's revised `createRef`/`useRef` signatures)
* `MutableRefObject` removed from public types; `RefObject` everywhere
* `FormEvent` → `SubmitEvent` for `onSubmit` handlers
* `TableColumn`/`TableNext` `render` type narrowed from `ComponentType<T> | ((props: T) => ReactNode)` to `(props: T, context?: any) => ReactNode` — the interface-with-call-signature union prevented TypeScript's contextual inference on render callback destructuring; a plain function type restores it. Functional component references are still assignable.

Key runtime changes:

* React 19 removed `defaultProps` on function components; `Badge` variant default moved to component logic; `GlobalStyles` rewritten to use `useContext(ThemeContext)` with a `defaultTheme` fallback instead of relying on `defaultProps` injection
* React 19 errors when a `key` prop is spread into JSX; `AlertsManager` now destructures `key` before spreading `alert` props

Changeset is `major` for all 4 packages (peer bump to React 19).

## Why?

Part of the React 19 support project ([LTRAC-1354](https://linear.app/commerce/issue/LTRAC-1354/research)–1370). Requires the SC6 flip (bigcommerce/big-design#1899) to be merged first, which it is.

## Screenshots/Screen Recordings

N/A — dependency and type update, no visible component changes.

## Testing/Proof

`pnpm run lint && pnpm run typecheck && pnpm run test` all pass green across all packages on React 19 + SC6. 95 snapshots updated to reflect minor SC class name changes from the dep flip.

[TRAC-1306]: https://bigcommercecloud.atlassian.net/browse/TRAC-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ