### PR TITLE
docs: TRAC-1308 add version support matrix to README(s) and docs site

### DIFF
--- a/.changeset/support-matrix-docs.md
+++ b/.changeset/support-matrix-docs.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/big-design": patch
+"@bigcommerce/big-design-icons": patch
+"@bigcommerce/big-design-patterns": patch
+"@bigcommerce/big-design-theme": patch
+"@bigcommerce/docs": patch
+---
+
+Add a version support matrix to the README(s) and docs site: the current major requires React 19 + styled-components >= 6.1.14, the 4.0.0-era release (`big-design@4.0.0` / `icons@2.0.0` / `patterns@6.0.0` / `theme@2.0.0`) is deprecated and should not be used, and the 3.x-era majors remain on React 18 + styled-components 5 with case-by-case backports. Also fixes the quick-start install snippets, which still referenced `styled-components@5`.

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ You can find documentation and examples on our [docs page](https://bigcommerce.g
 
 ### Quick start guide
 
-Add BigDesign and styled-components@5 to your project using `npm`:
+Add BigDesign and styled-components@6 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design styled-components@5
+npm install @bigcommerce/big-design styled-components@6
 ```
 
 or with `pnpm`:
 
 ```
-pnpm add @bigcommerce/big-design styled-components@5
+pnpm add @bigcommerce/big-design styled-components@6
 ```
 
 Add the font as a `<link>` in your `index.html`/`<head>` element.
@@ -62,6 +62,14 @@ import { Button, GlobalStyles } from '@bigcommerce/big-design';
   <Button>Click me</Button>
 </App>
 ```
+
+### Version support
+
+| Versions | React | styled-components | Status |
+| --- | --- | --- | --- |
+| `big-design@5.x` / `icons@3.x` / `patterns@7.x` / `theme@3.x` (latest) | 19 | `^6.1.14` | Active |
+| `big-design@4.0.0` / `icons@2.0.0` / `patterns@6.0.0` / `theme@2.0.0` | 18 | `^6.1.14` | **Deprecated, do not use** (broken Flex/Grid/icon layout defaults; see npm deprecation notice) |
+| `big-design@3.x` / `icons@1.x` / `patterns@4.x`–`5.x` / `theme@1.x` | 18 | `^5` | Maintained; backports considered case-by-case |
 
 ### Monorepo
 

--- a/packages/big-design-icons/README.md
+++ b/packages/big-design-icons/README.md
@@ -8,16 +8,16 @@ You can find documentation, list of icons, and examples on our [docs page](https
 
 ### Quick start guide
 
-Add BigDesign Icons and styled-components@5 to your project using `npm`:
+Add BigDesign Icons and styled-components@6 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design-icons styled-components@5
+npm install @bigcommerce/big-design-icons styled-components@6
 ```
 
 or with `pnpm`:
 
 ```
-pnpm add @bigcommerce/big-design-icons styled-components@5
+pnpm add @bigcommerce/big-design-icons styled-components@6
 ```
 
 Import any icon component and use it anywhere in your app.

--- a/packages/big-design-patterns/README.md
+++ b/packages/big-design-patterns/README.md
@@ -8,16 +8,16 @@ You can find documentation and examples on our [docs page](https://bigcommerce.g
 
 ### Quick start guide
 
-Add `@bigcommerce/big-design`, `@bigcommerce/big-design-patterns` and `styled-components@5` to your project using `npm`:
+Add `@bigcommerce/big-design`, `@bigcommerce/big-design-patterns` and `styled-components@6` to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design @bigcommerce/big-design-patterns styled-components@5
+npm install @bigcommerce/big-design @bigcommerce/big-design-patterns styled-components@6
 ```
 
 or with `pnpm`:
 
 ```
-pnpm add @bigcommerce/big-design @bigcommerce/big-design-patterns styled-components@5
+pnpm add @bigcommerce/big-design @bigcommerce/big-design-patterns styled-components@6
 ```
 
 Setup BigDesign as per the [Quick start guide](https://github.com/bigcommerce/big-design/tree/main/packages/big-design#quick-start-guide) and then import any pattern, such as `Page` and `Header`, to use it anywhere in your app.

--- a/packages/big-design-theme/README.md
+++ b/packages/big-design-theme/README.md
@@ -17,16 +17,16 @@ This package is only meant to be used directly when more advanced features are n
 
 ### Quick start guide
 
-Add the BigDesign theme and styled-components@5 to your project using `npm`:
+Add the BigDesign theme and styled-components@6 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design-theme styled-components@5
+npm install @bigcommerce/big-design-theme styled-components@6
 ```
 
 or with `pnpm`:
 
 ```
-pnpm add @bigcommerce/big-design-theme styled-components@5
+pnpm add @bigcommerce/big-design-theme styled-components@6
 ```
 
 ```tsx

--- a/packages/big-design/README.md
+++ b/packages/big-design/README.md
@@ -8,16 +8,16 @@ You can find documentation and examples on our [docs page](https://bigcommerce.g
 
 ### Quick start guide
 
-Add BigDesign and styled-components@5 to your project using `npm`:
+Add BigDesign and styled-components@6 to your project using `npm`:
 
 ```
-npm install @bigcommerce/big-design styled-components@5
+npm install @bigcommerce/big-design styled-components@6
 ```
 
 or with `pnpm`:
 
 ```
-pnpm add @bigcommerce/big-design styled-components@5
+pnpm add @bigcommerce/big-design styled-components@6
 ```
 
 Add the font as a `<link>` in your `index.html`/`<head>` element.
@@ -58,3 +58,11 @@ import { Button, GlobalStyles } from '@bigcommerce/big-design';
   <Button>Click me</Button>
 </App>
 ```
+
+### Version support
+
+| Versions | React | styled-components | Status |
+| --- | --- | --- | --- |
+| `5.x` (latest) | 19 | `^6.1.14` | Active |
+| `4.0.0` | 18 | `^6.1.14` | **Deprecated, do not use** (broken Flex/Grid/icon layout defaults; see npm deprecation notice) |
+| `3.x` | 18 | `^5` | Maintained; backports considered case-by-case |

--- a/packages/docs/pages/index.tsx
+++ b/packages/docs/pages/index.tsx
@@ -84,9 +84,18 @@ const GettingStartedPage = () => {
       </Panel>
 
       <Panel header="Getting started">
+        <Text>
+          The latest major requires React 19 and styled-components 6.1.14+. Staying on React 18? Use{' '}
+          <Code>big-design@3.x</Code> with styled-components 5 instead &mdash; see the{' '}
+          <Link href="https://github.com/bigcommerce/big-design#version-support" target="_blank">
+            version support matrix
+          </Link>
+          . <Code>big-design@4.0.0</Code> is deprecated, do not use it.
+        </Text>
+
         <Text>Add BigDesign and styled-components to your project:</Text>
         <CodeSnippet language="bash" showControls={false}>
-          npm install @bigcommerce/big-design styled-components@5
+          npm install @bigcommerce/big-design styled-components@6
         </CodeSnippet>
 
         <Text>


### PR DESCRIPTION
Jira: [TRAC-1308](https://bigcommercecloud.atlassian.net/browse/TRAC-1308)

## What?

Adds a version support matrix to the root README, the `big-design` package README (the one npmjs.com renders), and the docs site's Getting Started panel. Also fixes the quick-start `npm install`/`pnpm add` snippets across all 5 READMEs and the docs site, which still said `styled-components@5` even though the 4.0.0-era release already required styled-components 6.

## Why?

Part of the LTRAC-1370 release gate: before publishing the React 19 + styled-components 6 majors, consumers need a clear, in-repo answer to "which version should I be on?" — especially since the 4.0.0-era release (published mid-migration, missing the SC6 `defaultProps` fix) needs to be clearly marked as something to avoid, without a docs deploy to fall back on if npm deprecation notices go unnoticed.

## Screenshots/Screen Recordings

N/A — Markdown/text changes to READMEs and a docs-site panel; no component visual changes.

## Testing/Proof

- `pnpm run lint`, `pnpm run typecheck`, `pnpm run test`, and `pnpm run build` (including the docs site's Next.js build) all pass clean on this branch.
- Manually reviewed the rendered table markdown and the docs site JSX diff.

[TRAC-1308]: https://bigcommercecloud.atlassian.net/browse/TRAC-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ