### PR TITLE
fix(ci): TRAC-1544 add root prettier devDependency

### DIFF
--- a/.changeset/add-root-prettier-devdep.md
+++ b/.changeset/add-root-prettier-devdep.md
@@ -1,0 +1,14 @@
+---
+'@bigcommerce/big-design': patch
+'@bigcommerce/big-design-icons': patch
+'@bigcommerce/big-design-patterns': patch
+'@bigcommerce/big-design-theme': patch
+'@bigcommerce/docs': patch
+'@bigcommerce/examples': patch
+---
+
+fix(ci): add `prettier` as a root devDependency to fix the Changesets release job
+
+`@changesets/cli` 3.0.0 (`@changesets/apply-release-plan` 8.0.0 → `@changesets/format` 0.1.2) added a new post-`version` step that auto-detects a formatter and runs it over the touched CHANGELOG.md files. It found the root `prettier.config.js` and picked `prettier`, then ran `pnpm exec prettier --write ...` — but `prettier` was only ever a devDependency of `packages/big-design-icons` and `packages/docs`, never the workspace root, so a clean `pnpm install --frozen-lockfile` (as CI does) never resolves a `prettier` bin at the root and `pnpm exec prettier` fails with `Command "prettier" not found`, breaking the `Changesets / Release` job on every push to `main`.
+
+Adding `prettier@^3.9.6` (matching the version already pinned elsewhere) as a root devDependency gives `pnpm exec prettier` something to resolve. Verified by reproducing the exact CI failure in an isolated worktree with a genuine `pnpm install --frozen-lockfile`, then confirming `pnpm exec changeset version` completes cleanly after the fix.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@changesets/cli": "^3.0.0",
     "@swc/plugin-styled-components": "^13.0.0",
     "@types/babel__standalone": "^7.1.9",
+    "prettier": "^3.9.6",
     "turbo": "^2.10.11",
     "typescript": "^5.9.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@types/babel__standalone':
         specifier: ^7.1.9
         version: 7.1.9
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
       turbo:
         specifier: ^2.10.11
         version: 2.10.11


### PR DESCRIPTION
Jira: [TRAC-1544](https://bigcommercecloud.atlassian.net/browse/TRAC-1544)

## What?

Adds `prettier@^3.9.6` as a root-level devDependency.

## Why?

The `Changesets / Release` job has been failing on every push to `main`. `@changesets/cli` 3.0.0 (via `@changesets/apply-release-plan` 8.0.0 → `@changesets/format` 0.1.2) added a new post-`version` step that auto-detects a formatter by walking up from cwd for known config files, finds the root `prettier.config.js`, and shells out to `pnpm exec prettier --write` on the touched CHANGELOG.md files.

`prettier` was only ever declared as a devDependency inside `packages/big-design-icons` and `packages/docs`, never at the workspace root. A clean `pnpm install --frozen-lockfile` (exactly what CI does) therefore never resolves a `prettier` bin into the root `node_modules/.bin`, so `pnpm exec prettier` fails with `Command "prettier" not found` and the whole release job dies.

Root package.json previously had no direct need for `prettier` itself since linting/formatting is delegated per-package via `turbo run lint`, so this dependency never got hoisted before.

## Screenshots/Screen Recordings

N/A — CI/release tooling fix, no UI or visual impact.

## Testing/Proof

Reproduced the exact CI failure locally in an isolated `git worktree` with a genuine `pnpm install --frozen-lockfile` (confirming it wasn't an artifact of my local, drifted `node_modules`). Confirmed `pnpm exec changeset version` throws `[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "prettier" not found` before the fix, and completes cleanly ("All files have been updated. Review them and commit at your leisure") after adding the root devDependency and re-running `pnpm install --frozen-lockfile`.

[TRAC-1544]: https://bigcommercecloud.atlassian.net/browse/TRAC-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ