### PR TITLE
build(deps): TRAC-1514 upgrade Vite 7 to 8 and @vitejs/plugin-react 5 to 6

### DIFF
--- a/.changeset/fix-icons-type-only-import-elision.md
+++ b/.changeset/fix-icons-type-only-import-elision.md
@@ -1,0 +1,7 @@
+---
+'@bigcommerce/big-design-icons': patch
+---
+
+fix: mark type-only imports (`IconProps`, `PrivateIconProps`, `FlagIconProps`, `Colors`, `Spacing`, `ThemeInterface`) with the `type` modifier in `base/index.tsx`, `flags/base/index.tsx`, and all 361 generated icon components
+
+These names were imported as regular (value) specifiers even though they're only ever used in type position. Babel's per-file usage analysis failed to elide them, so the compiled `dist/es` output shipped `import` statements referencing names that don't exist at runtime. Classic Rollup silently tolerated the dangling references; Rolldown (Vite 8's new default bundler) treats them as fatal `MISSING_EXPORT` errors, which broke `@bigcommerce/examples`' production build. No public API or runtime behavior changes.

--- a/.changeset/upgrade-vite-8-examples.md
+++ b/.changeset/upgrade-vite-8-examples.md
@@ -1,0 +1,7 @@
+---
+'@bigcommerce/examples': patch
+---
+
+build(deps): upgrade `vite` 7.2.4 → 8.2.1 and `@vitejs/plugin-react` 5.2.0 → 6.0.5
+
+Vite 8's default production bundler moves from Rollup to Rolldown. No `vite.config.ts` changes were needed (no `build.rollupOptions` usage to rename to `build.rolldownOptions`), but Rolldown enforces stricter named-export validation than Rollup at build time. See the `@bigcommerce/big-design-icons` changeset in this same batch for a downstream fix that was required to keep `pnpm run build` passing under Rolldown's stricter checks.

--- a/packages/big-design-icons/scripts/svgr-flags.config.js
+++ b/packages/big-design-icons/scripts/svgr-flags.config.js
@@ -19,7 +19,7 @@ module.exports = {
       // **********************************
       import React, { forwardRef, memo, useId } from 'react';
 
-      import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+      import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
       const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({ svgRef, title = '${flagTitle}', theme, ...props }) => {
         const uniqueTitleId = useId();

--- a/packages/big-design-icons/scripts/svgr.config.js
+++ b/packages/big-design-icons/scripts/svgr.config.js
@@ -21,7 +21,7 @@ module.exports = {
       // **********************************
       import React, { forwardRef, memo, useId } from 'react';
 
-      import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+      import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
       const Icon: React.FC<IconProps & PrivateIconProps> = ({ svgRef, title, theme, color, size, ...props }) => {
         const uniqueTitleId = useId();

--- a/packages/big-design-icons/src/base/index.tsx
+++ b/packages/big-design-icons/src/base/index.tsx
@@ -1,8 +1,8 @@
 import {
-  Colors,
+  type Colors,
   theme as defaultTheme,
-  Spacing,
-  ThemeInterface,
+  type Spacing,
+  type ThemeInterface,
 } from '@bigcommerce/big-design-theme';
 import React, {
   ComponentPropsWithoutRef,

--- a/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/AddCircleOutlineIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/AddIcon.tsx
+++ b/packages/big-design-icons/src/components/AddIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/AllInclusiveIcon.tsx
+++ b/packages/big-design-icons/src/components/AllInclusiveIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ArrowBackIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowBackIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDownwardIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowDropDownIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowForwardIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
+++ b/packages/big-design-icons/src/components/ArrowUpwardIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/AssignmentIcon.tsx
+++ b/packages/big-design-icons/src/components/AssignmentIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/AutoAwesomeIcon.tsx
+++ b/packages/big-design-icons/src/components/AutoAwesomeIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
+++ b/packages/big-design-icons/src/components/BaselineHelpIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/BrushIcon.tsx
+++ b/packages/big-design-icons/src/components/BrushIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/BugReportIcon.tsx
+++ b/packages/big-design-icons/src/components/BugReportIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/CategorySearchIcon.tsx
+++ b/packages/big-design-icons/src/components/CategorySearchIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/CheckCircleIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckCircleIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/CheckIcon.tsx
+++ b/packages/big-design-icons/src/components/CheckIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronLeftIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ChevronRightIcon.tsx
+++ b/packages/big-design-icons/src/components/ChevronRightIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/CircleDashedIcon.tsx
+++ b/packages/big-design-icons/src/components/CircleDashedIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/CloseIcon.tsx
+++ b/packages/big-design-icons/src/components/CloseIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/CloudUploadIcon.tsx
+++ b/packages/big-design-icons/src/components/CloudUploadIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/CodeIcon.tsx
+++ b/packages/big-design-icons/src/components/CodeIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ContentCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/ContentCopyIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/DeleteIcon.tsx
+++ b/packages/big-design-icons/src/components/DeleteIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/DoNotDisturbOnTotalSilenceIcon.tsx
+++ b/packages/big-design-icons/src/components/DoNotDisturbOnTotalSilenceIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/DraftIcon.tsx
+++ b/packages/big-design-icons/src/components/DraftIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
+++ b/packages/big-design-icons/src/components/DragIndicatorIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/EditIcon.tsx
+++ b/packages/big-design-icons/src/components/EditIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ErrorIcon.tsx
+++ b/packages/big-design-icons/src/components/ErrorIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/EventBusyIcon.tsx
+++ b/packages/big-design-icons/src/components/EventBusyIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ExpandLessIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandLessIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
+++ b/packages/big-design-icons/src/components/ExpandMoreIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/FileCopyIcon.tsx
+++ b/packages/big-design-icons/src/components/FileCopyIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/FileDownloadIcon.tsx
+++ b/packages/big-design-icons/src/components/FileDownloadIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/FilterListIcon.tsx
+++ b/packages/big-design-icons/src/components/FilterListIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/FlareIcon.tsx
+++ b/packages/big-design-icons/src/components/FlareIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/FolderIcon.tsx
+++ b/packages/big-design-icons/src/components/FolderIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/GetAppIcon.tsx
+++ b/packages/big-design-icons/src/components/GetAppIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/HomeIcon.tsx
+++ b/packages/big-design-icons/src/components/HomeIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/InfoIcon.tsx
+++ b/packages/big-design-icons/src/components/InfoIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/InsertChartIcon.tsx
+++ b/packages/big-design-icons/src/components/InsertChartIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/InsertChartOutlinedIcon.tsx
+++ b/packages/big-design-icons/src/components/InsertChartOutlinedIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/InsertDriveFileIcon.tsx
+++ b/packages/big-design-icons/src/components/InsertDriveFileIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/InvertColorsIcon.tsx
+++ b/packages/big-design-icons/src/components/InvertColorsIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/KeyboardDoubleArrowLeftIcon.tsx
+++ b/packages/big-design-icons/src/components/KeyboardDoubleArrowLeftIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/LanguageIcon.tsx
+++ b/packages/big-design-icons/src/components/LanguageIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/LightbulbIcon.tsx
+++ b/packages/big-design-icons/src/components/LightbulbIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/LogoutIcon.tsx
+++ b/packages/big-design-icons/src/components/LogoutIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/MenuIcon.tsx
+++ b/packages/big-design-icons/src/components/MenuIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/MoreHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/MoreHorizIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/NotificationsIcon.tsx
+++ b/packages/big-design-icons/src/components/NotificationsIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/OpenInNewIcon.tsx
+++ b/packages/big-design-icons/src/components/OpenInNewIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/PinIcon.tsx
+++ b/packages/big-design-icons/src/components/PinIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/PlayArrowIcon.tsx
+++ b/packages/big-design-icons/src/components/PlayArrowIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/PlayCircleIcon.tsx
+++ b/packages/big-design-icons/src/components/PlayCircleIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ProductsIcon.tsx
+++ b/packages/big-design-icons/src/components/ProductsIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/PublicIcon.tsx
+++ b/packages/big-design-icons/src/components/PublicIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/RadioButtonCheckedIcon.tsx
+++ b/packages/big-design-icons/src/components/RadioButtonCheckedIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/RadioButtonUncheckedIcon.tsx
+++ b/packages/big-design-icons/src/components/RadioButtonUncheckedIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ReceiptIcon.tsx
+++ b/packages/big-design-icons/src/components/ReceiptIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/RedoIcon.tsx
+++ b/packages/big-design-icons/src/components/RedoIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/RefreshIcon.tsx
+++ b/packages/big-design-icons/src/components/RefreshIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveCircleOutlineIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/RemoveIcon.tsx
+++ b/packages/big-design-icons/src/components/RemoveIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/RestoreIcon.tsx
+++ b/packages/big-design-icons/src/components/RestoreIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/RocketIcon.tsx
+++ b/packages/big-design-icons/src/components/RocketIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/RocketLaunchIcon.tsx
+++ b/packages/big-design-icons/src/components/RocketLaunchIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ScienceIcon.tsx
+++ b/packages/big-design-icons/src/components/ScienceIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/SearchIcon.tsx
+++ b/packages/big-design-icons/src/components/SearchIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/SendIcon.tsx
+++ b/packages/big-design-icons/src/components/SendIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/SettingsIcon.tsx
+++ b/packages/big-design-icons/src/components/SettingsIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/SparkleIcon.tsx
+++ b/packages/big-design-icons/src/components/SparkleIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/SparkleOutlinedIcon.tsx
+++ b/packages/big-design-icons/src/components/SparkleOutlinedIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/StarBorderIcon.tsx
+++ b/packages/big-design-icons/src/components/StarBorderIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/StarHalfIcon.tsx
+++ b/packages/big-design-icons/src/components/StarHalfIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/StarIcon.tsx
+++ b/packages/big-design-icons/src/components/StarIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/StopCircleIcon.tsx
+++ b/packages/big-design-icons/src/components/StopCircleIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/StopIcon.tsx
+++ b/packages/big-design-icons/src/components/StopIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/StoreIcon.tsx
+++ b/packages/big-design-icons/src/components/StoreIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/StorefrontIcon.tsx
+++ b/packages/big-design-icons/src/components/StorefrontIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/SwapHorizIcon.tsx
+++ b/packages/big-design-icons/src/components/SwapHorizIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ThumbDownAltIcon.tsx
+++ b/packages/big-design-icons/src/components/ThumbDownAltIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ThumbDownOffAltIcon.tsx
+++ b/packages/big-design-icons/src/components/ThumbDownOffAltIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ThumbUpAltIcon.tsx
+++ b/packages/big-design-icons/src/components/ThumbUpAltIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/ThumbUpOffAltIcon.tsx
+++ b/packages/big-design-icons/src/components/ThumbUpOffAltIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/UndoIcon.tsx
+++ b/packages/big-design-icons/src/components/UndoIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/VisibilityIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
+++ b/packages/big-design-icons/src/components/VisibilityOffIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/WarningIcon.tsx
+++ b/packages/big-design-icons/src/components/WarningIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/WindowExpandIcon.tsx
+++ b/packages/big-design-icons/src/components/WindowExpandIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/components/WindowMinimizeIcon.tsx
+++ b/packages/big-design-icons/src/components/WindowMinimizeIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledIcon, IconProps, PrivateIconProps } from '../base';
+import { createStyledIcon, type IconProps, type PrivateIconProps } from '../base';
 
 const Icon: React.FC<IconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/base/index.tsx
+++ b/packages/big-design-icons/src/flags/base/index.tsx
@@ -1,4 +1,8 @@
-import { theme as defaultTheme, Spacing, ThemeInterface } from '@bigcommerce/big-design-theme';
+import {
+  theme as defaultTheme,
+  type Spacing,
+  type ThemeInterface,
+} from '@bigcommerce/big-design-theme';
 import {
   ComponentPropsWithoutRef,
   ForwardRefExoticComponent,

--- a/packages/big-design-icons/src/flags/components/ADFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ADFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AFFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AIFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ALFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ALFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AOFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AQFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ARABFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ARABFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ARFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ARFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ASFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ASFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ATFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ATFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AUFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AWFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AXFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/AZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/AZFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BBFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BDFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BFFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BHFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BIFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BJFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BLFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BOFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BQFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BSFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BTFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BVFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BWFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BYFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/BZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/BZFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CCFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CDFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CEFTAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CEFTAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CFFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CHFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CIFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CKFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CLFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/COFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/COFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CPFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CUFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CVFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CWFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CXFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CYFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/CZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/CZFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/DEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/DGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/DJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DJFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/DKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DKFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/DMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/DOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DOFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/DZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/DZFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/EACFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EACFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ECFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ECFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/EEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/EGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/EHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EHFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ERFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ERFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ESCTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESCTFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ESFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ESGAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESGAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ESPVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ESPVFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ETFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ETFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/EUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/EUFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/FIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FIFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/FJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FJFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/FKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FKFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/FMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/FOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FOFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/FRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/FRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GBENGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBENGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GBNIRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBNIRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GBSCTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBSCTFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GBWLSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GBWLSFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GDFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GFFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GHFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GIFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GLFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GPFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GQFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GSFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GTFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GUFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GWFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/GYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/GYFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/HKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HKFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/HMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/HNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/HRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/HTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HTFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/HUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/HUFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ICFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ICFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/IDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IDFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/IEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ILFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ILFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/IMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/INFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/INFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/IOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IOFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/IQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IQFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/IRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/IRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ISFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ISFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ITFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ITFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/JEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/JMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/JOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JOFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/JPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/JPFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KHFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KIFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KPFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KWFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KYFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/KZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/KZFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LBFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LCFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LIFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LKFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LSFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LTFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LUFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LVFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/LYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/LYFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MCFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MDFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MFFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MHFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MKFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MLFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MOFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MPFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MQFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MQFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MSFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MTFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MUFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MVFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MWFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MXFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MYFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/MZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/MZFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NCFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NFFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NIFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NLFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NOFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NPFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NPFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NUFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/NZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/NZFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/OMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/OMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PCFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PFFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PHFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PKFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PLFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PSFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PTFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PWFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/PYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/PYFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/QAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/QAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/REFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/REFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ROFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ROFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/RSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RSFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/RUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RUFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/RWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/RWFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SBFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SBFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SCFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SDFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SHACFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SHACFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SHFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SHFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SHHLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SHHLFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SHTAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SHTAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SIFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SJFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SKFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SLFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SOFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SSFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/STFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/STFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SVFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SXFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SYFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/SZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/SZFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TCFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TDFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TDFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TFFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/THFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/THFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TJFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TJFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TKFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TLFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TLFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TOFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TOFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TRFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TRFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TTFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TVFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TVFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TWFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/TZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/TZFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/UAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/UGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/UMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/UNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/USFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/USFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/UYFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UYFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/UZFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/UZFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/VAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/VCFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VCFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/VEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/VGFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VGFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/VIFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VIFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/VNFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VNFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/VUFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/VUFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/WFFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/WFFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/WSFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/WSFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/XKFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/XKFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/XXFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/XXFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/YEFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/YEFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/YTFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/YTFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ZAFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZAFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ZMFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZMFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/big-design-icons/src/flags/components/ZWFlagIcon.tsx
+++ b/packages/big-design-icons/src/flags/components/ZWFlagIcon.tsx
@@ -3,7 +3,7 @@
 // **********************************
 import React, { forwardRef, memo, useId } from 'react';
 
-import { createStyledFlagIcon, FlagIconProps, PrivateIconProps } from '../base';
+import { createStyledFlagIcon, type FlagIconProps, type PrivateIconProps } from '../base';
 
 const FlagIcon: React.FC<FlagIconProps & PrivateIconProps> = ({
   svgRef,

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -24,9 +24,9 @@
     "@types/node": "^24.13.3",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-react": "5.2.0",
+    "@vitejs/plugin-react": "6.0.5",
     "eslint": "^8.33.0",
     "typescript": "5.9.3",
-    "vite": "7.2.4"
+    "vite": "8.2.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,8 +619,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
-        specifier: 5.2.0
-        version: 5.2.0(vite@7.2.4(@types/node@24.13.3)(jiti@2.6.1)(yaml@2.8.1))
+        specifier: 6.0.5
+        version: 6.0.5(vite@8.2.1(@types/node@24.13.3)(jiti@2.6.1)(yaml@2.8.1))
       eslint:
         specifier: ^8.33.0
         version: 8.57.0
@@ -628,8 +628,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 7.2.4
-        version: 7.2.4(@types/node@24.13.3)(jiti@2.6.1)(yaml@2.8.1)
+        specifier: 8.2.1
+        version: 8.2.1(@types/node@24.13.3)(jiti@2.6.1)(yaml@2.8.1)
 
   packages/pack: {}
 
@@ -1263,18 +1263,6 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7':
-    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.29.7':
-    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-react-jsx@8.0.1':
     resolution: {integrity: sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -1582,162 +1570,6 @@ packages:
   '@es-joy/jsdoccomment@0.50.2':
     resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
     engines: {node: '>=18'}
-
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -2146,6 +1978,9 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@oxc-project/types@0.144.0':
+    resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2256,118 +2091,92 @@ packages:
       '@types/react':
         optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.3':
-    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
-
-  '@rollup/rollup-android-arm-eabi@4.53.3':
-    resolution: {integrity: sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.53.3':
-    resolution: {integrity: sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==}
+  '@rolldown/binding-android-arm64@1.2.4':
+    resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.53.3':
-    resolution: {integrity: sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==}
+  '@rolldown/binding-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.53.3':
-    resolution: {integrity: sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==}
+  '@rolldown/binding-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.53.3':
-    resolution: {integrity: sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.53.3':
-    resolution: {integrity: sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==}
+  '@rolldown/binding-freebsd-x64@1.2.4':
+    resolution: {integrity: sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
-    resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
+    resolution: {integrity: sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.53.3':
-    resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.53.3':
-    resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
+    resolution: {integrity: sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.53.3':
-    resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
+    resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.53.3':
-    resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.53.3':
-    resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
+    resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.3':
-    resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.53.3':
-    resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-s390x-gnu@4.53.3':
-    resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
+    resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.53.3':
-    resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
+    resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.53.3':
-    resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
+  '@rolldown/binding-linux-x64-musl@1.2.4':
+    resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openharmony-arm64@4.53.3':
-    resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
+  '@rolldown/binding-openharmony-arm64@1.2.4':
+    resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.3':
-    resolution: {integrity: sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
+    resolution: {integrity: sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.3':
-    resolution: {integrity: sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.53.3':
-    resolution: {integrity: sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==}
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
+    resolution: {integrity: sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.53.3':
-    resolution: {integrity: sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==}
-    cpu: [x64]
-    os: [win32]
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -2963,11 +2772,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitejs/plugin-react@5.2.0':
-    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+  '@vitejs/plugin-react@6.0.5':
+    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vscode/emmet-helper@2.9.3':
     resolution: {integrity: sha512-rB39LHWWPQYYlYfpv9qCoZOVioPCftKXXqrsyqN1mTWZM6dTnONT63Db+03vgrBbHzJN45IrgS/AGxw9iiqfEw==}
@@ -3660,11 +3476,6 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -4677,6 +4488,76 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -4810,6 +4691,11 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5026,6 +4912,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -5054,8 +4944,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -5166,10 +5056,6 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  react-refresh@0.18.0:
-    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
-    engines: {node: '>=0.10.0'}
-
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
@@ -5270,9 +5156,9 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rollup@4.53.3:
-    resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+  rolldown@1.2.4:
+    resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rrweb-cssom@0.8.0:
@@ -5614,6 +5500,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
@@ -5799,15 +5689,16 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  vite@7.2.4:
-    resolution: {integrity: sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==}
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -5818,11 +5709,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -6725,16 +6618,6 @@ snapshots:
       '@babel/core': 8.0.1
       '@babel/plugin-transform-react-jsx': 8.0.1(@babel/core@8.0.1)
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-react-jsx@8.0.1(@babel/core@8.0.1)':
     dependencies:
       '@babel/core': 8.0.1
@@ -7281,84 +7164,6 @@ snapshots:
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.1.0
 
-  '@esbuild/aix-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm@0.25.12':
-    optional: true
-
-  '@esbuild/android-x64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ia32@0.25.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-x64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-ia32@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.12':
-    optional: true
-
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
     dependencies:
       eslint: 8.57.0
@@ -7836,6 +7641,8 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@oxc-project/types@0.144.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -7919,73 +7726,49 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@rolldown/pluginutils@1.0.0-rc.3': {}
-
-  '@rollup/rollup-android-arm-eabi@4.53.3':
+  '@rolldown/binding-android-arm64@1.2.4':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.53.3':
+  '@rolldown/binding-darwin-arm64@1.2.4':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.53.3':
+  '@rolldown/binding-darwin-x64@1.2.4':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.53.3':
+  '@rolldown/binding-freebsd-x64@1.2.4':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.53.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.53.3':
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.53.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.3':
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.53.3':
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.53.3':
+  '@rolldown/binding-linux-x64-musl@1.2.4':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.3':
+  '@rolldown/binding-openharmony-arm64@1.2.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.3':
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.53.3':
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.3':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.53.3':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.53.3':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.53.3':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.53.3':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.53.3':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.53.3':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.53.3':
-    optional: true
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -8593,17 +8376,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@5.2.0(vite@7.2.4(@types/node@24.13.3)(jiti@2.6.1)(yaml@2.8.1))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@24.13.3)(jiti@2.6.1)(yaml@2.8.1))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 7.2.4(@types/node@24.13.3)(jiti@2.6.1)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - supports-color
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.2.1(@types/node@24.13.3)(jiti@2.6.1)(yaml@2.8.1)
 
   '@vscode/emmet-helper@2.9.3':
     dependencies:
@@ -9223,8 +8999,7 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  detect-libc@2.0.4:
-    optional: true
+  detect-libc@2.0.4: {}
 
   detect-newline@3.1.0: {}
 
@@ -9489,35 +9264,6 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
-
-  esbuild@0.25.12:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 
@@ -9851,6 +9597,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   figures@3.2.0:
     dependencies:
@@ -10940,6 +10690,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lines-and-columns@1.2.4: {}
 
   locate-path@5.0.0:
@@ -11047,6 +10846,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -11271,6 +11072,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.5: {}
+
   pify@4.0.1: {}
 
   pirates@4.0.6: {}
@@ -11293,9 +11096,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.6:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -11385,8 +11188,6 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       sucrase: 3.35.0
       use-editable: 2.3.3(react@19.2.8)
-
-  react-refresh@0.18.0: {}
 
   react@19.2.8: {}
 
@@ -11500,33 +11301,25 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rollup@4.53.3:
+  rolldown@1.2.4:
     dependencies:
-      '@types/estree': 1.0.8
+      '@oxc-project/types': 0.144.0
+      '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.53.3
-      '@rollup/rollup-android-arm64': 4.53.3
-      '@rollup/rollup-darwin-arm64': 4.53.3
-      '@rollup/rollup-darwin-x64': 4.53.3
-      '@rollup/rollup-freebsd-arm64': 4.53.3
-      '@rollup/rollup-freebsd-x64': 4.53.3
-      '@rollup/rollup-linux-arm-gnueabihf': 4.53.3
-      '@rollup/rollup-linux-arm-musleabihf': 4.53.3
-      '@rollup/rollup-linux-arm64-gnu': 4.53.3
-      '@rollup/rollup-linux-arm64-musl': 4.53.3
-      '@rollup/rollup-linux-loong64-gnu': 4.53.3
-      '@rollup/rollup-linux-ppc64-gnu': 4.53.3
-      '@rollup/rollup-linux-riscv64-gnu': 4.53.3
-      '@rollup/rollup-linux-riscv64-musl': 4.53.3
-      '@rollup/rollup-linux-s390x-gnu': 4.53.3
-      '@rollup/rollup-linux-x64-gnu': 4.53.3
-      '@rollup/rollup-linux-x64-musl': 4.53.3
-      '@rollup/rollup-openharmony-arm64': 4.53.3
-      '@rollup/rollup-win32-arm64-msvc': 4.53.3
-      '@rollup/rollup-win32-ia32-msvc': 4.53.3
-      '@rollup/rollup-win32-x64-gnu': 4.53.3
-      '@rollup/rollup-win32-x64-msvc': 4.53.3
-      fsevents: 2.3.3
+      '@rolldown/binding-android-arm64': 1.2.4
+      '@rolldown/binding-darwin-arm64': 1.2.4
+      '@rolldown/binding-darwin-x64': 1.2.4
+      '@rolldown/binding-freebsd-x64': 1.2.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.4
+      '@rolldown/binding-linux-arm64-gnu': 1.2.4
+      '@rolldown/binding-linux-arm64-musl': 1.2.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.4
+      '@rolldown/binding-linux-s390x-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-musl': 1.2.4
+      '@rolldown/binding-openharmony-arm64': 1.2.4
+      '@rolldown/binding-win32-arm64-msvc': 1.2.4
+      '@rolldown/binding-win32-x64-msvc': 1.2.4
 
   rrweb-cssom@0.8.0: {}
 
@@ -11928,6 +11721,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
   tldts-core@6.1.86: {}
 
   tldts@6.1.86:
@@ -12150,14 +11948,13 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite@7.2.4(@types/node@24.13.3)(jiti@2.6.1)(yaml@2.8.1):
+  vite@8.2.1(@types/node@24.13.3)(jiti@2.6.1)(yaml@2.8.1):
     dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
-      tinyglobby: 0.2.15
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.4
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.13.3
       fsevents: 2.3.3


### PR DESCRIPTION
## What?

Bumps `vite` 7.2.4 → 8.2.1 and `@vitejs/plugin-react` 5.2.0 → 6.0.5 in `packages/examples` (bumped together since `plugin-react` 6.0 requires Vite 8+). No `vite.config.ts` changes were needed — the config has no `build.rollupOptions` usage to rename to `build.rolldownOptions`.

Also fixes a latent bug in `@bigcommerce/big-design-icons` that Vite 8 exposed: `IconProps`, `PrivateIconProps`, `FlagIconProps`, `Colors`, `Spacing`, and `ThemeInterface` were imported as regular value specifiers (instead of with the `type` modifier) in `base/index.tsx`, `flags/base/index.tsx`, and all 361 generated icon components, even though they're only ever used in type position. Babel's per-file usage analysis failed to elide them, so the compiled `dist/es` output shipped `import` statements referencing names that don't exist at runtime.

## Why?

Vite 8's default production bundler moves from Rollup to Rolldown, which does much stricter named-export validation. Classic Rollup silently tolerated the icons package's dangling type-only import references; Rolldown treats them as fatal `MISSING_EXPORT` errors, which broke `@bigcommerce/examples`' production build (`pnpm run build`, which CI also runs). Fixing the `type` modifiers on those imports (and the `svgr.config.js`/`svgr-flags.config.js` codegen templates that generate them) restores clean elision and unblocks the Vite 8 bump. No public API or runtime behavior changes in `big-design-icons`.

`pnpm run start` (dev mode) was already unaffected either way, since Rolldown's stricter validation only runs during `vite build`, not in Vite's dev server.

## Screenshots/Screen Recordings

N/A — no visual changes; this is a private example app dependency bump plus a source-import fix in a sibling package.

## Testing/Proof

- `pnpm run build:icons` then `pnpm run build` (full monorepo, all 6 packages including `@bigcommerce/examples` and `@bigcommerce/docs`) — succeeds.
- `pnpm run typecheck` and `pnpm run lint` — clean across all 8 packages.
- `pnpm run test` — 70 suites / 1155 tests / 183 snapshots, all passing.
- Manually reproduced the failure pre-fix (`pnpm --filter=@bigcommerce/examples run build` failed with `[MISSING_EXPORT]` errors from Rolldown) and confirmed it's specific to Rolldown by rebuilding the same tree against Vite 7 (build succeeded there, only warning-level).
- Verified `pnpm run start` (Vite dev server) serves the app correctly under Vite 8.

Jira: [TRAC-1514](https://bigcommercecloud.atlassian.net/browse/TRAC-1514)

[TRAC-1514]: https://bigcommercecloud.atlassian.net/browse/TRAC-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ