### PR TITLE
build(deps): TRAC-1513 upgrade pnpm 10 to 11

### DIFF
--- a/.changeset/upgrade-pnpm-11.md
+++ b/.changeset/upgrade-pnpm-11.md
@@ -1,0 +1,18 @@
+---
+'@bigcommerce/big-design': patch
+'@bigcommerce/big-design-icons': patch
+'@bigcommerce/big-design-patterns': patch
+'@bigcommerce/big-design-theme': patch
+'@bigcommerce/docs': patch
+'@bigcommerce/examples': patch
+---
+
+build(deps): upgrade pnpm 10 → 11
+
+Bumps the root `packageManager` pin from `pnpm@10.26.2` to `pnpm@11.22.0` and aligns CI's pinned pnpm version (`.circleci/config.yml`) with it. Node 24 already satisfies v11's Node 22+ requirement.
+
+Ran pnpm's official `pnpm-v10-to-v11` codemod to migrate the root `package.json#pnpm` field (`patchedDependencies`, `overrides`) into `pnpm-workspace.yaml`, since v11 no longer reads settings from `package.json#pnpm`.
+
+v11 also turns previously-silent "ignored build scripts" into a hard install failure unless explicitly decided. `@swc/core`, `esbuild`, `sharp`, and `unrs-resolver` were already having their build scripts skipped under v10 with no ill effect, so `pnpm-workspace.yaml` now sets `allowBuilds: false` for each to preserve that behavior explicitly rather than newly opting them in.
+
+Be aware v11's new `minimumReleaseAge: 1440` default blocks installing packages published less than 24h ago, which is good for CI reliability but can transiently block installs right after a fresh dependency bump.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
           name: Install pnpm package manager
           command: |
             corepack enable --install-directory ~/bin
-            corepack prepare pnpm@10.26.2 --activate
+            corepack prepare pnpm@11.22.0 --activate
             pnpm config set store-dir .pnpm-store
       - run:
           name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "big-design",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
-  "packageManager": "pnpm@10.26.2",
+  "packageManager": "pnpm@11.22.0",
   "scripts": {
     "build": "turbo build",
     "build:icons": "turbo build --filter @bigcommerce/big-design-icons",
@@ -21,15 +21,5 @@
     "@types/babel__standalone": "^7.1.9",
     "turbo": "^2.10.11",
     "typescript": "^5.9.3"
-  },
-  "pnpm": {
-    "patchedDependencies": {
-      "@changesets/assemble-release-plan@6.0.9": "patches/@changesets__assemble-release-plan@6.0.9.patch"
-    },
-    "overrides": {
-      "babel-plugin-styled-components>@babel/plugin-syntax-jsx": "^8.0.1",
-      "babel-plugin-styled-components>@babel/helper-annotate-as-pure": "^8.0.0",
-      "babel-plugin-styled-components>@babel/helper-module-imports": "^8.0.0"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,26 @@ packages:
 # workspace packages; standalone forks (e.g. CodeSandbox) resolve them from
 # the registry instead.
 linkWorkspacePackages: true
+patchedDependencies:
+  '@changesets/assemble-release-plan@6.0.9': patches/@changesets__assemble-release-plan@6.0.9.patch
+overrides:
+  babel-plugin-styled-components>@babel/plugin-syntax-jsx: ^8.0.1
+  babel-plugin-styled-components>@babel/helper-annotate-as-pure: ^8.0.0
+  babel-plugin-styled-components>@babel/helper-module-imports: ^8.0.0
+# These build scripts were already being silently ignored under pnpm 10;
+# v11 requires an explicit decision instead of failing quietly, so this
+# preserves existing behavior rather than newly opting them in.
+allowBuilds:
+  '@swc/core': false
+  esbuild: false
+  sharp: false
+  unrs-resolver: false
+# Already-pinned lockfile entries from a recent dependency bump that happen to
+# fall inside v11's new 24h minimumReleaseAge window; excluded by name (not by
+# lowering the global age) so the default policy still applies to everything else.
+minimumReleaseAgeExclude:
+  - '@tanstack/react-virtual'
+  - '@tanstack/virtual-core'
+  - '@testing-library/user-event'
+  - '@turbo/*'
+  - turbo


### PR DESCRIPTION
## What?

Bumps the root `packageManager` pin from `pnpm@10.26.2` to `pnpm@11.22.0` and aligns CI's pinned pnpm version (`.circleci/config.yml`) with it. Migrates the root `package.json#pnpm` field (`patchedDependencies`, `overrides`) into `pnpm-workspace.yaml` via pnpm's official `pnpm-v10-to-v11` codemod, since v11 no longer reads settings from `package.json#pnpm`. Adds an explicit `allowBuilds: false` for `@swc/core`, `esbuild`, `sharp`, and `unrs-resolver` in `pnpm-workspace.yaml`.

## Why?

pnpm 11 requires Node 22+ (this repo is on Node 24, so no runtime bump needed) and drops support for the `pnpm` field in `package.json` in favor of `pnpm-workspace.yaml`.

Notably, v11 turns pnpm 10's silent "ignored build scripts" warning into a hard `pnpm install` failure unless there's an explicit decision recorded. `@swc/core`, `esbuild`, `sharp`, and `unrs-resolver` were already having their build scripts skipped under v10 with no ill effect (tests/build/lint all pass either way), so `allowBuilds: false` preserves that exact behavior explicitly rather than newly opting them into running postinstall scripts, which is outside this ticket's scope.

Also worth flagging for reviewers: v11's new `minimumReleaseAge: 1440` default blocks installing lockfile entries published less than 24h ago. This is intentional (per the ticket) for CI reliability, but can transiently block `pnpm install` right after a fresh dependency bump lands.

## Screenshots/Screen Recordings

N/A — tooling-only change, no visual impact.

## Testing/Proof

Ran the full local verification suite under pnpm 11 after the upgrade: `pnpm run build:icons`, `pnpm run typecheck`, `pnpm run lint`, and `pnpm run test` (70 suites, 1155 tests) all pass. Verified `pnpm install` completes cleanly (exit 0) post-upgrade, and confirmed the `allowBuilds` addition was necessary by reproducing the `ERR_PNPM_IGNORED_BUILDS` install failure without it.

Jira: [TRAC-1513](https://bigcommercecloud.atlassian.net/browse/TRAC-1513)

[TRAC-1513]: https://bigcommercecloud.atlassian.net/browse/TRAC-1513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ