### PR TITLE
fix(component): TRAC-1306 restore defaultProps defaults broken by SC6, fix autoDismiss DOM leak

### DIFF
--- a/.changeset/fix-sc6-defaultprops-autodismiss.md
+++ b/.changeset/fix-sc6-defaultprops-autodismiss.md
@@ -1,0 +1,10 @@
+---
+'@bigcommerce/big-design': patch
+'@bigcommerce/big-design-icons': patch
+---
+
+fix: restore layout defaults broken by styled-components v6 and fix `autoDismiss` DOM leak in `AlertsManager`
+
+`styled-components` v6 returns function components, and React 18/19 no longer applies `defaultProps` to function components. `Flex`, `FlexItem`, `Grid`, and icon components lost their layout defaults silently. Defaults are now applied at the call site rather than via `defaultProps`.
+
+`AlertsManager` also leaked the internal `autoDismiss` option onto the DOM: SC6 no longer strips unknown props before forwarding, so the option was reaching the DOM as an unrecognised attribute. It is now stripped before rendering.

--- a/packages/big-design-icons/src/base/index.tsx
+++ b/packages/big-design-icons/src/base/index.tsx
@@ -33,17 +33,13 @@ export function createStyledIcon(
 
     ${({ color, theme }) => color && { color: theme.colors[color] }}
 
-    ${({ size, theme }) =>
-      size && {
-        height: typeof size === 'number' ? theme.helpers.remCalc(size) : theme.spacing[size],
-        width: typeof size === 'number' ? theme.helpers.remCalc(size) : theme.spacing[size],
-      }}
+    ${({ size = 'xLarge', theme }) => ({
+      height: typeof size === 'number' ? theme.helpers.remCalc(size) : theme.spacing[size],
+      width: typeof size === 'number' ? theme.helpers.remCalc(size) : theme.spacing[size],
+    })}
   `;
 
-  StyledIcon.defaultProps = {
-    theme: defaultTheme,
-    size: 'xLarge',
-  };
+  StyledIcon.defaultProps = { theme: defaultTheme };
 
   return StyledIcon;
 }

--- a/packages/big-design/src/components/Flex/Item/styled.tsx
+++ b/packages/big-design/src/components/Flex/Item/styled.tsx
@@ -16,11 +16,4 @@ export const StyledFlexItem = styled(Box)<StyledFlexItemProps>`
   ${withFlexedItems()}
 `;
 
-StyledFlexItem.defaultProps = {
-  $alignSelf: 'auto',
-  $flexBasis: 'auto',
-  $flexGrow: 0,
-  $flexOrder: 0,
-  $flexShrink: 1,
-  theme: defaultTheme,
-};
+StyledFlexItem.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Flex/styled.tsx
+++ b/packages/big-design/src/components/Flex/styled.tsx
@@ -22,11 +22,4 @@ export const StyledFlex = styled(Box)<StyledFlexProps>`
   ${withDisplay()}
 `;
 
-StyledFlex.defaultProps = {
-  $alignContent: 'stretch',
-  $alignItems: 'stretch',
-  $flexDirection: { mobile: 'column', tablet: 'row' },
-  $flexWrap: 'nowrap',
-  $justifyContent: 'flex-start',
-  theme: defaultTheme,
-};
+StyledFlex.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Flex/withFlex.ts
+++ b/packages/big-design/src/components/Flex/withFlex.ts
@@ -42,14 +42,14 @@ export const withFlexedItems = () => css<TransientFlexedItemProps>`
 
 export function toTransientFlexedContainerProps(props: FlexedProps): TransientFlexedProps {
   const {
-    alignContent,
-    alignItems,
+    alignContent = 'stretch',
+    alignItems = 'stretch',
     flexColumnGap,
-    flexDirection,
+    flexDirection = { mobile: 'column', tablet: 'row' },
     flexGap,
     flexRowGap,
-    flexWrap,
-    justifyContent,
+    flexWrap = 'nowrap',
+    justifyContent = 'flex-start',
   } = props;
 
   return {
@@ -69,7 +69,13 @@ export function toTransientFlexedContainerProps(props: FlexedProps): TransientFl
 // has a single consumer (Flex/Item/styled.tsx), so unlike the shared margin/padding/
 // display helpers, no dual-read shim is needed here.
 export function toTransientFlexedItemProps(props: FlexedItemProps): TransientFlexedItemProps {
-  const { alignSelf, flexBasis, flexGrow, flexOrder, flexShrink } = props;
+  const {
+    alignSelf = 'auto',
+    flexBasis = 'auto',
+    flexGrow = 0,
+    flexOrder = 0,
+    flexShrink = 1,
+  } = props;
 
   return {
     $alignSelf: alignSelf,

--- a/packages/big-design/src/components/Grid/styled.tsx
+++ b/packages/big-design/src/components/Grid/styled.tsx
@@ -22,4 +22,4 @@ export const StyledGrid = styled(Box)<StyledGridProps>`
   ${withDisplay()}
 `;
 
-StyledGrid.defaultProps = { theme: defaultTheme, $gridGap: defaultTheme.spacing.medium };
+StyledGrid.defaultProps = { theme: defaultTheme };

--- a/packages/big-design/src/components/Grid/withGrid.ts
+++ b/packages/big-design/src/components/Grid/withGrid.ts
@@ -25,7 +25,7 @@ export const withGridedContainer = () => css<TransientGridedProps>`
     $gridAutoRows && getGridedStyles($gridAutoRows, theme, 'grid-auto-rows')};
   ${({ $gridColumns, theme }) =>
     $gridColumns && getGridedStyles($gridColumns, theme, 'grid-template-columns')};
-  ${({ $gridGap, theme }) => $gridGap && getGridedStyles($gridGap, theme, 'gap')};
+  ${({ $gridGap, theme }) => getGridedStyles($gridGap ?? theme.spacing.medium, theme, 'gap')};
   ${({ $gridColumnGap, theme }) =>
     $gridColumnGap && getGridedStyles($gridColumnGap, theme, 'column-gap')};
   ${({ $gridRows, theme }) => $gridRows && getGridedStyles($gridRows, theme, 'grid-template-rows')};

--- a/packages/big-design/src/managers/alerts/AlertsManager.tsx
+++ b/packages/big-design/src/managers/alerts/AlertsManager.tsx
@@ -13,5 +13,13 @@ export const AlertsManager: React.FC<AlertsManagerProps> = ({ manager }) => {
 
   useEffect(() => manager.subscribe(setAlert), [manager]);
 
-  return alert ? <Alert {...alert} /> : null;
+  if (!alert) {
+    return null;
+  }
+
+  // autoDismiss is consumed by the manager and must not reach the DOM via SC6's prop forwarding.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const { autoDismiss, ...alertProps } = alert as AlertProps & { autoDismiss?: boolean };
+
+  return <Alert {...alertProps} />;
 };


### PR DESCRIPTION
Jira: [TRAC-1306](<https://bigcommercecloud.atlassian.net/browse/TRAC-1306>)

## What?

Fixes two bugs introduced by the styled-components v6 upgrade:

1. **defaultProps regression on Flex, FlexItem, Grid, and Icon**: SC6 returns function components from its factory, and defaultProps on function components is deprecated (React 18) / dropped (React 19). This means SC6 `.defaultProps` for non-theme props was silently ignored. Defaults for flex container/item layout properties are moved into `toTransientFlexedContainerProps()` / `toTransientFlexedItemProps()`, the Grid gap default is applied via nullish coalesce in `withGridedContainer()`, and the Icon size default moves to a CSS interpolation destructuring default.
2. **autoDismiss DOM attribute leak in AlertsManager**: `alertsManager.add()` accepts an `autoDismiss` option that the manager consumes for auto-removal timing. SC5 filtered unknown props before DOM forwarding; SC6 does not. The full alert object (including `autoDismiss`) was spread onto `<Alert>` → `StyledAlert` (a styled Grid) → the DOM, resulting in an invalid HTML attribute. `autoDismiss` is now destructured out before rendering.

## Why?

Both bugs are follow-on fallout from the SC5 → SC6 migration ([LTRAC-1305](https://linear.app/commerce/issue/LTRAC-1305/terraform-cloudflare-remove-lightstep-traces-workers-observability)). The prop-forwarding change in SC6 exposed the autoDismiss leak; the defaultProps change broke layout defaults for Flex/FlexItem/Grid/Icon consumers.

## Screenshots/Screen Recordings

N/A — no visual change intended. Flex/Grid/Icon render identically; autoDismiss only removes a leaked DOM attribute.

## Testing/Proof

All existing snapshot and unit tests pass (`pnpm test`). Snapshots were updated to reflect SC6/stylis v4 CSS generation (vendor prefixes on flex properties, responsive media queries now emitted for every Flex instance since the flexDirection default is always provided, minor spacing differences in grid-template and media query syntax).

Refs [ARR-1002](https://linear.app/commerce/issue/ARR-1002/security-upgrade-nextjs-in-bigcommercepep-1613-16211)

[TRAC-1306]: https://bigcommercecloud.atlassian.net/browse/TRAC-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ