### PR TITLE
build(deps): TRAC-1509 upgrade react-datepicker 7.6 to 9.1

### DIFF
--- a/.changeset/upgrade-react-datepicker-9.md
+++ b/.changeset/upgrade-react-datepicker-9.md
@@ -1,0 +1,9 @@
+---
+'@bigcommerce/big-design': patch
+---
+
+chore(deps): upgrade `react-datepicker` 7.6.0 → 9.1.0, used in `Datepicker`. No functional or public API changes.
+
+The underlying library reworked the calendar's ARIA markup: day cells changed `role` from `option` to `gridcell` (now wrapped in `table`/`rowgroup`/`row`, matching the WAI-ARIA date picker pattern), and the day-name header row (Sun/Mon/Tue/...) now renders a visually-hidden full name alongside the visible abbreviation for screen readers. Since we don't import `react-datepicker`'s base stylesheet, that visually-hidden span had no CSS to hide it and rendered overlapping text in the header row; fixed by adding the missing `.react-datepicker__sr-only` visually-hidden rule to `Datepicker`'s styles. Test suite updated to match the new `gridcell` role.
+
+Also replaces the pre-existing popper.js-v2-shaped custom `popperModifiers` object (a `{ name, fn }` pair that manually subtracted 10px from `y`) with `@floating-ui/react`'s built-in `offset(-10)` middleware, canceling out `react-datepicker`'s internal `offset(10)` to keep the calendar flush against the input, same as before. No visual change.

--- a/packages/big-design/package.json
+++ b/packages/big-design/package.json
@@ -45,7 +45,7 @@
     "downshift": "9.4.0",
     "focus-trap": "^8.2.2",
     "polished": "^4.3.1",
-    "react-datepicker": "^7.6.0",
+    "react-datepicker": "^9.1.0",
     "react-intersection-observer": "^11.0.0",
     "@tanstack/react-virtual": "^3.14.10",
     "zustand": "^5.0.15"

--- a/packages/big-design/src/components/Datepicker/Datepicker.tsx
+++ b/packages/big-design/src/components/Datepicker/Datepicker.tsx
@@ -1,3 +1,4 @@
+import { offset } from '@floating-ui/react';
 import React, { ComponentPropsWithoutRef, forwardRef, memo, Ref, useEffect, useState } from 'react';
 import { default as ReactDatePicker, registerLocale } from 'react-datepicker';
 
@@ -68,14 +69,7 @@ const RawDatepicker: React.FC<DatepickerProps & PrivateProps> = ({
         onChange={updateDate}
         onFocus={onFocus}
         placeholderText={placeholder}
-        popperModifiers={[
-          {
-            name: 'removeOffset',
-            fn: ({ y }) => ({
-              y: y - 10,
-            }),
-          },
-        ]}
+        popperModifiers={[offset(-10)]}
         popperPlacement="bottom-start"
         ref={forwardedRef}
         renderCustomHeader={({

--- a/packages/big-design/src/components/Datepicker/spec.tsx
+++ b/packages/big-design/src/components/Datepicker/spec.tsx
@@ -38,7 +38,7 @@ test('calls onDateChange function when a date cell is clicked', async () => {
 
   await userEvent.click(input);
 
-  const cell = await screen.findByRole('option', { current: 'date' });
+  const cell = await screen.findByRole('gridcell', { current: 'date' });
 
   await userEvent.click(cell);
 

--- a/packages/big-design/src/components/Datepicker/styled.ts
+++ b/packages/big-design/src/components/Datepicker/styled.ts
@@ -18,6 +18,18 @@ export const StyledDatepicker = styled.div`
     display: none;
   }
 
+  & .react-datepicker__sr-only {
+    border: 0;
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
   & .react-datepicker__month-container {
     margin: ${({ theme }) => theme.spacing.medium};
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
       react-datepicker:
-        specifier: ^7.6.0
-        version: 7.6.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^9.1.0
+        version: 9.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-intersection-observer:
         specifier: ^11.0.0
         version: 11.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3545,9 +3545,6 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns@3.6.0:
-    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
-
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
@@ -5233,11 +5230,15 @@ packages:
   raf-schd@4.0.3:
     resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
 
-  react-datepicker@7.6.0:
-    resolution: {integrity: sha512-9cQH6Z/qa4LrGhzdc3XoHbhrxNcMi9MKjZmYgF/1MNNaJwvdSjv3Xd+jjvrEEbKEf71ZgCA3n7fQbdwd70qCRw==}
+  react-datepicker@9.1.0:
+    resolution: {integrity: sha512-lOp+m5bc+ttgtB5MHEjwiVu4nlp4CvJLS/PG1OiOe5pmg9kV73pEqO8H0Geqvg2E8gjqTaL9eRhSe+ZpeKP3nA==}
     peerDependencies:
+      date-fns-tz: ^3.0.0
       react: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
+    peerDependenciesMeta:
+      date-fns-tz:
+        optional: true
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -9493,8 +9494,6 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns@3.6.0: {}
-
   date-fns@4.4.0: {}
 
   debug@3.2.7:
@@ -11675,11 +11674,11 @@ snapshots:
 
   raf-schd@4.0.3: {}
 
-  react-datepicker@7.6.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-datepicker@9.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@floating-ui/react': 0.27.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       clsx: 2.1.1
-      date-fns: 3.6.0
+      date-fns: 4.4.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 


### PR DESCRIPTION
## What?

Bumps `react-datepicker` 7.6.0 → 9.1.0, used in `Datepicker`. Also replaces the pre-existing popper.js-v2-shaped custom `popperModifiers` object with `@floating-ui/react`'s built-in `offset(-10)` middleware.

## Why?

Two majors on paper, but the type defs diffed clean between 7.6.0 and 9.1.0 — every prop this repo uses (`customInput`, `dateFormat`, `locale`, `min`/`maxDate`, `onBlur`/`onChange`/`onFocus`, `placeholderText`, `popperModifiers`, `popperPlacement`, `showPopperArrow`, `renderCustomHeader`, `required`, `selected`, `registerLocale`) is unchanged; additions are purely additive. The popper→`@floating-ui/react` migration already happened before 7.6.0. The new optional peer dep `date-fns-tz` (only needed for the new `timeZone` prop, which we don't use) installs cleanly with no warnings.

Regression testing surfaced one real behavior change not visible in the type diff: the library reworked the calendar's ARIA markup. Day cells changed `role` from `option` to `gridcell` (now wrapped in `table`/`rowgroup`/`row`, matching the WAI-ARIA date picker pattern) — the spec.tsx query for `role: 'option'` was updated to `gridcell` to match. The day-name header row (Sun/Mon/Tue/...) now also renders a visually-hidden full name alongside the visible abbreviation for screen readers; since we don't import `react-datepicker`'s base stylesheet, that visually-hidden span had no CSS to actually hide it, so both the full name and abbreviation rendered on top of each other. Fixed by adding the missing `.react-datepicker__sr-only` visually-hidden rule (copied from react-datepicker's own stylesheet) to `Datepicker`'s styles.

While in the file, also cleaned up the pre-existing `popperModifiers` usage flagged in the ticket as tech debt. It was a popper.js-v2-shaped `{ name, fn }` object that manually subtracted 10px from `y` — under `@floating-ui/react`'s middleware pipeline (which react-datepicker migrated to before 7.6.0) this isn't a no-op: it cancels out react-datepicker's internal `offset(10)` middleware, which is what keeps the calendar flush against the input today. Replaced it with the equivalent, more idiomatic `offset(-10)` from `@floating-ui/react` (already a direct dependency, used elsewhere in Dropdown/Popover/Select). Verified pixel-identical positioning before and after (~1px gap in both cases).

## Screenshots/Screen Recordings

Not included inline; manually verified in Chrome — see Testing/Proof below.

## Testing/Proof

- `pnpm -F @bigcommerce/big-design run typecheck` — clean
- `pnpm -F @bigcommerce/big-design run test` — 70/70 suites, 1155/1155 tests pass (including the updated `Datepicker` spec)
- `pnpm -F @bigcommerce/big-design run lint` — clean
- Manually exercised the `Datepicker` docs page (basic + error-states examples) in Chrome: opened the calendar, confirmed the day-name header renders without overlapping text, selected a date, and measured the popup-to-input gap via JS (`popperRect.top - inputRect.bottom ≈ 1px`, matching pre-upgrade behavior).

Refs TRAC-1509