### PR TITLE
fix: TRAC-1548 fix circular require crash from inline type-only imports

### DIFF
--- a/.changeset/fix-circular-dependency-typedmemo.md
+++ b/.changeset/fix-circular-dependency-typedmemo.md
@@ -1,0 +1,7 @@
+---
+"@bigcommerce/big-design": patch
+"@bigcommerce/big-design-icons": patch
+"@bigcommerce/docs": patch
+---
+
+Fix a regression from the type-only-import fix (see the "ESM build shipping runtime imports for type-only names" changeset): using inline `type` modifiers (`import { type X }`) instead of the whole-statement form (`import type { X }`) still left a bare `require(...)` of the module behind, since Babel can't prove a plain import specifier has no side effects. In `utils/messagingHelpers.ts` and `utils/treeHelpers.ts`, that bare require created a real circular `require` chain back through `utils/index.ts` before its `typedMemo` export was assigned, crashing with `(0, _utils.typedMemo) is not a function` on `require('@bigcommerce/big-design')` — reproducible with no bundler involved, and present even under CommonJS/Node.js. `@typescript-eslint/consistent-type-imports`'s `fixStyle` is now `separate-type-imports`, which fully elides the runtime footprint whenever every binding from a specifier is type-only.

--- a/packages/big-design-icons/src/flags/base/index.tsx
+++ b/packages/big-design-icons/src/flags/base/index.tsx
@@ -3,11 +3,11 @@ import {
   type Spacing,
   type ThemeInterface,
 } from '@bigcommerce/big-design-theme';
-import {
-  type ComponentPropsWithoutRef,
-  type ForwardRefExoticComponent,
-  type PropsWithoutRef,
-  type RefAttributes,
+import type {
+  ComponentPropsWithoutRef,
+  ForwardRefExoticComponent,
+  PropsWithoutRef,
+  RefAttributes,
 } from 'react';
 import styled from 'styled-components';
 

--- a/packages/big-design-icons/src/types/styled.d.ts
+++ b/packages/big-design-icons/src/types/styled.d.ts
@@ -1,4 +1,4 @@
-import { type ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { ThemeInterface } from '@bigcommerce/big-design-theme';
 import 'styled-components';
 
 declare module 'styled-components' {

--- a/packages/big-design-theme/src/index.ts
+++ b/packages/big-design-theme/src/index.ts
@@ -2,10 +2,10 @@ import { createHelpers, type Helpers } from './helpers';
 import { type ThemeOptions, themeOptions } from './options';
 import { type Border, type BorderRadius, createBorder, createBorderRadius } from './system/border';
 import {
-  type Breakpoints,
   breakpoints,
-  type BreakpointValues,
+  type Breakpoints,
   breakpointValues,
+  type BreakpointValues,
 } from './system/breakpoints';
 import { type Colors, colors } from './system/colors';
 import * as keyframes from './system/keyframes';

--- a/packages/big-design-theme/src/styled/styled.d.ts
+++ b/packages/big-design-theme/src/styled/styled.d.ts
@@ -1,6 +1,6 @@
 import 'styled-components';
 
-import { type ThemeInterface } from '..';
+import type { ThemeInterface } from '..';
 
 declare module 'styled-components' {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/packages/big-design/src/components/AccordionPanel/spec.tsx
+++ b/packages/big-design/src/components/AccordionPanel/spec.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 
 import { Text } from '../Typography';
 
-import { type AccordionProps } from './Accordion';
+import type { AccordionProps } from './Accordion';
 
 import { AccordionPanel, useAccordionPanel } from '.';
 

--- a/packages/big-design/src/components/AccordionPanel/useAccordionPanel.ts
+++ b/packages/big-design/src/components/AccordionPanel/useAccordionPanel.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { type AccordionProps } from './Accordion';
+import type { AccordionProps } from './Accordion';
 
 type InitialPanels = Array<Omit<AccordionProps, 'isExpanded' | 'onClick'>>;
 

--- a/packages/big-design/src/components/Alert/styled.ts
+++ b/packages/big-design/src/components/Alert/styled.ts
@@ -5,9 +5,9 @@ import { getBorderStyle } from '../../utils';
 import { Grid } from '../Grid';
 import { Link } from '../Link';
 import { StyleableH4, StyleableSmall } from '../Typography/private';
-import { type TextProps } from '../Typography/types';
+import type { TextProps } from '../Typography/types';
 
-import { type AlertProps } from './Alert';
+import type { AlertProps } from './Alert';
 
 interface StyledAlertProps {
   type?: AlertProps['type'];

--- a/packages/big-design/src/components/Badge/Badge.tsx
+++ b/packages/big-design/src/components/Badge/Badge.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentPropsWithoutRef, memo } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { toTransientMarginProps } from '../../helpers/margins/margins';
 
 import { StyledBadge } from './styled';

--- a/packages/big-design/src/components/Badge/styled.tsx
+++ b/packages/big-design/src/components/Badge/styled.tsx
@@ -2,9 +2,9 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../helpers';
-import { type TransientMarginProps } from '../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../helpers/margins/margins';
 
-import { type BadgeProps } from './Badge';
+import type { BadgeProps } from './Badge';
 
 interface StyledBadgeProps extends TransientMarginProps {
   $variant?: BadgeProps['variant'];

--- a/packages/big-design/src/components/Box/Box.tsx
+++ b/packages/big-design/src/components/Box/Box.tsx
@@ -1,13 +1,7 @@
-import {
-  type Border,
-  type BorderRadius,
-  type Colors,
-  type Shadow,
-  type ZIndex,
-} from '@bigcommerce/big-design-theme';
+import type { Border, BorderRadius, Colors, Shadow, ZIndex } from '@bigcommerce/big-design-theme';
 import React, { type ComponentPropsWithoutRef, forwardRef, memo } from 'react';
 
-import { type DisplayProps, type MarginProps, type PaddingProps } from '../../helpers';
+import type { DisplayProps, MarginProps, PaddingProps } from '../../helpers';
 import { toTransientDisplayProps } from '../../helpers/display/display';
 import { toTransientMarginProps } from '../../helpers/margins/margins';
 import { toTransientPaddingProps } from '../../helpers/paddings/paddings';

--- a/packages/big-design/src/components/Box/styled.tsx
+++ b/packages/big-design/src/components/Box/styled.tsx
@@ -3,11 +3,11 @@ import { clearFix } from 'polished';
 import styled, { css } from 'styled-components';
 
 import { withDisplay, withMargins, withPaddings } from '../../helpers';
-import { type TransientDisplayProps } from '../../helpers/display/types';
-import { type TransientMarginProps } from '../../helpers/margins/margins';
-import { type TransientPaddingProps } from '../../helpers/paddings/paddings';
+import type { TransientDisplayProps } from '../../helpers/display/types';
+import type { TransientMarginProps } from '../../helpers/margins/margins';
+import type { TransientPaddingProps } from '../../helpers/paddings/paddings';
 
-import { type BoxProps } from './Box';
+import type { BoxProps } from './Box';
 
 // Internal-only prop shape: bespoke system props are `$`-prefixed so styled-components
 // never forwards them to the underlying DOM node. The public `BoxProps` is unchanged;

--- a/packages/big-design/src/components/Button/Button.tsx
+++ b/packages/big-design/src/components/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentPropsWithoutRef, forwardRef, memo, type Ref } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { toTransientMarginProps } from '../../helpers/margins/margins';
 import { ProgressCircle } from '../ProgressCircle';
 

--- a/packages/big-design/src/components/Button/styled.tsx
+++ b/packages/big-design/src/components/Button/styled.tsx
@@ -2,11 +2,11 @@ import { addValues, theme as defaultTheme } from '@bigcommerce/big-design-theme'
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../helpers';
-import { type TransientMarginProps } from '../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../helpers/margins/margins';
 import { withTransition } from '../../helpers/transitions';
 import { Flex } from '../Flex';
 
-import { type ButtonProps } from './index';
+import type { ButtonProps } from './index';
 
 export interface StyledButtonProps extends TransientMarginProps {
   $actionType?: ButtonProps['actionType'];

--- a/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/big-design/src/components/ButtonGroup/ButtonGroup.tsx
@@ -10,9 +10,9 @@ import React, {
   useState,
 } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { useWindowResizeListener } from '../../hooks';
-import { type ButtonProps } from '../Button';
+import type { ButtonProps } from '../Button';
 import { Dropdown } from '../Dropdown';
 import { Flex } from '../Flex';
 

--- a/packages/big-design/src/components/Checkbox/Label/styled.tsx
+++ b/packages/big-design/src/components/Checkbox/Label/styled.tsx
@@ -1,10 +1,10 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { hideVisually } from 'polished';
-import { type ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../../helpers';
-import { type TransientMarginProps } from '../../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../../helpers/margins/margins';
 
 export interface StyledLabelProps extends ComponentPropsWithoutRef<'label'> {
   hidden?: boolean;

--- a/packages/big-design/src/components/Chip/Chip.tsx
+++ b/packages/big-design/src/components/Chip/Chip.tsx
@@ -1,7 +1,7 @@
 import { CloseIcon } from '@bigcommerce/big-design-icons';
 import React, { memo } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { Text } from '../Typography';
 
 import { StyledChip, StyledChipIcon, StyledCloseButton } from './styled';

--- a/packages/big-design/src/components/Collapse/CollapsePanel/CollapsePanel.tsx
+++ b/packages/big-design/src/components/Collapse/CollapsePanel/CollapsePanel.tsx
@@ -1,7 +1,7 @@
 import type { Colors } from '@bigcommerce/big-design-theme';
 import React from 'react';
 
-import { type MarginProps, type PaddingProps } from '../../../helpers';
+import type { MarginProps, PaddingProps } from '../../../helpers';
 import { Box } from '../../Box';
 import { useCollapseContext } from '../useCollapseContext';
 

--- a/packages/big-design/src/components/Collapse/CollapseTrigger/CollapseTrigger.tsx
+++ b/packages/big-design/src/components/Collapse/CollapseTrigger/CollapseTrigger.tsx
@@ -1,7 +1,7 @@
 import { ExpandMoreIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
 
-import { type MarginProps } from '../../../helpers';
+import type { MarginProps } from '../../../helpers';
 import { useCollapseContext } from '../useCollapseContext';
 
 import { StyledButton } from './styled';

--- a/packages/big-design/src/components/Collapse/CollapseTrigger/styled.tsx
+++ b/packages/big-design/src/components/Collapse/CollapseTrigger/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { withTransition } from '../../../helpers/transitions';
-import { type ButtonProps } from '../../Button';
+import type { ButtonProps } from '../../Button';
 import { StyleableButton } from '../../Button/private';
 
 interface StyledButtonProps extends ButtonProps {

--- a/packages/big-design/src/components/Datepicker/spec.tsx
+++ b/packages/big-design/src/components/Datepicker/spec.tsx
@@ -3,7 +3,7 @@ import 'jest-styled-components';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import React, { createRef } from 'react';
-import { type default as ReactDatePicker } from 'react-datepicker';
+import type { default as ReactDatePicker } from 'react-datepicker';
 
 import { FormGroup } from '..';
 

--- a/packages/big-design/src/components/Dropdown/Dropdown.tsx
+++ b/packages/big-design/src/components/Dropdown/Dropdown.tsx
@@ -16,12 +16,7 @@ import { Box } from '../Box';
 import { List } from '../List';
 
 import { StyledBox } from './styled';
-import {
-  type DropdownItem,
-  type DropdownItemGroup,
-  type DropdownLinkItem,
-  type DropdownProps,
-} from './types';
+import type { DropdownItem, DropdownItemGroup, DropdownLinkItem, DropdownProps } from './types';
 
 export const isDropdownItemGroupArray = (
   items: Array<DropdownItemGroup | DropdownItem | DropdownLinkItem>,

--- a/packages/big-design/src/components/Dropdown/types.ts
+++ b/packages/big-design/src/components/Dropdown/types.ts
@@ -1,5 +1,5 @@
-import { type Placement } from '@popperjs/core';
-import { type ComponentPropsWithoutRef, type ReactElement } from 'react';
+import type { Placement } from '@popperjs/core';
+import type { ComponentPropsWithoutRef, ReactElement } from 'react';
 
 export interface DropdownProps extends Omit<ComponentPropsWithoutRef<'ul'>, 'children'> {
   autoWidth?: boolean;

--- a/packages/big-design/src/components/FeatureSet/FeatureSet.tsx
+++ b/packages/big-design/src/components/FeatureSet/FeatureSet.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentPropsWithoutRef, memo } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { toTransientMarginProps } from '../../helpers/margins/margins';
 
 import { StyledUl } from './styled';

--- a/packages/big-design/src/components/FeatureSet/styled.tsx
+++ b/packages/big-design/src/components/FeatureSet/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withMargins } from '../../helpers';
-import { type TransientMarginProps } from '../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../helpers/margins/margins';
 
 export const StyledUl = styled.ul<TransientMarginProps>`
   ${({ theme }) => theme.helpers.listReset}

--- a/packages/big-design/src/components/Fieldset/Legend/Legend.tsx
+++ b/packages/big-design/src/components/Fieldset/Legend/Legend.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 
-import { type HeadingProps } from '../../Typography';
+import type { HeadingProps } from '../../Typography';
 
 import { StyledFieldsetLegend } from './styled';
 

--- a/packages/big-design/src/components/Fieldset/Legend/styled.tsx
+++ b/packages/big-design/src/components/Fieldset/Legend/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { StyleableH4 } from '../../Typography/private';
-import { type HeadingProps } from '../../Typography/types';
+import type { HeadingProps } from '../../Typography/types';
 
 export const StyledFieldsetLegend = styled(StyleableH4).attrs({ as: 'legend' })<
   Partial<HeadingProps>

--- a/packages/big-design/src/components/FileUploader/DropZone.tsx
+++ b/packages/big-design/src/components/FileUploader/DropZone.tsx
@@ -19,7 +19,7 @@ import { Flex } from '../Flex';
 import { Small, Text } from '../Typography';
 
 import { StyledButton, StyledDropzone } from './styled';
-import { type Action, type Localization } from './types';
+import type { Action, Localization } from './types';
 import { validateFileFormat } from './utils';
 
 export interface Props extends ComponentPropsWithoutRef<'input'> {

--- a/packages/big-design/src/components/FileUploader/File.tsx
+++ b/packages/big-design/src/components/FileUploader/File.tsx
@@ -3,7 +3,7 @@ import React, { type ComponentPropsWithoutRef, useMemo } from 'react';
 
 import { Button } from '../Button';
 import { Dropdown } from '../Dropdown';
-import { type DropdownItem } from '../Dropdown/types';
+import type { DropdownItem } from '../Dropdown/types';
 
 import { StyledFile, StyledImage, StyledText } from './styled';
 

--- a/packages/big-design/src/components/FileUploader/FileUploader.tsx
+++ b/packages/big-design/src/components/FileUploader/FileUploader.tsx
@@ -12,7 +12,7 @@ import React, {
 } from 'react';
 
 import { warning } from '../../utils';
-import { type DropdownItem } from '../Dropdown';
+import type { DropdownItem } from '../Dropdown';
 import { FormControlDescription, FormControlLabel } from '../Form';
 import { useInputErrors } from '../Form/useInputErrors';
 import { InlineMessage } from '../InlineMessage';
@@ -20,7 +20,7 @@ import { InlineMessage } from '../InlineMessage';
 import { defaultLocalization } from './constants';
 import { File } from './File';
 import { StyledDropZoneWrapper, StyledFileUploaderWrapper, StyledList } from './styled';
-import { type Action, type Localization, type ValidatorConfig } from './types';
+import type { Action, Localization, ValidatorConfig } from './types';
 import { getImagesPreview, validateFiles } from './utils';
 
 export interface FileAction extends Omit<DropdownItem, 'onItemClick'> {

--- a/packages/big-design/src/components/FileUploader/constants.ts
+++ b/packages/big-design/src/components/FileUploader/constants.ts
@@ -1,4 +1,4 @@
-import { type Localization } from './types';
+import type { Localization } from './types';
 
 export const defaultLocalization: Localization = {
   upload: 'Upload',

--- a/packages/big-design/src/components/FileUploader/spec.tsx
+++ b/packages/big-design/src/components/FileUploader/spec.tsx
@@ -9,7 +9,7 @@ import { defaultLocalization } from './constants';
 import { DropZone } from './DropZone';
 import { File as FileComponent } from './File';
 import { type FileAction, FileUploader } from './FileUploader';
-import { type Action, type ValidatorConfig } from './types';
+import type { Action, ValidatorConfig } from './types';
 
 import 'jest-styled-components';
 

--- a/packages/big-design/src/components/FileUploader/types.ts
+++ b/packages/big-design/src/components/FileUploader/types.ts
@@ -1,5 +1,5 @@
-import { type MarginProps } from '../../helpers';
-import { type ButtonProps } from '../Button';
+import type { MarginProps } from '../../helpers';
+import type { ButtonProps } from '../Button';
 
 export interface Localization {
   upload: string;

--- a/packages/big-design/src/components/FileUploader/utils/validateFile.ts
+++ b/packages/big-design/src/components/FileUploader/utils/validateFile.ts
@@ -1,4 +1,4 @@
-import { type ValidatorConfig } from '../types';
+import type { ValidatorConfig } from '../types';
 
 export const validateFileFormat = (file: File | DataTransferItem, fileFormats = '') => {
   const allowedFormats = fileFormats.split(',').map((format) => format.trim());

--- a/packages/big-design/src/components/Flex/Flex.tsx
+++ b/packages/big-design/src/components/Flex/Flex.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef } from 'react';
 
-import { type BoxProps } from '../Box';
+import type { BoxProps } from '../Box';
 
 import { StyledFlex } from './styled';
-import { type FlexedProps } from './types';
+import type { FlexedProps } from './types';
 import { toTransientFlexedContainerProps } from './withFlex';
 
 export type FlexProps = BoxProps & FlexedProps;

--- a/packages/big-design/src/components/Flex/Item/Item.tsx
+++ b/packages/big-design/src/components/Flex/Item/Item.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 
-import { type BoxProps } from '../../Box';
-import { type FlexedItemProps } from '../types';
+import type { BoxProps } from '../../Box';
+import type { FlexedItemProps } from '../types';
 import { toTransientFlexedItemProps } from '../withFlex';
 
 import { StyledFlexItem } from './styled';

--- a/packages/big-design/src/components/Flex/Item/styled.tsx
+++ b/packages/big-design/src/components/Flex/Item/styled.tsx
@@ -2,10 +2,10 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { Box } from '../../Box';
-import { type TransientFlexedItemProps } from '../types';
+import type { TransientFlexedItemProps } from '../types';
 import { withFlexedItems } from '../withFlex';
 
-import { type FlexItemProps } from './Item';
+import type { FlexItemProps } from './Item';
 
 interface StyledFlexItemProps extends TransientFlexedItemProps {
   forwardedAs?: FlexItemProps['as'];

--- a/packages/big-design/src/components/Flex/styled.tsx
+++ b/packages/big-design/src/components/Flex/styled.tsx
@@ -1,16 +1,16 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import type { ElementType } from 'react';
+import type React from 'react';
 import styled from 'styled-components';
 
 import { withDisplay } from '../../helpers';
-import { type TransientDisplayProps } from '../../helpers/display/types';
+import type { TransientDisplayProps } from '../../helpers/display/types';
 import { Box } from '../Box';
 
-import { type TransientFlexedProps } from './types';
+import type { TransientFlexedProps } from './types';
 import { withFlexedContainer } from './withFlex';
 
 interface StyledFlexProps extends TransientFlexedProps, TransientDisplayProps {
-  forwardedAs?: ElementType;
+  forwardedAs?: React.ElementType;
 }
 
 // TODO: Remove the `forwardedAs` manual prop definition when @types get updated

--- a/packages/big-design/src/components/Flex/types.ts
+++ b/packages/big-design/src/components/Flex/types.ts
@@ -1,6 +1,6 @@
-import { type CSSRules, type ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { CSSRules, ThemeInterface } from '@bigcommerce/big-design-theme';
 
-import { type ResponsiveProp } from '../../types';
+import type { ResponsiveProp } from '../../types';
 
 type AlignContent = ResponsiveProp<
   | 'normal'

--- a/packages/big-design/src/components/Flex/withFlex.ts
+++ b/packages/big-design/src/components/Flex/withFlex.ts
@@ -6,12 +6,12 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import {
-  type FlexedItemProps,
-  type FlexedOverload,
-  type FlexedProps,
-  type TransientFlexedItemProps,
-  type TransientFlexedProps,
+import type {
+  FlexedItemProps,
+  FlexedOverload,
+  FlexedProps,
+  TransientFlexedItemProps,
+  TransientFlexedProps,
 } from './types';
 
 export const withFlexedContainer = () => css<TransientFlexedProps>`

--- a/packages/big-design/src/components/Form/Description/Description.tsx
+++ b/packages/big-design/src/components/Form/Description/Description.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { type LinkProps } from '../../Link';
+import type { LinkProps } from '../../Link';
 import { Small, type TextProps } from '../../Typography';
 
 import { StyledLink } from './styled';

--- a/packages/big-design/src/components/Form/Form.tsx
+++ b/packages/big-design/src/components/Form/Form.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentPropsWithoutRef, forwardRef, type Ref } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { toTransientMarginProps } from '../../helpers/margins/margins';
 import { typedMemo } from '../../utils';
 

--- a/packages/big-design/src/components/Form/Label/styled.tsx
+++ b/packages/big-design/src/components/Form/Label/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withMargins } from '../../../helpers';
-import { type TransientMarginProps } from '../../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../../helpers/margins/margins';
 
 import { type FormControlLabelProps } from './Label';
 

--- a/packages/big-design/src/components/Form/styled.tsx
+++ b/packages/big-design/src/components/Form/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withMargins } from '../../helpers';
-import { type TransientMarginProps } from '../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../helpers/margins/margins';
 import { StyledFileUploaderWrapper } from '../FileUploader/styled';
 import { StyledInputWrapper } from '../Input/styled';
 import { StyledTextareaWrapper } from '../Textarea/styled';

--- a/packages/big-design/src/components/Grid/Grid.tsx
+++ b/packages/big-design/src/components/Grid/Grid.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef } from 'react';
 
-import { type BoxProps } from '../Box';
+import type { BoxProps } from '../Box';
 
 import { StyledGrid } from './styled';
-import { type GridedProps } from './types';
+import type { GridedProps } from './types';
 import { toTransientGridedContainerProps } from './withGrid';
 
 export type GridProps = BoxProps & GridedProps;

--- a/packages/big-design/src/components/Grid/Item/Item.tsx
+++ b/packages/big-design/src/components/Grid/Item/Item.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { type BoxProps } from '../../Box';
-import { type GridedItemProps } from '../types';
+import type { BoxProps } from '../../Box';
+import type { GridedItemProps } from '../types';
 import { toTransientGridedItemProps } from '../withGrid';
 
 import { StyledGridItem } from './styled';

--- a/packages/big-design/src/components/Grid/Item/styled.tsx
+++ b/packages/big-design/src/components/Grid/Item/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { Box } from '../../Box';
-import { type TransientGridedItemProps } from '../types';
+import type { TransientGridedItemProps } from '../types';
 import { withGridedItems } from '../withGrid';
 
 export const StyledGridItem = styled(Box)<TransientGridedItemProps>`

--- a/packages/big-design/src/components/Grid/styled.tsx
+++ b/packages/big-design/src/components/Grid/styled.tsx
@@ -1,16 +1,16 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import type { ElementType } from 'react';
+import type React from 'react';
 import styled from 'styled-components';
 
 import { withDisplay } from '../../helpers';
-import { type TransientDisplayProps } from '../../helpers/display/types';
+import type { TransientDisplayProps } from '../../helpers/display/types';
 import { Box } from '../Box';
 
-import { type TransientGridedProps } from './types';
+import type { TransientGridedProps } from './types';
 import { withGridedContainer } from './withGrid';
 
 interface StyledGridProps extends TransientGridedProps, TransientDisplayProps {
-  forwardedAs?: ElementType;
+  forwardedAs?: React.ElementType;
 }
 
 // TODO: Remove the `forwardedAs` manual prop definition when @types get updated

--- a/packages/big-design/src/components/Grid/types.ts
+++ b/packages/big-design/src/components/Grid/types.ts
@@ -1,6 +1,6 @@
-import { type CSSRules, type ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { CSSRules, ThemeInterface } from '@bigcommerce/big-design-theme';
 
-import { type ResponsiveProp } from '../../types';
+import type { ResponsiveProp } from '../../types';
 
 type GridAreas = ResponsiveProp<string>;
 

--- a/packages/big-design/src/components/Grid/withGrid.ts
+++ b/packages/big-design/src/components/Grid/withGrid.ts
@@ -6,12 +6,12 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import {
-  type GridedItemProps,
-  type GridedOverload,
-  type GridedProps,
-  type TransientGridedItemProps,
-  type TransientGridedProps,
+import type {
+  GridedItemProps,
+  GridedOverload,
+  GridedProps,
+  TransientGridedItemProps,
+  TransientGridedProps,
 } from './types';
 
 export const withGridedContainer = () => css<TransientGridedProps>`

--- a/packages/big-design/src/components/InlineMessage/styled.ts
+++ b/packages/big-design/src/components/InlineMessage/styled.ts
@@ -6,9 +6,9 @@ import { Flex } from '../Flex';
 import { Grid } from '../Grid';
 import { Link } from '../Link';
 import { StyleableH4, StyleableSmall } from '../Typography/private';
-import { type TextProps } from '../Typography/types';
+import type { TextProps } from '../Typography/types';
 
-import { type InlineMessageProps } from './InlineMessage';
+import type { InlineMessageProps } from './InlineMessage';
 
 interface StyledInlineMessageProps {
   type?: InlineMessageProps['type'];

--- a/packages/big-design/src/components/Input/styled.tsx
+++ b/packages/big-design/src/components/Input/styled.tsx
@@ -2,10 +2,10 @@ import { addValues, theme as defaultTheme, remCalc } from '@bigcommerce/big-desi
 import styled, { css } from 'styled-components';
 
 import { withPaddings } from '../../helpers';
-import { type TransientPaddingProps } from '../../helpers/paddings/paddings';
+import type { TransientPaddingProps } from '../../helpers/paddings/paddings';
 import { withTransition } from '../../helpers/transitions';
 
-import { type InputProps } from './Input';
+import type { InputProps } from './Input';
 
 export interface StyledInputWrapperProps {
   disabled?: boolean;

--- a/packages/big-design/src/components/Link/Link.tsx
+++ b/packages/big-design/src/components/Link/Link.tsx
@@ -1,7 +1,7 @@
 import { OpenInNewIcon } from '@bigcommerce/big-design-icons';
 import React, { type ComponentPropsWithoutRef, forwardRef, memo, type Ref } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { toTransientMarginProps } from '../../helpers/margins/margins';
 
 import { StyledLink } from './styled';

--- a/packages/big-design/src/components/Link/styled.tsx
+++ b/packages/big-design/src/components/Link/styled.tsx
@@ -3,7 +3,7 @@ import { ellipsis } from 'polished';
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../helpers';
-import { type TransientMarginProps } from '../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../helpers/margins/margins';
 import { withTransition } from '../../helpers/transitions';
 
 interface StyledLinkProps extends TransientMarginProps {

--- a/packages/big-design/src/components/List/Item/Content.tsx
+++ b/packages/big-design/src/components/List/Item/Content.tsx
@@ -1,10 +1,10 @@
-import { type IconProps } from '@bigcommerce/big-design-icons';
+import type { IconProps } from '@bigcommerce/big-design-icons';
 import { offset, shift } from '@floating-ui/react';
 import React, { cloneElement, isValidElement, memo, useCallback, useMemo } from 'react';
 
-import { type DropdownItem, type DropdownLinkItem } from '../../Dropdown';
+import type { DropdownItem, DropdownLinkItem } from '../../Dropdown';
 import { Flex, FlexItem } from '../../Flex';
-import { type SelectAction, type SelectOption } from '../../Select';
+import type { SelectAction, SelectOption } from '../../Select';
 import { Tooltip } from '../../Tooltip';
 import { Small } from '../../Typography';
 

--- a/packages/big-design/src/components/List/Item/Item.tsx
+++ b/packages/big-design/src/components/List/Item/Item.tsx
@@ -1,11 +1,11 @@
 import { CheckIcon } from '@bigcommerce/big-design-icons';
-import { type UseComboboxPropGetters, type UseSelectPropGetters } from 'downshift';
+import type { UseComboboxPropGetters, UseSelectPropGetters } from 'downshift';
 import React, { type ComponentPropsWithoutRef, forwardRef, memo, type Ref } from 'react';
 
 import { typedMemo } from '../../../utils';
 import { Checkbox } from '../../Checkbox';
-import { type DropdownItem, type DropdownLinkItem } from '../../Dropdown';
-import { type SelectAction, type SelectOption } from '../../Select';
+import type { DropdownItem, DropdownLinkItem } from '../../Dropdown';
+import type { SelectAction, SelectOption } from '../../Select';
 
 import { Content } from './Content';
 import { StyledListItem } from './styled';

--- a/packages/big-design/src/components/List/Item/styled.tsx
+++ b/packages/big-design/src/components/List/Item/styled.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 
 import { withTransition } from '../../../helpers/transitions';
 
-import { type ListItemProps } from '.';
+import type { ListItemProps } from '.';
 
 interface StyledListItemProps {
   disabled?: boolean;

--- a/packages/big-design/src/components/List/List.tsx
+++ b/packages/big-design/src/components/List/List.tsx
@@ -1,4 +1,4 @@
-import { type UseComboboxPropGetters, type UseSelectPropGetters } from 'downshift';
+import type { UseComboboxPropGetters, UseSelectPropGetters } from 'downshift';
 import React, {
   type ComponentPropsWithoutRef,
   forwardRef,
@@ -13,19 +13,9 @@ import React, {
 import { useIsomorphicLayoutEffect, useWindowSize } from '../../hooks';
 import { typedMemo } from '../../utils';
 import { Box } from '../Box';
-import {
-  type DropdownItem,
-  type DropdownItemGroup,
-  type DropdownLinkItem,
-  type DropdownProps,
-} from '../Dropdown';
-import { type MultiSelectLocalization } from '../MultiSelect/types';
-import {
-  type SelectAction,
-  type SelectOption,
-  type SelectOptionGroup,
-  type SelectProps,
-} from '../Select';
+import type { DropdownItem, DropdownItemGroup, DropdownLinkItem, DropdownProps } from '../Dropdown';
+import type { MultiSelectLocalization } from '../MultiSelect/types';
+import type { SelectAction, SelectOption, SelectOptionGroup, SelectProps } from '../Select';
 
 import { ListGroupHeader } from './GroupHeader';
 import { ListGroupSeparator } from './GroupSeparator';

--- a/packages/big-design/src/components/List/styled.tsx
+++ b/packages/big-design/src/components/List/styled.tsx
@@ -1,7 +1,7 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
-import { type ListProps } from './List';
+import type { ListProps } from './List';
 
 export const StyledListOverflowWrapper = styled.div`
   ${({ theme }) => theme.shadow.raised}

--- a/packages/big-design/src/components/Lozenge/styled.tsx
+++ b/packages/big-design/src/components/Lozenge/styled.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 
 import { Box } from '../Box';
 
-import { type LozengeProps } from './Lozenge';
+import type { LozengeProps } from './Lozenge';
 
 interface StyledLozengeProps {
   $hasTooltip?: boolean;

--- a/packages/big-design/src/components/Message/styled.ts
+++ b/packages/big-design/src/components/Message/styled.ts
@@ -6,9 +6,9 @@ import { Flex } from '../Flex';
 import { Grid } from '../Grid';
 import { Link } from '../Link';
 import { StyleableH4, StyleableSmall } from '../Typography/private';
-import { type TextProps } from '../Typography/types';
+import type { TextProps } from '../Typography/types';
 
-import { type MessageProps } from './Message';
+import type { MessageProps } from './Message';
 
 interface StyledMessageProps {
   type?: MessageProps['type'];

--- a/packages/big-design/src/components/Modal/styled.tsx
+++ b/packages/big-design/src/components/Modal/styled.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 
 import { Flex } from '../Flex';
 
-import { type ModalProps } from './Modal';
+import type { ModalProps } from './Modal';
 
 interface StyledModalProps {
   $backdrop?: ModalProps['backdrop'];

--- a/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/big-design/src/components/MultiSelect/MultiSelect.tsx
@@ -23,10 +23,10 @@ import { Box } from '../Box';
 import { FormControlLabel } from '../Form';
 import { Input } from '../Input';
 import { List } from '../List';
-import { type SelectAction, type SelectOption, type SelectOptionGroup } from '../Select';
+import type { SelectAction, SelectOption, SelectOptionGroup } from '../Select';
 import { DropdownButton, StyledDropdownIcon, StyledInputContainer } from '../Select/styled';
 
-import { type MultiSelectLocalization, type MultiSelectProps } from './types';
+import type { MultiSelectLocalization, MultiSelectProps } from './types';
 
 export const defaultLocalization: MultiSelectLocalization = {
   selectAll: 'Select All',

--- a/packages/big-design/src/components/MultiSelect/types.ts
+++ b/packages/big-design/src/components/MultiSelect/types.ts
@@ -1,9 +1,9 @@
-import { type Placement } from '@popperjs/core';
+import type { Placement } from '@popperjs/core';
 import type { ComponentPropsWithoutRef, ReactNode, Ref, RefObject } from 'react';
 
-import { type InputProps } from '../Input';
-import { type SelectAction, type SelectOption } from '../Select';
-import { type SelectOptionGroup } from '../Select/types';
+import type { InputProps } from '../Input';
+import type { SelectAction, SelectOption } from '../Select';
+import type { SelectOptionGroup } from '../Select/types';
 
 interface BaseSelect extends Omit<ComponentPropsWithoutRef<'input'>, 'children' | 'value'> {
   action?: SelectAction;

--- a/packages/big-design/src/components/OffsetPagination/OffsetPagination.tsx
+++ b/packages/big-design/src/components/OffsetPagination/OffsetPagination.tsx
@@ -5,7 +5,7 @@ import {
 } from '@bigcommerce/big-design-icons';
 import React, { memo, useCallback, useEffect, useState } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { Dropdown, type DropdownItem } from '../Dropdown';
 import { Flex, FlexItem } from '../Flex';
 

--- a/packages/big-design/src/components/Panel/Panel.tsx
+++ b/packages/big-design/src/components/Panel/Panel.tsx
@@ -6,7 +6,7 @@ import React, {
   type Ref,
 } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { excludePaddingProps } from '../../helpers/paddings/paddings';
 import { warning } from '../../utils';
 import { Badge, type BadgeProps } from '../Badge/Badge';

--- a/packages/big-design/src/components/PillTabs/toDropDownItem.tsx
+++ b/packages/big-design/src/components/PillTabs/toDropDownItem.tsx
@@ -1,7 +1,7 @@
 import { CheckIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
 
-import { type DropdownItem } from '../Dropdown';
+import type { DropdownItem } from '../Dropdown';
 
 interface Pill {
   title: string;

--- a/packages/big-design/src/components/PillTabs/toDropdownItemGroups.ts
+++ b/packages/big-design/src/components/PillTabs/toDropdownItemGroups.ts
@@ -1,4 +1,4 @@
-import { type DropdownItemGroup, type DropdownProps } from '../Dropdown';
+import type { DropdownItemGroup, DropdownProps } from '../Dropdown';
 import { isDropdownItemGroupArray } from '../Dropdown/Dropdown';
 
 type Items = DropdownProps['items'];

--- a/packages/big-design/src/components/Popover/Popover.tsx
+++ b/packages/big-design/src/components/Popover/Popover.tsx
@@ -1,5 +1,5 @@
 import { autoUpdate, offset, shift, size, useFloating } from '@floating-ui/react';
-import { type Placement } from '@popperjs/core';
+import type { Placement } from '@popperjs/core';
 import React, { useEffect, useId, useRef, useState } from 'react';
 
 import { excludeMarginProps } from '../../helpers';

--- a/packages/big-design/src/components/Popover/spec.tsx
+++ b/packages/big-design/src/components/Popover/spec.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 
 import { Popover } from './Popover';
 
-import { type PopoverProps } from '.';
+import type { PopoverProps } from '.';
 
 const TestComponent: React.FC<Partial<PopoverProps>> = ({ isOpen = false, ...rest }) => {
   const [open, setOpen] = useState(isOpen);

--- a/packages/big-design/src/components/ProgressBar/styled.tsx
+++ b/packages/big-design/src/components/ProgressBar/styled.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 
 import { withTransition } from '../../helpers/transitions';
 
-import { type ProgressBarProps } from './ProgressBar';
+import type { ProgressBarProps } from './ProgressBar';
 
 export const StyledProgressBar = styled.div`
   background-color: ${({ theme }) => theme.colors.secondary20};

--- a/packages/big-design/src/components/ProgressCircle/styled.tsx
+++ b/packages/big-design/src/components/ProgressCircle/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css, keyframes } from 'styled-components';
 
 import { CIRCLE_CIRCUMFERENCES, CIRCLE_DIMENSIONS, CIRCLE_STROKE_WIDTHS } from './constants';
-import { type ProgressCircleProps } from './ProgressCircle';
+import type { ProgressCircleProps } from './ProgressCircle';
 
 interface StyledProgressCircleProps {
   $percent?: ProgressCircleProps['percent'];

--- a/packages/big-design/src/components/Radio/Label/styled.tsx
+++ b/packages/big-design/src/components/Radio/Label/styled.tsx
@@ -1,9 +1,9 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import { type ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 import styled, { css } from 'styled-components';
 
 import { withMargins } from '../../../helpers';
-import { type TransientMarginProps } from '../../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../../helpers/margins/margins';
 
 export interface StyledLabelProps extends ComponentPropsWithoutRef<'label'> {
   disabled?: boolean;

--- a/packages/big-design/src/components/Search/Search.tsx
+++ b/packages/big-design/src/components/Search/Search.tsx
@@ -6,7 +6,7 @@ import { Flex, FlexItem } from '../Flex';
 import { Form } from '../Form';
 import { Input } from '../Input';
 
-import { type SearchLocalization, type SearchProps } from './types';
+import type { SearchLocalization, SearchProps } from './types';
 
 const defaultLocalization: SearchLocalization = {
   search: 'Search',

--- a/packages/big-design/src/components/Search/types.ts
+++ b/packages/big-design/src/components/Search/types.ts
@@ -1,7 +1,7 @@
-import { type ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 
-import { type FormProps } from '../Form';
-import { type InputProps } from '../Input';
+import type { FormProps } from '../Form';
+import type { InputProps } from '../Input';
 
 export interface SearchLocalization {
   search: string;

--- a/packages/big-design/src/components/Select/Select.tsx
+++ b/packages/big-design/src/components/Select/Select.tsx
@@ -18,9 +18,9 @@ import { Box } from '../Box';
 import { FormControlLabel } from '../Form';
 import { Input } from '../Input';
 import { List } from '../List';
-import { type SelectOption, type SelectOptionGroup, type SelectProps } from '../Select';
+import type { SelectOption, SelectOptionGroup, SelectProps } from '../Select';
 import { DropdownButton, StyledDropdownIcon, StyledInputContainer } from '../Select/styled';
-import { type SelectAction } from '../Select/types';
+import type { SelectAction } from '../Select/types';
 
 export const Select = typedMemo(
   <T,>({

--- a/packages/big-design/src/components/Select/types.ts
+++ b/packages/big-design/src/components/Select/types.ts
@@ -1,7 +1,7 @@
-import { type Placement } from '@popperjs/core';
+import type { Placement } from '@popperjs/core';
 import type { ComponentPropsWithoutRef, ReactElement, ReactNode, Ref, RefObject } from 'react';
 
-import { type InputProps } from '../Input';
+import type { InputProps } from '../Input';
 
 interface BaseSelect extends Omit<ComponentPropsWithoutRef<'input'>, 'children' | 'value'> {
   action?: SelectAction;

--- a/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
+++ b/packages/big-design/src/components/StatefulTable/StatefulTable.tsx
@@ -3,11 +3,11 @@ import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import { useDidUpdate } from '../../hooks';
 import { typedMemo } from '../../utils';
 import { Box } from '../Box';
-import { type OffsetPaginationProps } from '../OffsetPagination';
-import { type OffsetPaginationLocalization } from '../OffsetPagination/OffsetPagination';
+import type { OffsetPaginationProps } from '../OffsetPagination';
+import type { OffsetPaginationLocalization } from '../OffsetPagination/OffsetPagination';
 import { type PillTabItem, PillTabs, type PillTabsProps } from '../PillTabs';
 import { Search } from '../Search';
-import { type SearchLocalization } from '../Search/types';
+import type { SearchLocalization } from '../Search/types';
 import {
   Table,
   type TableColumn,

--- a/packages/big-design/src/components/StatefulTable/reducer.ts
+++ b/packages/big-design/src/components/StatefulTable/reducer.ts
@@ -1,12 +1,12 @@
-import { type Reducer } from 'react';
+import type { Reducer } from 'react';
 
 import { isPillTabItemGroupArray, type PillTabItem, type PillTabsProps } from '../PillTabs';
-import { type TableSortDirection } from '../Table';
+import type { TableSortDirection } from '../Table';
 
-import {
-  type StatefulTableColumn,
-  type StatefulTablePillTabFilter,
-  type StatefulTableSortFn,
+import type {
+  StatefulTableColumn,
+  StatefulTablePillTabFilter,
+  StatefulTableSortFn,
 } from './StatefulTable';
 
 interface State<T> {

--- a/packages/big-design/src/components/StatefulTree/StatefulTree.tsx
+++ b/packages/big-design/src/components/StatefulTree/StatefulTree.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { typedMemo } from '../../utils';
 import { Tree, type TreeNodeId, type TreeSelectable, useNodeMap, useTreeKeyEvents } from '../Tree';
 import { useFlatVisibleNodes } from '../Tree/hooks/useFlatVisibleNodes';
-import { type TreeBaseProps, type TreeVirtualizationProps } from '../Tree/types';
+import type { TreeBaseProps, TreeVirtualizationProps } from '../Tree/types';
 
 import { useExpandable, useFocusable, useSelectable } from './hooks';
 

--- a/packages/big-design/src/components/StatefulTree/hooks/useExpandable.ts
+++ b/packages/big-design/src/components/StatefulTree/hooks/useExpandable.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { type TreeExpandable } from '../../Tree';
-import { type StatefulTreeProps } from '../StatefulTree';
+import type { TreeExpandable } from '../../Tree';
+import type { StatefulTreeProps } from '../StatefulTree';
 
 interface UseExpandableProps<T> {
   defaultExpanded: StatefulTreeProps<T>['defaultExpanded'];

--- a/packages/big-design/src/components/StatefulTree/hooks/useFocusable.ts
+++ b/packages/big-design/src/components/StatefulTree/hooks/useFocusable.ts
@@ -1,11 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import {
-  type TreeFocusable,
-  type TreeNodeId,
-  type TreeNodeProps,
-  type TreeSelectableType,
-} from '../../Tree';
+import type { TreeFocusable, TreeNodeId, TreeNodeProps, TreeSelectableType } from '../../Tree';
 
 interface UseFocusableProps<T> {
   nodes: Array<TreeNodeProps<T>>;

--- a/packages/big-design/src/components/StatefulTree/hooks/useSelectable.ts
+++ b/packages/big-design/src/components/StatefulTree/hooks/useSelectable.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { depthFirstSearch } from '../../../utils';
-import { type TreeNodeId, type TreeSelectable } from '../../Tree';
-import { type StatefulTreeProps } from '../StatefulTree';
+import type { TreeNodeId, TreeSelectable } from '../../Tree';
+import type { StatefulTreeProps } from '../StatefulTree';
 
 interface UseSelectableProps<T> {
   defaultSelected: StatefulTreeProps<T>['defaultSelected'];

--- a/packages/big-design/src/components/StatelessPagination/StatelessPagination.tsx
+++ b/packages/big-design/src/components/StatelessPagination/StatelessPagination.tsx
@@ -5,7 +5,7 @@ import {
 } from '@bigcommerce/big-design-icons';
 import React, { memo, useMemo } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { Dropdown, type DropdownItem } from '../Dropdown';
 import { Flex, FlexItem } from '../Flex';
 

--- a/packages/big-design/src/components/StatusMessage/styled.tsx
+++ b/packages/big-design/src/components/StatusMessage/styled.tsx
@@ -1,7 +1,7 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { type StatusMessageProps, type StatusMessageVariantType } from './StatusMessage';
+import type { StatusMessageProps, StatusMessageVariantType } from './StatusMessage';
 
 function svgToCssBackground(svgString: string): string {
   // Minify: remove newlines and excessive spaces

--- a/packages/big-design/src/components/Table/Actions/Actions.tsx
+++ b/packages/big-design/src/components/Table/Actions/Actions.tsx
@@ -5,11 +5,7 @@ import { FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
 import { SelectAll } from '../SelectAll';
 import { TablePagination } from '../TablePagination';
-import {
-  type DiscriminatedTablePaginationProps,
-  type TableItem,
-  type TableSelectable,
-} from '../types';
+import type { DiscriminatedTablePaginationProps, TableItem, TableSelectable } from '../types';
 
 import { StyledFlex } from './styled';
 

--- a/packages/big-design/src/components/Table/Actions/styled.tsx
+++ b/packages/big-design/src/components/Table/Actions/styled.tsx
@@ -1,7 +1,7 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { type TransientFlexedProps } from '../../Flex/types';
+import type { TransientFlexedProps } from '../../Flex/types';
 import { withFlexedContainer } from '../../Flex/withFlex';
 
 interface StyledFlexProps extends TransientFlexedProps {

--- a/packages/big-design/src/components/Table/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/Table/DataCell/DataCell.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentPropsWithoutRef, memo } from 'react';
 
-import { type TableColumnDisplayProps } from '../helpers';
+import type { TableColumnDisplayProps } from '../helpers';
 
 import { StyledTableDataCell, StyledTableDataCheckbox } from './styled';
 

--- a/packages/big-design/src/components/Table/DataCell/styled.tsx
+++ b/packages/big-design/src/components/Table/DataCell/styled.tsx
@@ -2,9 +2,9 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { withTableColumnDisplay } from '../helpers';
-import { type TransientTableColumnDisplayProps } from '../helpers/display/types';
+import type { TransientTableColumnDisplayProps } from '../helpers/display/types';
 
-import { type DataCellProps } from './DataCell';
+import type { DataCellProps } from './DataCell';
 
 interface StyledTableDataCellProps extends TransientTableColumnDisplayProps {
   $align?: DataCellProps['align'];

--- a/packages/big-design/src/components/Table/Head/styled.tsx
+++ b/packages/big-design/src/components/Table/Head/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { hideVisually } from 'polished';
 import styled from 'styled-components';
 
-import { type HeadProps } from './Head';
+import type { HeadProps } from './Head';
 
 // `hidden` intentionally stays un-prefixed: it's a real DOM attribute, and jest-dom's
 // toBeVisible() relies on it leaking through (hideVisually() alone doesn't satisfy it).

--- a/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -9,8 +9,8 @@ import { useComponentSize } from '../../../hooks';
 import { typedMemo } from '../../../utils';
 import { Box } from '../../Box';
 import { Tooltip } from '../../Tooltip';
-import { type TableColumnDisplayProps } from '../helpers';
-import { type TableColumn, type TableItem } from '../types';
+import type { TableColumnDisplayProps } from '../helpers';
+import type { TableColumn, TableItem } from '../types';
 
 import { StyledFlex, StyledTableHeaderCell, StyledTableHeaderIcon } from './styled';
 

--- a/packages/big-design/src/components/Table/HeaderCell/styled.tsx
+++ b/packages/big-design/src/components/Table/HeaderCell/styled.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 
 import { Flex } from '../../Flex';
 import { withTableColumnDisplay } from '../helpers';
-import { type TransientTableColumnDisplayProps } from '../helpers/display/types';
+import type { TransientTableColumnDisplayProps } from '../helpers/display/types';
 
 interface StyledTableHeaderCellProps extends TransientTableColumnDisplayProps {
   $isSortable?: boolean;

--- a/packages/big-design/src/components/Table/Row/Row.tsx
+++ b/packages/big-design/src/components/Table/Row/Row.tsx
@@ -14,7 +14,7 @@ import { createPortal } from 'react-dom';
 import { typedMemo } from '../../../utils';
 import { Checkbox } from '../../Checkbox';
 import { DataCell } from '../DataCell';
-import { type TableColumn, type TableItem } from '../types';
+import type { TableColumn, TableItem } from '../types';
 
 import { StyledDragHandle, StyledDragPreview, StyledTableRow } from './styled';
 

--- a/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/Table/SelectAll/SelectAll.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Checkbox } from '../../Checkbox';
 import { Flex, FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
-import { type TableItem, type TablePaginationProps, type TableSelectable } from '../types';
+import type { TableItem, TablePaginationProps, TableSelectable } from '../types';
 
 export interface SelectAllProps<T> {
   items: T[];

--- a/packages/big-design/src/components/Table/Table.tsx
+++ b/packages/big-design/src/components/Table/Table.tsx
@@ -7,7 +7,7 @@ import {
 } from '@atlaskit/pragmatic-drag-and-drop-live-region';
 import React, { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { toTransientMarginProps } from '../../helpers/margins/margins';
 import { useEventCallback } from '../../hooks';
 import { typedMemo } from '../../utils';
@@ -20,7 +20,7 @@ import { HeaderCell } from './HeaderCell';
 import { DragIconHeaderCell, HeaderCheckboxCell } from './HeaderCell/HeaderCell';
 import { Row } from './Row';
 import { StyledTable, StyledTableFigure } from './styled';
-import { type TableColumn, type TableItem, type TableProps } from './types';
+import type { TableColumn, TableItem, TableProps } from './types';
 
 interface Localization {
   ascendingOrder: string;

--- a/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/Table/TablePagination/TablePagination.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 
 import { OffsetPagination } from '../../OffsetPagination';
 import { StatelessPagination } from '../../StatelessPagination';
-import { type DiscriminatedTablePaginationProps } from '../types';
+import type { DiscriminatedTablePaginationProps } from '../types';
 
 import { StyledPaginationContainer } from './styled';
 

--- a/packages/big-design/src/components/Table/discriminatePagination.ts
+++ b/packages/big-design/src/components/Table/discriminatePagination.ts
@@ -1,4 +1,4 @@
-import { type DiscriminatedTablePaginationProps, type TablePaginationProps } from './types';
+import type { DiscriminatedTablePaginationProps, TablePaginationProps } from './types';
 
 export const discriminatePagination = (
   pagination: TablePaginationProps,

--- a/packages/big-design/src/components/Table/helpers/display/display.tsx
+++ b/packages/big-design/src/components/Table/helpers/display/display.tsx
@@ -6,7 +6,7 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { type TableColumnDisplayOverload, type TransientTableColumnDisplayProps } from './types';
+import type { TableColumnDisplayOverload, TransientTableColumnDisplayProps } from './types';
 
 export const withTableColumnDisplay = () => css<TransientTableColumnDisplayProps>`
   ${({ $display, theme }) => $display && getDisplayStyles($display, theme, 'display')};

--- a/packages/big-design/src/components/Table/helpers/display/spec.tsx
+++ b/packages/big-design/src/components/Table/helpers/display/spec.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { withTableColumnDisplay } from './display';
-import { type TransientTableColumnDisplayProps } from './types';
+import type { TransientTableColumnDisplayProps } from './types';
 
 const TestComponent = styled.div<TransientTableColumnDisplayProps>`
   ${withTableColumnDisplay()};

--- a/packages/big-design/src/components/Table/helpers/display/types.ts
+++ b/packages/big-design/src/components/Table/helpers/display/types.ts
@@ -1,6 +1,6 @@
-import { type CSSRules, type ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { CSSRules, ThemeInterface } from '@bigcommerce/big-design-theme';
 
-import { type ResponsiveProp } from '../../../../types';
+import type { ResponsiveProp } from '../../../../types';
 
 type TableColumnDisplayProp = ResponsiveProp<'table-cell' | 'none'>;
 

--- a/packages/big-design/src/components/Table/spec.tsx
+++ b/packages/big-design/src/components/Table/spec.tsx
@@ -4,7 +4,7 @@ import React, { type CSSProperties } from 'react';
 import 'jest-styled-components';
 
 import { Table, TableFigure } from './Table';
-import { type TableColumn, type TableItem } from './types';
+import type { TableColumn, TableItem } from './types';
 
 interface SimpleTableOptions {
   className?: string;

--- a/packages/big-design/src/components/Table/styled.tsx
+++ b/packages/big-design/src/components/Table/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withMargins } from '../../helpers';
-import { type TransientMarginProps } from '../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../helpers/margins/margins';
 
 export const StyledTableFigure = styled.figure<TransientMarginProps>`
   margin: 0;

--- a/packages/big-design/src/components/Table/types.ts
+++ b/packages/big-design/src/components/Table/types.ts
@@ -1,10 +1,10 @@
-import { type ComponentPropsWithoutRef, type ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
-import { type MarginProps } from '../../helpers';
-import { type OffsetPaginationProps } from '../OffsetPagination';
-import { type StatelessPaginationProps } from '../StatelessPagination';
+import type { MarginProps } from '../../helpers';
+import type { OffsetPaginationProps } from '../OffsetPagination';
+import type { StatelessPaginationProps } from '../StatelessPagination';
 
-import { type TableColumnDisplayProps } from './helpers';
+import type { TableColumnDisplayProps } from './helpers';
 
 export interface TableSelectable<T> {
   selectedItems: T[];

--- a/packages/big-design/src/components/TableNext/Actions/Actions.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/Actions.tsx
@@ -5,12 +5,12 @@ import { FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
 import { SelectAll } from '../SelectAll';
 import { TablePagination } from '../TablePagination';
-import {
-  type DiscriminatedTablePaginationProps,
-  type TableExpandable,
-  type TableItem,
-  type TableProps,
-  type TableSelectable,
+import type {
+  DiscriminatedTablePaginationProps,
+  TableExpandable,
+  TableItem,
+  TableProps,
+  TableSelectable,
 } from '../types';
 
 import { StyledFlex } from './styled';

--- a/packages/big-design/src/components/TableNext/Actions/styled.tsx
+++ b/packages/big-design/src/components/TableNext/Actions/styled.tsx
@@ -1,7 +1,7 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { type TransientFlexedProps } from '../../Flex/types';
+import type { TransientFlexedProps } from '../../Flex/types';
 import { withFlexedContainer } from '../../Flex/withFlex';
 
 interface StyledFlexProps extends TransientFlexedProps {

--- a/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/DataCell.tsx
@@ -1,8 +1,8 @@
 import React, { type ComponentPropsWithoutRef, memo } from 'react';
 
-import { type PaddingProps } from '../../../helpers';
+import type { PaddingProps } from '../../../helpers';
 import { toTransientPaddingProps } from '../../../helpers/paddings/paddings';
-import { type TableColumnDisplayProps } from '../helpers';
+import type { TableColumnDisplayProps } from '../helpers';
 
 import { StyledTableDataCell, StyledTableDataCheckbox } from './styled';
 

--- a/packages/big-design/src/components/TableNext/DataCell/styled.tsx
+++ b/packages/big-design/src/components/TableNext/DataCell/styled.tsx
@@ -2,11 +2,11 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
 import { withPaddings } from '../../../helpers';
-import { type TransientPaddingProps } from '../../../helpers/paddings/paddings';
+import type { TransientPaddingProps } from '../../../helpers/paddings/paddings';
 import { withTableColumnDisplay } from '../helpers';
-import { type TransientTableColumnDisplayProps } from '../helpers/display/types';
+import type { TransientTableColumnDisplayProps } from '../helpers/display/types';
 
-import { type DataCellProps } from './DataCell';
+import type { DataCellProps } from './DataCell';
 
 interface StyledTableDataCellProps extends TransientTableColumnDisplayProps, TransientPaddingProps {
   $align?: DataCellProps['align'];

--- a/packages/big-design/src/components/TableNext/Head/styled.tsx
+++ b/packages/big-design/src/components/TableNext/Head/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import { hideVisually } from 'polished';
 import styled from 'styled-components';
 
-import { type HeadProps } from './Head';
+import type { HeadProps } from './Head';
 
 export const StyledTableHead = styled.thead<HeadProps>`
   ${({ hidden }) => hidden && hideVisually()}

--- a/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/HeaderCell.tsx
@@ -9,8 +9,8 @@ import { useComponentSize } from '../../../hooks';
 import { typedMemo } from '../../../utils';
 import { Box } from '../../Box';
 import { Tooltip } from '../../Tooltip';
-import { type TableColumnDisplayProps } from '../helpers';
-import { type TableColumn, type TableItem } from '../types';
+import type { TableColumnDisplayProps } from '../helpers';
+import type { TableColumn, TableItem } from '../types';
 
 import { StyledFlex, StyledTableHeaderCell, StyledTableHeaderIcon } from './styled';
 

--- a/packages/big-design/src/components/TableNext/HeaderCell/styled.tsx
+++ b/packages/big-design/src/components/TableNext/HeaderCell/styled.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 
 import { Flex } from '../../Flex';
 import { withTableColumnDisplay } from '../helpers';
-import { type TransientTableColumnDisplayProps } from '../helpers/display/types';
+import type { TransientTableColumnDisplayProps } from '../helpers/display/types';
 
 interface StyledTableHeaderCellProps extends TransientTableColumnDisplayProps {
   $isSortable?: boolean;

--- a/packages/big-design/src/components/TableNext/Row/Row.tsx
+++ b/packages/big-design/src/components/TableNext/Row/Row.tsx
@@ -21,9 +21,9 @@ import { typedMemo } from '../../../utils';
 import { MessagingButton } from '../../Button/private';
 import { Checkbox } from '../../Checkbox';
 import { Flex } from '../../Flex';
-import { type FlexedProps } from '../../Flex/types';
+import type { FlexedProps } from '../../Flex/types';
 import { DataCell } from '../DataCell';
-import { type TableColumn, type TableItem, type TableSelectable } from '../types';
+import type { TableColumn, TableItem, TableSelectable } from '../types';
 
 import { StyledDragHandle, StyledDragPreview, StyledTableRow } from './styled';
 import { useRowState } from './useRowState';

--- a/packages/big-design/src/components/TableNext/Row/spec.tsx
+++ b/packages/big-design/src/components/TableNext/Row/spec.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import 'jest-styled-components';
 
-import { type TableColumn } from '../types';
+import type { TableColumn } from '../types';
 
 import { Row } from './Row';
 

--- a/packages/big-design/src/components/TableNext/Row/useRowState.ts
+++ b/packages/big-design/src/components/TableNext/Row/useRowState.ts
@@ -1,4 +1,4 @@
-import { type TableSelectable } from '../types';
+import type { TableSelectable } from '../types';
 
 interface UseRowStateProps {
   isParentRow: boolean;

--- a/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
+++ b/packages/big-design/src/components/TableNext/RowContainer/RowContainer.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { typedMemo } from '../../../utils';
 import { StyleableButton } from '../../Button/Button';
 import { DataCell } from '../DataCell';
-import { type OnItemSelectFn } from '../hooks';
+import type { OnItemSelectFn } from '../hooks';
 import { Row, type RowProps } from '../Row';
-import { type TableExpandable, type TableItem, type TableProps } from '../types';
+import type { TableExpandable, TableItem, TableProps } from '../types';
 
 import { calculateColSpan } from './helpers';
 

--- a/packages/big-design/src/components/TableNext/RowContainer/helpers.ts
+++ b/packages/big-design/src/components/TableNext/RowContainer/helpers.ts
@@ -1,4 +1,4 @@
-import { type RowProps } from '../Row';
+import type { RowProps } from '../Row';
 
 interface CalculateColSpanArg<T> {
   columns: RowProps<T>['columns'];

--- a/packages/big-design/src/components/TableNext/RowContainer/spec.ts
+++ b/packages/big-design/src/components/TableNext/RowContainer/spec.ts
@@ -1,4 +1,4 @@
-import { type TableColumn } from '../types';
+import type { TableColumn } from '../types';
 
 import { calculateColSpan } from './helpers';
 

--- a/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
+++ b/packages/big-design/src/components/TableNext/SelectAll/SelectAll.tsx
@@ -3,12 +3,12 @@ import React, { type Dispatch, type SetStateAction } from 'react';
 import { Checkbox } from '../../Checkbox';
 import { Flex, FlexItem } from '../../Flex';
 import { Text } from '../../Typography';
-import {
-  type TableExpandable,
-  type TableItem,
-  type TablePaginationProps,
-  type TableProps,
-  type TableSelectable,
+import type {
+  TableExpandable,
+  TableItem,
+  TablePaginationProps,
+  TableProps,
+  TableSelectable,
 } from '../types';
 
 import { useSelectAllState } from './useSelectAllState';

--- a/packages/big-design/src/components/TableNext/SelectAll/helpers.ts
+++ b/packages/big-design/src/components/TableNext/SelectAll/helpers.ts
@@ -1,7 +1,7 @@
 import { getPagedIndex } from '../helpers';
-import { type TableExpandable, type TableSelectable } from '../types';
+import type { TableExpandable, TableSelectable } from '../types';
 
-import { type SelectAllProps } from './SelectAll';
+import type { SelectAllProps } from './SelectAll';
 
 type SelectAllRowsArg<T> = Omit<SelectAllProps<T>, 'onChange'>;
 

--- a/packages/big-design/src/components/TableNext/SelectAll/useSelectAllState.ts
+++ b/packages/big-design/src/components/TableNext/SelectAll/useSelectAllState.ts
@@ -1,5 +1,5 @@
 import { areAllInPageSelected, areSomeInPageSelected, getSelectAllState } from './helpers';
-import { type SelectAllProps } from './SelectAll';
+import type { SelectAllProps } from './SelectAll';
 
 // prettier-ignore
 export const useSelectAllState = <T,>(props: SelectAllProps<T>) => {

--- a/packages/big-design/src/components/TableNext/TableNext.tsx
+++ b/packages/big-design/src/components/TableNext/TableNext.tsx
@@ -7,7 +7,7 @@ import {
 } from '@atlaskit/pragmatic-drag-and-drop-live-region';
 import React, { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 import { toTransientMarginProps } from '../../helpers/margins/margins';
 import { typedMemo } from '../../utils';
 
@@ -26,7 +26,7 @@ import { useExpandable, useSelectable } from './hooks';
 import { Row } from './Row';
 import { RowContainer } from './RowContainer';
 import { StyledTable, StyledTableFigure } from './styled';
-import { type TableColumn, type TableItem, type TableProps } from './types';
+import type { TableColumn, TableItem, TableProps } from './types';
 
 interface Localization {
   ascendingOrder: string;

--- a/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
+++ b/packages/big-design/src/components/TableNext/TablePagination/TablePagination.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 
 import { OffsetPagination } from '../../OffsetPagination';
 import { StatelessPagination } from '../../StatelessPagination';
-import { type DiscriminatedTablePaginationProps } from '../types';
+import type { DiscriminatedTablePaginationProps } from '../types';
 
 import { StyledPaginationContainer } from './styled';
 

--- a/packages/big-design/src/components/TableNext/discriminatePagination.ts
+++ b/packages/big-design/src/components/TableNext/discriminatePagination.ts
@@ -1,4 +1,4 @@
-import { type DiscriminatedTablePaginationProps, type TablePaginationProps } from './types';
+import type { DiscriminatedTablePaginationProps, TablePaginationProps } from './types';
 
 export const discriminatePagination = (
   pagination: TablePaginationProps,

--- a/packages/big-design/src/components/TableNext/helpers/display/display.tsx
+++ b/packages/big-design/src/components/TableNext/helpers/display/display.tsx
@@ -6,7 +6,7 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { type TableColumnDisplayOverload, type TransientTableColumnDisplayProps } from './types';
+import type { TableColumnDisplayOverload, TransientTableColumnDisplayProps } from './types';
 
 export const withTableColumnDisplay = () => css<TransientTableColumnDisplayProps>`
   ${({ $display, theme }) => $display && getDisplayStyles($display, theme, 'display')};

--- a/packages/big-design/src/components/TableNext/helpers/display/spec.tsx
+++ b/packages/big-design/src/components/TableNext/helpers/display/spec.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { withTableColumnDisplay } from './display';
-import { type TransientTableColumnDisplayProps } from './types';
+import type { TransientTableColumnDisplayProps } from './types';
 
 const TestComponent = styled.div<TransientTableColumnDisplayProps>`
   ${withTableColumnDisplay()};

--- a/packages/big-design/src/components/TableNext/helpers/display/types.ts
+++ b/packages/big-design/src/components/TableNext/helpers/display/types.ts
@@ -1,6 +1,6 @@
-import { type CSSRules, type ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { CSSRules, ThemeInterface } from '@bigcommerce/big-design-theme';
 
-import { type ResponsiveProp } from '../../../../types';
+import type { ResponsiveProp } from '../../../../types';
 
 type TableColumnDisplayProp = ResponsiveProp<'table-cell' | 'none'>;
 

--- a/packages/big-design/src/components/TableNext/helpers/pagination/index.ts
+++ b/packages/big-design/src/components/TableNext/helpers/pagination/index.ts
@@ -1,4 +1,4 @@
-import { type TablePaginationProps } from '../../types';
+import type { TablePaginationProps } from '../../types';
 
 export function getPagedIndex(index: number, pagination?: TablePaginationProps) {
   const { currentPage, itemsPerPage } = { currentPage: 1, itemsPerPage: 0, ...pagination };

--- a/packages/big-design/src/components/TableNext/hooks/useExpandable/useExpandable.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useExpandable/useExpandable.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { useEventCallback } from '../../../../hooks';
-import { type TableExpandable } from '../../types';
+import type { TableExpandable } from '../../types';
 
 // prettier-ignore
 export const useExpandable = <T,>(expandable?: TableExpandable<T>) => {

--- a/packages/big-design/src/components/TableNext/hooks/useSelectable/helpers.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useSelectable/helpers.ts
@@ -1,6 +1,6 @@
-import { type Dispatch, type SetStateAction } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 
-import { type TableSelectable } from '../../types';
+import type { TableSelectable } from '../../types';
 
 export interface SelectRowArg {
   isTheOnlySelectedChildRow?: boolean;

--- a/packages/big-design/src/components/TableNext/hooks/useSelectable/useSelectable.ts
+++ b/packages/big-design/src/components/TableNext/hooks/useSelectable/useSelectable.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { useEventCallback } from '../../../../hooks';
-import { type TableSelectable } from '../../types';
+import type { TableSelectable } from '../../types';
 
 import {
   getTotalSelectedChildRows,

--- a/packages/big-design/src/components/TableNext/spec.tsx
+++ b/packages/big-design/src/components/TableNext/spec.tsx
@@ -4,7 +4,7 @@ import React, { type CSSProperties } from 'react';
 import 'jest-styled-components';
 
 import { TableFigureNext, TableNext } from './TableNext';
-import { type TableColumn } from './types';
+import type { TableColumn } from './types';
 
 interface Item {
   sku: string;

--- a/packages/big-design/src/components/TableNext/styled.tsx
+++ b/packages/big-design/src/components/TableNext/styled.tsx
@@ -2,7 +2,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled from 'styled-components';
 
 import { withMargins } from '../../helpers';
-import { type TransientMarginProps } from '../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../helpers/margins/margins';
 
 export const StyledTableFigure = styled.figure<TransientMarginProps>`
   margin: 0;

--- a/packages/big-design/src/components/TableNext/types.ts
+++ b/packages/big-design/src/components/TableNext/types.ts
@@ -1,10 +1,10 @@
 import type { ComponentPropsWithoutRef, MouseEvent, ReactElement, ReactNode } from 'react';
 
-import { type MarginProps } from '../../helpers';
-import { type OffsetPaginationProps } from '../OffsetPagination';
-import { type StatelessPaginationProps } from '../StatelessPagination';
+import type { MarginProps } from '../../helpers';
+import type { OffsetPaginationProps } from '../OffsetPagination';
+import type { StatelessPaginationProps } from '../StatelessPagination';
 
-import { type TableColumnDisplayProps } from './helpers';
+import type { TableColumnDisplayProps } from './helpers';
 
 export interface TableSelectable {
   selectedItems: Record<string, true>;

--- a/packages/big-design/src/components/Tabs/styled.tsx
+++ b/packages/big-design/src/components/Tabs/styled.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 import { StyleableButton } from '../Button/private';
 import { Flex } from '../Flex';
 
-import { type TabItem } from './Tabs';
+import type { TabItem } from './Tabs';
 
 interface TabProps extends Omit<TabItem, 'title'> {
   $activeTab?: string;

--- a/packages/big-design/src/components/Textarea/styled.tsx
+++ b/packages/big-design/src/components/Textarea/styled.tsx
@@ -1,12 +1,12 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
-import type { ReactNode } from 'react';
+import type React from 'react';
 import styled, { css } from 'styled-components';
 
 import { withTransition } from '../../helpers/transitions';
 
 interface StyledTextareaProps {
   $resize?: boolean;
-  $error?: ReactNode | ReactNode[];
+  $error?: React.ReactNode | React.ReactNode[];
 }
 
 export const StyledTextareaWrapper = styled.span`

--- a/packages/big-design/src/components/Tree/Tree.tsx
+++ b/packages/big-design/src/components/Tree/Tree.tsx
@@ -6,7 +6,7 @@ import { useFlatVisibleNodes } from './hooks/useFlatVisibleNodes';
 import { useTreeVirtualizer } from './hooks/useTreeVirtualizer';
 import { StyledUl, StyledVirtualSpacer } from './styled';
 import { TreeNode } from './TreeNode';
-import { type TreeContextState, type TreeNodeId, type TreeProps } from './types';
+import type { TreeContextState, TreeNodeId, TreeProps } from './types';
 
 const EMPTY_COUNTS: Map<TreeNodeId, number> = new Map();
 const EMPTY_NODES: never[] = [];

--- a/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
+++ b/packages/big-design/src/components/Tree/TreeNode/TreeNode.tsx
@@ -3,11 +3,11 @@ import React, { useCallback, useContext, useEffect, useMemo, useRef } from 'reac
 
 import { typedMemo } from '../../../utils';
 import { StyledCheckbox } from '../../Checkbox/private';
-import { type FlexItemProps } from '../../Flex';
+import type { FlexItemProps } from '../../Flex';
 import { StyledRadio } from '../../Radio/styled';
 import { StyledUl } from '../styled';
 import { TreeContext } from '../Tree';
-import { type TreeNodeProps } from '../types';
+import type { TreeNodeProps } from '../types';
 
 import {
   StyledArrowWrapper,

--- a/packages/big-design/src/components/Tree/hooks/spec.ts
+++ b/packages/big-design/src/components/Tree/hooks/spec.ts
@@ -1,18 +1,18 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { renderHook } from '@testing-library/react';
-import { type RefObject } from 'react';
+import type { RefObject } from 'react';
 
 import { getSelectedChildrenCounts } from '../../../utils';
-import {
-  type NodeMap,
-  type TreeExpandable,
-  type TreeFocusable,
-  type TreeNodeId,
-  type TreeNodeProps,
-  type TreeSelectable,
+import type {
+  NodeMap,
+  TreeExpandable,
+  TreeFocusable,
+  TreeNodeId,
+  TreeNodeProps,
+  TreeSelectable,
 } from '../types';
 
-import { type FlatTreeNode } from './useFlatVisibleNodes';
+import type { FlatTreeNode } from './useFlatVisibleNodes';
 import { useNodeMap } from './useNodeMap';
 import { useTreeKeyEvents } from './useTreeKeyEvents';
 import { useTreeVirtualizer } from './useTreeVirtualizer';

--- a/packages/big-design/src/components/Tree/hooks/useFlatVisibleNodes.ts
+++ b/packages/big-design/src/components/Tree/hooks/useFlatVisibleNodes.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { type TreeNodeId, type TreeNodeProps } from '../types';
+import type { TreeNodeId, TreeNodeProps } from '../types';
 
 export interface FlatTreeNode<T> {
   node: TreeNodeProps<T>;

--- a/packages/big-design/src/components/Tree/hooks/useNodeMap.ts
+++ b/packages/big-design/src/components/Tree/hooks/useNodeMap.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { type NodeMap, type TreeNodeId, type TreeNodeProps } from '../types';
+import type { NodeMap, TreeNodeId, TreeNodeProps } from '../types';
 
 interface UseNodeMapProps<T> {
   nodes: Array<TreeNodeProps<T>>;

--- a/packages/big-design/src/components/Tree/hooks/useTreeKeyEvents.ts
+++ b/packages/big-design/src/components/Tree/hooks/useTreeKeyEvents.ts
@@ -1,12 +1,12 @@
 import { useCallback } from 'react';
 
-import {
-  type NodeMap,
-  type TreeExpandable,
-  type TreeFocusable,
-  type TreeNodeId,
-  type TreeOnKeyDown,
-  type TreeSelectable,
+import type {
+  NodeMap,
+  TreeExpandable,
+  TreeFocusable,
+  TreeNodeId,
+  TreeOnKeyDown,
+  TreeSelectable,
 } from '../types';
 
 interface UseTreeKeyEventsProps<T> {

--- a/packages/big-design/src/components/Tree/hooks/useTreeVirtualizer.ts
+++ b/packages/big-design/src/components/Tree/hooks/useTreeVirtualizer.ts
@@ -2,9 +2,9 @@ import { type Rect, useVirtualizer, type Virtualizer } from '@tanstack/react-vir
 import { type RefObject, useEffect, useMemo, useRef } from 'react';
 
 import { useEventCallback } from '../../../hooks';
-import { type TreeNodeId, type TreeNodeProps } from '../types';
+import type { TreeNodeId, TreeNodeProps } from '../types';
 
-import { type FlatTreeNode } from './useFlatVisibleNodes';
+import type { FlatTreeNode } from './useFlatVisibleNodes';
 
 const ROW_HEIGHT_ESTIMATE = 40;
 const OVERSCAN = 20;

--- a/packages/big-design/src/components/Tree/spec.tsx
+++ b/packages/big-design/src/components/Tree/spec.tsx
@@ -4,12 +4,12 @@ import { userEvent } from '@testing-library/user-event';
 import React, { useContext } from 'react';
 
 import { Tree, TreeContext } from './Tree';
-import {
-  type TreeExpandable,
-  type TreeFocusable,
-  type TreeNodeProps,
-  type TreeOnKeyDown,
-  type TreeProps,
+import type {
+  TreeExpandable,
+  TreeFocusable,
+  TreeNodeProps,
+  TreeOnKeyDown,
+  TreeProps,
 } from './types';
 
 const nodes: Array<TreeNodeProps<number>> = [

--- a/packages/big-design/src/components/Tree/types.ts
+++ b/packages/big-design/src/components/Tree/types.ts
@@ -1,4 +1,4 @@
-import { type RefObject } from 'react';
+import type { RefObject } from 'react';
 
 export type TreeNodeId = string;
 

--- a/packages/big-design/src/components/Typography/Typography.tsx
+++ b/packages/big-design/src/components/Typography/Typography.tsx
@@ -12,13 +12,13 @@ import {
   StyledSmall,
   StyledText,
 } from './styled';
-import {
-  type HeadingProps,
-  type HeadingTag,
-  type HRProps,
-  type TextModifiers,
-  type TextProps,
-  type TypographyProps,
+import type {
+  HeadingProps,
+  HeadingTag,
+  HRProps,
+  TextModifiers,
+  TextProps,
+  TypographyProps,
 } from './types';
 
 function toTransientTextProps(props: TypographyProps & TextModifiers) {

--- a/packages/big-design/src/components/Typography/styled.tsx
+++ b/packages/big-design/src/components/Typography/styled.tsx
@@ -3,15 +3,15 @@ import { ellipsis } from 'polished';
 import styled, { css } from 'styled-components';
 
 import { type MarginProps, withMargins } from '../../helpers';
-import { type TransientMarginProps } from '../../helpers/margins/margins';
+import type { TransientMarginProps } from '../../helpers/margins/margins';
 
-import {
-  type HeadingProps,
-  type HRProps,
-  type TextProps,
-  type TransientTextModifiers,
-  type TransientTypographyProps,
-  type TypographyProps,
+import type {
+  HeadingProps,
+  HRProps,
+  TextProps,
+  TransientTextModifiers,
+  TransientTypographyProps,
+  TypographyProps,
 } from './types';
 
 type StyledHeadingProps = Omit<HeadingProps, keyof MarginProps> &

--- a/packages/big-design/src/components/Typography/types.ts
+++ b/packages/big-design/src/components/Typography/types.ts
@@ -1,7 +1,7 @@
-import { type Colors, type ThemeInterface } from '@bigcommerce/big-design-theme';
-import { type ComponentPropsWithoutRef } from 'react';
+import type { Colors, ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { ComponentPropsWithoutRef } from 'react';
 
-import { type MarginProps } from '../../helpers';
+import type { MarginProps } from '../../helpers';
 
 export interface TypographyProps {
   color?: keyof Colors;

--- a/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/Cell.tsx
@@ -7,12 +7,12 @@ import { Small } from '../../Typography';
 import { CheckboxEditor, ModalEditor, SelectEditor, TextEditor, ToggleEditor } from '../editors';
 import { MultiSelectEditor } from '../editors/MultiSelectEditor';
 import { useAutoFilling, useEditableCell, useWorksheetStore } from '../hooks';
-import {
-  type InternalWorksheetColumn,
-  type Cell as TCell,
-  type WorksheetItem,
-  type WorksheetSelectableColumn,
-  type WorksheetTextColumn,
+import type {
+  InternalWorksheetColumn,
+  Cell as TCell,
+  WorksheetItem,
+  WorksheetSelectableColumn,
+  WorksheetTextColumn,
 } from '../types';
 import { getCellIdx } from '../utils';
 

--- a/packages/big-design/src/components/Worksheet/Cell/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/Cell/styled.tsx
@@ -1,7 +1,7 @@
 import { type Colors, theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { type Cell, type WorksheetItem } from '../types';
+import type { Cell, WorksheetItem } from '../types';
 
 interface StyledCellProps<Item> {
   $isFirstSelected: boolean;

--- a/packages/big-design/src/components/Worksheet/Modal/Modal.tsx
+++ b/packages/big-design/src/components/Worksheet/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import { useShallow } from 'zustand/shallow';
 import { typedMemo } from '../../../utils';
 import { Modal } from '../../Modal';
 import { useTableFocus, useUpdateItems, useWorksheetStore } from '../hooks';
-import { type WorksheetItem, type WorksheetModalColumn } from '../types';
+import type { WorksheetItem, WorksheetModalColumn } from '../types';
 
 interface WorksheetModalProps<Item> {
   column: WorksheetModalColumn<Item>;

--- a/packages/big-design/src/components/Worksheet/Row/Row.tsx
+++ b/packages/big-design/src/components/Worksheet/Row/Row.tsx
@@ -5,13 +5,13 @@ import { typedMemo } from '../../../utils';
 import { Cell } from '../Cell';
 import { useWorksheetStore } from '../hooks';
 import { RowStatus } from '../RowStatus';
-import {
-  type InternalWorksheetColumn,
-  type WorksheetItem,
-  type WorksheetModalColumn,
-  type WorksheetNumberColumn,
-  type WorksheetSelectableColumn,
-  type WorksheetTextColumn,
+import type {
+  InternalWorksheetColumn,
+  WorksheetItem,
+  WorksheetModalColumn,
+  WorksheetNumberColumn,
+  WorksheetSelectableColumn,
+  WorksheetTextColumn,
 } from '../types';
 
 interface RowProps<Item> {

--- a/packages/big-design/src/components/Worksheet/Worksheet.tsx
+++ b/packages/big-design/src/components/Worksheet/Worksheet.tsx
@@ -10,7 +10,7 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
-import { type StoreApi } from 'zustand';
+import type { StoreApi } from 'zustand';
 import { useShallow } from 'zustand/shallow';
 
 import { typedMemo } from '../../utils';
@@ -24,13 +24,13 @@ import { WorksheetModal } from './Modal';
 import { Row } from './Row';
 import { Status } from './RowStatus/styled';
 import { Header, StyledBox, Table } from './styled';
-import {
-  type InternalTableInterface,
-  type InternalWorksheetColumn,
-  type WorksheetItem,
-  type WorksheetLocalization,
-  type WorksheetModalColumn,
-  type WorksheetProps,
+import type {
+  InternalTableInterface,
+  InternalWorksheetColumn,
+  WorksheetItem,
+  WorksheetLocalization,
+  WorksheetModalColumn,
+  WorksheetProps,
 } from './types';
 import { editedRows, invalidRows } from './utils';
 

--- a/packages/big-design/src/components/Worksheet/context/updateItems/updateItems.tsx
+++ b/packages/big-design/src/components/Worksheet/context/updateItems/updateItems.tsx
@@ -3,7 +3,7 @@ import { useShallow } from 'zustand/shallow';
 
 import { typedMemo } from '../../../../utils';
 import { useWorksheetStore } from '../../hooks';
-import { type Cell, type WorksheetItem } from '../../types';
+import type { Cell, WorksheetItem } from '../../types';
 
 export interface UpdateItemsContextType<T> {
   updateItems(items: Array<Cell<T>>, newValue: unknown[]): void;

--- a/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/CheckboxEditor/CheckboxEditor.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect } from 'react';
 
 import { typedMemo } from '../../../../utils';
 import { Checkbox } from '../../../Checkbox';
-import { type Cell, type WorksheetItem } from '../../types';
+import type { Cell, WorksheetItem } from '../../types';
 
 import { CheckboxWrapper } from './styled';
 

--- a/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/ModalEditor/ModalEditor.tsx
@@ -5,7 +5,7 @@ import { typedMemo } from '../../../../utils';
 import { Flex } from '../../../Flex';
 import { Small } from '../../../Typography';
 import { useWorksheetStore } from '../../hooks';
-import { type Cell, type WorksheetItem, type WorksheetModalColumn } from '../../types';
+import type { Cell, WorksheetItem, WorksheetModalColumn } from '../../types';
 
 import { StyledButton, StyledFlexItem } from './styled';
 

--- a/packages/big-design/src/components/Worksheet/editors/MultiSelectEditor/MultiSelectEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/MultiSelectEditor/MultiSelectEditor.tsx
@@ -4,7 +4,7 @@ import { useShallow } from 'zustand/shallow';
 import { typedMemo } from '../../../../utils';
 import { MultiSelect } from '../../../MultiSelect';
 import { useWorksheetStore } from '../../hooks';
-import { type Cell, type WorksheetItem, type WorksheetSelectableColumn } from '../../types';
+import type { Cell, WorksheetItem, WorksheetSelectableColumn } from '../../types';
 
 import { MultiSelectWrapper } from './styled';
 

--- a/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/SelectEditor/SelectEditor.tsx
@@ -4,7 +4,7 @@ import { useShallow } from 'zustand/shallow';
 import { typedMemo } from '../../../../utils';
 import { Select } from '../../../Select';
 import { useWorksheetStore } from '../../hooks';
-import { type Cell, type WorksheetItem, type WorksheetSelectableColumn } from '../../types';
+import type { Cell, WorksheetItem, WorksheetSelectableColumn } from '../../types';
 
 import { SelectWrapper } from './styled';
 

--- a/packages/big-design/src/components/Worksheet/editors/TextEditor/TextEditor.tsx
+++ b/packages/big-design/src/components/Worksheet/editors/TextEditor/TextEditor.tsx
@@ -2,8 +2,8 @@ import React, { useCallback, useId, useMemo, useRef, useState } from 'react';
 
 import { typedMemo } from '../../../../utils';
 import { Flex } from '../../../Flex';
-import { type EditableCellOnKeyDown } from '../../hooks';
-import { type Cell, type WorksheetItem, type WorksheetTextColumn } from '../../types';
+import type { EditableCellOnKeyDown } from '../../hooks';
+import type { Cell, WorksheetItem, WorksheetTextColumn } from '../../types';
 
 import { ActionButton, StyledInput } from './styled';
 

--- a/packages/big-design/src/components/Worksheet/hooks/useAutoFilling/useAutoFilling.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useAutoFilling/useAutoFilling.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
 
-import { type Cell, type WorksheetItem } from '../../types';
+import type { Cell, WorksheetItem } from '../../types';
 import { useUpdateItems } from '../useUpdateItems';
 import { useWorksheetStore } from '../useWorksheetStore';
 

--- a/packages/big-design/src/components/Worksheet/hooks/useCopyPaste/useCopyPaste.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useCopyPaste/useCopyPaste.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
 
-import { type Cell, type InternalWorksheetColumn } from '../../types';
+import type { Cell, InternalWorksheetColumn } from '../../types';
 import { useUpdateItems } from '../useUpdateItems';
 import { useWorksheetStore } from '../useWorksheetStore';
 

--- a/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useEditableCell/useEditableCell.ts
@@ -1,7 +1,7 @@
 import { type FocusEvent, type KeyboardEvent, useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
 
-import { type Cell, type WorksheetItem } from '../../types';
+import type { Cell, WorksheetItem } from '../../types';
 import { useTableFocus } from '../useTableFocus';
 import { useUpdateItems } from '../useUpdateItems';
 import { useWorksheetStore } from '../useWorksheetStore';

--- a/packages/big-design/src/components/Worksheet/hooks/useNavigation/useNavigation.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useNavigation/useNavigation.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
 
-import { type Cell, type InternalWorksheetColumn, type WorksheetItem } from '../../types';
+import type { Cell, InternalWorksheetColumn, WorksheetItem } from '../../types';
 import { useWorksheetStore } from '../useWorksheetStore';
 
 interface Coordinate {

--- a/packages/big-design/src/components/Worksheet/hooks/useWorksheetStore/useWorksheetStore.ts
+++ b/packages/big-design/src/components/Worksheet/hooks/useWorksheetStore/useWorksheetStore.ts
@@ -1,16 +1,16 @@
 import { useContext } from 'react';
 import { createStore, useStore } from 'zustand';
 
-import {
-  type Cell,
-  type DisabledRows,
-  type ExpandableRows,
-  type InternalWorksheetColumn,
-  type WorksheetItem,
+import type {
+  Cell,
+  DisabledRows,
+  ExpandableRows,
+  InternalWorksheetColumn,
+  WorksheetItem,
 } from '../../types';
 import { deleteCells, getCellsMap, getHiddenRows, mergeCells } from '../../utils';
 import { WorksheetContext } from '../../Worksheet';
-import { type EditingCellsArgs } from '../useKeyEvents';
+import type { EditingCellsArgs } from '../useKeyEvents';
 
 export interface SetEditingCellArgs<T> extends EditingCellsArgs {
   cell: Cell<T> | null;

--- a/packages/big-design/src/components/Worksheet/spec.tsx
+++ b/packages/big-design/src/components/Worksheet/spec.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { StatefulTree } from '../StatefulTree';
 
-import { type WorksheetColumn } from './types';
+import type { WorksheetColumn } from './types';
 import { Worksheet } from './Worksheet';
 
 interface Product {

--- a/packages/big-design/src/components/Worksheet/styled.tsx
+++ b/packages/big-design/src/components/Worksheet/styled.tsx
@@ -1,7 +1,7 @@
 import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import styled, { css } from 'styled-components';
 
-import { type InternalWorksheetColumn } from './types';
+import type { InternalWorksheetColumn } from './types';
 
 export const Table = styled.table<{
   $minWidth?: number;

--- a/packages/big-design/src/components/Worksheet/types.ts
+++ b/packages/big-design/src/components/Worksheet/types.ts
@@ -1,7 +1,7 @@
-import { type Colors } from '@bigcommerce/big-design-theme';
+import type { Colors } from '@bigcommerce/big-design-theme';
 import type { KeyboardEventHandler, ReactEventHandler, ReactNode, RefObject } from 'react';
 
-import { type SelectOption } from '../Select';
+import type { SelectOption } from '../Select';
 
 export type ExpandableRows = Record<string, Array<string | number>>;
 

--- a/packages/big-design/src/components/Worksheet/utils.ts
+++ b/packages/big-design/src/components/Worksheet/utils.ts
@@ -1,4 +1,4 @@
-import { type Cell, type ExpandableRows, type WorksheetError, type WorksheetItem } from './types';
+import type { Cell, ExpandableRows, WorksheetError, WorksheetItem } from './types';
 
 export const mergeCells = <T extends WorksheetItem>(
   oldCells: Array<Cell<T>>,

--- a/packages/big-design/src/helpers/display/display.tsx
+++ b/packages/big-design/src/helpers/display/display.tsx
@@ -6,7 +6,7 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { type DisplayOverload, type DisplayProps, type TransientDisplayProps } from './types';
+import type { DisplayOverload, DisplayProps, TransientDisplayProps } from './types';
 
 export const withDisplay = () => css<TransientDisplayProps>`
   ${({ $display, theme }) => $display && getDisplayStyles($display, theme, 'display')};

--- a/packages/big-design/src/helpers/display/spec.tsx
+++ b/packages/big-design/src/helpers/display/spec.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { withDisplay } from './display';
-import { type TransientDisplayProps } from './types';
+import type { TransientDisplayProps } from './types';
 
 const TestComponent = styled.div<TransientDisplayProps>`
   ${withDisplay()};

--- a/packages/big-design/src/helpers/display/types.ts
+++ b/packages/big-design/src/helpers/display/types.ts
@@ -1,6 +1,6 @@
-import { type CSSRules, type ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { CSSRules, ThemeInterface } from '@bigcommerce/big-design-theme';
 
-import { type ResponsiveProp } from '../../types';
+import type { ResponsiveProp } from '../../types';
 
 type DisplayProp = ResponsiveProp<
   'block' | 'inline-block' | 'inline' | 'inline-flex' | 'flex' | 'grid' | 'inline-grid' | 'none'

--- a/packages/big-design/src/helpers/margins/margins.tsx
+++ b/packages/big-design/src/helpers/margins/margins.tsx
@@ -1,7 +1,7 @@
-import { type Spacing } from '@bigcommerce/big-design-theme';
+import type { Spacing } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { type ResponsiveProp } from '../../types';
+import type { ResponsiveProp } from '../../types';
 import { getSpacingStyles } from '../spacings';
 
 type MarginProp = ResponsiveProp<keyof Spacing | 'auto'>;

--- a/packages/big-design/src/helpers/paddings/paddings.tsx
+++ b/packages/big-design/src/helpers/paddings/paddings.tsx
@@ -1,7 +1,7 @@
-import { type Spacing } from '@bigcommerce/big-design-theme';
+import type { Spacing } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { type ResponsiveProp } from '../../types';
+import type { ResponsiveProp } from '../../types';
 import { getSpacingStyles } from '../spacings';
 
 type PaddingProp = ResponsiveProp<keyof Spacing>;

--- a/packages/big-design/src/helpers/spacings/spacings.ts
+++ b/packages/big-design/src/helpers/spacings/spacings.ts
@@ -6,7 +6,7 @@ import {
 } from '@bigcommerce/big-design-theme';
 import { css } from 'styled-components';
 
-import { type Responsive } from '../../types';
+import type { Responsive } from '../../types';
 
 type SingleSpacingProp<T> = keyof Spacing | T;
 type ResponsiveSpacingProp<T> = Responsive<keyof Spacing | T>;

--- a/packages/big-design/src/managers/alerts/AlertsManager.tsx
+++ b/packages/big-design/src/managers/alerts/AlertsManager.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { Alert, type AlertProps } from '../../components';
 
-import { type createAlertsManager } from './manager';
+import type { createAlertsManager } from './manager';
 
 export interface AlertsManagerProps {
   manager: ReturnType<typeof createAlertsManager>;

--- a/packages/big-design/src/managers/alerts/manager.ts
+++ b/packages/big-design/src/managers/alerts/manager.ts
@@ -1,6 +1,6 @@
-import { type AlertProps } from '../../components/Alert';
+import type { AlertProps } from '../../components/Alert';
 
-import { type Subscriber, type TypeMap } from './types';
+import type { Subscriber, TypeMap } from './types';
 
 interface AddAlertConfig extends AlertProps {
   autoDismiss?: boolean;

--- a/packages/big-design/src/managers/alerts/spec.tsx
+++ b/packages/big-design/src/managers/alerts/spec.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import 'jest-styled-components';
 import React from 'react';
 
-import { type AlertProps } from '../../components/Alert';
+import type { AlertProps } from '../../components/Alert';
 
 import { AlertsManager } from './AlertsManager';
 import { createAlertsManager } from './manager';

--- a/packages/big-design/src/managers/alerts/types.ts
+++ b/packages/big-design/src/managers/alerts/types.ts
@@ -1,5 +1,5 @@
-import { type AlertProps } from '../../components';
-import { type MessagingType } from '../../utils';
+import type { AlertProps } from '../../components';
+import type { MessagingType } from '../../utils';
 
 export type TypeMap = Record<MessagingType, number>;
 

--- a/packages/big-design/src/types/responsive.ts
+++ b/packages/big-design/src/types/responsive.ts
@@ -1,4 +1,4 @@
-import { type Breakpoints } from '@bigcommerce/big-design-theme';
+import type { Breakpoints } from '@bigcommerce/big-design-theme';
 
 export type Responsive<T> = { [key in keyof Breakpoints]?: T };
 

--- a/packages/big-design/src/types/styled.d.ts
+++ b/packages/big-design/src/types/styled.d.ts
@@ -1,6 +1,6 @@
 import 'styled-components';
 
-import { type ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { ThemeInterface } from '@bigcommerce/big-design-theme';
 
 declare module 'styled-components' {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/packages/big-design/src/utils/floatingPlacement.ts
+++ b/packages/big-design/src/utils/floatingPlacement.ts
@@ -1,5 +1,5 @@
 import { autoPlacement, flip, type Middleware, type Placement } from '@floating-ui/react';
-import { type Placement as PopperPlacement } from '@popperjs/core';
+import type { Placement as PopperPlacement } from '@popperjs/core';
 
 // Placement props are still typed with popper's Placement, which includes 'auto*'
 // values that floating-ui only supports via the autoPlacement middleware.

--- a/packages/big-design/src/utils/messagingHelpers.tsx
+++ b/packages/big-design/src/utils/messagingHelpers.tsx
@@ -1,11 +1,11 @@
 import { CheckCircleIcon, ErrorIcon, InfoIcon, WarningIcon } from '@bigcommerce/big-design-icons';
-import { type ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { ThemeInterface } from '@bigcommerce/big-design-theme';
 import React, { type ComponentPropsWithoutRef } from 'react';
 import { css } from 'styled-components';
 
-import { type ButtonProps } from '../components/Button';
-import { type LinkProps } from '../components/Link';
-import { type MarginProps } from '../helpers/margins';
+import type { ButtonProps } from '../components/Button';
+import type { LinkProps } from '../components/Link';
+import type { MarginProps } from '../helpers/margins';
 
 export interface SharedMessagingProps extends ComponentPropsWithoutRef<'div'> {
   actions?: MessageAction[];

--- a/packages/big-design/src/utils/treeHelpers.ts
+++ b/packages/big-design/src/utils/treeHelpers.ts
@@ -1,4 +1,4 @@
-import { type TreeNodeId, type TreeNodeProps, type TreeProps } from '../components/Tree';
+import type { TreeNodeId, TreeNodeProps, TreeProps } from '../components/Tree';
 
 export function depthFirstSearch<T>(
   nodes: TreeProps<T>['nodes'],

--- a/packages/configs/eslint/base.js
+++ b/packages/configs/eslint/base.js
@@ -27,9 +27,16 @@ module.exports = {
         // (Vite/Rollup/Rolldown, webpack with strictExportPresence). See LTRAC-1370.
         // Scoped to ts/tsx only: the rule needs type info, which isn't set up for the
         // plain .js config files (e.g. .eslintrc.js) this config also lints.
+        // fixStyle MUST be 'separate-type-imports', not 'inline-type-imports': when every
+        // binding from a specifier is type-only, Babel only removes the whole import
+        // statement's runtime footprint for the *whole-statement* `import type {...}` form.
+        // The inline `import { type X }` form still leaves a bare `require(...)` for the
+        // module (Babel can't prove it's side-effect-free), which reintroduces exactly the
+        // kind of stray runtime import this rule exists to eliminate, and can create real
+        // circular-require chains that a type-only import never should.
         '@typescript-eslint/consistent-type-imports': [
           'error',
-          { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
+          { prefer: 'type-imports', fixStyle: 'separate-type-imports' },
         ],
       },
     },

--- a/packages/docs/components/Code/styled.tsx
+++ b/packages/docs/components/Code/styled.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { type CodeProps } from './';
+import type { CodeProps } from './';
 
 interface StyledCodeProps {
   $highlight?: CodeProps['highlight'];

--- a/packages/docs/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/docs/components/CodeSnippet/CodeSnippet.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@bigcommerce/big-design';
 import clipboardCopy from 'clipboard-copy';
-import { type Language } from 'prism-react-renderer';
+import type { Language } from 'prism-react-renderer';
 import React, { useContext } from 'react';
 import { Editor } from 'react-live';
 

--- a/packages/docs/components/ColorCards/ColorCard.tsx
+++ b/packages/docs/components/ColorCards/ColorCard.tsx
@@ -3,7 +3,7 @@ import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import React, { useContext } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 
-import { type ColorDetails } from './availableColors';
+import type { ColorDetails } from './availableColors';
 
 const StyledColor = styled(Flex)`
   height: ${({ theme }) => theme.helpers.remCalc(160)};

--- a/packages/docs/components/ColorCards/ColorCards.tsx
+++ b/packages/docs/components/ColorCards/ColorCards.tsx
@@ -1,7 +1,7 @@
 import { Flex, FlexItem } from '@bigcommerce/big-design';
 import React from 'react';
 
-import { type ColorDetails } from './availableColors';
+import type { ColorDetails } from './availableColors';
 import ColorCard from './ColorCard';
 
 interface ColorCardsProps {

--- a/packages/docs/components/ColorCards/availableColors.ts
+++ b/packages/docs/components/ColorCards/availableColors.ts
@@ -1,4 +1,4 @@
-import { type ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { ThemeInterface } from '@bigcommerce/big-design-theme';
 
 type Colors = ThemeInterface['colors'];
 type Color = keyof Colors;

--- a/packages/docs/components/ContentRoutingTabs/ContentRoutingTabs.tsx
+++ b/packages/docs/components/ContentRoutingTabs/ContentRoutingTabs.tsx
@@ -1,7 +1,7 @@
 import { Box, PillTabs } from '@bigcommerce/big-design';
 import React from 'react';
 
-import { type ContentRoutingTabsProps } from './types';
+import type { ContentRoutingTabsProps } from './types';
 import { useContentRoutingTabs } from './useContentRoutingTabs';
 
 const RawContentRoutingTabs: React.FC<ContentRoutingTabsProps> = ({ routes, id }) => {

--- a/packages/docs/components/ContentRoutingTabs/types.ts
+++ b/packages/docs/components/ContentRoutingTabs/types.ts
@@ -1,4 +1,4 @@
-import { type PillTabItem } from '@bigcommerce/big-design';
+import type { PillTabItem } from '@bigcommerce/big-design';
 
 export interface Route extends PillTabItem {
   render(): React.JSX.Element;

--- a/packages/docs/components/ContentRoutingTabs/useContentRoutingTabs.ts
+++ b/packages/docs/components/ContentRoutingTabs/useContentRoutingTabs.ts
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 
-import { type Route } from './types';
+import type { Route } from './types';
 
 export const useContentRoutingTabs = (routes: Route[], id: string) => {
   const { query, push } = useRouter();

--- a/packages/docs/components/GuidelinesTable/GuidelinesTable.tsx
+++ b/packages/docs/components/GuidelinesTable/GuidelinesTable.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, FlexItem, StatefulTable } from '@bigcommerce/big-design';
 import { CheckCircleIcon, ErrorIcon } from '@bigcommerce/big-design-icons';
 import React from 'react';
 
-import { type GuidelinesTableProps } from './types';
+import type { GuidelinesTableProps } from './types';
 
 export const GuidelinesTable: React.FC<GuidelinesTableProps> = ({ recommended, discouraged }) => {
   return (

--- a/packages/docs/components/List/List.tsx
+++ b/packages/docs/components/List/List.tsx
@@ -1,4 +1,7 @@
-import React, { type CSSProperties, type ReactElement, type ReactNode } from 'react';
+// eslint-disable-next-line import/no-duplicates -- React below is a genuine value import; the rest is type-only
+import React from 'react';
+// eslint-disable-next-line import/no-duplicates -- see above
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 
 import { ListItem } from './Item';
 import { StyledOrderedList, StyledUnorderedList } from './styled';

--- a/packages/docs/components/List/styled.tsx
+++ b/packages/docs/components/List/styled.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { type ListProps } from './List';
+import type { ListProps } from './List';
 
 interface StyledListProps {
   $columnCount?: ListProps['columnCount'];

--- a/packages/docs/components/MethodBadge/MethodBadge.tsx
+++ b/packages/docs/components/MethodBadge/MethodBadge.tsx
@@ -1,5 +1,8 @@
-import { type MarginProps } from '@bigcommerce/big-design';
-import React, { type ComponentPropsWithoutRef } from 'react';
+import type { MarginProps } from '@bigcommerce/big-design';
+// eslint-disable-next-line import/no-duplicates -- React below is a genuine value import; the rest is type-only
+import React from 'react';
+// eslint-disable-next-line import/no-duplicates -- see above
+import type { ComponentPropsWithoutRef, FC } from 'react';
 
 import { StyledMethodBadge } from './styled';
 
@@ -7,7 +10,7 @@ export interface MethodBadgeProps extends ComponentPropsWithoutRef<'div'>, Margi
   label: string;
 }
 
-export const MethodBadge: React.FC<MethodBadgeProps> = ({
+export const MethodBadge: FC<MethodBadgeProps> = ({
   className,
   style,
   label,

--- a/packages/docs/components/MethodBadge/styled.ts
+++ b/packages/docs/components/MethodBadge/styled.ts
@@ -1,7 +1,7 @@
 import { type MarginProps, withMargins } from '@bigcommerce/big-design';
 import styled from 'styled-components';
 
-import { type MethodBadgeProps } from './MethodBadge';
+import type { MethodBadgeProps } from './MethodBadge';
 
 interface StyledMethodBadgeProps extends Omit<MethodBadgeProps, 'label' | keyof MarginProps> {
   $margin?: MarginProps['margin'];

--- a/packages/docs/styled.d.ts
+++ b/packages/docs/styled.d.ts
@@ -1,4 +1,4 @@
-import { type ThemeInterface } from '@bigcommerce/big-design-theme';
+import type { ThemeInterface } from '@bigcommerce/big-design-theme';
 import 'styled-components';
 
 declare module 'styled-components' {


### PR DESCRIPTION
Jira: [TRAC-1548](<https://bigcommercecloud.atlassian.net/browse/TRAC-1548>)

## What?

Follow-up to [LTRAC-1546](https://linear.app/commerce/issue/LTRAC-1546/unblock-makeswift-is-not-connected-cases-with-www-redirects) (bigcommerce/big-design#1925, already merged). Changes `@typescript-eslint/consistent-type-imports`'s `fixStyle` from `'inline-type-imports'` to `'separate-type-imports'` (the rule's default) and reapplies the resulting import corrections across `big-design`, `big-design-icons`, and `packages/docs` — the packages actually affected by the style difference.

## Why?

[LTRAC-1546](https://linear.app/commerce/issue/LTRAC-1546/unblock-makeswift-is-not-connected-cases-with-www-redirects) fixed the "type-only import compiles into a real runtime import" bug, but the `fixStyle` it used doesn't fully fix it. Verified with a minimal isolated repro through the real `@babel/core`: an inline `import { type X } from 'y'` still compiles to a bare `require('y')` for the module specifier — Babel can't prove the module has no side effects, so it keeps a side-effect-only import around. Only the whole-statement `import type { X } from 'y'` form is fully elided with zero runtime footprint.

That distinction is not cosmetic: `utils/messagingHelpers.ts` and `treeHelpers.ts` import prop types from `../components/Button`, `../components/Link`, and `../components/Tree`. Under the inline style, the compiled output still requires those modules, creating a real circular require chain back through `utils/index.ts` before its `typedMemo` export (declared near the end of the barrel) is assigned — crashing with `TypeError: (0, _utils.typedMemo) is not a function` the moment anything imports `@bigcommerce/big-design`.

This is reproducible with a plain `node -e "require('@bigcommerce/big-design')"` — no bundler, no Next.js, nothing involved beyond Node's own CommonJS loader. Confirmed via side-by-side tarball tests that it's a genuine regression from the Babel 8 toolchain upgrade ([LTRAC-1512](https://linear.app/commerce/issue/LTRAC-1512/goalie-rotation-22)): the currently-published `4.0.0` (built with Babel 7) doesn't crash; a fresh tarball built from `changeset-release/main` before this fix does. Also confirmed this fix is independent of and unblocks the separate `@babel/runtime` regenerator-subpath question ([LTRAC-1547](https://linear.app/commerce/issue/LTRAC-1547/cornerstone-versions-after-6190-dont-display-rule-based-out-of-stock)): a tarball with only this fix applied, `@babel/runtime` left at `^8.0.0`, loads cleanly via plain `require`, and a full Next.js app on SWC now serves every route at 200 where every route previously crashed.

## Screenshots/Screen Recordings

N/A — import-statement syntax only, no visual changes.

## Testing/Proof

* `pnpm run lint` / `pnpm run typecheck` / `pnpm run test` (1155 tests) / `pnpm run build` all pass clean on this branch (based on current `main`, includes the [LTRAC-1545](https://linear.app/commerce/issue/LTRAC-1545/fix-makeswift-preview-loading-for-golfboxcomau) test fixes already merged there).
* Verified the compiled `dist/cjs/utils/messagingHelpers.js` and `treeHelpers.js` no longer contain the bare `require(...)` calls to `../components/Button`, `../components/Link`, `../components/Tree`.
* Repro/fix verified with a plain `node -e "require('@bigcommerce/big-design')"` against a freshly packed tarball, both before (crashes) and after (succeeds) this fix.

This is a correctness regression currently live on `main` (merged via bigcommerce/big-design#1925 before this was found) — should merge promptly, and definitely before [#1905](<https://github.com/bigcommerce/big-design/issues/1905>).

[TRAC-1548]: https://bigcommercecloud.atlassian.net/browse/TRAC-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ