### PR TITLE
test: TRAC-1545 Fix act(...) warnings in Dropdown, Header, Table, MultiSelect specs

### DIFF
--- a/.changeset/fix-act-warnings-in-tests.md
+++ b/.changeset/fix-act-warnings-in-tests.md
@@ -1,0 +1,8 @@
+---
+'@bigcommerce/big-design': patch
+'@bigcommerce/big-design-patterns': patch
+---
+
+Fix React `act(...)` warnings in tests for `Dropdown`, `Header`, `Table`, and `MultiSelect`.
+
+Each of these components mounts a `@floating-ui/react` positioned element even while closed (to have a ref for positioning), which triggers an async state update right after mount. Tests that synchronously rendered and asserted without ever giving that update a chance to flush inside an `act(...)` boundary logged a `console.error`. Switched the affected assertions to `screen.findBy*` queries, which flush the pending update via Testing Library's own `act`-wrapped polling instead of adding a bare `act(() => Promise.resolve())` flush.

--- a/packages/big-design-patterns/src/components/Header/spec.tsx
+++ b/packages/big-design-patterns/src/components/Header/spec.tsx
@@ -60,7 +60,7 @@ test('renders with dropdown action', async () => {
   expect(dropdownItemCallback).toHaveBeenCalled();
 });
 
-test('renders with both button and dropdown actions', () => {
+test('renders with both button and dropdown actions', async () => {
   render(
     <Header
       actions={[
@@ -74,7 +74,7 @@ test('renders with both button and dropdown actions', () => {
     />,
   );
 
-  expect(screen.getByRole('button', { name: 'Action 1' })).toBeInTheDocument();
+  expect(await screen.findByRole('button', { name: 'Action 1' })).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Open menu' })).toBeInTheDocument();
 });
 

--- a/packages/big-design/src/components/Dropdown/spec.tsx
+++ b/packages/big-design/src/components/Dropdown/spec.tsx
@@ -76,23 +76,23 @@ const DropdownWithItemsDescriptions = (
   />
 );
 
-test('renders dropdown toggle', () => {
+test('renders dropdown toggle', async () => {
   render(DropdownMock);
 
-  const toggle = screen.getByRole('button');
+  const toggle = await screen.findByRole('button');
 
   expect(toggle).toBeInTheDocument();
 });
 
-test('dropdown toggle has an id', () => {
+test('dropdown toggle has an id', async () => {
   render(DropdownMock);
 
-  const toggle = screen.getByRole('button');
+  const toggle = await screen.findByRole('button');
 
   expect(toggle.id).toBeDefined();
 });
 
-test('dropdown toggle accepts a custom id', () => {
+test('dropdown toggle accepts a custom id', async () => {
   render(
     <Dropdown
       items={[{ content: 'Option', onItemClick }]}
@@ -100,15 +100,15 @@ test('dropdown toggle accepts a custom id', () => {
     />,
   );
 
-  const toggle = screen.getByRole('button');
+  const toggle = await screen.findByRole('button');
 
   expect(toggle.id).toBe('testId');
 });
 
-test('dropdown toggle has aria-haspopup', () => {
+test('dropdown toggle has aria-haspopup', async () => {
   render(DropdownMock);
 
-  const toggle = screen.getByRole('button');
+  const toggle = await screen.findByRole('button');
 
   expect(toggle).toHaveAttribute('aria-haspopup', 'menu');
 });
@@ -123,8 +123,10 @@ test('dropdown toggle has aria-expanded when dropdown menu is open', async () =>
   expect(toggle).toHaveAttribute('aria-expanded', 'true');
 });
 
-test('renders the dropdown menu closed', () => {
+test('renders the dropdown menu closed', async () => {
   render(DropdownMock);
+
+  await screen.findByRole('button');
 
   expect(screen.queryByRole('menu')).not.toBeInTheDocument();
 });

--- a/packages/big-design/src/components/MultiSelect/spec.tsx
+++ b/packages/big-design/src/components/MultiSelect/spec.tsx
@@ -1294,7 +1294,7 @@ test('input value clears on blur', async () => {
   expect(input).toHaveValue('');
 });
 
-test('does not render invalid label type', () => {
+test('does not render invalid label type', async () => {
   const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
   render(
@@ -1305,6 +1305,8 @@ test('does not render invalid label type', () => {
       options={mockOptions}
     />,
   );
+
+  await screen.findByTestId('multi-select');
 
   // Invalid label should not be rendered
   expect(screen.queryByText('Invalid Label')).not.toBeInTheDocument();

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -368,7 +368,7 @@ describe('stateless pagination', () => {
   });
 
   describe('selectable', () => {
-    test('renders a summary of the selected items, without reference to the total number of items', () => {
+    test('renders a summary of the selected items, without reference to the total number of items', async () => {
       const selectedItems = [
         { sku: 'CLC', name: '[Sample] Canvas Laundry Cart', stock: 2 },
         { sku: 'CGLD', name: '[Sample] Laundry Detergent', stock: 29 },
@@ -404,7 +404,7 @@ describe('stateless pagination', () => {
         />,
       );
 
-      const tableControls = screen.getByRole('toolbar', { name: 'Table Controls' });
+      const tableControls = await screen.findByRole('toolbar', { name: 'Table Controls' });
 
       expect(within(tableControls).queryByText('2/6')).not.toBeInTheDocument();
       expect(within(tableControls).getByText('2')).toBeInTheDocument();


### PR DESCRIPTION
Jira: [TRAC-1545](https://bigcommercecloud.atlassian.net/browse/TRAC-1545)

## What?

Fixes React `act(...)` `console.error` warnings surfaced by 8 tests across `Dropdown`, `Table`, and `MultiSelect` (`@bigcommerce/big-design`), and `Header` (`@bigcommerce/big-design-patterns`).

## Why?

Each of these components mounts a `@floating-ui/react` positioned element even while closed, to keep a ref available for positioning. That triggers an async state update right after mount. The affected tests rendered synchronously and asserted immediately, never giving that update a chance to flush inside an `act(...)` boundary, so React logged a warning once the update landed on a later microtask.

Rather than adding a bare `act(() => Promise.resolve())` flush (an existing pattern in `ButtonGroup`'s spec that works but asserts nothing and needs a comment to explain why it's there), the affected assertions were switched to `screen.findBy*` queries. Testing Library's `findBy*`/`waitFor` polling is itself wrapped in an async `act(...)` call, so it flushes the same pending update as a side effect of a real assertion instead of an opaque flush.

## Screenshots/Screen Recordings

N/A — test-only change, no runtime or UI behavior change.

## Testing/Proof

Bisected each affected spec file test-by-test with `jest -t` to isolate exactly which tests produced the warning (the React-emitted stack traces bottom out entirely in `react-dom`/`floating-ui`/`downshift` internals, with no application frame, so they can't be attributed to a test from the stack alone).

Before: `pnpm run test` at the repo root surfaced 36 `not wrapped in act(...)` console.error calls across 8 tests in 4 spec files. After: `pnpm run test` is clean (0 occurrences), all 1155 tests still pass, and `pnpm run lint` / `pnpm run typecheck` are both clean for `@bigcommerce/big-design` and `@bigcommerce/big-design-patterns`.

[TRAC-1545]: https://bigcommercecloud.atlassian.net/browse/TRAC-1545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ