### PR TITLE
build(deps): TRAC-1518 rewrite big-design-icons build script off camelcase

### DIFF
--- a/.changeset/rewrite-icons-build-camelcase.md
+++ b/.changeset/rewrite-icons-build-camelcase.md
@@ -1,0 +1,9 @@
+---
+'@bigcommerce/big-design-icons': patch
+---
+
+build(deps): rewrite `scripts/build.js` off `camelcase` 6, upgrade to `camelcase` 9.0.0
+
+`camelcase` went ESM-only starting at v7, breaking the script's plain `require('camelcase')` with `ERR_REQUIRE_ESM` — a straight version bump wasn't possible. The script is renamed to `scripts/build.mjs` and rewritten as a native ES module (static `import`s, top-level `await`, `import.meta.dirname` in place of `__dirname`).
+
+The package's `lint` script now passes `--ext .js,.mjs` so the new `.mjs` file is covered by ESLint, and `.eslintrc.js` adds an override requiring file extensions on relative imports in `.mjs` files (native ESM needs them; the base config forbids them for `.js`). Dev-only icon build tooling; no shipped-artifact or consumer impact.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,3 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'inquirer-autocomplete-prompt'
         update-types: ['version-update:semver-major']
-      - dependency-name: 'camelcase'
-        update-types: ['version-update:semver-major']

--- a/packages/big-design-icons/.eslintrc.js
+++ b/packages/big-design-icons/.eslintrc.js
@@ -2,4 +2,13 @@
 module.exports = {
   root: true,
   extends: [require.resolve('@bigcommerce/configs/eslint/base.js')],
+  overrides: [
+    {
+      // Native ESM requires relative import specifiers to include the file extension.
+      files: ['*.mjs'],
+      rules: {
+        'import/extensions': ['error', 'always', { ignorePackages: true }],
+      },
+    },
+  ],
 };

--- a/packages/big-design-icons/package.json
+++ b/packages/big-design-icons/package.json
@@ -17,10 +17,10 @@
     "build:cjs": "NODE_ENV=production BABEL_ENV=cjs babel --extensions \".ts,.tsx\" ./src --out-dir ./dist/cjs",
     "build:es": "NODE_ENV=production BABEL_ENV=es babel --extensions \".ts,.tsx\" ./src --out-dir ./dist/es",
     "build:dt": "tsc --emitDeclarationOnly",
-    "build:icons": "node scripts/build.js",
+    "build:icons": "node scripts/build.mjs",
     "build:flags": "node scripts/build-flags.js",
     "download": "node scripts/downloader.js",
-    "lint": "eslint . --max-warnings 0",
+    "lint": "eslint . --ext .js,.mjs --max-warnings 0",
     "typecheck": "tsc --noEmit"
   },
   "files": [
@@ -57,7 +57,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "babel-plugin-styled-components": "^2.0.7",
-    "camelcase": "^6.3.0",
+    "camelcase": "^9.0.0",
     "eslint": "^8.33.0",
     "flag-icons": "^7.5.0",
     "fs-extra": "^11.4.0",

--- a/packages/big-design-icons/scripts/build.mjs
+++ b/packages/big-design-icons/scripts/build.mjs
@@ -1,16 +1,18 @@
-const { transform } = require('@svgr/core');
-const camelcase = require('camelcase');
-const { outputFile, readFile } = require('fs-extra');
-const { glob } = require('glob');
-const { cpus } = require('os');
-const { basename, join } = require('path');
-const { rimraf } = require('rimraf');
-const asyncPool = require('tiny-async-pool');
+import { transform } from '@svgr/core';
+import camelcase from 'camelcase';
+import fsExtra from 'fs-extra';
+import { glob } from 'glob';
+import { cpus } from 'os';
+import { basename, join } from 'path';
+import { rimraf } from 'rimraf';
+import asyncPool from 'tiny-async-pool';
 
-const config = require('./svgr.config');
+import config from './svgr.config.js';
 
-const SOURCE = join(__dirname, '..', 'svgs', '*', '*.svg');
-const DEST_PATH = join(__dirname, '..', 'src', 'components');
+const { outputFile, readFile } = fsExtra;
+
+const SOURCE = join(import.meta.dirname, '..', 'svgs', '*', '*.svg');
+const DEST_PATH = join(import.meta.dirname, '..', 'src', 'components');
 
 const componentNames = new Set();
 
@@ -47,16 +49,14 @@ function cleanDestDirectory() {
   return rimraf(DEST_PATH);
 }
 
-(async () => {
-  await cleanDestDirectory();
-  await generateIcons();
+await cleanDestDirectory();
+await generateIcons();
 
-  const indexFile = Array.from(componentNames)
-    .sort()
-    .map((name) => `export * from './${name}';`);
+const indexFile = Array.from(componentNames)
+  .sort()
+  .map((name) => `export * from './${name}';`);
 
-  await outputFile(join(DEST_PATH, 'index.ts'), indexFile.join('\n'));
+await outputFile(join(DEST_PATH, 'index.ts'), indexFile.join('\n'));
 
-  // eslint-disable-next-line no-console
-  console.log('Done!');
-})();
+// eslint-disable-next-line no-console
+console.log('Done!');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,8 +238,8 @@ importers:
         specifier: ^2.0.7
         version: 2.1.4(@babel/core@8.0.1)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       camelcase:
-        specifier: ^6.3.0
-        version: 6.3.0
+        specifier: ^9.0.0
+        version: 9.0.0
       eslint:
         specifier: ^8.33.0
         version: 8.57.0(supports-color@8.1.1)
@@ -481,7 +481,7 @@ importers:
     dependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.12.0
-        version: 2.12.0(@testing-library/dom@10.4.1)(@types/eslint@8.56.10)(eslint@8.57.0(supports-color@8.1.1))(jest@30.2.0(@types/node@25.0.3)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 2.12.0(@testing-library/dom@10.4.1)(@types/eslint@8.56.10)(eslint@8.57.0(supports-color@8.1.1))(jest@30.2.0(@types/node@24.13.3)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       eslint:
         specifier: ^8.33.0
         version: 8.57.0(supports-color@8.1.1)
@@ -3094,6 +3094,10 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  camelcase@9.0.0:
+    resolution: {integrity: sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw==}
+    engines: {node: '>=20'}
 
   caniuse-lite@1.0.30001767:
     resolution: {integrity: sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==}
@@ -8664,6 +8668,8 @@ snapshots:
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
+
+  camelcase@9.0.0: {}
 
   caniuse-lite@1.0.30001767: {}
 


### PR DESCRIPTION
Jira: [TRAC-1518](https://bigcommercecloud.atlassian.net/browse/TRAC-1518)

## What?

Rewrites `big-design-icons/scripts/build.js` as a native ES module (`scripts/build.mjs`), and bumps `camelcase` 6.3.0 → 9.0.0.

## Why?

`camelcase` went ESM-only starting at v7, so a bare `require('camelcase')` throws `ERR_REQUIRE_ESM` once bumped past v6 — a straight version bump wasn't possible. The script is rewritten as a native ES module (static `import`s, top-level `await`, `import.meta.dirname` in place of `__dirname`) so it can consume the upgraded `camelcase` directly.

The package's `lint` script now passes `--ext .js,.mjs` so the new `.mjs` file is actually covered by ESLint (its default extension list silently skips `.mjs`). `.eslintrc.js` also adds a scoped override requiring file extensions on relative imports in `.mjs` files, since native ESM needs them (`./svgr.config.js`) while the base config forbids them for `.js`/`.ts`. Also drops the now-stale `dependabot.yml` major-version ignore rule for `camelcase`.

Isolated to dev-only icon build tooling; no shipped-artifact or consumer impact.

## Screenshots/Screen Recordings

N/A — dev tooling change, no visual/component output difference.

## Testing/Proof

Ran `node scripts/build.mjs` before and after the change and confirmed the generated `src/components/*.tsx` output was unchanged (same component names/casing for all 91 real icon filenames in `svgs/*/*.svg`, no `ERR_REQUIRE_ESM`). Also ran `pnpm --filter @bigcommerce/big-design-icons lint`, `typecheck`, and `prettier --check` on the changed files, all passing.

[TRAC-1518]: https://bigcommercecloud.atlassian.net/browse/TRAC-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ